### PR TITLE
Relax error check for oa controller actuator node Issue 4272

### DIFF
--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -1286,9 +1286,8 @@ namespace MixedAir {
 				OAController( OutAirNum ).MixNode = GetOnlySingleNode( AlphArray( 4 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Sensor, 1, ObjectIsNotParent );
 				OAController( OutAirNum ).OANode = GetOnlySingleNode( AlphArray( 5 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Actuator, 1, ObjectIsNotParent );
 				if ( ! CheckOutAirNodeNumber( OAController( OutAirNum ).OANode ) ) {
-					ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid field " );
-					ShowContinueError( cAlphaFields( 5 ) + "=\"" + AlphArray( 5 ) + "\", must be an OutdoorAir:Node for outdoor air to be effective." );
-					ErrorsFound = true;
+					ShowWarningError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" has a nonstandard input." );
+					ShowContinueError( cAlphaFields( 5 ) + "=\"" + AlphArray( 5 ) + "\", is not an OutdoorAir:Node, confirm intended source for outdoor air stream." );
 				}
 				if ( SameString( AlphArray( 6 ), "NoEconomizer" ) ) {
 					OAController( OutAirNum ).Econo = NoEconomizer;

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -1172,17 +1172,9 @@ namespace MixedAir {
 		int MaxAlphas; // Maximum alphas in multiple objects
 		int MaxNums; // Maximum numbers in multiple objects
 		//INTEGER :: ERVControllerNum     ! Index to Controller:Stand Alone ERV
-		int ControlledZoneNum; // Index to controlled zones
-		bool AirNodeFound; // Used to determine if control zone is valid
-		bool AirLoopFound; // Used to determine if control zone is served by furnace air loop
 		int AirLoopNumber; // Used to determine if control zone is served by furnace air loop
 		int BranchNum; // Used to determine if control zone is served by furnace air loop
 		int CompNum; // Used to determine if control zone is served by furnace air loop
-		int HStatZoneNum; // Used to determine if control zone has a humidistat object
-		int OASysNum; // Used to find OA System index for OA Controller
-		int OASysIndex; // Index to OA System
-		bool OASysFound; // OA Controller found OA System index
-		Real64 OAFlowRatio; // Ratio of minimum OA flow rate to maximum OA flow rate
 
 		int NumGroups; // Number of extensible input groups of the VentilationMechanical object
 		int numBaseNum; // base number for numeric arguments (for readability)
@@ -1278,285 +1270,8 @@ namespace MixedAir {
 					ErrorsFound = true;
 					if ( IsBlank ) AlphArray( 1 ) = "xxxxx";
 				}
-				OAController( OutAirNum ).Name = AlphArray( 1 );
-				OAController( OutAirNum ).ControllerType = CurrentModuleObject;
-				OAController( OutAirNum ).ControllerType_Num = ControllerOutsideAir;
-				OAController( OutAirNum ).MaxOA = NumArray( 2 );
-				OAController( OutAirNum ).MinOA = NumArray( 1 );
-				OAController( OutAirNum ).MixNode = GetOnlySingleNode( AlphArray( 4 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Sensor, 1, ObjectIsNotParent );
-				OAController( OutAirNum ).OANode = GetOnlySingleNode( AlphArray( 5 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Actuator, 1, ObjectIsNotParent );
-				if ( ! CheckOutAirNodeNumber( OAController( OutAirNum ).OANode ) ) {
-					ShowWarningError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" has a nonstandard input." );
-					ShowContinueError( cAlphaFields( 5 ) + "=\"" + AlphArray( 5 ) + "\", is not an OutdoorAir:Node, confirm intended source for outdoor air stream." );
-				}
-				if ( SameString( AlphArray( 6 ), "NoEconomizer" ) ) {
-					OAController( OutAirNum ).Econo = NoEconomizer;
-				} else if ( SameString( AlphArray( 6 ), "FixedDryBulb" ) ) {
-					OAController( OutAirNum ).Econo = FixedDryBulb;
-				} else if ( SameString( AlphArray( 6 ), "FixedEnthalpy" ) ) {
-					OAController( OutAirNum ).Econo = FixedEnthalpy;
-				} else if ( SameString( AlphArray( 6 ), "FixedDewPointAndDryBulb" ) ) {
-					OAController( OutAirNum ).Econo = FixedDewPointAndDryBulb;
-				} else if ( SameString( AlphArray( 6 ), "DifferentialDryBulb" ) ) {
-					OAController( OutAirNum ).Econo = DifferentialDryBulb;
-				} else if ( SameString( AlphArray( 6 ), "DifferentialEnthalpy" ) ) {
-					OAController( OutAirNum ).Econo = DifferentialEnthalpy;
-				} else if ( SameString( AlphArray( 6 ), "DifferentialDryBulbAndEnthalpy" ) ) {
-					OAController( OutAirNum ).Econo = DifferentialDryBulbAndEnthalpy;
-				} else if ( SameString( AlphArray( 6 ), "ElectronicEnthalpy" ) ) {
-					OAController( OutAirNum ).Econo = ElectronicEnthalpy;
-				} else {
-					ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 6 ) + "=\"" + AlphArray( 6 ) + "\" value." );
-					ErrorsFound = true;
-				}
-				//Bypass choice - Added by Amit for new feature implementation
-				if ( SameString( AlphArray( 7 ), "ModulateFlow" ) ) {
-					OAController( OutAirNum ).EconBypass = false;
-				} else if ( SameString( AlphArray( 7 ), "MinimumFlowWithBypass" ) ) {
-					OAController( OutAirNum ).EconBypass = true;
-				} else {
-					ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 7 ) + "=\"" + AlphArray( 7 ) + "\" value." );
-					ErrorsFound = true;
-				}
 
-				//    IF((OAController(OutAirNum)%Econo > NoEconomizer) .AND. OAController(OutAirNum)%EconBypass) THEN
-				//      CALL ShowSevereError(TRIM(CurrentModuleObject)//'="'//TRIM(AlphArray(1))//'" invalid '//  &
-				//         TRIM(cAlphaFields(6))//'="'//TRIM(AlphArray(6))//'" and ')
-				//      CALL ShowContinueError(TRIM(cAlphaFields(7))//'="'//TRIM(AlphArray(7))//'" incompatible specifications.')
-				//      ErrorsFound = .TRUE.
-				//    END IF
-				if ( SameString( AlphArray( 9 ), "NoLockout" ) ) {
-					OAController( OutAirNum ).Lockout = NoLockoutPossible;
-				} else if ( SameString( AlphArray( 9 ), "LockoutWithHeating" ) ) {
-					OAController( OutAirNum ).Lockout = LockoutWithHeatingPossible;
-				} else if ( SameString( AlphArray( 9 ), "LockoutWithCompressor" ) ) {
-					OAController( OutAirNum ).Lockout = LockoutWithCompressorPossible;
-				} else {
-					ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 9 ) + "=\"" + AlphArray( 9 ) + "\" value." );
-					ErrorsFound = true;
-				}
-				if ( SameString( AlphArray( 10 ), "FixedMinimum" ) ) {
-					OAController( OutAirNum ).FixedMin = true;
-				} else {
-					OAController( OutAirNum ).FixedMin = false;
-				}
-				if ( lNumericBlanks( 3 ) ) {
-					OAController( OutAirNum ).TempLim = BlankNumeric;
-				} else {
-					OAController( OutAirNum ).TempLim = NumArray( 3 );
-				}
-
-				if ( lNumericBlanks( 4 ) ) {
-					OAController( OutAirNum ).EnthLim = BlankNumeric;
-				} else {
-					OAController( OutAirNum ).EnthLim = NumArray( 4 );
-				}
-				if ( lNumericBlanks( 5 ) ) {
-					OAController( OutAirNum ).DPTempLim = BlankNumeric;
-				} else {
-					OAController( OutAirNum ).DPTempLim = NumArray( 5 );
-				}
-
-				if ( lNumericBlanks( 6 ) ) {
-					OAController( OutAirNum ).TempLowLim = BlankNumeric;
-				} else {
-					OAController( OutAirNum ).TempLowLim = NumArray( 6 );
-				}
-
-				if ( ! lAlphaBlanks( 8 ) ) {
-					OAController( OutAirNum ).EnthalpyCurvePtr = GetCurveIndex( AlphArray( 8 ) ); // convert curve name to number
-					if ( OAController( OutAirNum ).EnthalpyCurvePtr == 0 ) {
-						ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 8 ) + "=\"" + AlphArray( 8 ) + "\" not found." );
-						ErrorsFound = true;
-					} else {
-						// Verify Curve Object, only legal types are Quadratic and Cubic
-						{ auto const SELECT_CASE_var( GetCurveType( OAController( OutAirNum ).EnthalpyCurvePtr ) );
-
-						if ( SELECT_CASE_var == "QUADRATIC" ) {
-
-						} else if ( SELECT_CASE_var == "CUBIC" ) {
-
-						} else {
-							ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 8 ) + "=\"" + AlphArray( 8 ) + "\"." );
-							ShowContinueError( "...must be Quadratic or Cubic curve." );
-							ErrorsFound = true;
-						}}
-					}
-				}
-
-				OAController( OutAirNum ).RelNode = GetOnlySingleNode( AlphArray( 2 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Actuator, 1, ObjectIsNotParent );
-				OAController( OutAirNum ).RetNode = GetOnlySingleNode( AlphArray( 3 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Sensor, 1, ObjectIsNotParent );
-				OAController( OutAirNum ).MinOASch = AlphArray( 11 );
-				OAController( OutAirNum ).MinOASchPtr = GetScheduleIndex( AlphArray( 11 ) );
-				if ( OAController( OutAirNum ).MinOASchPtr == 0 && ( ! lAlphaBlanks( 11 ) ) ) {
-					ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 11 ) + "=\"" + AlphArray( 11 ) + "\" not found." );
-					ErrorsFound = true;
-				}
-
-				// Changed by Amit for new feature implementation
-				OAController( OutAirNum ).MinOAflowSch = AlphArray( 12 );
-				OAController( OutAirNum ).MinOAflowSchPtr = GetScheduleIndex( AlphArray( 12 ) );
-				if ( OAController( OutAirNum ).MinOAflowSchPtr == 0 && ( ! lAlphaBlanks( 12 ) ) ) {
-					ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 12 ) + "=\"" + AlphArray( 12 ) + "\" not found." );
-					ErrorsFound = true;
-				}
-
-				OAController( OutAirNum ).MaxOAflowSch = AlphArray( 13 );
-				OAController( OutAirNum ).MaxOAflowSchPtr = GetScheduleIndex( AlphArray( 13 ) );
-				if ( OAController( OutAirNum ).MaxOAflowSchPtr == 0 && ( ! lAlphaBlanks( 13 ) ) ) {
-					ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 13 ) + "=\"" + AlphArray( 13 ) + "\" not found." );
-					ErrorsFound = true;
-				}
-				OAController( OutAirNum ).VentilationMechanicalName = AlphArray( 14 );
-
-				//   Check for a time of day economizer control schedule
-				OAController( OutAirNum ).EconomizerOASchedPtr = GetScheduleIndex( AlphArray( 15 ) );
-
-				//   High humidity control option can be used with any economizer flag
-				if ( SameString( AlphArray( 16 ), "Yes" ) ) {
-
-					OAController( OutAirNum ).HumidistatZoneNum = FindItemInList( AlphArray( 17 ), Zone.Name(), NumOfZones );
-
-					// Get the node number for the zone with the humidistat
-					if ( OAController( OutAirNum ).HumidistatZoneNum > 0 ) {
-						AirNodeFound = false;
-						AirLoopFound = false;
-						OASysFound = false;
-						for ( ControlledZoneNum = 1; ControlledZoneNum <= NumOfZones; ++ControlledZoneNum ) {
-							if ( ZoneEquipConfig( ControlledZoneNum ).ActualZoneNum != OAController( OutAirNum ).HumidistatZoneNum ) continue;
-							//           Find the controlled zone number for the specified humidistat location
-							OAController( OutAirNum ).NodeNumofHumidistatZone = ZoneEquipConfig( ControlledZoneNum ).ZoneNode;
-							//           Determine which OA System uses this OA Controller
-							OASysIndex = 0;
-							for ( OASysNum = 1; OASysNum <= NumOASystems; ++OASysNum ) {
-								for ( OAControllerNum = 1; OAControllerNum <= OutsideAirSys( OASysNum ).NumControllers; ++OAControllerNum ) {
-									if ( ! SameString( OutsideAirSys( OASysNum ).ControllerType( OAControllerNum ), CurrentModuleObject ) || ! SameString( OutsideAirSys( OASysNum ).ControllerName( OAControllerNum ), OAController( OutAirNum ).Name ) ) continue;
-									OASysIndex = OASysNum;
-									OASysFound = true;
-									break;
-								}
-								if ( OASysFound ) break;
-							}
-							//           Determine if furnace is on air loop served by the humidistat location specified
-							AirLoopNumber = ZoneEquipConfig( ControlledZoneNum ).AirLoopNum;
-							if ( AirLoopNumber > 0 && OASysIndex > 0 ) {
-								for ( BranchNum = 1; BranchNum <= PrimaryAirSystem( AirLoopNumber ).NumBranches; ++BranchNum ) {
-									for ( CompNum = 1; CompNum <= PrimaryAirSystem( AirLoopNumber ).Branch( BranchNum ).TotalComponents; ++CompNum ) {
-										if ( ! SameString( PrimaryAirSystem( AirLoopNumber ).Branch( BranchNum ).Comp( CompNum ).Name, OutsideAirSys( OASysIndex ).Name ) || ! SameString( PrimaryAirSystem( AirLoopNumber ).Branch( BranchNum ).Comp( CompNum ).TypeOf, "AirLoopHVAC:OutdoorAirSystem" ) ) continue;
-										AirLoopFound = true;
-										break;
-									}
-									if ( AirLoopFound ) break;
-								}
-								for ( HStatZoneNum = 1; HStatZoneNum <= NumHumidityControlZones; ++HStatZoneNum ) {
-									if ( HumidityControlZone( HStatZoneNum ).ActualZoneNum != OAController( OutAirNum ).HumidistatZoneNum ) continue;
-									AirNodeFound = true;
-									break;
-								}
-							} else {
-								if ( AirLoopNumber == 0 ) {
-									ShowSevereError( "Did not find a Primary Air Loop for " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
-									ShowContinueError( "Specified " + cAlphaFields( 17 ) + " = " + AlphArray( 17 ) );
-									ErrorsFound = true;
-								}
-								if ( OASysIndex == 0 ) {
-									ShowSevereError( "Did not find an AirLoopHVAC:OutdoorAirSystem for " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
-									ErrorsFound = true;
-								}
-							}
-							break;
-						}
-						if ( ! AirNodeFound ) {
-							ShowSevereError( "Did not find Air Node (Zone with Humidistat), " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
-							ShowContinueError( "Specified " + cAlphaFields( 17 ) + " = " + AlphArray( 17 ) );
-							ShowContinueError( "Both a ZoneHVAC:EquipmentConnections object and a ZoneControl:Humidistat object must be specified for this zone." );
-							ErrorsFound = true;
-						}
-						if ( ! AirLoopFound ) {
-							ShowSevereError( "Did not find correct Primary Air Loop for " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
-							ShowContinueError( cAlphaFields( 17 ) + " = " + AlphArray( 17 ) + " is not served by this Primary Air Loop equipment." );
-							ErrorsFound = true;
-						}
-					} else {
-						ShowSevereError( "Did not find Air Node (Zone with Humidistat), " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
-						ShowContinueError( "Specified " + cAlphaFields( 17 ) + " = " + AlphArray( 17 ) );
-						ShowContinueError( "Both a ZoneHVAC:EquipmentConnections object and a ZoneControl:Humidistat object must be specified for this zone." );
-						ErrorsFound = true;
-					}
-
-					OAController( OutAirNum ).HighRHOAFlowRatio = NumArray( 7 );
-					if ( OAController( OutAirNum ).HighRHOAFlowRatio <= 0.0 && NumNums > 6 ) {
-						ShowWarningError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\"" );
-						ShowContinueError( ' ' + cNumericFields( 7 ) + " must be greater than 0." );
-						ShowContinueError( ' ' + cNumericFields( 7 ) + " is reset to 1 and the simulation continues." );
-						OAController( OutAirNum ).HighRHOAFlowRatio = 1.0;
-					}
-
-					if ( SameString( AlphArray( 16 ), "Yes" ) && OAController( OutAirNum ).FixedMin ) {
-						if ( OAController( OutAirNum ).MaxOA > 0.0 && OAController( OutAirNum ).MinOA != AutoSize ) {
-							OAFlowRatio = OAController( OutAirNum ).MinOA / OAController( OutAirNum ).MaxOA;
-							if ( OAController( OutAirNum ).HighRHOAFlowRatio < OAFlowRatio ) {
-								ShowWarningError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\"" );
-								ShowContinueError( "... A fixed minimum outside air flow rate and high humidity control have been specified." );
-								ShowContinueError( "... The " + cNumericFields( 7 ) + " is less than the ratio of the outside air controllers minimum to maximum outside air flow rate." );
-								ShowContinueError( "... Controller " + cNumericFields( 1 ) + " = " + TrimSigDigits( OAController( OutAirNum ).MinOA, 4 ) + " m3/s." );
-								ShowContinueError( "... Controller " + cNumericFields( 2 ) + " = " + TrimSigDigits( OAController( OutAirNum ).MaxOA, 4 ) + " m3/s." );
-								ShowContinueError( "... Controller minimum to maximum flow ratio = " + TrimSigDigits( OAFlowRatio, 4 ) + '.' );
-								ShowContinueError( "... " + cNumericFields( 7 ) + " = " + TrimSigDigits( OAController( OutAirNum ).HighRHOAFlowRatio, 4 ) + '.' );
-							}
-						}
-					}
-
-					if ( SameString( AlphArray( 18 ), "Yes" ) ) {
-						OAController( OutAirNum ).ModifyDuringHighOAMoisture = false;
-					} else if ( SameString( AlphArray( 18 ), "No" ) ) {
-						OAController( OutAirNum ).ModifyDuringHighOAMoisture = true;
-					} else {
-						ShowSevereError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\", invalid field value" );
-						ShowContinueError( "..." + cAlphaFields( 18 ) + "=\"" + AlphArray( 18 ) + "\" - valid values are \"Yes\" or \"No\"." );
-						ErrorsFound = true;
-					}
-
-				} else if ( SameString( AlphArray( 16 ), "No" ) || lAlphaBlanks( 16 ) ) {
-					if ( NumAlphas >= 18 ) {
-						if ( ! SameString( AlphArray( 18 ), "Yes" ) && ! SameString( AlphArray( 18 ), "No" ) ) {
-							ShowSevereError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\", invalid field value" );
-							ShowContinueError( "..." + cAlphaFields( 18 ) + "=\"" + AlphArray( 18 ) + "\" - valid values are \"Yes\" or \"No\"." );
-							ErrorsFound = true;
-						}
-					}
-				} else { // Invalid field 16
-					ShowSevereError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\", invalid field value" );
-					ShowContinueError( "..." + cAlphaFields( 16 ) + "=\"" + AlphArray( 16 ) + "\" - valid values are \"Yes\" or \"No\"." );
-					ErrorsFound = true;
-					if ( NumAlphas >= 18 ) {
-						if ( ! SameString( AlphArray( 18 ), "Yes" ) && ! SameString( AlphArray( 18 ), "No" ) ) {
-							ShowSevereError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\", invalid field value" );
-							ShowContinueError( "..." + cAlphaFields( 18 ) + "=\"" + AlphArray( 18 ) + "\" - valid values are \"Yes\" or \"No\"." );
-							ErrorsFound = true;
-						}
-					}
-				}
-
-				if ( NumAlphas > 18 ) {
-					if ( ! lAlphaBlanks( 19 ) ) {
-						if ( SameString( AlphArray( 19 ), "BypassWhenWithinEconomizerLimits" ) ) {
-							OAController( OutAirNum ).HeatRecoveryBypassControlType = BypassWhenWithinEconomizerLimits;
-						} else if ( SameString( AlphArray( 19 ), "BypassWhenOAFlowGreaterThanMinimum" ) ) {
-							OAController( OutAirNum ).HeatRecoveryBypassControlType = BypassWhenOAFlowGreaterThanMinimum;
-						} else {
-							ShowWarningError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 19 ) + "=\"" + AlphArray( 19 ) + "\"." );
-							ShowContinueError( "...assuming \"BypassWhenWithinEconomizerLimits\" and the simulation continues." );
-							OAController( OutAirNum ).HeatRecoveryBypassControlType = BypassWhenWithinEconomizerLimits;
-						}
-					}
-				}
-
-				if ( SameString( AlphArray( 16 ), "Yes" ) && OAController( OutAirNum ).Econo == NoEconomizer ) {
-					ShowWarningError( OAController( OutAirNum ).ControllerType + " \"" + OAController( OutAirNum ).Name + "\"" );
-					ShowContinueError( "...Economizer operation must be enabled when " + cAlphaFields( 16 ) + " is set to YES." );
-					ShowContinueError( "...The high humidity control option will be disabled and the simulation continues." );
-				}
+				ProcessOAControllerInputs( CurrentModuleObject, OutAirNum, AlphArray, NumAlphas, NumArray, NumNums, lNumericBlanks, lAlphaBlanks, cAlphaFields, cNumericFields, ErrorsFound );
 
 				//     Mangesh code to fix CR 8225 - 09/14/2010
 				if ( ( NumControllerLists > 0 ) && ( NumOASystems > 0 ) ) {
@@ -2429,6 +2144,372 @@ namespace MixedAir {
 		}
 
 		GetOAMixerInputFlag = false;
+
+	}
+
+	void
+	ProcessOAControllerInputs(
+		std::string const & CurrentModuleObject,
+		int const OutAirNum,
+		FArray1_string const & AlphArray,
+		int & NumAlphas,
+		FArray1< Real64 > const & NumArray,
+		int & NumNums,
+		FArray1_bool const & lNumericBlanks, //Unused
+		FArray1_bool const & lAlphaBlanks,
+		FArray1_string const & cAlphaFields,
+		FArray1_string const & cNumericFields, //Unused
+		bool & ErrorsFound // If errors found in input
+	)
+	{
+
+		// SUBROUTINE INFORMATION:
+		//       AUTHOR         Fred Buhl
+		//       DATE WRITTEN   Oct 1998
+		//       MODIFIED       Shirey/Raustad FSEC, June 2003, Jan 2004
+		//                      Mangesh Basarkar, 06/2011: Getting zone OA specifications from Design Specification Object
+		//                      Tianzhen Hong, 3/2012: getting zone air distribution effectiveness and secondary recirculation
+		//                       from DesignSpecification:ZoneAirDistribution objects
+		//       RE-ENGINEERED  MJW: Split out processing controller:outdoorair input to facilitate unit testing, Feb 2015
+
+		// PURPOSE OF THIS SUBROUTINE
+		// Input the OAController data and store it in the OAController array.
+
+		// METHODOLOGY EMPLOYED:
+
+		// REFERENCES:
+		// na
+
+		// Using/Aliasing
+		using namespace InputProcessor;
+		using namespace DataDefineEquip;
+		using General::TrimSigDigits;
+		using General::RoundSigDigits;
+		using NodeInputManager::GetOnlySingleNode;
+		using DataZoneEquipment::ZoneEquipConfig;
+		using DataZoneEquipment::ZoneEquipList;
+		using DataZoneEquipment::NumOfZoneEquipLists;
+		using DataHeatBalance::Zone;
+		using DataHeatBalance::ZoneList;
+		using DataHeatBalance::NumOfZoneLists;
+		using CurveManager::GetCurveIndex;
+		using CurveManager::GetCurveType;
+		using namespace OutputReportPredefined;
+
+		using DataAirSystems::PrimaryAirSystem;
+		using DataZoneControls::HumidityControlZone;
+		using DataZoneControls::NumHumidityControlZones;
+		using DataContaminantBalance::Contaminant;
+		using OutAirNodeManager::CheckOutAirNodeNumber;
+
+		// Locals
+		// SUBROUTINE ARGUMENT DEFINITIONS:
+		// na
+
+		// SUBROUTINE PARAMETER DEFINITIONS:
+		static std::string const RoutineName( "GetOAControllerInputs: " ); // include trailing blank space
+
+		// INTERFACE BLOCK SPECIFICATIONS
+		// na
+
+		// DERIVED TYPE DEFINITIONS
+		// na
+
+		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
+
+		int OAControllerNum; // Index to Controller:OutdoorAir or CONTROLLER:STAND ALONE ERV objects
+		int ControlledZoneNum; // Index to controlled zones
+		bool AirNodeFound; // Used to determine if control zone is valid
+		bool AirLoopFound; // Used to determine if control zone is served by furnace air loop
+		int AirLoopNumber; // Used to determine if control zone is served by furnace air loop
+		int BranchNum; // Used to determine if control zone is served by furnace air loop
+		int CompNum; // Used to determine if control zone is served by furnace air loop
+		int HStatZoneNum; // Used to determine if control zone has a humidistat object
+		int OASysNum; // Used to find OA System index for OA Controller
+		int OASysIndex; // Index to OA System
+		bool OASysFound; // OA Controller found OA System index
+		Real64 OAFlowRatio; // Ratio of minimum OA flow rate to maximum OA flow rate
+
+		OAController( OutAirNum ).Name = AlphArray( 1 );
+		OAController( OutAirNum ).ControllerType = CurrentModuleObject;
+		OAController( OutAirNum ).ControllerType_Num = ControllerOutsideAir;
+		OAController( OutAirNum ).MaxOA = NumArray( 2 );
+		OAController( OutAirNum ).MinOA = NumArray( 1 );
+		OAController( OutAirNum ).MixNode = GetOnlySingleNode( AlphArray( 4 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Sensor, 1, ObjectIsNotParent );
+		OAController( OutAirNum ).OANode = GetOnlySingleNode( AlphArray( 5 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Actuator, 1, ObjectIsNotParent );
+		if ( ! CheckOutAirNodeNumber( OAController( OutAirNum ).OANode ) ) {
+			ShowWarningError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\": " + cAlphaFields( 5 ) + "=\"" + AlphArray( 5 ) + "\" is not an OutdoorAir:Node." );
+			ShowContinueError( "Confirm that this is the intended source for the outdoor air stream." );
+		}
+		if ( SameString( AlphArray( 6 ), "NoEconomizer" ) ) {
+			OAController( OutAirNum ).Econo = NoEconomizer;
+		} else if ( SameString( AlphArray( 6 ), "FixedDryBulb" ) ) {
+			OAController( OutAirNum ).Econo = FixedDryBulb;
+		} else if ( SameString( AlphArray( 6 ), "FixedEnthalpy" ) ) {
+			OAController( OutAirNum ).Econo = FixedEnthalpy;
+		} else if ( SameString( AlphArray( 6 ), "FixedDewPointAndDryBulb" ) ) {
+			OAController( OutAirNum ).Econo = FixedDewPointAndDryBulb;
+		} else if ( SameString( AlphArray( 6 ), "DifferentialDryBulb" ) ) {
+			OAController( OutAirNum ).Econo = DifferentialDryBulb;
+		} else if ( SameString( AlphArray( 6 ), "DifferentialEnthalpy" ) ) {
+			OAController( OutAirNum ).Econo = DifferentialEnthalpy;
+		} else if ( SameString( AlphArray( 6 ), "DifferentialDryBulbAndEnthalpy" ) ) {
+			OAController( OutAirNum ).Econo = DifferentialDryBulbAndEnthalpy;
+		} else if ( SameString( AlphArray( 6 ), "ElectronicEnthalpy" ) ) {
+			OAController( OutAirNum ).Econo = ElectronicEnthalpy;
+		} else {
+			ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 6 ) + "=\"" + AlphArray( 6 ) + "\" value." );
+			ErrorsFound = true;
+		}
+		//Bypass choice - Added by Amit for new feature implementation
+		if ( SameString( AlphArray( 7 ), "ModulateFlow" ) ) {
+			OAController( OutAirNum ).EconBypass = false;
+		} else if ( SameString( AlphArray( 7 ), "MinimumFlowWithBypass" ) ) {
+			OAController( OutAirNum ).EconBypass = true;
+		} else {
+			ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 7 ) + "=\"" + AlphArray( 7 ) + "\" value." );
+			ErrorsFound = true;
+		}
+
+		//    IF((OAController(OutAirNum)%Econo > NoEconomizer) .AND. OAController(OutAirNum)%EconBypass) THEN
+		//      CALL ShowSevereError(TRIM(CurrentModuleObject)//'="'//TRIM(AlphArray(1))//'" invalid '//  &
+		//         TRIM(cAlphaFields(6))//'="'//TRIM(AlphArray(6))//'" and ')
+		//      CALL ShowContinueError(TRIM(cAlphaFields(7))//'="'//TRIM(AlphArray(7))//'" incompatible specifications.')
+		//      ErrorsFound = .TRUE.
+		//    END IF
+		if ( SameString( AlphArray( 9 ), "NoLockout" ) ) {
+			OAController( OutAirNum ).Lockout = NoLockoutPossible;
+		} else if ( SameString( AlphArray( 9 ), "LockoutWithHeating" ) ) {
+			OAController( OutAirNum ).Lockout = LockoutWithHeatingPossible;
+		} else if ( SameString( AlphArray( 9 ), "LockoutWithCompressor" ) ) {
+			OAController( OutAirNum ).Lockout = LockoutWithCompressorPossible;
+		} else {
+			ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 9 ) + "=\"" + AlphArray( 9 ) + "\" value." );
+			ErrorsFound = true;
+		}
+		if ( SameString( AlphArray( 10 ), "FixedMinimum" ) ) {
+			OAController( OutAirNum ).FixedMin = true;
+		} else {
+			OAController( OutAirNum ).FixedMin = false;
+		}
+		if ( lNumericBlanks( 3 ) ) {
+			OAController( OutAirNum ).TempLim = BlankNumeric;
+		} else {
+			OAController( OutAirNum ).TempLim = NumArray( 3 );
+		}
+
+		if ( lNumericBlanks( 4 ) ) {
+			OAController( OutAirNum ).EnthLim = BlankNumeric;
+		} else {
+			OAController( OutAirNum ).EnthLim = NumArray( 4 );
+		}
+		if ( lNumericBlanks( 5 ) ) {
+			OAController( OutAirNum ).DPTempLim = BlankNumeric;
+		} else {
+			OAController( OutAirNum ).DPTempLim = NumArray( 5 );
+		}
+
+		if ( lNumericBlanks( 6 ) ) {
+			OAController( OutAirNum ).TempLowLim = BlankNumeric;
+		} else {
+			OAController( OutAirNum ).TempLowLim = NumArray( 6 );
+		}
+
+		if ( ! lAlphaBlanks( 8 ) ) {
+			OAController( OutAirNum ).EnthalpyCurvePtr = GetCurveIndex( AlphArray( 8 ) ); // convert curve name to number
+			if ( OAController( OutAirNum ).EnthalpyCurvePtr == 0 ) {
+				ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 8 ) + "=\"" + AlphArray( 8 ) + "\" not found." );
+				ErrorsFound = true;
+			} else {
+				// Verify Curve Object, only legal types are Quadratic and Cubic
+				{ auto const SELECT_CASE_var( GetCurveType( OAController( OutAirNum ).EnthalpyCurvePtr ) );
+
+				if ( SELECT_CASE_var == "QUADRATIC" ) {
+
+				} else if ( SELECT_CASE_var == "CUBIC" ) {
+
+				} else {
+					ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 8 ) + "=\"" + AlphArray( 8 ) + "\"." );
+					ShowContinueError( "...must be Quadratic or Cubic curve." );
+					ErrorsFound = true;
+				}}
+			}
+		}
+
+		OAController( OutAirNum ).RelNode = GetOnlySingleNode( AlphArray( 2 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Actuator, 1, ObjectIsNotParent );
+		OAController( OutAirNum ).RetNode = GetOnlySingleNode( AlphArray( 3 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Air, NodeConnectionType_Sensor, 1, ObjectIsNotParent );
+		OAController( OutAirNum ).MinOASch = AlphArray( 11 );
+		OAController( OutAirNum ).MinOASchPtr = GetScheduleIndex( AlphArray( 11 ) );
+		if ( OAController( OutAirNum ).MinOASchPtr == 0 && ( ! lAlphaBlanks( 11 ) ) ) {
+			ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 11 ) + "=\"" + AlphArray( 11 ) + "\" not found." );
+			ErrorsFound = true;
+		}
+
+		// Changed by Amit for new feature implementation
+		OAController( OutAirNum ).MinOAflowSch = AlphArray( 12 );
+		OAController( OutAirNum ).MinOAflowSchPtr = GetScheduleIndex( AlphArray( 12 ) );
+		if ( OAController( OutAirNum ).MinOAflowSchPtr == 0 && ( ! lAlphaBlanks( 12 ) ) ) {
+			ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 12 ) + "=\"" + AlphArray( 12 ) + "\" not found." );
+			ErrorsFound = true;
+		}
+
+		OAController( OutAirNum ).MaxOAflowSch = AlphArray( 13 );
+		OAController( OutAirNum ).MaxOAflowSchPtr = GetScheduleIndex( AlphArray( 13 ) );
+		if ( OAController( OutAirNum ).MaxOAflowSchPtr == 0 && ( ! lAlphaBlanks( 13 ) ) ) {
+			ShowSevereError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 13 ) + "=\"" + AlphArray( 13 ) + "\" not found." );
+			ErrorsFound = true;
+		}
+		OAController( OutAirNum ).VentilationMechanicalName = AlphArray( 14 );
+
+		//   Check for a time of day economizer control schedule
+		OAController( OutAirNum ).EconomizerOASchedPtr = GetScheduleIndex( AlphArray( 15 ) );
+
+		//   High humidity control option can be used with any economizer flag
+		if ( SameString( AlphArray( 16 ), "Yes" ) ) {
+
+			OAController( OutAirNum ).HumidistatZoneNum = FindItemInList( AlphArray( 17 ), Zone.Name(), NumOfZones );
+
+			// Get the node number for the zone with the humidistat
+			if ( OAController( OutAirNum ).HumidistatZoneNum > 0 ) {
+				AirNodeFound = false;
+				AirLoopFound = false;
+				OASysFound = false;
+				for ( ControlledZoneNum = 1; ControlledZoneNum <= NumOfZones; ++ControlledZoneNum ) {
+					if ( ZoneEquipConfig( ControlledZoneNum ).ActualZoneNum != OAController( OutAirNum ).HumidistatZoneNum ) continue;
+					//           Find the controlled zone number for the specified humidistat location
+					OAController( OutAirNum ).NodeNumofHumidistatZone = ZoneEquipConfig( ControlledZoneNum ).ZoneNode;
+					//           Determine which OA System uses this OA Controller
+					OASysIndex = 0;
+					for ( OASysNum = 1; OASysNum <= NumOASystems; ++OASysNum ) {
+						for ( OAControllerNum = 1; OAControllerNum <= OutsideAirSys( OASysNum ).NumControllers; ++OAControllerNum ) {
+							if ( ! SameString( OutsideAirSys( OASysNum ).ControllerType( OAControllerNum ), CurrentModuleObject ) || ! SameString( OutsideAirSys( OASysNum ).ControllerName( OAControllerNum ), OAController( OutAirNum ).Name ) ) continue;
+							OASysIndex = OASysNum;
+							OASysFound = true;
+							break;
+						}
+						if ( OASysFound ) break;
+					}
+					//           Determine if furnace is on air loop served by the humidistat location specified
+					AirLoopNumber = ZoneEquipConfig( ControlledZoneNum ).AirLoopNum;
+					if ( AirLoopNumber > 0 && OASysIndex > 0 ) {
+						for ( BranchNum = 1; BranchNum <= PrimaryAirSystem( AirLoopNumber ).NumBranches; ++BranchNum ) {
+							for ( CompNum = 1; CompNum <= PrimaryAirSystem( AirLoopNumber ).Branch( BranchNum ).TotalComponents; ++CompNum ) {
+								if ( ! SameString( PrimaryAirSystem( AirLoopNumber ).Branch( BranchNum ).Comp( CompNum ).Name, OutsideAirSys( OASysIndex ).Name ) || ! SameString( PrimaryAirSystem( AirLoopNumber ).Branch( BranchNum ).Comp( CompNum ).TypeOf, "AirLoopHVAC:OutdoorAirSystem" ) ) continue;
+								AirLoopFound = true;
+								break;
+							}
+							if ( AirLoopFound ) break;
+						}
+						for ( HStatZoneNum = 1; HStatZoneNum <= NumHumidityControlZones; ++HStatZoneNum ) {
+							if ( HumidityControlZone( HStatZoneNum ).ActualZoneNum != OAController( OutAirNum ).HumidistatZoneNum ) continue;
+							AirNodeFound = true;
+							break;
+						}
+					} else {
+						if ( AirLoopNumber == 0 ) {
+							ShowSevereError( "Did not find a Primary Air Loop for " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
+							ShowContinueError( "Specified " + cAlphaFields( 17 ) + " = " + AlphArray( 17 ) );
+							ErrorsFound = true;
+						}
+						if ( OASysIndex == 0 ) {
+							ShowSevereError( "Did not find an AirLoopHVAC:OutdoorAirSystem for " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
+							ErrorsFound = true;
+						}
+					}
+					break;
+				}
+				if ( ! AirNodeFound ) {
+					ShowSevereError( "Did not find Air Node (Zone with Humidistat), " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
+					ShowContinueError( "Specified " + cAlphaFields( 17 ) + " = " + AlphArray( 17 ) );
+					ShowContinueError( "Both a ZoneHVAC:EquipmentConnections object and a ZoneControl:Humidistat object must be specified for this zone." );
+					ErrorsFound = true;
+				}
+				if ( ! AirLoopFound ) {
+					ShowSevereError( "Did not find correct Primary Air Loop for " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
+					ShowContinueError( cAlphaFields( 17 ) + " = " + AlphArray( 17 ) + " is not served by this Primary Air Loop equipment." );
+					ErrorsFound = true;
+				}
+			} else {
+				ShowSevereError( "Did not find Air Node (Zone with Humidistat), " + OAController( OutAirNum ).ControllerType + " = \"" + OAController( OutAirNum ).Name + "\"" );
+				ShowContinueError( "Specified " + cAlphaFields( 17 ) + " = " + AlphArray( 17 ) );
+				ShowContinueError( "Both a ZoneHVAC:EquipmentConnections object and a ZoneControl:Humidistat object must be specified for this zone." );
+				ErrorsFound = true;
+			}
+
+			OAController( OutAirNum ).HighRHOAFlowRatio = NumArray( 7 );
+			if ( OAController( OutAirNum ).HighRHOAFlowRatio <= 0.0 && NumNums > 6 ) {
+				ShowWarningError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\"" );
+				ShowContinueError( ' ' + cNumericFields( 7 ) + " must be greater than 0." );
+				ShowContinueError( ' ' + cNumericFields( 7 ) + " is reset to 1 and the simulation continues." );
+				OAController( OutAirNum ).HighRHOAFlowRatio = 1.0;
+			}
+
+			if ( SameString( AlphArray( 16 ), "Yes" ) && OAController( OutAirNum ).FixedMin ) {
+				if ( OAController( OutAirNum ).MaxOA > 0.0 && OAController( OutAirNum ).MinOA != AutoSize ) {
+					OAFlowRatio = OAController( OutAirNum ).MinOA / OAController( OutAirNum ).MaxOA;
+					if ( OAController( OutAirNum ).HighRHOAFlowRatio < OAFlowRatio ) {
+						ShowWarningError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\"" );
+						ShowContinueError( "... A fixed minimum outside air flow rate and high humidity control have been specified." );
+						ShowContinueError( "... The " + cNumericFields( 7 ) + " is less than the ratio of the outside air controllers minimum to maximum outside air flow rate." );
+						ShowContinueError( "... Controller " + cNumericFields( 1 ) + " = " + TrimSigDigits( OAController( OutAirNum ).MinOA, 4 ) + " m3/s." );
+						ShowContinueError( "... Controller " + cNumericFields( 2 ) + " = " + TrimSigDigits( OAController( OutAirNum ).MaxOA, 4 ) + " m3/s." );
+						ShowContinueError( "... Controller minimum to maximum flow ratio = " + TrimSigDigits( OAFlowRatio, 4 ) + '.' );
+						ShowContinueError( "... " + cNumericFields( 7 ) + " = " + TrimSigDigits( OAController( OutAirNum ).HighRHOAFlowRatio, 4 ) + '.' );
+					}
+				}
+			}
+
+			if ( SameString( AlphArray( 18 ), "Yes" ) ) {
+				OAController( OutAirNum ).ModifyDuringHighOAMoisture = false;
+			} else if ( SameString( AlphArray( 18 ), "No" ) ) {
+				OAController( OutAirNum ).ModifyDuringHighOAMoisture = true;
+			} else {
+				ShowSevereError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\", invalid field value" );
+				ShowContinueError( "..." + cAlphaFields( 18 ) + "=\"" + AlphArray( 18 ) + "\" - valid values are \"Yes\" or \"No\"." );
+				ErrorsFound = true;
+			}
+
+		} else if ( SameString( AlphArray( 16 ), "No" ) || lAlphaBlanks( 16 ) ) {
+			if ( NumAlphas >= 18 ) {
+				if ( ! SameString( AlphArray( 18 ), "Yes" ) && ! SameString( AlphArray( 18 ), "No" ) ) {
+					ShowSevereError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\", invalid field value" );
+					ShowContinueError( "..." + cAlphaFields( 18 ) + "=\"" + AlphArray( 18 ) + "\" - valid values are \"Yes\" or \"No\"." );
+					ErrorsFound = true;
+				}
+			}
+		} else { // Invalid field 16
+			ShowSevereError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\", invalid field value" );
+			ShowContinueError( "..." + cAlphaFields( 16 ) + "=\"" + AlphArray( 16 ) + "\" - valid values are \"Yes\" or \"No\"." );
+			ErrorsFound = true;
+			if ( NumAlphas >= 18 ) {
+				if ( ! SameString( AlphArray( 18 ), "Yes" ) && ! SameString( AlphArray( 18 ), "No" ) ) {
+					ShowSevereError( CurrentModuleObject + " \"" + OAController( OutAirNum ).Name + "\", invalid field value" );
+					ShowContinueError( "..." + cAlphaFields( 18 ) + "=\"" + AlphArray( 18 ) + "\" - valid values are \"Yes\" or \"No\"." );
+					ErrorsFound = true;
+				}
+			}
+		}
+
+		if ( NumAlphas > 18 ) {
+			if ( ! lAlphaBlanks( 19 ) ) {
+				if ( SameString( AlphArray( 19 ), "BypassWhenWithinEconomizerLimits" ) ) {
+					OAController( OutAirNum ).HeatRecoveryBypassControlType = BypassWhenWithinEconomizerLimits;
+				} else if ( SameString( AlphArray( 19 ), "BypassWhenOAFlowGreaterThanMinimum" ) ) {
+					OAController( OutAirNum ).HeatRecoveryBypassControlType = BypassWhenOAFlowGreaterThanMinimum;
+				} else {
+					ShowWarningError( CurrentModuleObject + "=\"" + AlphArray( 1 ) + "\" invalid " + cAlphaFields( 19 ) + "=\"" + AlphArray( 19 ) + "\"." );
+					ShowContinueError( "...assuming \"BypassWhenWithinEconomizerLimits\" and the simulation continues." );
+					OAController( OutAirNum ).HeatRecoveryBypassControlType = BypassWhenWithinEconomizerLimits;
+				}
+			}
+		}
+
+		if ( SameString( AlphArray( 16 ), "Yes" ) && OAController( OutAirNum ).Econo == NoEconomizer ) {
+			ShowWarningError( OAController( OutAirNum ).ControllerType + " \"" + OAController( OutAirNum ).Name + "\"" );
+			ShowContinueError( "...Economizer operation must be enabled when " + cAlphaFields( 16 ) + " is set to YES." );
+			ShowContinueError( "...The high humidity control option will be disabled and the simulation continues." );
+		}
+
 
 	}
 

