### PR TITLE
Remove stray int main function from third party source code

### DIFF
--- a/third_party/BCVTB/utilSocket.c
+++ b/third_party/BCVTB/utilSocket.c
@@ -1177,10 +1177,4 @@ int closeipc(int* sockfd){
 }
 
 
-int main( int argc, const char* argv[] )
-{
-  fprintf(stderr, "Calling establ...'\n");
-  //  establishclientsocket("socket.cfg");
-}
-
 


### PR DESCRIPTION
Remove stray `int main` from third party source code
