### PR TITLE
Fix issues with previous version transition tools

### DIFF
--- a/src/Transition/CreateNewIDFUsingRulesV8_1_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_1_0.f90
@@ -368,7 +368,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 if (samestring(OutArgs(8),'autosize')) OutArgs(8)='autocalculate'
                 OutArgs(9)=blank
                 OutArgs(10)=InArgs(9)
-                if (samestring(OutArgs(8),'autosize')) OutArgs(10)='autocalculate'
+                if (samestring(OutArgs(9),'autosize')) OutArgs(10)='autocalculate'
                 OutArgs(11)=blank
                 OutArgs(12)=InArgs(10)
                 OutArgs(13)=blank

--- a/src/Transition/CreateNewIDFUsingRulesV8_1_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_1_0.f90
@@ -368,7 +368,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 if (samestring(OutArgs(8),'autosize')) OutArgs(8)='autocalculate'
                 OutArgs(9)=blank
                 OutArgs(10)=InArgs(9)
-                if (samestring(OutArgs(9),'autosize')) OutArgs(10)='autocalculate'
+                if (samestring(OutArgs(10),'autosize')) OutArgs(10)='autocalculate'
                 OutArgs(11)=blank
                 OutArgs(12)=InArgs(10)
                 OutArgs(13)=blank

--- a/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
@@ -421,6 +421,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 ! new fields F21-25 are shifted
                 OutArgs(21:25) = InArgs(14:18)
                 ! there are some additional new fields, but they are optional and intentionally blank
+                CurArgs = CurArgs + 7
                 
               CASE('EVAPORATIVECOOLER:DIRECT:RESEARCHSPECIAL')
                 ! data center hvac changes
@@ -437,6 +438,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 ! shift the rest
                 OutArgs(8:13) = InArgs(5:10)
                 ! there are some additional new fields, but they are optional and intentionally blank
+                CurArgs = CurArgs + 3
                 
     !!!   Changes for report variables, meters, tables -- update names
               CASE('OUTPUT:VARIABLE')


### PR DESCRIPTION
This fixes two transition issues:
- The cooling tower issue in 8.0 to 8.1 #4456 
- The evap cooler issue in 8.2 to 8.3 #4850 

My gut says this doesn't necessitate a re-release on its own.  But, if a re-release does happen, include this one.
