### PR TITLE
Assigned OA rates to the OAController

### DIFF
--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -3838,6 +3838,7 @@ namespace MixedAir {
 									// "Carbon Dioxide Control Availability Schedule" for ZoneControl:ContaminantController not found
 									ZoneOA = ZoneOABZ / ZoneEz;
 								}
+								SysOA = SysOA + ZoneOA;
 							}
 
 							// Get the zone supply air flow rate
@@ -3931,7 +3932,12 @@ namespace MixedAir {
 						if ( SysEv <= 0.0 ) SysEv = 1.0;
 
 						// Calc system outdoor air requirement
-						SysOA = SysOAuc / SysEv;
+						if (VentilationMechanical(VentMechObjectNum).SystemOAMethod == SOAM_ProportionalControl) {
+							SysOA = SysOA / SysEv;
+						}
+						else {
+							SysOA = SysOAuc / SysEv;
+						}
 					}
 
 					// Finally calc the system supply OA mass flow rate


### PR DESCRIPTION
Two fixes were performed:
Revised MixedAir module to assign the calculated OA rates to the
OAController
Added two ZoneControl:ContaminantController objects in the testing file
to cover zones served by the OAController and Airloop.
