### PR TITLE
Re-add sizing period object accidentally removed in beef0d8

### DIFF
--- a/testfiles/MultiStory.idf
+++ b/testfiles/MultiStory.idf
@@ -104,6 +104,16 @@
     460,                     !- Wind Speed Profile Boundary Layer Thickness {m}
     0.0065;                  !- Air Temperature Gradient Coefficient {K/m}
 
+  SizingPeriod:WeatherFileDays,
+    Weather File Sizing Period,  !- Name
+    7,                       !- Begin Month
+    18,                      !- Begin Day of Month
+    7,                       !- End Month
+    25,                      !- End Day of Month
+    SummerDesignDay,         !- Day of Week for Start Day
+    No,                      !- Use Weather File Daylight Saving Period
+    No;                      !- Use Weather File Rain and Snow Indicators
+
   Timestep,6;
 
   ShadowCalculation,


### PR DESCRIPTION
During a previous PR, I had added this SizingPeriod object to the multistory example file to flush out some code coverage in DataEnvironment.cc.  

It's not a crucial change, but adds a couple fractions of a percent and is a nice addition without any risk.   