### PR TITLE
Fix high speed UA autosizing fatal error for FluidCooler:TwoSpeed

### DIFF
--- a/src/EnergyPlus/FluidCoolers.cc
+++ b/src/EnergyPlus/FluidCoolers.cc
@@ -482,6 +482,9 @@ namespace FluidCoolers {
 			TestCompSet( cCurrentModuleObject, AlphArray( 1 ), AlphArray( 2 ), AlphArray( 3 ), "Chilled Water Nodes" );
 
 			SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUA = NumArray( 1 );
+			if ( SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUA == AutoSize ) {
+				SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUAWasAutoSized = true;
+			}
 			SimpleFluidCooler( FluidCoolerNum ).LowSpeedFluidCoolerUA = NumArray( 2 );
 			if ( SimpleFluidCooler( FluidCoolerNum ).LowSpeedFluidCoolerUA == AutoSize ) {
 				SimpleFluidCooler( FluidCoolerNum ).LowSpeedFluidCoolerUAWasAutoSized = true;

--- a/tst/EnergyPlus/unit/FluidCoolers.unit.cc
+++ b/tst/EnergyPlus/unit/FluidCoolers.unit.cc
@@ -83,3 +83,61 @@ TEST( TwoSpeedFluidCoolerInput, Test1 )
 
 	SimpleFluidCooler.deallocate();
 }
+TEST( TwoSpeedFluidCoolerInput, Test2 ) {
+	ShowMessage( "Begin Test: TwoSpeedFluidCoolerInput, Test2" );
+
+	using DataSizing::AutoSize;
+	int StringArraySize = 20;
+	Array1D_string cNumericFieldNames;
+	cNumericFieldNames.allocate( StringArraySize );
+	Array1D_string cAlphaFieldNames;
+	cAlphaFieldNames.allocate( StringArraySize );
+	Array1D_string AlphArray;
+	AlphArray.allocate( StringArraySize );
+	for ( int i = 1; i <= StringArraySize; ++i ) {
+		cAlphaFieldNames( i ) = "AlphaField";
+		cNumericFieldNames( i ) = "NumerField";
+		AlphArray( i ) = "FieldValues";
+	}
+	std::string const cCurrentModuleObject( "FluidCooler:TwoSpeed" );
+	int FluidCoolerNum( 1 );
+	bool ErrrorsFound( false );
+	SimpleFluidCooler.allocate( FluidCoolerNum );
+
+	SimpleFluidCooler( FluidCoolerNum ).Name = "Test";
+	SimpleFluidCooler( FluidCoolerNum ).FluidCoolerMassFlowRateMultiplier = 1.0;
+	SimpleFluidCooler( FluidCoolerNum ).PerformanceInputMethod_Num = PIM_UFactor;
+	SimpleFluidCooler( FluidCoolerNum ).DesignEnteringWaterTemp = 52;
+	SimpleFluidCooler( FluidCoolerNum ).DesignEnteringAirTemp = 35;
+	SimpleFluidCooler( FluidCoolerNum ).DesignEnteringAirWetBulbTemp = 25;
+	SimpleFluidCooler( FluidCoolerNum ).DesignWaterFlowRate = AutoSize;
+	SimpleFluidCooler( FluidCoolerNum ).DesignWaterFlowRateWasAutoSized = true;
+	SimpleFluidCooler( FluidCoolerNum ).HighSpeedAirFlowRate = AutoSize;
+	SimpleFluidCooler( FluidCoolerNum ).HighSpeedAirFlowRateWasAutoSized = true;
+	SimpleFluidCooler( FluidCoolerNum ).HighSpeedFanPower = AutoSize;
+	SimpleFluidCooler( FluidCoolerNum ).HighSpeedFanPowerWasAutoSized = true;
+	SimpleFluidCooler( FluidCoolerNum ).LowSpeedAirFlowRate = AutoSize;
+	SimpleFluidCooler( FluidCoolerNum ).LowSpeedAirFlowRateWasAutoSized = true;
+	SimpleFluidCooler( FluidCoolerNum ).LowSpeedFanPower = AutoSize;
+	SimpleFluidCooler( FluidCoolerNum ).LowSpeedFanPowerWasAutoSized = true;
+	SimpleFluidCooler( FluidCoolerNum ).FluidCoolerLowSpeedNomCap = 30000;
+	SimpleFluidCooler( FluidCoolerNum ).LowSpeedFluidCoolerUA = AutoSize;
+	SimpleFluidCooler( FluidCoolerNum ).LowSpeedFluidCoolerUAWasAutoSized = true;
+
+	AlphArray( 4 ) = "UFactorTimesAreaAndDesignWaterFlowRate";
+	SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUA = AutoSize;
+	SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUAWasAutoSized = false;
+	bool testResult = TestFluidCoolerTwoSpeedInputForDesign( cCurrentModuleObject, AlphArray, cNumericFieldNames, cAlphaFieldNames, FluidCoolerNum );
+	EXPECT_TRUE( testResult ); // error message triggered
+
+	ErrrorsFound = false;
+	SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUA = AutoSize;
+	SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUAWasAutoSized = true;
+	testResult = TestFluidCoolerTwoSpeedInputForDesign( cCurrentModuleObject, AlphArray, cNumericFieldNames, cAlphaFieldNames, FluidCoolerNum );
+	EXPECT_FALSE( testResult ); // no error message triggered
+
+	SimpleFluidCooler.deallocate();
+	cNumericFieldNames.deallocate();
+	cAlphaFieldNames.deallocate();
+	AlphArray.deallocate();
+}


### PR DESCRIPTION
This bug issue corrects fatal out problem when High Speed UA parameter is auto-sized and the performance input method is UFactorTimesAreaAndDesignWaterFlowRate for FluidCooler:TwoSpeed.
A unit test case has been created and regression run is also complete.  This issue is ready for reviewing and merging into develop.

 High Speed UA autosizing sizing fatal out for FluidCooler:TwoSpeed #4895 
