### PR TITLE
Fix missing data in DaylightMaps table

### DIFF
--- a/src/EnergyPlus/SQLiteProcedures.cc
+++ b/src/EnergyPlus/SQLiteProcedures.cc
@@ -987,7 +987,7 @@ void SQLite::initializeDaylightMapTables()
 	const std::string daylightMapTitleInsertSQL =
 		"INSERT INTO DaylightMaps VALUES(?,?,?,?,?,?,?);";
 
-	sqlitePrepareStatement(m_daylightMapHorlyTitleInsertStmt,daylightMapTitleInsertSQL);
+	sqlitePrepareStatement(m_daylightMapTitleInsertStmt,daylightMapTitleInsertSQL);
 
 	const std::string daylightMapHourlyReportsTableSQL =
 		"CREATE TABLE DaylightMapHourlyReports (HourlyReportIndex INTEGER PRIMARY KEY, "


### PR DESCRIPTION
The data for DaylightMaps was not getting inserted into the SQLite database due to an incorrect variable used in the preparedStatement.

This should probably be included in the hot-fix of 8.2.0 as well.
@kbenne @Myoldmopar 
