### PR TITLE
Fix Zone Air Mass Flow Balance Simulation eio output

### DIFF
--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -1060,10 +1060,10 @@ namespace HeatBalanceManager {
 
 		gio::write(OutputFileInits, Format_732);
 		if (ZoneAirMassFlow.EnforceZoneMassBalance) {
-			gio::write(OutputFileInits, Format_733) << "Yes" << AlphaName(1);
+			gio::write(OutputFileInits, Format_733) << "Yes";
 		}
 		else {
-			gio::write(OutputFileInits, Format_733) << "No" << "N/A";
+			gio::write(OutputFileInits, Format_733) << "No";
 		}
 
 	}


### PR DESCRIPTION
Fixes #4490 
CI will report regression failures because all eio outputs will change
