### PR TITLE
76890548 review co2 and contaminant calculations

### DIFF
--- a/src/EnergyPlus/DualDuct.cc
+++ b/src/EnergyPlus/DualDuct.cc
@@ -1908,10 +1908,10 @@ namespace DualDuct {
 				}
 				else {
 					if ( Contaminant.CO2Simulation ) {
-						Node( OutletNode ).CO2 = Node( OAInletNode ).CO2;
+						Node( OutletNode ).CO2 = max( Node( OAInletNode ).CO2, Node( RAInletNode ).CO2 );
 					}
 					if ( Contaminant.GenericContamSimulation ) {
-						Node( OutletNode ).GenContam = Node( OAInletNode ).GenContam;
+						Node( OutletNode ).GenContam = max( Node( OAInletNode ).GenContam, Node( RAInletNode ).GenContam );
 					}
 				}
 


### PR DESCRIPTION
The zero mass flow protection was added in both scenarios. After running 7 example input files using dualduct objects, no differences were found. This bug is fixed. Pull request will be created.
