### PR TITLE
Fix IDD install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The C++ code in EnergyPlus utilizes many C++11 features, and so a modern compile
 7. Browse to the build folder and there will be a Visual Studio solution file you can click on, EnergyPlus.sln. It will include multiple projects for each build target.  Choose the type of build (Debug or Release), then right click on EnergyPlus in the solution explorer and "Build".  This will build EnergyPlus and all of its dependencies.  The target executables will be found in the Products subfolder.
 8. The solution will include the ZERO_CHECK project as the default target to run when you execute, so when you are ready to debug, manually set the default target to EnergyPlus.
 9. In the EnergyPlus and EnergyPlusLib projects: right click on each project and select Properties. Under Configuration Properties select Debugging. In the Environment field, enter ```_NO_DEBUG_HEAP=1```.  The debug heap in Visual Studio doesn't play nicely with the input processor in EnergyPlus, and for debug builds, skipping this will result in a _very_ long IDD reading time.
+10. For the EnergyPlus project, right click on the project and select Properties. Under Configuration Properties select Debugging. In the Working Directory field, enter $(SolutionDir)\Products. This is the target path for the Energy+.idd file and will be the working directory for interactive debugging.  Put in.idf, in.epw and the like here.  Or enter command line arguments in the Command Arguments field to specify the locations of files.
 
 ## Linux
 

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -32,7 +32,7 @@ configure_file(cmake/license.in.txt "${CMAKE_BINARY_DIR}/license.txt" @ONLY)
 install(FILES "${CMAKE_BINARY_DIR}/license.txt" DESTINATION "./")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_BINARY_DIR}/license.txt")
 
-install( FILES "${CMAKE_BINARY_DIR}/Energy+.idd" DESTINATION ./ )
+install( FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Energy+.idd" DESTINATION ./ )
 
 # Install files that are in the current repo
 INSTALL(FILES "${CMAKE_SOURCE_DIR}/datasets/AirCooledChiller.idf" DESTINATION "./DataSets")
@@ -150,7 +150,7 @@ install_remote(FILES "https://raw.github.com/NREL/EnergyPlusBuildSupport/v8.2.0/
 install_remote(FILES "https://raw.github.com/NREL/EnergyPlusBuildSupport/v8.2.0/release/${RULES_XLS}" "./")
 install_remote(FILES "https://raw.github.com/NREL/EnergyPlusBuildSupport/v8.2.0/release/Report%20Variables%208-1-0-009%20to%208-2-0.csv" "PreProcess/IDFVersionUpdater/" "Report Variables 8-1-0-009 to 8-2-0.csv")
 install(FILES "${CMAKE_SOURCE_DIR}/idd/V8-1-0-Energy+.idd" DESTINATION "PreProcess/IDFVersionUpdater/")
-install( FILES "${CMAKE_BINARY_DIR}/Energy+.idd" DESTINATION "PreProcess/IDFVersionUpdater/" RENAME "V${CMAKE_VERSION_MAJOR}-${CMAKE_VERSION_MINOR}-${CMAKE_VERSION_PATCH}-Energy+.idd" )
+install( FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Energy+.idd" DESTINATION "PreProcess/IDFVersionUpdater/" RENAME "V${CMAKE_VERSION_MAJOR}-${CMAKE_VERSION_MINOR}-${CMAKE_VERSION_PATCH}-Energy+.idd" )
 install_remote(FILES "https://raw.github.com/NREL/EnergyPlusBuildSupport/v8.2.0/release/VariableNameListAudit.xlsx" "./")
 install_remote(FILES "https://raw.github.com/NREL/EnergyPlusBuildSupport/v8.2.0/bin/CurveFitTools/IceStorageCurveFitTool.xlsm" "PreProcess/HVACCurveFitTool/")
 


### PR DESCRIPTION
IDD install commands have been adjusted to install the IDD located in
<build>/Products instead of the incorrect path <build>/.  This bug was
breaking package builds.

fix #4724