### PR TITLE
[#71785012] Fix air chiller vertical location bug

### DIFF
--- a/src/EnergyPlus/RefrigeratedCase.cc
+++ b/src/EnergyPlus/RefrigeratedCase.cc
@@ -12560,7 +12560,7 @@ namespace RefrigeratedCase {
 					case Ceiling:
 						// purposely fall through
 					case Middle:
-					    CoilInletTemp = ZoneMixedAirDryBulb;
+						CoilInletTemp = ZoneMixedAirDryBulb;
 						CoilInletEnthalpy = ZoneMixedAirEnthalpy;
 						CoilInletRHFrac = ZoneMixedAirRHFrac;
 						CoilInletDensity = ZoneMixedAirDensity;


### PR DESCRIPTION
@Myoldmopar @frickeba 

The Floor and Ceiling options did not have any code in them and did not
set variables used later in the simulation that then causes a divide by
zero segfault.

It now uses a switch statement and “falls through” the three different
cases since they should all be the same at the moment. It would require
more thought to make them different but I can’t imagine in a mixed zone
how different heights would affect the calculations. Maybe @frickeba
has a better answer.

I came across this bug when adding Refrigeration components to OpenStudio
and testing various configurations.

This fixes #4240 
