### PR TITLE
88734010 afn horizontal openings

### DIFF
--- a/src/EnergyPlus/AirflowNetworkSolver.cc
+++ b/src/EnergyPlus/AirflowNetworkSolver.cc
@@ -520,8 +520,14 @@ namespace AirflowNetworkSolver {
 			if ( LIST >= 1 ) {
 				gio::write( Unit21, Format_901 ) << "Flow: " << i << n << M << AirflowNetworkLinkSimu( i ).DP << AFLOW( i ) << AFLOW2( i );
 			}
-			SUMAF( n ) = SUMAF( n ) - AFLOW( i ) - AFLOW2( i );
-			SUMAF( M ) += AFLOW( i ) + AFLOW2( i );
+			if ( AirflowNetworkCompData( AirflowNetworkLinkageData( i ).CompNum ).CompTypeNum == CompTypeNum_HOP ) {
+				SUMAF( n ) = SUMAF( n ) - AFLOW( i );
+				SUMAF( M ) += AFLOW( i );
+			}
+			else {
+				SUMAF( n ) = SUMAF( n ) - AFLOW( i ) - AFLOW2( i );
+				SUMAF( M ) += AFLOW( i ) + AFLOW2( i );
+			}
 		}
 		for ( n = 1; n <= NetworkNumOfNodes; ++n ) {
 			if ( LIST >= 1 ) gio::write( Unit21, Format_903 ) << "Room: " << n << PZ( n ) << SUMAF( n ) << TZ( n );
@@ -539,9 +545,12 @@ namespace AirflowNetworkSolver {
 				AirflowNetworkLinkSimu( i ).FLOW2 = -AFLOW( i );
 			}
 			if ( AirflowNetworkCompData( AirflowNetworkLinkageData( i ).CompNum ).CompTypeNum == CompTypeNum_HOP ) {
-				if ( AFLOW2( i ) != 0.0 ) {
+				if ( AFLOW( i ) > 0.0 ) {
 					AirflowNetworkLinkSimu( i ).FLOW = AFLOW( i ) + AFLOW2( i );
 					AirflowNetworkLinkSimu( i ).FLOW2 = AFLOW2( i );
+				} else {
+					AirflowNetworkLinkSimu( i ).FLOW = AFLOW2( i );
+					AirflowNetworkLinkSimu( i ).FLOW2 = -AFLOW( i ) + AFLOW2( i );
 				}
 			}
 			if ( AirflowNetworkLinkageData( i ).DetOpenNum > 0 ) {
@@ -918,9 +927,6 @@ namespace AirflowNetworkSolver {
 			AFLOW( i ) = F( 1 );
 			AFLOW2( i ) = 0.0;
 			if ( AirflowNetworkCompData( j ).CompTypeNum == CompTypeNum_DOP ) {
-				AFLOW2( i ) = F( 2 );
-			}
-			if ( AirflowNetworkCompData( j ).CompTypeNum == CompTypeNum_HOP ) {
 				AFLOW2( i ) = F( 2 );
 			}
 			if ( LIST >= 3 ) gio::write( Unit21, Format_901 ) << " NRi:" << i << n << M << AirflowNetworkLinkSimu( i ).DP << F( 1 ) << DF( 1 );
@@ -3162,7 +3168,7 @@ Label999: ;
 		DH = 4.0 * ( Width * Height ) / 2.0 / ( Width + Height ) * Fact;
 
 		// Check which zone is higher
-
+		NF = 1;
 		if ( Fact == 0.0 ) {
 			GenericCrack( coef, expn, LFLAG, PDROP, n, M, F, DF, NF );
 			return;
@@ -3222,7 +3228,7 @@ Label999: ;
 		DF( 1 ) = dp1fma12 - dp1fma21;
 		F( 2 ) = 0.0;
 		if ( fma12 != 0.0 && fma21 != 0.0 ) {
-			F( 2 ) = fma21;
+			F( 2 ) = BuoFlow;
 		}
 		DF( 2 ) = 0.0;
 

--- a/tst/EnergyPlus/unit/AirflowNetworkSolver.unit.cc
+++ b/tst/EnergyPlus/unit/AirflowNetworkSolver.unit.cc
@@ -1,0 +1,81 @@
+// EnergyPlus::DXCoils unit tests
+// DX heating coil defrost capacity with electric resistance
+
+// Google test headers
+#include <gtest/gtest.h>
+
+// C++ Headers
+#include <cassert>
+#include <cmath>
+#include <string>
+
+// ObjexxFCL Headers
+#include <ObjexxFCL/FArray.functions.hh>
+#include <ObjexxFCL/Fmath.hh>
+#include <ObjexxFCL/gio.hh>
+
+// EnergyPlus Headers
+#include <DataAirflowNetwork.hh>
+#include <AirflowNetworkBalanceManager.hh>
+#include <AirflowNetworkSolver.hh>
+
+using namespace EnergyPlus;
+using namespace AirflowNetworkBalanceManager;
+using namespace DataAirflowNetwork;
+using namespace AirflowNetworkSolver;
+
+TEST( AirflowNetworkSolverTest, Test1 )
+{
+
+//	FArray1D< DXCoilData > DXCoil;
+	int i = 1;
+	int j = 1;
+	int CurveNum;
+	int n;
+	int m;
+	int NF;
+	FArray1D< Real64 > F;
+	FArray1D< Real64 > DF;
+
+	n = 1;
+	m = 2;
+
+
+	AirflowNetworkCompData.allocate( j );
+	AirflowNetworkCompData( j ).TypeNum = 1;
+	MultizoneSurfaceData.allocate( i );
+	MultizoneSurfaceData( i ).Width = 10.0;
+	MultizoneSurfaceData( i ).Height = 5.0;
+	MultizoneSurfaceData( i ).OpenFactor = 1.0;
+
+	RHOZ.allocate( 2 );
+	RHOZ( 1 ) = 1.2;
+	RHOZ( 2 ) = 1.18;
+
+	MultizoneCompHorOpeningData.allocate( 1 );
+	MultizoneCompHorOpeningData( 1 ).FlowCoef = 0.1;
+	MultizoneCompHorOpeningData( 1 ).FlowExpo = 0.5;
+	MultizoneCompHorOpeningData( 1 ).Slope = 90.0;
+	MultizoneCompHorOpeningData( 1 ).DischCoeff = 0.2;
+
+	F.allocate( 2 );
+	DF.allocate( 2 );
+
+	AirflowNetworkLinkageData.allocate( i );
+	AirflowNetworkLinkageData( i ).NodeHeights( 1 ) = 4.0;
+	AirflowNetworkLinkageData( i ).NodeHeights( 2 ) = 2.0;
+
+	AFEHOP( 1, 1, 0.05, 1, 1, 2, F, DF, NF );
+	EXPECT_NEAR( 3.47863, F( 1 ), 0.00001 );
+	EXPECT_NEAR( 34.7863, DF( 1 ), 0.0001 );
+	EXPECT_NEAR( 2.96657, F( 2 ), 0.00001 );
+	EXPECT_EQ( 0.0, DF( 2 ) );
+
+	AFEHOP( 1, 1, -0.05, 1, 1, 2, F, DF, NF );
+	EXPECT_NEAR( -3.42065, F( 1 ), 0.00001 );
+	EXPECT_NEAR( 34.20649, DF( 1 ), 0.0001 );
+	EXPECT_NEAR( 2.96657, F( 2 ), 0.00001 );
+	EXPECT_EQ( 0.0, DF( 2 ) );
+}
+
+

--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -2,6 +2,7 @@ INCLUDE_DIRECTORIES( ${CMAKE_SOURCE_DIR}/src )
 INCLUDE_DIRECTORIES( ${CMAKE_SOURCE_DIR}/src/EnergyPlus )
 
 set( test_src
+  AirflowNetworkSolver.unit.cc
   DataPlant.unit.cc
   DXCoils.unit.cc
   ExteriorEnergyUse.unit.cc


### PR DESCRIPTION
Bug fix #4736

Revised AirflowNetworkSolver file by changing convergence check for horizontal opening components. The program ran to completion.
Tested example files using the AirflowNetwork model. Differences were found in an example file of AirflowNetwork_Multizone_HorizontalOpening.idf, as expected.
A unit test file was created and test was performed. 