### PR TITLE
77737300 4370 unitary system single coil no fan

### DIFF
--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -4608,6 +4608,13 @@ namespace HVACUnitarySystem {
 						errFlag = false;
 					}
 
+					UnitarySystem( UnitarySysNum ).DesignHeatingCapacity = GetWtoAHPCoilCapacity( HeatingCoilType, HeatingCoilName, errFlag );
+					if ( errFlag ) {
+						ShowContinueError( "Occurs in " + CurrentModuleObject + " = " + UnitarySystem( UnitarySysNum ).Name );
+						ErrorsFound = true;
+						errFlag = false;
+					}
+
 					// Get the Heating Coil Inlet Node
 					errFlag = false;
 					HeatingCoilInletNode = GetWtoAHPCoilInletNode( HeatingCoilType, HeatingCoilName, errFlag );
@@ -5228,6 +5235,13 @@ namespace HVACUnitarySystem {
 						if ( UnitarySystem( UnitarySysNum ).CoolingCoilIndex == 0 ) {
 							ShowSevereError( CurrentModuleObject + " = " + UnitarySystem( UnitarySysNum ).Name );
 							ShowContinueError( "Illegal " + cAlphaFields( iCoolingCoilNameAlphaNum ) + " = " + CoolingCoilName );
+							ErrorsFound = true;
+							errFlag = false;
+						}
+
+						UnitarySystem( UnitarySysNum ).DesignCoolingCapacity = GetWtoAHPCoilCapacity( CoolingCoilType, CoolingCoilName, errFlag );
+						if ( errFlag ) {
+							ShowContinueError( "Occurs in " + CurrentModuleObject + " = " + UnitarySystem( UnitarySysNum ).Name );
 							ErrorsFound = true;
 							errFlag = false;
 						}


### PR DESCRIPTION
Issue #4370: An AirloopHVAC branch with one UnitarySystem with a single cooling coil, and a second downstream UnitarySystem with a single heating coil, could not autosize the heating coil. The model previously looked for a DX cooling coil on the branch and used that coil size for sizing the heating coil (as if it were a HP). This methodology now also works for this coil type. If a cooling coil is not found, the heating coil is sized using sizing inputs.

No diff's in example files (tik-tok bot confirms).

Defect file now sizes heating coil and runs to completion.
 Component Sizing Information, AirLoopHVAC:UnitarySystem, CORE_RETAIL CLGCOIL UNITARY, Nominal Cooling Capacity [W], 484731.03225
 Component Sizing Information, AirLoopHVAC:UnitarySystem, CORE_RETAIL HTGCOIL UNITARY, Nominal Heating Capacity [W], 484731.03225

Changes in code also exist where select case statements were removed. I started doing this and stopped since it interferes with viewing changes due solely to this issue. When reviewing changes where CoilType_Num is shown replacing SELECT_CASE_var, disregard as pertinent to this issue.

Defect file: GitHub\EnergyPlusDevSupport\DefectFiles\4370 (might change this annual run to a single day to save time)
https://github.com/NREL/EnergyPlusDevSupport/tree/master/DefectFiles/4370
