### PR TITLE
Fix schedule:file uninitialized variable

### DIFF
--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -2506,7 +2506,6 @@ namespace CurveManager {
 		TableNum = PerfCurve( CurveNum ).TableIndex;
 
 		if ( ReadFromFile ) {
-			FileExists = false;
 			CheckForActualFileName( FileName, FileExists, TempFullFileName );
 			if ( ! FileExists ) goto Label999;
 			FileNum = GetNewUnitNumber();

--- a/src/EnergyPlus/DataSystemVariables.cc
+++ b/src/EnergyPlus/DataSystemVariables.cc
@@ -178,7 +178,7 @@ namespace DataSystemVariables {
 		// na
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-		bool FileExist;
+		bool FileExist( false ); // initialize to false, then override to true if present
 		static int EchoInputFile; // found unit number for "eplusout.audit"
 		static bool firstTime( true );
 		std::string InputFileName; // save for changing out path characters


### PR DESCRIPTION
Added initialization to filefound variable in the routine, removed unnecessary initialization from caller.

[#70179394]
