### PR TITLE
Disable Linux LTO compiling

### DIFF
--- a/.decent_ci-Linux.yaml
+++ b/.decent_ci-Linux.yaml
@@ -5,7 +5,7 @@ compilers:
     release_build_enable_pgo: true
     release_build_training_cmake_extra_flags: -DPROFILE_GENERATE:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=OFF
     release_build_training_ctest_filter:  -R  "integration.(RefBldg.*|.*Slab|.*[^g]Basement|.*5Zone.*|Rad|Pip|.*Network.*|Window|CentralChillerHeaterSystem_Cooling_Heating|CmplxGlz_.*|ConvectionAdaptiveSmallOffice|DElight.*|DaylightingDevice.*|DisplacementVent_Nat_AirflowNetwork_AdaptiveComfort|DOADualDuctSchool|EMS.*|Flr_Rf_8Sides|FluidCooler|GSHP.*|GeneratorswithPV|HeatPumpWaterToAir.*|HospitalBaselineReheatReportEMS|HospitalLowEnergy|MicroCogeneration|PlantApplicationsGuide.*|PlateHeatExchanger|PurchAirWithDaylighting|RefrigeratedWarehouse|SolarCollectorFlatPlateWater|SurfaceTest|ThermalChimneyTest|UserDefinedRoomAirPatterns|VSHeatPumpWaterToAirEquationFit|WaterHeater.*|_CTFTestsPart2|_HybridVentilationControlGlobalAN|CentralChillerHeaterSystem)"
-    release_build_cmake_extra_flags: -DPROFILE_GENERATE:BOOL=OFF -DPROFILE_USE:BOOL=ON -DENABLE_LTO:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=ON
+    release_build_cmake_extra_flags: -DPROFILE_GENERATE:BOOL=OFF -DPROFILE_USE:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=ON
     cmake_extra_flags: -DBUILD_FORTRAN=ON -DBUILD_PACKAGE:BOOL=ON -DBUILD_TESTING:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=ON -DREGRESSION_BASELINE_PATH:PATH=$REGRESSION_BASELINE -DREGRESSION_SCRIPT_PATH:PATH=$REGRESSION_DIR -DREGRESSION_BASELINE_SHA:STRING=$REGRESSION_BASELINE_SHA -DCOMMIT_SHA=$COMMIT_SHA -DENABLE_GTEST_DEBUG_MODE:BOOL=OFF
 
   - name: cppcheck


### PR DESCRIPTION
OK, I think I want to take out LTO.  Looks like it is killing the Linux package builds right now.  @lefticus @kbenne Could you confirm what we should do before I do anything drastic?  If this goes in, it will fix #4814.