### PR TITLE
Fix #4620 unit label issue with LEED report

### DIFF
--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -142,6 +142,7 @@ namespace OutputReportTabular {
 	int const unitsStyleJtoMJ( 2 );
 	int const unitsStyleJtoGJ( 3 );
 	int const unitsStyleInchPound( 4 );
+	int const unitsStyleNotFound( 5 );
 
 	int const isAverage( 1 );
 	int const isSum( 2 );
@@ -1487,18 +1488,8 @@ namespace OutputReportTabular {
 			}
 			//MonthlyUnitConversion
 			if ( NumAlphas >= 2 ) {
-				if ( SameString( AlphArray( 2 ), "None" ) ) {
-					unitsStyle = unitsStyleNone;
-				} else if ( SameString( AlphArray( 2 ), "JTOKWH" ) ) {
-					unitsStyle = unitsStyleJtoKWH;
-				} else if ( SameString( AlphArray( 2 ), "JTOMJ" ) ) {
-					unitsStyle = unitsStyleJtoMJ;
-				} else if ( SameString( AlphArray( 2 ), "JTOGJ" ) ) {
-					unitsStyle = unitsStyleJtoGJ;
-				} else if ( SameString( AlphArray( 2 ), "INCHPOUND" ) ) {
-					unitsStyle = unitsStyleInchPound;
-				} else {
-					unitsStyle = unitsStyleNone;
+				unitsStyle = SetUnitsStyleFromString( AlphArray( 2 ) );
+				if (unitsStyle == unitsStyleNotFound) {
 					ShowWarningError( CurrentModuleObject + ": Invalid " + cAlphaFieldNames( 2 ) + "=\"" + AlphArray( 2 ) + "\". No unit conversion will be performed. Normal SI units will be shown." );
 				}
 			} else {
@@ -1527,6 +1518,33 @@ namespace OutputReportTabular {
 		AlphArray.deallocate();
 		NumArray.deallocate();
 
+	}
+
+	int
+	SetUnitsStyleFromString(
+	std::string unitStringIn
+	)
+	{
+		int unitsStyleReturn;
+		if ( SameString( unitStringIn, "None" ) ) {
+			unitsStyleReturn = unitsStyleNone;
+		}
+		else if ( SameString( unitStringIn, "JTOKWH" ) ) {
+			unitsStyleReturn = unitsStyleJtoKWH;
+		}
+		else if ( SameString( unitStringIn, "JTOMJ" ) ) {
+			unitsStyleReturn = unitsStyleJtoMJ;
+		}
+		else if ( SameString( unitStringIn, "JTOGJ" ) ) {
+			unitsStyleReturn = unitsStyleJtoGJ;
+		}
+		else if ( SameString( unitStringIn, "INCHPOUND" ) ) {
+			unitsStyleReturn = unitsStyleInchPound;
+		}
+		else {
+			unitsStyleReturn = unitsStyleNotFound;
+		}
+		return unitsStyleReturn;
 	}
 
 	void
@@ -5826,8 +5844,11 @@ namespace OutputReportTabular {
 		//CALL PreDefTableEntry(pdchLeedGenData,'Heating Degree Days','-')
 		//CALL PreDefTableEntry(pdchLeedGenData,'Cooling Degree Days','-')
 		PreDefTableEntry( pdchLeedGenData, "HDD and CDD data source", "Weather File Stat" );
-		PreDefTableEntry( pdchLeedGenData, "Total gross floor area [m2]", "-" );
-
+		if ( unitsStyle == unitsStyleInchPound ) {
+			PreDefTableEntry( pdchLeedGenData, "Total gross floor area [ft2]", "-" );
+		} else {
+			PreDefTableEntry( pdchLeedGenData, "Total gross floor area [m2]", "-" );
+		}
 	}
 
 	void
@@ -7072,7 +7093,11 @@ namespace OutputReportTabular {
 
 			tableBody = "";
 			tableBody( 1, 1 ) = RealToStr( convBldgGrossFloorArea, 2 );
-			PreDefTableEntry( pdchLeedGenData, "Total gross floor area [m2]", RealToStr( convBldgGrossFloorArea, 2 ) );
+			if ( unitsStyle == unitsStyleInchPound ) {
+				PreDefTableEntry( pdchLeedGenData, "Total gross floor area [ft2]", RealToStr( convBldgGrossFloorArea, 2 ) );
+			} else {
+				PreDefTableEntry( pdchLeedGenData, "Total gross floor area [m2]", RealToStr( convBldgGrossFloorArea, 2 ) );
+			}
 			tableBody( 2, 1 ) = RealToStr( convBldgCondFloorArea, 2 );
 			tableBody( 3, 1 ) = RealToStr( convBldgGrossFloorArea - convBldgCondFloorArea, 2 );
 

--- a/src/EnergyPlus/OutputReportTabular.hh
+++ b/src/EnergyPlus/OutputReportTabular.hh
@@ -54,6 +54,7 @@ namespace OutputReportTabular {
 	extern int const unitsStyleJtoMJ;
 	extern int const unitsStyleJtoGJ;
 	extern int const unitsStyleInchPound;
+	extern int const unitsStyleNotFound;
 
 	extern int const isAverage;
 	extern int const isSum;
@@ -764,6 +765,13 @@ namespace OutputReportTabular {
 
 	void
 	GetInputTabularStyle();
+
+
+	int
+	SetUnitsStyleFromString(
+		std::string unitStringIn
+		);
+
 
 	void
 	GetInputTabularPredefined();

--- a/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
+++ b/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
@@ -1,0 +1,21 @@
+// EnergyPlus::OutpurReportTabular Unit Tests
+
+// Google Test Headers
+#include <gtest/gtest.h>
+
+// EnergyPlus Headers
+#include <EnergyPlus/OutputReportTabular.hh>
+
+using namespace EnergyPlus;
+using namespace EnergyPlus::OutputReportTabular;
+using namespace ObjexxFCL;
+
+TEST( OutputReportTabularTest, ConfirmSetUnitsStyleFromString )
+{
+	EXPECT_EQ( unitsStyleNone, SetUnitsStyleFromString( "None" ) );
+	EXPECT_EQ( unitsStyleJtoKWH, SetUnitsStyleFromString( "JTOKWH" ) );
+	EXPECT_EQ( unitsStyleJtoMJ, SetUnitsStyleFromString( "JTOMJ" ) );
+	EXPECT_EQ( unitsStyleJtoGJ, SetUnitsStyleFromString( "JTOGJ" ) );
+	EXPECT_EQ( unitsStyleInchPound, SetUnitsStyleFromString( "INCHPOUND" ) );
+	EXPECT_EQ( unitsStyleNotFound, SetUnitsStyleFromString( "qqq" ) );
+}


### PR DESCRIPTION
FIxes the unit label issue found in #4620 so that the m2 or ft2 is shown correctly in Sec1.1A-General Information of the LEED tabular report. Also includes a unit test for confirming the units style based on  the string provided.