### PR TITLE
Fix autosizing of ideal load cooling capacity - Issue #4604

### DIFF
--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -855,7 +855,7 @@ namespace ReportSizingManager {
 						AutosizeDes = ZoneEqSizing ( CurZoneEqNum ).DesCoolingLoad;
 						DesVolFlow = DataFlowUsedForSizing;
 					} else {
-						if ( SameString( CompType, "COIL:COOLING:WATER" ) || SameString( CompType, "COIL:COOLING:WATER:DETAILEDGEOMETRY" ) ) {
+						if ( SameString( CompType, "COIL:COOLING:WATER" ) || SameString( CompType, "COIL:COOLING:WATER:DETAILEDGEOMETRY") || SameString( CompType, "ZONEHVAC:IDEALLOADSAIRSYSTEM" ) ) {
 							if ( TermUnitIU ) {
 								AutosizeDes = TermUnitSizing( CurZoneEqNum ).DesCoolingLoad;
 							} else if ( ZoneEqFanCoil ) {


### PR DESCRIPTION
Fixes #4604 The logic in RequestSizing for zone equipment for CoolingCapacitySizing is different from the equivalent logic for HeatingCapacitySizing.  The existing logic allowed ideal loads to fall through with zero capacity.  This fix solves the immediate problem, but it seems that this case should fall into the same type of else block that the heating capacity does for ideal loads. @rraustad Any insight to offer here?