### PR TITLE
Coverage final implementation 

### DIFF
--- a/.decent_ci-Linux.yaml
+++ b/.decent_ci-Linux.yaml
@@ -18,8 +18,8 @@ compilers:
     cmake_extra_flags: -DBUILD_FORTRAN=ON -DBUILD_PACKAGE:BOOL=ON -DBUILD_TESTING:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=OFF -DREGRESSION_BASELINE_PATH:PATH=$REGRESSION_BASELINE -DREGRESSION_SCRIPT_PATH:PATH=$REGRESSION_DIR -DREGRESSION_BASELINE_SHA:STRING=$REGRESSION_BASELINE_SHA -DCOMMIT_SHA=$COMMIT_SHA -DENABLE_COVERAGE:BOOL=ON
     coverage_enabled: true
     coverage_base_dir: src/EnergyPlus
-    coverage_pass_limit: 90
-    coverage_warn_limit: 80
+    coverage_pass_limit: 68.88
+    coverage_warn_limit: 66
     coverage_s3_bucket: energyplus
     build_tag: UnitTestsCoverage
     ctest_filter: -E "integration.*"
@@ -34,8 +34,8 @@ compilers:
     cmake_extra_flags: -DBUILD_FORTRAN=ON -DBUILD_PACKAGE:BOOL=ON -DBUILD_TESTING:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=OFF -DREGRESSION_BASELINE_PATH:PATH=$REGRESSION_BASELINE -DREGRESSION_SCRIPT_PATH:PATH=$REGRESSION_DIR -DREGRESSION_BASELINE_SHA:STRING=$REGRESSION_BASELINE_SHA -DCOMMIT_SHA=$COMMIT_SHA -DENABLE_COVERAGE:BOOL=ON
     coverage_enabled: true
     coverage_base_dir: src/EnergyPlus
-    coverage_pass_limit: 90
-    coverage_warn_limit: 80
+    coverage_pass_limit: 2.32
+    coverage_warn_limit: 2.30
     coverage_s3_bucket: energyplus
     build_tag: IntegrationCoverage
     skip_regression: true

--- a/.decent_ci-Linux.yaml
+++ b/.decent_ci-Linux.yaml
@@ -18,8 +18,8 @@ compilers:
     cmake_extra_flags: -DBUILD_FORTRAN=ON -DBUILD_PACKAGE:BOOL=ON -DBUILD_TESTING:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=OFF -DREGRESSION_BASELINE_PATH:PATH=$REGRESSION_BASELINE -DREGRESSION_SCRIPT_PATH:PATH=$REGRESSION_DIR -DREGRESSION_BASELINE_SHA:STRING=$REGRESSION_BASELINE_SHA -DCOMMIT_SHA=$COMMIT_SHA -DENABLE_COVERAGE:BOOL=ON
     coverage_enabled: true
     coverage_base_dir: src/EnergyPlus
-    coverage_pass_limit: 68.88
-    coverage_warn_limit: 66
+    coverage_pass_limit: 2.32
+    coverage_warn_limit: 2.30
     coverage_s3_bucket: energyplus
     build_tag: UnitTestsCoverage
     ctest_filter: -E "integration.*"
@@ -34,8 +34,8 @@ compilers:
     cmake_extra_flags: -DBUILD_FORTRAN=ON -DBUILD_PACKAGE:BOOL=ON -DBUILD_TESTING:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=OFF -DREGRESSION_BASELINE_PATH:PATH=$REGRESSION_BASELINE -DREGRESSION_SCRIPT_PATH:PATH=$REGRESSION_DIR -DREGRESSION_BASELINE_SHA:STRING=$REGRESSION_BASELINE_SHA -DCOMMIT_SHA=$COMMIT_SHA -DENABLE_COVERAGE:BOOL=ON
     coverage_enabled: true
     coverage_base_dir: src/EnergyPlus
-    coverage_pass_limit: 2.32
-    coverage_warn_limit: 2.30
+    coverage_pass_limit: 68.88
+    coverage_warn_limit: 66
     coverage_s3_bucket: energyplus
     build_tag: IntegrationCoverage
     skip_regression: true


### PR DESCRIPTION
- [x] Verify that SQL is *not* being called - Correct, no integration test generates SQL files
- [X] Adjust coverage thresholds to get everything green - See commits on this branch for how to adjust coverage limits
- [X] Make dip in coverage to be considered an error - https://github.com/lefticus/decent_ci/commit/22c96fdd2d4d9862055368c637785db6d6e0209b
- [X] Have ability to filter lines of code - See http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php "Exclusion Markers"

For [#84695188]

@kbenne @Myoldmopar 