### PR TITLE
Added reporting of sizing parameters when coil sizes to 0.

### DIFF
--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -922,18 +922,19 @@ namespace ReportSizingManager {
 								}
 							} else {
 								AutosizeDes = 0.0;
+								CoilOutTemp = -999.0;
 							}
 						}
 					}
 					AutosizeDes = AutosizeDes * DataFracOfAutosizedCoolingCapacity;
-					if( DisplayExtraWarnings && AutosizeDes <= 0.0 ) {
+					if ( DisplayExtraWarnings && AutosizeDes <= 0.0 ) {
 						ShowWarningMessage( CallingRoutine + ": Potential issue with equipment sizing for " + CompType + ' ' + CompName );
-						ShowContinueError( "...Rated Total Cooling Capacity = 0." );
-						if( ZoneEqSizing( CurZoneEqNum ).CoolingCapacity ) {
+						ShowContinueError( "...Rated Total Cooling Capacity = " + TrimSigDigits( AutosizeDes, 2 ) + " [W]" );
+						if ( ZoneEqSizing( CurZoneEqNum ).CoolingCapacity ) {
 							ShowContinueError( "...Capacity passed by parent object to size child component = " + TrimSigDigits( AutosizeDes, 2 ) + " [W]" );
 						} else {
-							if( SameString( CompType, "COIL:COOLING:WATER" ) || SameString( CompType, "COIL:COOLING:WATER:DETAILEDGEOMETRY" ) || SameString( CompType, "ZONEHVAC:IDEALLOADSAIRSYSTEM" ) ) {
-								if( TermUnitIU || ZoneEqFanCoil ) {
+							if ( SameString( CompType, "COIL:COOLING:WATER" ) || SameString( CompType, "COIL:COOLING:WATER:DETAILEDGEOMETRY" ) || SameString( CompType, "ZONEHVAC:IDEALLOADSAIRSYSTEM" ) ) {
+								if ( TermUnitIU || ZoneEqFanCoil ) {
 									ShowContinueError( "...Capacity passed by parent object to size child component = " + TrimSigDigits( AutosizeDes, 2 ) + " [W]" );
 								} else {
 									ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesVolFlow, 5 ) + " [m3/s]" );
@@ -941,13 +942,17 @@ namespace ReportSizingManager {
 									ShowContinueError( "...Coil outlet air temperature used for sizing = " + TrimSigDigits( CoilOutTemp, 2 ) + " [C]" );
 								}
 							} else {
-								ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesVolFlow, 5 ) + " [m3/s]" );
-								ShowContinueError( "...Coil inlet air temperature used for sizing = " + TrimSigDigits( CoilInTemp, 2 ) + " [C]" );
-								ShowContinueError( "...Coil outlet air temperature used for sizing = " + TrimSigDigits( CoilOutTemp, 2 ) + " [C]" );
+								if ( CoilOutTemp > -999.0 ) {
+									ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesVolFlow, 5 ) + " [m3/s]" );
+									ShowContinueError( "...Coil inlet air temperature used for sizing = " + TrimSigDigits( CoilInTemp, 2 ) + " [C]" );
+									ShowContinueError( "...Coil outlet air temperature used for sizing = " + TrimSigDigits( CoilOutTemp, 2 ) + " [C]" );
+								} else {
+									ShowContinueError( "...Capacity used to size child component set to 0 [W]" );
+								}
 							}
 						}
 					}
