### PR TITLE
Fixes to Github issue 4395 related to life cycle costing. 

### DIFF
--- a/idd/Energy+.idd
+++ b/idd/Energy+.idd
@@ -80990,6 +80990,10 @@ LifeCycleCost:UsePriceEscalation,
         \required-field
         \type choice
         \key Electricity
+        \key ElectricityPurchased
+        \key ElectricityProduced
+        \key ElectricitySurplusSold
+        \key ElectricityNet
         \key NaturalGas
         \key Steam
         \key Gasoline
@@ -81132,6 +81136,10 @@ LifeCycleCost:UseAdjustment,
         \required-field
         \type choice
         \key Electricity
+        \key ElectricityPurchased
+        \key ElectricityProduced
+        \key ElectricitySurplusSold
+        \key ElectricityNet
         \key NaturalGas
         \key Steam
         \key Gasoline

--- a/src/EnergyPlus/EconomicLifeCycleCost.cc
+++ b/src/EnergyPlus/EconomicLifeCycleCost.cc
@@ -1449,7 +1449,7 @@ namespace EconomicLifeCycleCost {
 			{ auto const SELECT_CASE_var( CashFlow( iCashFlow ).SourceKind );
 			if ( SELECT_CASE_var == skResource ) {
 				//only for real fuels purchased such as electricity, natural gas, etc..
-				if ( ( CashFlow( iCashFlow ).Resource ) >= iRT_Electricity && ( CashFlow( iCashFlow ).Resource <= iRT_ResidualOil ) ) {
+				if ((CashFlow(iCashFlow).Resource) >= iRT_Electricity && (CashFlow(iCashFlow).Resource <= iRT_ElectricitySurplusSold)) {
 					CashFlow( iCashFlow ).pvKind = pvkEnergy;
 				} else {
 					CashFlow( iCashFlow ).pvKind = pvkNonEnergy;
@@ -1539,7 +1539,10 @@ namespace EconomicLifeCycleCost {
 			}}
 		}
 		// sum by category
-		for ( iCashFlow = countOfCostCat + 1; iCashFlow <= numCashFlow; ++iCashFlow ) {
+		for ( int i = 1; i <= countOfCostCat; ++i ) {
+			CashFlow(i).presentValue = 0; //initialize value to zero before summing in next for loop
+		}
+		for (iCashFlow = countOfCostCat + 1; iCashFlow <= numCashFlow; ++iCashFlow) {
 			curCategory = CashFlow( iCashFlow ).Category;
 			if ( ( curCategory <= countOfCostCat ) && ( curCategory >= 1 ) ) {
 				CashFlow( curCategory ).presentValue += CashFlow( iCashFlow ).presentValue;

--- a/testfiles/5ZoneEconomicsTariffAndLifeCycleCosts.idf
+++ b/testfiles/5ZoneEconomicsTariffAndLifeCycleCosts.idf
@@ -5077,7 +5077,43 @@
 
   LifeCycleCost:UsePriceEscalation,
     MidWest  Commercial-Electricity,  !- Name
-    Electricity,             !- Resource
+    ElectricityPurchased,
+    2012,                    !- Escalation Start Year
+    January,                 !- Escalation Start Month
+    1.0072,                  !- Year 1 Escalation
+    1.0148,                  !- Year 2 Escalation
+    1.0315,                  !- Year 3 Escalation
+    1.0493,                  !- Year 4 Escalation
+    1.0505,                  !- Year 5 Escalation
+    1.0451,                  !- Year 6 Escalation
+    1.0429,                  !- Year 7 Escalation
+    1.0410,                  !- Year 8 Escalation
+    1.0406,                  !- Year 9 Escalation
+    1.0444,                  !- Year 10 Escalation
+    1.0505,                  !- Year 11 Escalation
+    1.0535,                  !- Year 12 Escalation
+    1.0524,                  !- Year 13 Escalation
+    1.0478,                  !- Year 14 Escalation
+    1.0429,                  !- Year 15 Escalation
+    1.0391,                  !- Year 16 Escalation
+    1.0372,                  !- Year 17 Escalation
+    1.0360,                  !- Year 18 Escalation
+    1.0341,                  !- Year 19 Escalation
+    1.0319,                  !- Year 20 Escalation
+    1.0288,                  !- Year 21 Escalation
+    1.0341,                  !- Year 22 Escalation
+    1.0425,                  !- Year 23 Escalation
+    1.0508,                  !- Year 24 Escalation
+    1.0569,                  !- Year 25 Escalation
+    1.0626,                  !- Year 26 Escalation
+    1.0694,                  !- Year 27 Escalation
+    1.0721,                  !- Year 28 Escalation
+    1.0744,                  !- Year 29 Escalation
+    1.0774;                  !- Year 30 Escalation
+
+  LifeCycleCost:UsePriceEscalation,
+    MidWest  Commercial-Electricity,  !- Name
+    ElectricitySurplusSold,
     2012,                    !- Escalation Start Year
     January,                 !- Escalation Start Month
     1.0072,                  !- Year 1 Escalation


### PR DESCRIPTION
The UseEscalation needs to have the same energy resource as the utility rates that are passing along costs. The IDD was updated to include them and the example file was also. In addition, a small fix was made to the code to utilize resources that are higher in number in the enumeration list including the ones that should have been used in the example file. Also an initialization issue was fixed related to the Present Value by Category table in the Life-Cycle Cost Report. This is related to PivotalTracker story 78574460.
