### PR TITLE
SolarShading: Remove extra line left during redimension mig [Fixes #4676]

### DIFF
--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -3143,7 +3143,6 @@ namespace SolarShading {
 			}
 
 			if ( DisplayExtraWarnings ) {
-				++NumTooManyFigures;
 				TrackTooManyFigures.redimension( ++NumTooManyFigures );
 				TrackTooManyFigures( NumTooManyFigures ).SurfIndex1 = CurrentShadowingSurface;
 				TrackTooManyFigures( NumTooManyFigures ).SurfIndex2 = CurrentSurfaceBeingShadowed;


### PR DESCRIPTION
This should fix #4676. This was a leftover line (my goof) from my big migration to using array redimension calls (to reduce heap allocations and copies and code).