### PR TITLE
Remove unnecessary minimum value for second daylighting control point z ...

### DIFF
--- a/idd/Energy+.idd
+++ b/idd/Energy+.idd
@@ -19975,7 +19975,6 @@ Daylighting:Controls,
   N7 , \field Z-Coordinate of Second Reference Point
        \units m
        \type real
-       \minimum 0.0
        \default 0.8
   N8 , \field Fraction of Zone Controlled by First Reference Point
        \type real


### PR DESCRIPTION
This should be a very quick merge, as there is no reason the absolute z-coordinate should be forced to be > 0.  For example, in basement zones where the z coordinate is < 0.  

Fixes #4451
[#79206134]