-				} else if( SizingType == HeatingCapacitySizing ) {
+				} else if ( SizingType == HeatingCapacitySizing ) {
 					if ( ZoneEqSizing(CurZoneEqNum).HeatingCapacity ) {
 						NominalCapacityDes = ZoneEqSizing(CurZoneEqNum).DesHeatingLoad;
 						if ( DataFlowUsedForSizing > 0.0 ) {
@@ -1012,15 +1017,15 @@ namespace ReportSizingManager {
 					}
 					if ( DisplayExtraWarnings && AutosizeDes <= 0.0 ) {
 						ShowWarningMessage( CallingRoutine + ": Potential issue with equipment sizing for " + CompType + ' ' + CompName );
-						ShowContinueError( "...Rated Total Heating Capacity = 0." );
+						ShowContinueError( "...Rated Total Heating Capacity = " + TrimSigDigits( AutosizeDes, 2 ) + " [W]" );
 						if ( ZoneEqSizing( CurZoneEqNum ).HeatingCapacity || ( DataCoolCoilCap > 0.0 && DataFlowUsedForSizing > 0.0 ) ) {
 							ShowContinueError( "...Capacity passed by parent object to size child component = " + TrimSigDigits( NominalCapacityDes, 2 ) + " [W]" );
 						} else {
-							if( CoilOutTemp > -999.0 ) {
+							if ( CoilOutTemp > -999.0 ) {
 								ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesVolFlow, 5 ) + " [m3/s]" );
 								ShowContinueError( "...Coil inlet air temperature used for sizing = " + TrimSigDigits( CoilInTemp, 2 ) + " [C]" );
 								ShowContinueError( "...Coil outlet air temperature used for sizing = " + TrimSigDigits( CoilOutTemp, 2 ) + " [C]" );
-							} else{
+							} else {
 								ShowContinueError( "...Capacity used to size child component set to 0 [W]" );
 							}
 						}
@@ -1047,9 +1052,9 @@ namespace ReportSizingManager {
 					AutosizeDes = NominalCapacityDes * DataHeatSizeRatio;
 					if( DisplayExtraWarnings && AutosizeDes <= 0.0 ) {
 						ShowWarningMessage( CallingRoutine + ": Potential issue with equipment sizing for " + CompType + ' ' + CompName );
-						ShowContinueError( "...Rated Total Heating Capacity = 0." );
+						ShowContinueError( "...Rated Total Heating Capacity = " + TrimSigDigits( AutosizeDes, 2 ) + " [W]" );
 						ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesMassFlow / StdRhoAir, 5 ) + " [m3/s]" );
-						if( TermUnitSingDuct || TermUnitPIU || TermUnitIU || ZoneEqFanCoil ) {
+						if ( TermUnitSingDuct || TermUnitPIU || TermUnitIU || ZoneEqFanCoil ) {
 							ShowContinueError( "...Plant loop temperature difference = " + TrimSigDigits( PlantSizData( DataPltSizHeatNum ).DeltaT, 2 ) + " [C]" );
 						} else {
 							ShowContinueError( "...Coil inlet air temperature used for sizing = " + TrimSigDigits( CoilInTemp, 2 ) + " [C]" );
@@ -1553,8 +1558,8 @@ namespace ReportSizingManager {
 					} // IF(OASysFlag) THEN or ELSE IF(AirLoopSysFlag) THEN
 					if( DisplayExtraWarnings && AutosizeDes <= 0.0 ) {
 						ShowWarningMessage( CallingRoutine + ": Potential issue with equipment sizing for " + CompType + ' ' + CompName );
-						ShowContinueError( "...Rated Total Cooling Capacity = 0." );
-						if( OASysFlag || AirLoopSysFlag || FinalSysSizing( CurSysNum ).CoolingCapMethod == CapacityPerFloorArea || ( FinalSysSizing( CurSysNum ).CoolingCapMethod == CoolingDesignCapacity && FinalSysSizing( CurSysNum ).CoolingTotalCapacity ) ) {
+						ShowContinueError( "...Rated Total Cooling Capacity = " + TrimSigDigits( AutosizeDes, 2 ) + " [W]" );
+						if ( OASysFlag || AirLoopSysFlag || FinalSysSizing( CurSysNum ).CoolingCapMethod == CapacityPerFloorArea || ( FinalSysSizing( CurSysNum ).CoolingCapMethod == CoolingDesignCapacity && FinalSysSizing( CurSysNum ).CoolingTotalCapacity ) ) {
 							ShowContinueError( "...Capacity passed by parent object to size child component = " + TrimSigDigits( AutosizeDes, 2 ) + " [W]" );
 						} else {
 							ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesVolFlow, 5 ) + " [m3/s]" );
@@ -1662,10 +1667,10 @@ namespace ReportSizingManager {
 						}
 						DesCoilLoad = NominalCapacityDes;
 						CoilOutTemp = -999.0;
-					} else if( FinalSysSizing( CurSysNum ).HeatingCapMethod == CapacityPerFloorArea ) {
+					} else if ( FinalSysSizing( CurSysNum ).HeatingCapMethod == CapacityPerFloorArea ) {
 						NominalCapacityDes = FinalSysSizing( CurSysNum ).HeatingTotalCapacity;
 						CoilOutTemp = -999.0;
-					} else if( FinalSysSizing( CurSysNum ).HeatingCapMethod == HeatingDesignCapacity && FinalSysSizing( CurSysNum ).HeatingTotalCapacity > 0.0 ) {
+					} else if ( FinalSysSizing( CurSysNum ).HeatingCapMethod == HeatingDesignCapacity && FinalSysSizing( CurSysNum ).HeatingTotalCapacity > 0.0 ) {
 						NominalCapacityDes = FinalSysSizing( CurSysNum ).HeatingTotalCapacity;
 						CoilOutTemp = -999.0;
 					} else {
@@ -1679,9 +1684,9 @@ namespace ReportSizingManager {
 						CoilOutTemp = -999.0;
 					}
 					AutosizeDes = NominalCapacityDes * DataHeatSizeRatio * DataFracOfAutosizedHeatingCapacity;
-					if( DisplayExtraWarnings && AutosizeDes <= 0.0 ) {
+					if ( DisplayExtraWarnings && AutosizeDes <= 0.0 ) {
 						ShowWarningMessage( CallingRoutine + ": Potential issue with equipment sizing for " + CompType + ' ' + CompName );
-						ShowContinueError( "...Rated Total Heating Capacity = 0." );
+						ShowContinueError( "...Rated Total Heating Capacity = " + TrimSigDigits( AutosizeDes, 2 ) + " [W]" );
 						if ( CoilOutTemp > -999.0 ) {
 							ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesVolFlow, 5 ) + " [m3/s]" );
 							ShowContinueError( "...Outdoor air fraction used for sizing = " + TrimSigDigits( OutAirFrac, 2 ) );

--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -982,7 +982,8 @@ namespace ReportSizingManager {
 							CoilOutHumRat = FinalZoneSizing( CurZoneEqNum ).HeatDesHumRat;
 							CpAir = PsyCpAirFnWTdb( CoilOutHumRat, 0.5 * ( CoilInTemp + CoilOutTemp ) );
 							DesCoilLoad = CpAir * StdRhoAir * TermUnitSizing( CurZoneEqNum ).AirVolFlow * ( CoilOutTemp - CoilInTemp );
-						} else if ( TermUnitIU ) {
+							DesVolFlow = TermUnitSizing( CurZoneEqNum ).AirVolFlow;
+						} else if( TermUnitIU ) {
 							if ( TermUnitSizing( CurZoneEqNum ).InducRat > 0.01 ) {
 								DesVolFlow = TermUnitSizing( CurZoneEqNum ).AirVolFlow / TermUnitSizing( CurZoneEqNum ).InducRat;
 								CpAir = PsyCpAirFnWTdb( FinalZoneSizing( CurZoneEqNum ).HeatDesHumRat, FinalZoneSizing( CurZoneEqNum ).HeatDesTemp );
@@ -997,10 +998,12 @@ namespace ReportSizingManager {
 							CoilOutHumRat = FinalZoneSizing( CurZoneEqNum ).HeatDesHumRat;
 							CpAir = PsyCpAirFnWTdb( CoilOutHumRat, 0.5 * ( CoilInTemp + CoilOutTemp ) );
 							DesCoilLoad = CpAir * FinalZoneSizing( CurZoneEqNum ).DesHeatMassFlow * ( CoilOutTemp - CoilInTemp );
+							DesVolFlow = FinalZoneSizing( CurZoneEqNum ).DesHeatMassFlow / StdRhoAir;
 						}
-							NominalCapacityDes = max( 0.0, DesCoilLoad );
+						NominalCapacityDes = max( 0.0, DesCoilLoad );
 					} else {
 						NominalCapacityDes = 0.0;
+						CoilOutTemp = -999.0;
 					}
 					if ( DataCoolCoilCap > 0.0 ) {
 						AutosizeDes = NominalCapacityDes * DataHeatSizeRatio;
@@ -1013,9 +1016,13 @@ namespace ReportSizingManager {
 						if ( ZoneEqSizing( CurZoneEqNum ).HeatingCapacity || ( DataCoolCoilCap > 0.0 && DataFlowUsedForSizing > 0.0 ) ) {
 							ShowContinueError( "...Capacity passed by parent object to size child component = " + TrimSigDigits( NominalCapacityDes, 2 ) + " [W]" );
 						} else {
-							ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesVolFlow, 5 ) + " [m3/s]" );
-							ShowContinueError( "...Coil inlet air temperature used for sizing = " + TrimSigDigits( CoilInTemp, 2 ) + " [C]" );
-							ShowContinueError( "...Coil outlet air temperature used for sizing = " + TrimSigDigits( CoilOutTemp, 2 ) + " [C]" );
+							if( CoilOutTemp > -999.0 ) {
+								ShowContinueError( "...Air flow rate used for sizing = " + TrimSigDigits( DesVolFlow, 5 ) + " [m3/s]" );
+								ShowContinueError( "...Coil inlet air temperature used for sizing = " + TrimSigDigits( CoilInTemp, 2 ) + " [C]" );
+								ShowContinueError( "...Coil outlet air temperature used for sizing = " + TrimSigDigits( CoilOutTemp, 2 ) + " [C]" );
+							} else{
+								ShowContinueError( "...Capacity used to size child component set to 0 [W]" );
+							}
 						}
 					}
 				} else if( SizingType == WaterHeatingCapacitySizing ) {

--- a/tst/EnergyPlus/unit/DXCoils.unit.cc
+++ b/tst/EnergyPlus/unit/DXCoils.unit.cc
@@ -47,7 +47,10 @@
 
 using namespace EnergyPlus;
 using namespace DXCoils;
+using namespace DataAirLoop;
+using namespace DataAirSystems;
 using namespace DataHVACGlobals;
+using namespace DataSizing;
 using namespace CurveManager;
 using namespace OutputReportPredefined;
 using namespace EnergyPlus::Psychrometrics;
@@ -184,5 +187,110 @@ TEST( DXCoilsTest, Test1 )
 	cached_Psat.deallocate();
 
 }
+TEST( DXCoilsTest, Test2 )
+{
 
+	using CurveManager::Quadratic;
+	using CurveManager::BiQuadratic;
+	using CurveManager::NumCurves;
+	int DXCoilNum;
+	int CurveNum;
+
+	InitializePsychRoutines();
+	DisplayExtraWarnings = true;
+	SysSizingRunDone = true;
+	FinalSysSizing.allocate( 1 );
+	PrimaryAirSystem.allocate( 1 );
+	AirLoopControlInfo.allocate( 1 );
+	CurSysNum = 1;
+	NumDXCoils = 2;
+	DXCoilNum = 2;
+	UnitarySysEqSizing.allocate( 1 );
+	DXCoil.allocate( NumDXCoils );
+	DXCoil( 1 ).DXCoilType_Num = CoilDX_CoolingSingleSpeed;
+	DXCoil( 2 ).DXCoilType_Num = CoilDX_HeatingEmpirical;
+	DXCoil( DXCoilNum ).DXCoilType = "Coil:Heating:DX:SingleSpeed";
+	DXCoil( 2 ).CompanionUpstreamDXCoil = 1;
+
+	DXCoilNumericFields.allocate( NumDXCoils );
+	DXCoilNumericFields( 2 ).PerfMode.allocate( 1 );
+	DXCoilNumericFields( 2 ).PerfMode( 1 ).FieldNames.allocate( 20 );
+	DXCoil( 2 ).DefrostStrategy = Resistive;
+	DXCoil( 2 ).DefrostCapacity = 5000.0;
+	DXCoil( 2 ).Name = "DX Heating coil";
+
+	DXCoil( 1 ).RatedTotCap( 1 ) = AutoSize;
+	DXCoil( 1 ).RatedTotCap( 2 ) = AutoSize;
+	DXCoil( 2 ).RatedTotCap( 1 ) = AutoSize;
+	DXCoil( DXCoilNum ).RegionNum = 4;
+	DXCoil( DXCoilNum ).MinOATCompressor = -17.78;
+	DXCoil( DXCoilNum ).CCapFFlow( 1 ) = 1;
+	DXCoil( DXCoilNum ).CCapFTemp( 1 ) = 1;
+	DXCoil( DXCoilNum ).EIRFFlow( 1 ) = 1;
+	DXCoil( DXCoilNum ).EIRFTemp( 1 ) = 1;
+	DXCoil( DXCoilNum ).PLFFPLR( 1 ) = 1;
+	NumCurves = 3;
+	PerfCurve.allocate( NumCurves );
+
+	CurveNum = 1;
+	PerfCurve( CurveNum ).CurveType = Quadratic;
+	PerfCurve( CurveNum ).ObjectType = CurveType_Quadratic;
+	PerfCurve( CurveNum ).InterpolationType = EvaluateCurveToLimits;
+	PerfCurve( CurveNum ).Coeff1 = 1;
+	PerfCurve( CurveNum ).Coeff2 = 0.0;
+	PerfCurve( CurveNum ).Coeff3 = 0.0;
+	PerfCurve( CurveNum ).Coeff4 = 0.0;
+	PerfCurve( CurveNum ).Coeff5 = 0.0;
+	PerfCurve( CurveNum ).Coeff6 = 0.0;
+	PerfCurve( CurveNum ).Var1Min = 0.0;
+	PerfCurve( CurveNum ).Var1Max = 2.0;
+	PerfCurve( CurveNum ).Var2Min = 0.0;
+	PerfCurve( CurveNum ).Var2Max = 2.0;
+
+	CurveNum = 2;
+	PerfCurve( CurveNum ).CurveType = Quadratic;
+	PerfCurve( CurveNum ).ObjectType = CurveType_Quadratic;
+	PerfCurve( CurveNum ).InterpolationType = EvaluateCurveToLimits;
+	PerfCurve( CurveNum ).Coeff1 = 1;
+	PerfCurve( CurveNum ).Coeff2 = 0.0;
+	PerfCurve( CurveNum ).Coeff3 = 0.0;
+	PerfCurve( CurveNum ).Coeff4 = 0.0;
+	PerfCurve( CurveNum ).Coeff5 = 0.0;
+	PerfCurve( CurveNum ).Coeff6 = 0.0;
+	PerfCurve( CurveNum ).Var1Min = 0.0;
+	PerfCurve( CurveNum ).Var1Max = 1.0;
+	PerfCurve( CurveNum ).Var2Min = 0.7;
+	PerfCurve( CurveNum ).Var2Max = 1.0;
+
+	CurveNum = 3;
+	PerfCurve( CurveNum ).CurveType = BiQuadratic;
+	PerfCurve( CurveNum ).ObjectType = CurveType_BiQuadratic;
+	PerfCurve( CurveNum ).InterpolationType = EvaluateCurveToLimits;
+	PerfCurve( CurveNum ).Coeff1 = 1;
+	PerfCurve( CurveNum ).Coeff2 = 0.0;
+	PerfCurve( CurveNum ).Coeff3 = 0.0;
+	PerfCurve( CurveNum ).Coeff4 = 0.0;
+	PerfCurve( CurveNum ).Coeff5 = 0.0;
+	PerfCurve( CurveNum ).Coeff6 = 0.0;
+	PerfCurve( CurveNum ).Var1Min = -100.0;
+	PerfCurve( CurveNum ).Var1Max = 100.0;
+	PerfCurve( CurveNum ).Var2Min = -100.0;
+	PerfCurve( CurveNum ).Var2Max = 100.0;
+
+	SetPredefinedTables();
+	SizeDXCoil( 2 );
+	EXPECT_DOUBLE_EQ( 0.0, DXCoil( 2 ).RatedTotCap( 1 ) );
+
+	// Clean up
+	DXCoil.deallocate();
+	DXCoilNumericFields.deallocate();
+	UnitarySysEqSizing.deallocate();
+	PerfCurve.deallocate();
+	FinalSysSizing.deallocate();
+	PrimaryAirSystem.deallocate();
+	AirLoopControlInfo.deallocate();
+	cached_Twb.deallocate();
+	cached_Psat.deallocate();
+
+}
 


### PR DESCRIPTION
Fixes #4826 

Error file using DisplayExtraWarnings:

   ** Warning ** SizeDXCoil: Potential issue with equipment sizing for Coil:Heating:DX:SingleSpeed PSZ-AC:1_UNITARY_PACKAGE_DX_HPHT
   **   ~~~   ** ...Rated Total Heating Capacity = 0.
   **   ~~~   ** ...Air flow rate used for sizing = 1.96842 [m3/s]
   **   ~~~   ** ...Outdoor air fraction used for sizing = 0.11
   **   ~~~   ** ...Coil inlet air temperature used for sizing = 19.36 [C]
   **   ~~~   ** ...Coil outlet air temperature used for sizing = -15.00 [C]