--- a/src/EnergyPlus/MixedAir.hh
+++ b/src/EnergyPlus/MixedAir.hh
@@ -729,7 +729,22 @@ namespace MixedAir {
 	void
 	GetOAMixerInputs();
 
-	// End of Get Input subroutines for the Module
+	void
+	ProcessOAControllerInputs(
+		std::string const & CurrentModuleObject,
+		int const OutAirNum,
+		FArray1_string const & AlphArray,
+		int & NumAlphas,
+		FArray1< Real64 > const & NumArray,
+		int & NumNums,
+		FArray1_bool const & lNumericBlanks, //Unused
+		FArray1_bool const & lAlphaBlanks,
+		FArray1_string const & cAlphaFields,
+		FArray1_string const & cNumericFields, //Unused
+		bool & ErrorsFound // If errors found in input
+	);
+
+		// End of Get Input subroutines for the Module
 	//******************************************************************************
 
 	// Beginning Initialization Section of the Module

--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -11,6 +11,7 @@ set( test_src
   ExteriorEnergyUse.unit.cc
   HeatBalanceManager.unit.cc
   HVACStandaloneERV.unit.cc
+  MixedAir.unit.cc
   SolarShading.unit.cc
   SortAndStringUtilities.unit.cc
   Vectors.unit.cc

--- a/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
@@ -33,8 +33,8 @@ TEST( ProcessZoneDataTest, Test1 )
 //		, !- Floor Area{ m2 }
 //		AdaptiveConvectionAlgorithm;  !- Zone Inside Convection Algorithm
 
-	static bool ErrorsFound( false ); // If errors detected in input
-	static int ZoneNum( 0 ); // Zone number
+	bool ErrorsFound( false ); // If errors detected in input
+	int ZoneNum( 0 ); // Zone number
 	int NumAlphas ( 2 );
 	int NumNumbers ( 9 );
 

--- a/tst/EnergyPlus/unit/MixedAir.unit.cc
+++ b/tst/EnergyPlus/unit/MixedAir.unit.cc
@@ -41,12 +41,12 @@ TEST( ProcessOAControllerTest, Test1 )
 	int NumNumbers ( 7 );
 	int NumOfOAControllers( 2 );
 
-	static int StandardErrorOutput;
-	int write_stat;
-
 	// Open the Error Output File (lifted from UtilityRoutines.cc)
-	StandardErrorOutput = GetNewUnitNumber( );
-	{ IOFlags flags; flags.ACTION( "write" ); gio::open( StandardErrorOutput, DataStringGlobals::outputErrFileName, flags ); write_stat = flags.ios( ); }
+	int StandardErrorOutput = GetNewUnitNumber( );
+	IOFlags flags;
+	flags.ACTION( "write" );
+	gio::open( StandardErrorOutput, DataStringGlobals::outputErrFileName, flags );
+	int write_stat = flags.ios( );
 
 	cCurrentModuleObject = "Controller:OutdoorAir";
 	OAController.allocate( NumOfOAControllers );
@@ -147,4 +147,14 @@ TEST( ProcessOAControllerTest, Test1 )
 	EXPECT_FALSE( ErrorsFound );
 	EXPECT_EQ( 4, OAController( 2 ).OANode );
 	EXPECT_FALSE( CheckOutAirNodeNumber( OAController( 2 ).OANode ) );
+
+	OAController.deallocate();
+	OutsideAirNodeList.deallocate();
+
+	lNumericFieldBlanks.deallocate();
+	lAlphaFieldBlanks.deallocate();
+	cAlphaFieldNames.deallocate();
+	cNumericFieldNames.deallocate();
+	cAlphaArgs.deallocate();
+	rNumericArgs.deallocate();
 }

--- a/tst/EnergyPlus/unit/MixedAir.unit.cc
+++ b/tst/EnergyPlus/unit/MixedAir.unit.cc
@@ -1,0 +1,150 @@
+// EnergyPlus::MixedAir Unit Tests
+
+// Google Test Headers
+#include <gtest/gtest.h>
+
+// EnergyPlus Headers
+#include <MixedAir.hh>
+#include <OutAirNodeManager.hh>
+#include <InputProcessor.hh>
+#include <DataHeatBalance.hh>
+#include <DataIPShortCuts.hh>
+#include <DataGlobals.hh>
+#include <DataStringGlobals.hh>
+#include <ObjexxFCL/gio.hh>
+#include <DataLoopNode.hh>
+
+using namespace EnergyPlus;
+using namespace EnergyPlus::MixedAir;
+using namespace EnergyPlus::OutAirNodeManager;
+using namespace EnergyPlus::InputProcessor;
+using namespace EnergyPlus::DataIPShortCuts;
+using namespace EnergyPlus::DataGlobals;
+using namespace EnergyPlus::DataLoopNode;
+using namespace ObjexxFCL;
+
+TEST( ProcessOAControllerTest, Test1 )
+{
+// Test input processing of portion of Controller:OutdoorAir object
+	//  Controller:OutdoorAir,
+	//    OA Controller 1,         !- Name
+	//    Relief Air Outlet Node 1,!- Relief Air Outlet Node Name
+	//    VAV Sys 1 Inlet Node,    !- Return Air Node Name
+	//    Mixed Air Node 1,        !- Mixed Air Node Name
+	//    Outside Air Inlet Node 1,!- Actuator Node Name
+	//    autosize,                !- Minimum Outdoor Air Flow Rate {m3/s}
+	//    autosize,                !- Maximum Outdoor Air Flow Rate {m3/s}
+
+	static bool ErrorsFound( false ); // If errors detected in input
+	static int ControllerNum( 0 ); // Controller number
+	int NumAlphas ( 17 );
+	int NumNumbers ( 7 );
+	int NumOfOAControllers( 2 );
+
+	static int StandardErrorOutput;
+	int write_stat;
+
+	// Open the Error Output File (lifted from UtilityRoutines.cc)
+	StandardErrorOutput = GetNewUnitNumber( );
+	{ IOFlags flags; flags.ACTION( "write" ); gio::open( StandardErrorOutput, DataStringGlobals::outputErrFileName, flags ); write_stat = flags.ios( ); }
+
+	cCurrentModuleObject = "Controller:OutdoorAir";
+	OAController.allocate( NumOfOAControllers );
+
+	// Set up OutdoorAir:Node list
+	GetOutAirNodesInput( );
+	OutsideAirNodeList.allocate( 1 );
+	OutsideAirNodeList( 1 ) = 2; // Nodes will be registered in the order they appear in the firat controller object, so the OA actuator node will be node 5
+
+	//Set up Node array
+	NumOfNodes = 10;
+	// GetOnlySingleNode requires that the IDD object definition for NodeList is present, so populate it here
+	ListOfObjects.dimension( 1 );
+	ListOfObjects( 1 ) = "NodeList";
+	iListOfObjects.dimension( 1 );
+	iListOfObjects( 1 ) = 1;
+	NumObjectDefs = 1;
+	ObjectDef.allocate( 1 );
+	ObjectDef( 1 ).NumParams = 4;
+	ObjectDef( 1 ).NumAlpha = 4;
+	ObjectDef( 1 ).NumNumeric = 0;
+
+
+	// Set up Controller input objects
+	lNumericFieldBlanks.allocate ( NumNumbers );
+	lAlphaFieldBlanks.allocate( NumAlphas );
+	cAlphaFieldNames.allocate( NumAlphas );
+	cNumericFieldNames.allocate( NumNumbers );
+	cAlphaArgs.allocate( NumAlphas );
+	rNumericArgs.allocate( NumNumbers );
+	lNumericFieldBlanks = false;
+	lAlphaFieldBlanks = false;
+	cAlphaFieldNames = " ";
+	cNumericFieldNames = " ";
+	cAlphaArgs = " ";
+	rNumericArgs = 0.0;
+
+	ControllerNum = 1;
+	cAlphaArgs( 1 ) = "OA Controller 1"; // Name
+	// cAlphaArgs( 2 ) = "Relief Node 1"; // Relief Air Outlet Node Name - not used
+	// cAlphaArgs( 3 ) = "Return Node 1"; // Return Air Node Name - not used
+	cAlphaArgs( 4 ) = "Mixed Air Node 1"; // Mixed Air Node Name
+	cAlphaArgs( 5 ) = "OA Inlet Node 1"; // Actuator Node Name
+	rNumericArgs( 1 ) = 0.00; // Minimum Outdoor Air Flow Rate {m3/s}
+	rNumericArgs( 2 ) = 0.01; // Maximum Outdoor Air Flow Rate {m3/s}
+	cAlphaArgs( 6 ) = "NoEconomizer";
+	cAlphaArgs( 7 ) = "ModulateFlow";
+	lNumericFieldBlanks( 3 ) = true;
+	lNumericFieldBlanks( 4 ) = true;
+	lNumericFieldBlanks( 5 ) = true;
+	lAlphaFieldBlanks( 8 ) = true;
+	lNumericFieldBlanks( 6 ) = true;
+	cAlphaArgs( 9 ) = "NoLockout";
+	cAlphaArgs( 10 ) = "ProportionalMinimum";
+	lAlphaFieldBlanks( 11 ) = true;
+	lAlphaFieldBlanks( 12 ) = true;
+	lAlphaFieldBlanks( 13 ) = true;
+	lAlphaFieldBlanks( 14 ) = true;
+	lAlphaFieldBlanks( 15 ) = true;
+	lAlphaFieldBlanks( 16 ) = true;
+	lAlphaFieldBlanks( 17 ) = true;
+	lNumericFieldBlanks( 7 ) = true;
+
+	ErrorsFound = false;
+	ProcessOAControllerInputs( cCurrentModuleObject, ControllerNum, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames, ErrorsFound );
+	EXPECT_FALSE( ErrorsFound );
+	EXPECT_EQ( 2, OAController( 1 ).OANode );
+	EXPECT_TRUE( CheckOutAirNodeNumber( OAController( 1 ).OANode ) );
+
+	ControllerNum = 2;
+	cAlphaArgs( 1 ) = "OA Controller 2"; // Name
+	// cAlphaArgs( 2 ) = "Relief Node 2"; // Relief Air Outlet Node Name - not used
+	// cAlphaArgs( 3 ) = "Return Node 2"; // Return Air Node Name - not used
+	cAlphaArgs( 4 ) = "Mixed Air Node 2"; // Mixed Air Node Name
+	cAlphaArgs( 5 ) = "OA Inlet Node 2"; // Actuator Node Name
+	rNumericArgs( 1 ) = 0.00; // Minimum Outdoor Air Flow Rate {m3/s}
+	rNumericArgs( 2 ) = 0.01; // Maximum Outdoor Air Flow Rate {m3/s}
+	cAlphaArgs( 6 ) = "NoEconomizer";
+	cAlphaArgs( 7 ) = "ModulateFlow";
+	lNumericFieldBlanks( 3 ) = true;
+	lNumericFieldBlanks( 4 ) = true;
+	lNumericFieldBlanks( 5 ) = true;
+	lAlphaFieldBlanks( 8 ) = true;
+	lNumericFieldBlanks( 6 ) = true;
+	cAlphaArgs( 9 ) = "NoLockout";
+	cAlphaArgs( 10 ) = "ProportionalMinimum";
+	lAlphaFieldBlanks( 11 ) = true;	
+	lAlphaFieldBlanks( 12 ) = true;
+	lAlphaFieldBlanks( 13 ) = true;
+	lAlphaFieldBlanks( 14 ) = true;
+	lAlphaFieldBlanks( 15 ) = true;
+	lAlphaFieldBlanks( 16 ) = true;
+	lAlphaFieldBlanks( 17 ) = true;
+	lNumericFieldBlanks( 7 ) = true;
+
+	ErrorsFound = false;
+	ProcessOAControllerInputs( cCurrentModuleObject, ControllerNum, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames, ErrorsFound );
+	EXPECT_FALSE( ErrorsFound );
+	EXPECT_EQ( 4, OAController( 2 ).OANode );
+	EXPECT_FALSE( CheckOutAirNodeNumber( OAController( 2 ).OANode ) );
+}

--- a/tst/EnergyPlus/unit/MixedAir.unit.cc
+++ b/tst/EnergyPlus/unit/MixedAir.unit.cc
@@ -35,8 +35,8 @@ TEST( ProcessOAControllerTest, Test1 )
 	//    autosize,                !- Minimum Outdoor Air Flow Rate {m3/s}
 	//    autosize,                !- Maximum Outdoor Air Flow Rate {m3/s}
 
-	static bool ErrorsFound( false ); // If errors detected in input
-	static int ControllerNum( 0 ); // Controller number
+	bool ErrorsFound( false ); // If errors detected in input
+	int ControllerNum( 0 ); // Controller number
 	int NumAlphas ( 17 );
 	int NumNumbers ( 7 );
 	int NumOfOAControllers( 2 );


### PR DESCRIPTION
Previously if the Controller:OutdoorAir actuator node was not on an OutdoorAir:Node list then this was a fatal error.  Now it's just a warning to allow usage such as drawing OA from a preconditioning space such as a thermal labyrinth.  Fixes #4272 

GetOAControllerInputs was refactored to facilitate unit tests.  Part of this routine was moved to ProcessOAControllerInputs.  Unit tests were still a bit messy though requiring some additional setup, opening the err file, etc.