### PR TITLE
GitHub #4366

### DIFF
--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
@@ -683,8 +683,8 @@ namespace HVACMultiSpeedHeatPump {
 							if ( ComfortControlledZone( TstatZoneNum ).ActualZoneNum != MSHeatPump( MSHPNum ).ControlZoneNum ) continue;
 							AirNodeFound = true;
 						}
-						for (TstatZoneNum = 1; TstatZoneNum <= NumStageCtrZone; ++TstatZoneNum) {
-							if (StageControlledZone(TstatZoneNum).ActualZoneNum != MSHeatPump(MSHPNum).ControlZoneNum) continue;
+						for ( TstatZoneNum = 1; TstatZoneNum <= NumStageCtrZone; ++TstatZoneNum ) {
+							if ( StageControlledZone( TstatZoneNum ).ActualZoneNum != MSHeatPump( MSHPNum ).ControlZoneNum ) continue;
 							AirNodeFound = true;
 						}
 					} else {


### PR DESCRIPTION
The bug is fixed. The program runs to completion.

I created a pair of example input file:

MultiSpeedHP_StagedThermostat_old.idf (original)
MultiSpeedHP_StagedThermostat_new.idf (Commented the ZoneControl:Thermostat object)

No differences were found by running 6 example input files using multispeed heatpump.
