### PR TITLE
Display OutputVariables in EmsSensor A3 - IDD change

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -65576,8 +65576,7 @@ EnergyManagementSystem:Sensor,
   A3 ; \field Output:Variable or Output:Meter Name
        \required-field
        \type external-list
-       \external-list autoRDDvariable
-       \external-list autoRDDmeter
+       \external-list autoRDDvariableMeter
 
 EnergyManagementSystem:Actuator,
        \memo Hardware portion of EMS used to set up actuators in the model


### PR DESCRIPTION
Change the \external-list flag in the IDD for EMS sensor output variable or meter name field so that both meters and output variables will show in the IDF Editor dropdown list.  Fixes #4708 