### PR TITLE
Make iteration build identify as 8.1.1-BUILDNUMBER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ Project(EnergyPlus)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 set( CMAKE_VERSION_MAJOR 8 )
-set( CMAKE_VERSION_MINOR 2 )
-set( CMAKE_VERSION_PATCH 0 ) 
+set( CMAKE_VERSION_MINOR 1 )
+set( CMAKE_VERSION_PATCH 1 ) 
 
 set( CMAKE_VERSION_BUILD "Unknown" CACHE STRING "Build number" )
 find_package(Git)


### PR DESCRIPTION
Need to be at 8.2.0 at fall release, so increment on 8.1 series until
then.  Next iteration will be 8.1.2, 8.1.3, etc.
