### PR TITLE
ObjexxFCL: Array iterators added, Vector2/3 APIs refined

### DIFF
--- a/src/EnergyPlus/SolarReflectionManager.cc
+++ b/src/EnergyPlus/SolarReflectionManager.cc
@@ -1347,7 +1347,7 @@ namespace SolarReflectionManager {
 		diff( A( 2 ), vertex( 3 ), V( 2 ) );
 
 		// Vector normal to surface
-		SN.cross( A( 1 ), A( 2 ) );
+		SN = cross( A( 1 ), A( 2 ) );
 
 		// Scale factor, the solution of SN.(CPhit-V2) = 0 and
 		// CPhit = R1 + SCALE*RN, where CPhit is the point that RN,
@@ -1370,20 +1370,20 @@ namespace SolarReflectionManager {
 			// 0 < CCC.BBB < BBB.BBB AND 0 < CCC.AAA < AAA.AAA
 
 			// CCC = CPhit - V2  ! Vector from vertex 2 to CPhit
-			CCC.diff( CPhit, V( 2 ) );
+			CCC = CPhit - V( 2 );
 
 			// Set third V just for here
 			assign( V( 3 ), vertex( 3 ) );
 
 			// BBB = V3 - V2
-			BBB.diff( V( 3 ), V( 2 ) );
+			BBB = V( 3 ) - V( 2 );
 
 			DOTCB = dot( CCC, BBB );
 			if ( DOTCB < 0.0 ) return;
 			if ( DOTCB > BBB.magnitude_squared() ) return;
 
 			// AAA = V1 - V2
-			AAA.diff( V( 1 ), V( 2 ) );
+			AAA = V( 1 ) - V( 2 );
 
 			DOTCA = dot( CCC, AAA );
 			if ( DOTCA < 0.0 ) return;
@@ -1395,13 +1395,13 @@ namespace SolarReflectionManager {
 
 			// First two of V & A already set
 			// test first vertex:
-			C( 1 ).diff( CPhit, V( 1 ) );
-			AXC.cross( A( 1 ), C( 1 ) );
+			C( 1 ) = CPhit - V( 1 );
+			AXC = cross( A( 1 ), C( 1 ) );
 			if ( dot( AXC, SN ) < 0.0 ) return; // If at least one dot product is negative, intersection outside of surface
 
 			// test second vertex:
-			C( 2 ).diff( CPhit, V( 2 ) );
-			AXC.cross( A( 2 ), C( 2 ) );
+			C( 2 ) = CPhit - V( 2 );
+			AXC = cross( A( 2 ), C( 2 ) );
 			if ( dot( AXC, SN ) < 0.0 ) return; // If at least one dot product is negative, intersection outside of surface
 
 			NV = surface.Sides;
@@ -1409,17 +1409,17 @@ namespace SolarReflectionManager {
 				for ( N = 3; N <= NV - 1; ++N ) {
 					assign( V( N ), vertex( N ) );
 					diff( A( N ), vertex( N + 1 ), V( N ) );
-					C( N ).diff( CPhit, V( N ) );
-					AXC.cross( A( N ), C( N ) );
+					C( N ) = CPhit - V( N );
+					AXC = cross( A( N ), C( N ) );
 					if ( dot( AXC, SN ) < 0.0 ) return; // If at least one dot product is negative, intersection outside of surface
 				}
 			}
 
 			// Last vertex (NV=3 or NV=4)
 			assign( V( NV ), vertex( NV ) );
-			A( NV ).diff( V( 1 ), V( NV ) );
-			C( NV ).diff( CPhit, V( NV ) );
-			AXC.cross( A( NV ), C( NV ) );
+			A( NV ) = V( 1 ) - V( NV );
+			C( NV ) = CPhit - V( NV );
+			AXC = cross( A( NV ), C( NV ) );
 			if ( dot( AXC, SN ) < 0.0 ) return; // If at least one dot product is negative, intersection outside of surface
 
 			IPIERC = 1; // Surface is intersected

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
@@ -42,6 +42,7 @@
 #include <initializer_list>
 #include <iomanip>
 #include <istream>
+#include <iterator>
 #include <limits>
 #include <ostream>
 #include <type_traits>
@@ -92,6 +93,10 @@ public: // Types
 	typedef  T const &  const_reference;
 	typedef  T *  pointer;
 	typedef  T const *  const_pointer;
+	typedef  T *  iterator;
+	typedef  T const *  const_iterator;
+	typedef  std::reverse_iterator< T * >  reverse_iterator;
+	typedef  std::reverse_iterator< T const * >  const_reverse_iterator;
 	typedef  std::size_t  size_type;
 	typedef  std::ptrdiff_t  difference_type;
 
@@ -101,6 +106,10 @@ public: // Types
 	typedef  T const &  ConstReference;
 	typedef  T *  Pointer;
 	typedef  T const *  ConstPointer;
+	typedef  T *  Iterator;
+	typedef  T const *  ConstIterator;
+	typedef  std::reverse_iterator< T * >  ReverseIterator;
+	typedef  std::reverse_iterator< T const * >  ConstReverseIterator;
 	typedef  std::size_t  Size;
 	typedef  std::ptrdiff_t  Difference;
 
@@ -1466,6 +1475,70 @@ public: // Inspector
 	virtual
 	int
 	isize( int const d ) const = 0;
+
+	// Array Begin Iterator
+	inline
+	T const *
+	begin() const
+	{
+		return data_;
+	}
+
+	// Array Begin Iterator
+	inline
+	T *
+	begin()
+	{
+		return data_;
+	}
+
+	// Array End Iterator
+	inline
+	T const *
+	end() const
+	{
+		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ : nullptr );
+	}
+
+	// Array End Iterator
+	inline
+	T *
+	end()
+	{
+		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ : nullptr );
+	}
+
+	// Array Reverse Begin Iterator
+	inline
+	std::reverse_iterator< T const * >
+	rbegin() const
+	{
+		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ - 1 : nullptr );
+	}
+
+	// Array Reverse Begin Iterator
+	inline
+	std::reverse_iterator< T * >
+	rbegin()
+	{
+		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ - 1 : nullptr );
+	}
+
+	// Array Reverse End Iterator
+	inline
+	std::reverse_iterator< T const * >
+	rend() const
+	{
+		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ - 1 : nullptr );
+	}
+
+	// Array Reverse End Iterator
+	inline
+	std::reverse_iterator< T * >
+	rend()
+	{
+		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ - 1 : nullptr );
+	}
 
 	// Array Data Pointer
 	inline

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
@@ -62,6 +62,10 @@ public: // Types
 	typedef  typename Super::const_reference  const_reference;
 	typedef  typename Super::pointer  pointer;
 	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
 	typedef  typename Super::size_type  size_type;
 	typedef  typename Super::difference_type  difference_type;
 
@@ -71,6 +75,10 @@ public: // Types
 	typedef  typename Super::ConstReference  ConstReference;
 	typedef  typename Super::Pointer  Pointer;
 	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.hh
@@ -32,26 +32,34 @@ private: // Types
 public: // Types
 
 	typedef  typename Super::Base  Base;
-	typedef  typename Base::Tail  Tail;
+	typedef  typename Super::Tail  Tail;
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	using Super::conformable;
 	using Super::npos;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.hh
@@ -42,22 +42,30 @@ public: // Types
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	typedef  ArrayInitializer< T, ObjexxFCL::Array1D >  Initializer;
 	typedef  typename Initializer::Function  InitializerFunction;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
@@ -60,6 +60,10 @@ public: // Types
 	typedef  typename Super::const_reference  const_reference;
 	typedef  typename Super::pointer  pointer;
 	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
 	typedef  typename Super::size_type  size_type;
 	typedef  typename Super::difference_type  difference_type;
 
@@ -69,6 +73,10 @@ public: // Types
 	typedef  typename Super::ConstReference  ConstReference;
 	typedef  typename Super::Pointer  Pointer;
 	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.hh
@@ -32,26 +32,34 @@ private: // Types
 public: // Types
 
 	typedef  typename Super::Base  Base;
-	typedef  typename Base::Tail  Tail;
+	typedef  typename Super::Tail  Tail;
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	using Super::conformable;
 	using Super::npos;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.hh
@@ -42,22 +42,30 @@ public: // Types
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	typedef  ArrayInitializer< T, ObjexxFCL::Array2D >  Initializer;
 	typedef  typename Initializer::Function  InitializerFunction;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
@@ -59,6 +59,10 @@ public: // Types
 	typedef  typename Super::const_reference  const_reference;
 	typedef  typename Super::pointer  pointer;
 	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
 	typedef  typename Super::size_type  size_type;
 	typedef  typename Super::difference_type  difference_type;
 
@@ -68,6 +72,10 @@ public: // Types
 	typedef  typename Super::ConstReference  ConstReference;
 	typedef  typename Super::Pointer  Pointer;
 	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.hh
@@ -32,26 +32,34 @@ private: // Types
 public: // Types
 
 	typedef  typename Super::Base  Base;
-	typedef  typename Base::Tail  Tail;
+	typedef  typename Super::Tail  Tail;
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	using Super::conformable;
 	using Super::npos;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.hh
@@ -42,22 +42,30 @@ public: // Types
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	typedef  ArrayInitializer< T, ObjexxFCL::Array3D >  Initializer;
 	typedef  typename Initializer::Function  InitializerFunction;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
@@ -59,6 +59,10 @@ public: // Types
 	typedef  typename Super::const_reference  const_reference;
 	typedef  typename Super::pointer  pointer;
 	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
 	typedef  typename Super::size_type  size_type;
 	typedef  typename Super::difference_type  difference_type;
 
@@ -68,6 +72,10 @@ public: // Types
 	typedef  typename Super::ConstReference  ConstReference;
 	typedef  typename Super::Pointer  Pointer;
 	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.hh
@@ -32,26 +32,34 @@ private: // Types
 public: // Types
 
 	typedef  typename Super::Base  Base;
-	typedef  typename Base::Tail  Tail;
+	typedef  typename Super::Tail  Tail;
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	using Super::conformable;
 	using Super::npos;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.hh
@@ -42,22 +42,30 @@ public: // Types
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	typedef  ArrayInitializer< T, ObjexxFCL::Array4D >  Initializer;
 	typedef  typename Initializer::Function  InitializerFunction;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
@@ -59,6 +59,10 @@ public: // Types
 	typedef  typename Super::const_reference  const_reference;
 	typedef  typename Super::pointer  pointer;
 	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
 	typedef  typename Super::size_type  size_type;
 	typedef  typename Super::difference_type  difference_type;
 
@@ -68,6 +72,10 @@ public: // Types
 	typedef  typename Super::ConstReference  ConstReference;
 	typedef  typename Super::Pointer  Pointer;
 	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.hh
@@ -32,26 +32,34 @@ private: // Types
 public: // Types
 
 	typedef  typename Super::Base  Base;
-	typedef  typename Base::Tail  Tail;
+	typedef  typename Super::Tail  Tail;
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	using Super::conformable;
 	using Super::npos;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.hh
@@ -42,22 +42,30 @@ public: // Types
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	typedef  ArrayInitializer< T, ObjexxFCL::Array5D >  Initializer;
 	typedef  typename Initializer::Function  InitializerFunction;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
@@ -59,6 +59,10 @@ public: // Types
 	typedef  typename Super::const_reference  const_reference;
 	typedef  typename Super::pointer  pointer;
 	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
 	typedef  typename Super::size_type  size_type;
 	typedef  typename Super::difference_type  difference_type;
 
@@ -68,6 +72,10 @@ public: // Types
 	typedef  typename Super::ConstReference  ConstReference;
 	typedef  typename Super::Pointer  Pointer;
 	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.hh
@@ -32,26 +32,34 @@ private: // Types
 public: // Types
 
 	typedef  typename Super::Base  Base;
-	typedef  typename Base::Tail  Tail;
+	typedef  typename Super::Tail  Tail;
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	using Super::conformable;
 	using Super::npos;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.hh
@@ -42,22 +42,30 @@ public: // Types
 	typedef  typename Super::IR  IR;
 
 	// STL Style
-	typedef  typename Base::value_type  value_type;
-	typedef  typename Base::reference  reference;
-	typedef  typename Base::const_reference  const_reference;
-	typedef  typename Base::pointer  pointer;
-	typedef  typename Base::const_pointer  const_pointer;
-	typedef  typename Base::size_type  size_type;
-	typedef  typename Base::difference_type  difference_type;
+	typedef  typename Super::value_type  value_type;
+	typedef  typename Super::reference  reference;
+	typedef  typename Super::const_reference  const_reference;
+	typedef  typename Super::pointer  pointer;
+	typedef  typename Super::const_pointer  const_pointer;
+	typedef  typename Super::iterator  iterator;
+	typedef  typename Super::const_iterator  const_iterator;
+	typedef  typename Super::reverse_iterator  reverse_iterator;
+	typedef  typename Super::const_reverse_iterator  const_reverse_iterator;
+	typedef  typename Super::size_type  size_type;
+	typedef  typename Super::difference_type  difference_type;
 
 	// C++ Style
-	typedef  typename Base::Value  Value;
-	typedef  typename Base::Reference  Reference;
-	typedef  typename Base::ConstReference  ConstReference;
-	typedef  typename Base::Pointer  Pointer;
-	typedef  typename Base::ConstPointer  ConstPointer;
-	typedef  typename Base::Size  Size;
-	typedef  typename Base::Difference  Difference;
+	typedef  typename Super::Value  Value;
+	typedef  typename Super::Reference  Reference;
+	typedef  typename Super::ConstReference  ConstReference;
+	typedef  typename Super::Pointer  Pointer;
+	typedef  typename Super::ConstPointer  ConstPointer;
+	typedef  typename Super::Iterator  Iterator;
+	typedef  typename Super::ConstIterator  ConstIterator;
+	typedef  typename Super::ReverseIterator  ReverseIterator;
+	typedef  typename Super::ConstReverseIterator  ConstReverseIterator;
+	typedef  typename Super::Size  Size;
+	typedef  typename Super::Difference  Difference;
 
 	typedef  ArrayInitializer< T, ObjexxFCL::Array6D >  Initializer;
 	typedef  typename Initializer::Function  InitializerFunction;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Vector2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Vector2.hh
@@ -15,6 +15,7 @@
 
 // ObjexxFCL Headers
 #include <ObjexxFCL/Vector2.fwd.hh>
+#include <ObjexxFCL/Fmath.hh>
 #include <ObjexxFCL/TypeTraits.hh>
 
 // C++ Headers
@@ -565,48 +566,6 @@ public: // Properties: Predicates
 		return ( length_squared() == T( 1 ) );
 	}
 
-public: // Properties: Comparison
-
-	// Equal Length?
-	inline
-	bool
-	equal_length( Vector2 const & v )
-	{
-		return ( length_squared() == v.length_squared() );
-	}
-
-	// Longer?
-	inline
-	bool
-	longer( Vector2 const & v )
-	{
-		return ( length_squared() > v.length_squared() );
-	}
-
-	// Longer or Equal Length?
-	inline
-	bool
-	longer_or_equal( Vector2 const & v )
-	{
-		return ( length_squared() >= v.length_squared() );
-	}
-
-	// Shorter?
-	inline
-	bool
-	shorter( Vector2 const & v )
-	{
-		return ( length_squared() < v.length_squared() );
-	}
-
-	// Shorter or Equal Length?
-	inline
-	bool
-	shorter_or_equal( Vector2 const & v )
-	{
-		return ( length_squared() <= v.length_squared() );
-	}
-
 public: // Properties: General
 
 	// Size
@@ -673,7 +632,7 @@ public: // Properties: General
 		return std::max( std::abs( x ), std::abs( y ) );
 	}
 
-	// Distance
+	// Distance to a Vector2
 	inline
 	T
 	distance( Vector2 const & v ) const
@@ -681,7 +640,7 @@ public: // Properties: General
 		return std::sqrt( square( x - v.x ) + square( y - v.y ) );
 	}
 
-	// Distance Squared
+	// Distance Squared to a Vector2
 	inline
 	T
 	distance_squared( Vector2 const & v ) const
@@ -689,7 +648,7 @@ public: // Properties: General
 		return square( x - v.x ) + square( y - v.y );
 	}
 
-	// Dot Product
+	// Dot Product with a Vector2
 	inline
 	T
 	dot( Vector2 const & v ) const
@@ -697,7 +656,7 @@ public: // Properties: General
 		return ( x * v.x ) + ( y * v.y );
 	}
 
-	// Dot Product
+	// Dot Product with an Array
 	template< typename A, class = typename std::enable_if< std::is_assignable< T&, typename A::value_type >::value >::type >
 	inline
 	T
@@ -807,6 +766,22 @@ public: // Modifiers
 		return *this;
 	}
 
+	// Normalize to a Length: Uniform Vector2 if Length is Zero
+	inline
+	Vector2 &
+	normalize_uniform( T const & tar_length = T( 1 ) )
+	{
+		T const cur_length( length() );
+		if ( cur_length > T( 0 ) ) {
+			T const dilation( tar_length / cur_length );
+			x *= dilation;
+			y *= dilation;
+		} else { // Set uniform vector
+			operator =( uniform_vector( tar_length ) );
+		}
+		return *this;
+	}
+
 	// Normalize to a Length: x Vector2 if Length is Zero
 	inline
 	Vector2 &
@@ -841,23 +816,7 @@ public: // Modifiers
 		return *this;
 	}
 
-	// Normalize to a Length: Uniform Vector2 if Length is Zero
-	inline
-	Vector2 &
-	normalize_uniform( T const & tar_length = T( 1 ) )
-	{
-		T const cur_length( length() );
-		if ( cur_length > T( 0 ) ) {
-			T const dilation( tar_length / cur_length );
-			x *= dilation;
-			y *= dilation;
-		} else { // Set uniform vector
-			operator =( uniform_vector( tar_length ) );
-		}
-		return *this;
-	}
-
-	// Set Minimum Coordinates wrt a Vector2
+	// Minimum Coordinates with a Vector2
 	inline
 	Vector2 &
 	min( Vector2 const & v )
@@ -867,7 +826,7 @@ public: // Modifiers
 		return *this;
 	}
 
-	// Set Maximum Coordinates wrt a Vector2
+	// Maximum Coordinates with a Vector2
 	inline
 	Vector2 &
 	max( Vector2 const & v )
@@ -877,68 +836,27 @@ public: // Modifiers
 		return *this;
 	}
 
-	// Sum of Vector2s
+	// Sum In a Vector2
 	inline
 	Vector2 &
-	sum( Vector2 const & a, Vector2 const & b )
+	sum( Vector2 const & v )
 	{
-		x = a.x + b.x;
-		y = a.y + b.y;
+		x += v.x;
+		y += v.y;
 		return *this;
 	}
 
-	// Difference of Vector2s
+	// Subtract Out a Vector2
 	inline
 	Vector2 &
-	diff( Vector2 const & a, Vector2 const & b )
+	sub( Vector2 const & v )
 	{
-		x = a.x - b.x;
-		y = a.y - b.y;
+		x -= v.x;
+		y -= v.y;
 		return *this;
 	}
 
-	// Midpoint of Two Vector2s
-	inline
-	Vector2 &
-	mid( Vector2 const & a, Vector2 const & b )
-	{
-		x = T( 0.5 * ( a.x + b.x ) );
-		y = T( 0.5 * ( a.y + b.y ) );
-		return *this;
-	}
-
-	// Center of Two Vector2s
-	inline
-	Vector2 &
-	cen( Vector2 const & a, Vector2 const & b )
-	{
-		x = T( 0.5 * ( a.x + b.x ) );
-		y = T( 0.5 * ( a.y + b.y ) );
-		return *this;
-	}
-
-	// Center of Three Vector2s
-	inline
-	Vector2 &
-	cen( Vector2 const & a, Vector2 const & b, Vector2 const & c )
-	{
-		static long double const third( 1.0 / 3.0 );
-		x = T( third * ( a.x + b.x + c.x ) );
-		y = T( third * ( a.y + b.y + c.y ) );
-		return *this;
-	}
-
-	// Center of Four Vector2s
-	inline
-	Vector2 &
-	cen( Vector2 const & a, Vector2 const & b, Vector2 const & c, Vector2 const & d )
-	{
-		x = T( 0.25 * ( a.x + b.x + c.x + d.x ) );
-		y = T( 0.25 * ( a.y + b.y + c.y + d.y ) );
-		return *this;
-	}
-
-	// Project Normally onto a Vector2
+	// Project Normal to a Vector2
 	inline
 	Vector2 &
 	project_normal( Vector2 const & v )
@@ -950,7 +868,7 @@ public: // Modifiers
 		return *this;
 	}
 
-	// Project in Direction of a Vector2
+	// Project onto a Vector2
 	inline
 	Vector2 &
 	project_parallel( Vector2 const & v )
@@ -1011,6 +929,23 @@ public: // Generators
 		}
 	}
 
+	// Normalized to a Length: Uniform Vector2 if Length is Zero
+	inline
+	Vector2
+	normalized_uniform( T const & tar_length = T( 1 ) ) const
+	{
+		T const cur_length( length() );
+		if ( cur_length > T( 0 ) ) {
+			T const dilation( tar_length / cur_length );
+			return Vector2(
+			 x * dilation,
+			 y * dilation
+			);
+		} else { // Return uniform vector
+			return uniform_vector( tar_length );
+		}
+	}
+
 	// Normalized to a Length: x Vector2 if Length is Zero
 	inline
 	Vector2
@@ -1042,40 +977,6 @@ public: // Generators
 			);
 		} else { // Return y vector
 			return Vector2( T( 0 ), tar_length, T( 0 ) );
-		}
-	}
-
-	// Normalized to a Length: z Vector2 if Length is Zero
-	inline
-	Vector2
-	normalized_z( T const & tar_length = T( 1 ) ) const
-	{
-		T const cur_length( length() );
-		if ( cur_length > T( 0 ) ) {
-			T const dilation( tar_length / cur_length );
-			return Vector2(
-			 x * dilation,
-			 y * dilation
-			);
-		} else { // Return z vector
-			return Vector2( tar_length, T( 0 ), T( 0 ), tar_length );
-		}
-	}
-
-	// Normalized to a Length: Uniform Vector2 if Length is Zero
-	inline
-	Vector2
-	normalized_uniform( T const & tar_length = T( 1 ) ) const
-	{
-		T const cur_length( length() );
-		if ( cur_length > T( 0 ) ) {
-			T const dilation( tar_length / cur_length );
-			return Vector2(
-			 x * dilation,
-			 y * dilation
-			);
-		} else { // Return uniform vector
-			return uniform_vector( tar_length );
 		}
 	}
 
@@ -1205,7 +1106,7 @@ public: // Generators
 		return Vector2( t / v.x, t / v.y );
 	}
 
-	// Vector2 with Min Coordinates of Two Vector2s
+	// Minimum of Two Vector2s
 	friend
 	inline
 	Vector2
@@ -1217,7 +1118,31 @@ public: // Generators
 		);
 	}
 
-	// Vector2 with Max Coordinates of Two Vector2s
+	// Minimum of Three Vector2s
+	friend
+	inline
+	Vector2
+	min( Vector2 const & a, Vector2 const & b, Vector2 const & c )
+	{
+		return Vector2(
+		 ObjexxFCL::min( a.x, b.x, c.x ),
+		 ObjexxFCL::min( a.y, b.y, c.y )
+		);
+	}
+
+	// Minimum of Four Vector2s
+	friend
+	inline
+	Vector2
+	min( Vector2 const & a, Vector2 const & b, Vector2 const & c, Vector2 const & d )
+	{
+		return Vector2(
+		 ObjexxFCL::min( a.x, b.x, c.x, d.x ),
+		 ObjexxFCL::min( a.y, b.y, c.y, d.y )
+		);
+	}
+
+	// Maximum of Two Vector2s
 	friend
 	inline
 	Vector2
@@ -1229,7 +1154,116 @@ public: // Generators
 		);
 	}
 
-	// Projected Normally onto a Vector2
+	// Maximum of Three Vector2s
+	friend
+	inline
+	Vector2
+	max( Vector2 const & a, Vector2 const & b, Vector2 const & c )
+	{
+		return Vector2(
+		 ObjexxFCL::max( a.x, b.x, c.x ),
+		 ObjexxFCL::max( a.y, b.y, c.y )
+		);
+	}
+
+	// Maximum of Four Vector2s
+	friend
+	inline
+	Vector2
+	max( Vector2 const & a, Vector2 const & b, Vector2 const & c, Vector2 const & d )
+	{
+		return Vector2(
+		 ObjexxFCL::max( a.x, b.x, c.x, d.x ),
+		 ObjexxFCL::max( a.y, b.y, c.y, d.y )
+		);
+	}
+
+	// Sum of Two Vector2s
+	friend
+	inline
+	Vector2
+	sum( Vector2 const & a, Vector2 const & b )
+	{
+		return Vector2( a.x + b.x, a.y + b.y );
+	}
+
+	// Sum of Three Vector2s
+	friend
+	inline
+	Vector2
+	sum( Vector2 const & a, Vector2 const & b, Vector2 const & c )
+	{
+		return Vector2( a.x + b.x + c.x, a.y + b.y + c.y );
+	}
+
+	// Sum of Four Vector2s
+	friend
+	inline
+	Vector2
+	sum( Vector2 const & a, Vector2 const & b, Vector2 const & c, Vector2 const & d )
+	{
+		return Vector2( a.x + b.x + c.x + d.x, a.y + b.y + c.y + d.y );
+	}
+
+	// Subtract of Two Vector2s
+	friend
+	inline
+	Vector2
+	sub( Vector2 const & a, Vector2 const & b )
+	{
+		return Vector2( a.x - b.x, a.y - b.y );
+	}
+
+	// Midpoint of Two Vector2s
+	friend
+	inline
+	Vector2
+	mid( Vector2 const & a, Vector2 const & b )
+	{
+		return Vector2(
+		 T( 0.5 * ( a.x + b.x ) ),
+		 T( 0.5 * ( a.y + b.y ) )
+		);
+	}
+
+	// Center of Two Vector2s
+	friend
+	inline
+	Vector2
+	cen( Vector2 const & a, Vector2 const & b )
+	{
+		return Vector2(
+		 T( 0.5 * ( a.x + b.x ) ),
+		 T( 0.5 * ( a.y + b.y ) )
+		);
+	}
+
+	// Center of Three Vector2s
+	friend
+	inline
+	Vector2
+	cen( Vector2 const & a, Vector2 const & b, Vector2 const & c )
+	{
+		static long double const third( 1.0 / 3.0 );
+		return Vector2(
+		 T( third * ( a.x + b.x + c.x ) ),
+		 T( third * ( a.y + b.y + c.y ) )
+		);
+	}
+
+	// Center of Four Vector2s
+	friend
+	inline
+	Vector2
+	cen( Vector2 const & a, Vector2 const & b, Vector2 const & c, Vector2 const & d )
+	{
+		return Vector2(
+		 T( 0.25 * ( a.x + b.x + c.x + d.x ) ),
+		 T( 0.25 * ( a.y + b.y + c.y + d.y ) )
+		);
+	}
+
+	// Projected Normal to a Vector2
 	inline
 	Vector2
 	projected_normal( Vector2 const & v ) const
@@ -1239,7 +1273,7 @@ public: // Generators
 		return Vector2( x - ( c * v.x ), y - ( c * v.y ) );
 	}
 
-	// Projected in Direction of a Vector2
+	// Projected onto a Vector2
 	inline
 	Vector2
 	projected_parallel( Vector2 const & v ) const
@@ -1475,14 +1509,6 @@ public: // Friends: Comparison
 	}
 
 	// Not Equal Length?
-	inline
-	bool
-	not_equal_length( Vector2 const & v )
-	{
-		return ( length_squared() != v.length_squared() );
-	}
-
-	// Not Equal Length?
 	friend
 	inline
 	bool
@@ -1527,55 +1553,6 @@ public: // Friends
 	cross( Vector2 const & a, Vector2 const & b )
 	{
 		return ( a.x * b.y ) - ( a.y * b.x );
-	}
-
-	// Midpoint of Two Vector2s
-	friend
-	inline
-	Vector2
-	mid( Vector2 const & a, Vector2 const & b )
-	{
-		return Vector2(
-		 T( 0.5 * ( a.x + b.x ) ),
-		 T( 0.5 * ( a.y + b.y ) )
-		);
-	}
-
-	// Center of Two Vector2s
-	friend
-	inline
-	Vector2
-	cen( Vector2 const & a, Vector2 const & b )
-	{
-		return Vector2(
-		 T( 0.5 * ( a.x + b.x ) ),
-		 T( 0.5 * ( a.y + b.y ) )
-		);
-	}
-
-	// Center of Three Vector2s
-	friend
-	inline
-	Vector2
-	cen( Vector2 const & a, Vector2 const & b, Vector2 const & c )
-	{
-		static long double const third( 1.0 / 3.0 );
-		return Vector2(
-		 T( third * ( a.x + b.x + c.x ) ),
-		 T( third * ( a.y + b.y + c.y ) )
-		);
-	}
-
-	// Center of Four Vector2s
-	friend
-	inline
-	Vector2
-	cen( Vector2 const & a, Vector2 const & b, Vector2 const & c, Vector2 const & d )
-	{
-		return Vector2(
-		 T( 0.25 * ( a.x + b.x + c.x + d.x ) ),
-		 T( 0.25 * ( a.y + b.y + c.y + d.y ) )
-		);
 	}
 
 	// Angle Between Two Vector2s (in Radians on [0,pi])

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Vector3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Vector3.hh
@@ -15,6 +15,7 @@
 
 // ObjexxFCL Headers
 #include <ObjexxFCL/Vector3.fwd.hh>
+#include <ObjexxFCL/Fmath.hh>
 #include <ObjexxFCL/TypeTraits.hh>
 
 // C++ Headers
@@ -614,48 +615,6 @@ public: // Properties: Predicates
 		return ( length_squared() == T( 1 ) );
 	}
 
-public: // Properties: Comparison
-
-	// Equal Length?
-	inline
-	bool
-	equal_length( Vector3 const & v )
-	{
-		return ( length_squared() == v.length_squared() );
-	}
-
-	// Longer?
-	inline
-	bool
-	longer( Vector3 const & v )
-	{
-		return ( length_squared() > v.length_squared() );
-	}
-
-	// Longer or Equal Length?
-	inline
-	bool
-	longer_or_equal( Vector3 const & v )
-	{
-		return ( length_squared() >= v.length_squared() );
-	}
-
-	// Shorter?
-	inline
-	bool
-	shorter( Vector3 const & v )
-	{
-		return ( length_squared() < v.length_squared() );
-	}
-
-	// Shorter or Equal Length?
-	inline
-	bool
-	shorter_or_equal( Vector3 const & v )
-	{
-		return ( length_squared() <= v.length_squared() );
-	}
-
 public: // Properties: General
 
 	// Size
@@ -719,7 +678,7 @@ public: // Properties: General
 	T
 	norm_Linf() const
 	{
-		return max3( std::abs( x ), std::abs( y ), std::abs( z ) );
+		return ObjexxFCL::max( std::abs( x ), std::abs( y ), std::abs( z ) );
 	}
 
 	// Distance
@@ -883,6 +842,23 @@ public: // Modifiers
 		return *this;
 	}
 
+	// Normalize to a Length: Uniform Vector3 if Length is Zero
+	inline
+	Vector3 &
+	normalize_uniform( T const & tar_length = T( 1 ) )
+	{
+		T const cur_length( length() );
+		if ( cur_length > T( 0 ) ) {
+			T const dilation( tar_length / cur_length );
+			x *= dilation;
+			y *= dilation;
+			z *= dilation;
+		} else { // Set uniform vector
+			operator =( uniform_vector( tar_length ) );
+		}
+		return *this;
+	}
+
 	// Normalize to a Length: x Vector3 if Length is Zero
 	inline
 	Vector3 &
@@ -937,24 +913,7 @@ public: // Modifiers
 		return *this;
 	}
 
-	// Normalize to a Length: Uniform Vector3 if Length is Zero
-	inline
-	Vector3 &
-	normalize_uniform( T const & tar_length = T( 1 ) )
-	{
-		T const cur_length( length() );
-		if ( cur_length > T( 0 ) ) {
-			T const dilation( tar_length / cur_length );
-			x *= dilation;
-			y *= dilation;
-			z *= dilation;
-		} else { // Set uniform vector
-			operator =( uniform_vector( tar_length ) );
-		}
-		return *this;
-	}
-
-	// Set Minimum Coordinates wrt a Vector3
+	// Minimum Coordinates with a Vector3
 	inline
 	Vector3 &
 	min( Vector3 const & v )
@@ -965,7 +924,7 @@ public: // Modifiers
 		return *this;
 	}
 
-	// Set Maximum Coordinates wrt a Vector3
+	// Maximum Coordinates with a Vector3
 	inline
 	Vector3 &
 	max( Vector3 const & v )
@@ -976,85 +935,29 @@ public: // Modifiers
 		return *this;
 	}
 
-	// Sum of Vector3s
+	// Sum In a Vector3
 	inline
 	Vector3 &
-	sum( Vector3 const & a, Vector3 const & b )
+	sum( Vector3 const & v )
 	{
-		x = a.x + b.x;
-		y = a.y + b.y;
-		z = a.z + b.z;
+		x += v.x;
+		y += v.y;
+		z += v.z;
 		return *this;
 	}
 
-	// Difference of Vector3s
+	// Subtract Out a Vector3
 	inline
 	Vector3 &
-	diff( Vector3 const & a, Vector3 const & b )
+	sub( Vector3 const & v )
 	{
-		x = a.x - b.x;
-		y = a.y - b.y;
-		z = a.z - b.z;
+		x -= v.x;
+		y -= v.y;
+		z -= v.z;
 		return *this;
 	}
 
-	// Cross Product of Vector3s
-	inline
-	Vector3 &
-	cross( Vector3 const & a, Vector3 const & b )
-	{
-		x = ( a.y * b.z ) - ( a.z * b.y );
-		y = ( a.z * b.x ) - ( a.x * b.z );
-		z = ( a.x * b.y ) - ( a.y * b.x );
-		return *this;
-	}
-
-	// Midpoint of Two Vector3s
-	inline
-	Vector3 &
-	mid( Vector3 const & a, Vector3 const & b )
-	{
-		x = T( 0.5 * ( a.x + b.x ) );
-		y = T( 0.5 * ( a.y + b.y ) );
-		z = T( 0.5 * ( a.z + b.z ) );
-		return *this;
-	}
-
-	// Center of Two Vector3s
-	inline
-	Vector3 &
-	cen( Vector3 const & a, Vector3 const & b )
-	{
-		x = T( 0.5 * ( a.x + b.x ) );
-		y = T( 0.5 * ( a.y + b.y ) );
-		z = T( 0.5 * ( a.z + b.z ) );
-		return *this;
-	}
-
-	// Center of Three Vector3s
-	inline
-	Vector3 &
-	cen( Vector3 const & a, Vector3 const & b, Vector3 const & c )
-	{
-		static long double const third( 1.0 / 3.0 );
-		x = T( third * ( a.x + b.x + c.x ) );
-		y = T( third * ( a.y + b.y + c.y ) );
-		z = T( third * ( a.z + b.z + c.z ) );
-		return *this;
-	}
-
-	// Center of Four Vector3s
-	inline
-	Vector3 &
-	cen( Vector3 const & a, Vector3 const & b, Vector3 const & c, Vector3 const & d )
-	{
-		x = T( 0.25 * ( a.x + b.x + c.x + d.x ) );
-		y = T( 0.25 * ( a.y + b.y + c.y + d.y ) );
-		z = T( 0.25 * ( a.z + b.z + c.z + d.z ) );
-		return *this;
-	}
-
-	// Project Normally onto a Vector3
+	// Project Normal to a Vector3
 	inline
 	Vector3 &
 	project_normal( Vector3 const & v )
@@ -1067,7 +970,7 @@ public: // Modifiers
 		return *this;
 	}
 
-	// Project in Direction of a Vector3
+	// Project onto a Vector3
 	inline
 	Vector3 &
 	project_parallel( Vector3 const & v )
@@ -1131,6 +1034,24 @@ public: // Generators
 		}
 	}
 
+	// Normalized to a Length: Uniform Vector3 if Length is Zero
+	inline
+	Vector3
+	normalized_uniform( T const & tar_length = T( 1 ) ) const
+	{
+		T const cur_length( length() );
+		if ( cur_length > T( 0 ) ) {
+			T const dilation( tar_length / cur_length );
+			return Vector3(
+			 x * dilation,
+			 y * dilation,
+			 z * dilation
+			);
+		} else { // Return uniform vector
+			return uniform_vector( tar_length );
+		}
+	}
+
 	// Normalized to a Length: x Vector3 if Length is Zero
 	inline
 	Vector3
@@ -1182,24 +1103,6 @@ public: // Generators
 			);
 		} else { // Return z vector
 			return Vector3( tar_length, T( 0 ), T( 0 ), tar_length );
-		}
-	}
-
-	// Normalized to a Length: Uniform Vector3 if Length is Zero
-	inline
-	Vector3
-	normalized_uniform( T const & tar_length = T( 1 ) ) const
-	{
-		T const cur_length( length() );
-		if ( cur_length > T( 0 ) ) {
-			T const dilation( tar_length / cur_length );
-			return Vector3(
-			 x * dilation,
-			 y * dilation,
-			 z * dilation
-			);
-		} else { // Return uniform vector
-			return uniform_vector( tar_length );
 		}
 	}
 
@@ -1331,7 +1234,7 @@ public: // Generators
 		return Vector3( t / v.x, t / v.y, t / v.z );
 	}
 
-	// Vector3 with Min Coordinates of Two Vector3s
+	// Minimum of Two Vector3s
 	friend
 	inline
 	Vector3
@@ -1344,7 +1247,33 @@ public: // Generators
 		);
 	}
 
-	// Vector3 with Max Coordinates of Two Vector3s
+	// Minimum of Three Vector3s
+	friend
+	inline
+	Vector3
+	min( Vector3 const & a, Vector3 const & b, Vector3 const & c )
+	{
+		return Vector3(
+		 ObjexxFCL::min( a.x, b.x, c.x ),
+		 ObjexxFCL::min( a.y, b.y, c.y ),
+		 ObjexxFCL::min( a.z, b.z, c.z )
+		);
+	}
+
+	// Minimum of Four Vector3s
+	friend
+	inline
+	Vector3
+	min( Vector3 const & a, Vector3 const & b, Vector3 const & c, Vector3 const & d )
+	{
+		return Vector3(
+		 ObjexxFCL::min( a.x, b.x, c.x, d.x ),
+		 ObjexxFCL::min( a.y, b.y, c.y, d.y ),
+		 ObjexxFCL::min( a.z, b.z, c.z, d.z )
+		);
+	}
+
+	// Maximum of Two Vector3s
 	friend
 	inline
 	Vector3
@@ -1357,7 +1286,122 @@ public: // Generators
 		);
 	}
 
-	// Projected Normally onto a Vector3
+	// Maximum of Three Vector3s
+	friend
+	inline
+	Vector3
+	max( Vector3 const & a, Vector3 const & b, Vector3 const & c )
+	{
+		return Vector3(
+		 ObjexxFCL::max( a.x, b.x, c.x ),
+		 ObjexxFCL::max( a.y, b.y, c.y ),
+		 ObjexxFCL::max( a.z, b.z, c.z )
+		);
+	}
+
+	// Maximum of Four Vector3s
+	friend
+	inline
+	Vector3
+	max( Vector3 const & a, Vector3 const & b, Vector3 const & c, Vector3 const & d )
+	{
+		return Vector3(
+		 ObjexxFCL::max( a.x, b.x, c.x, d.x ),
+		 ObjexxFCL::max( a.y, b.y, c.y, d.y ),
+		 ObjexxFCL::max( a.z, b.z, c.z, d.z )
+		);
+	}
+
+	// Sum of Two Vector3s
+	friend
+	inline
+	Vector3
+	sum( Vector3 const & a, Vector3 const & b )
+	{
+		return Vector3( a.x + b.x, a.y + b.y, a.z + b.z );
+	}
+
+	// Sum of Three Vector3s
+	friend
+	inline
+	Vector3
+	sum( Vector3 const & a, Vector3 const & b, Vector3 const & c )
+	{
+		return Vector3( a.x + b.x + c.x, a.y + b.y + c.y, a.z + b.z + c.z );
+	}
+
+	// Sum of Four Vector3s
+	friend
+	inline
+	Vector3
+	sum( Vector3 const & a, Vector3 const & b, Vector3 const & c, Vector3 const & d )
+	{
+		return Vector3( a.x + b.x + c.x + d.x, a.y + b.y + c.y + d.y, a.z + b.z + c.z + d.z );
+	}
+
+	// Subtract of Two Vector3s
+	friend
+	inline
+	Vector3
+	sub( Vector3 const & a, Vector3 const & b )
+	{
+		return Vector3( a.x - b.x, a.y - b.y, a.z - b.z );
+	}
+
+	// Midpoint of Two Vector3s
+	friend
+	inline
+	Vector3
+	mid( Vector3 const & a, Vector3 const & b )
+	{
+		return Vector3(
+		 T( 0.5 * ( a.x + b.x ) ),
+		 T( 0.5 * ( a.y + b.y ) ),
+		 T( 0.5 * ( a.z + b.z ) )
+		);
+	}
+
+	// Center of Two Vector3s
+	friend
+	inline
+	Vector3
+	cen( Vector3 const & a, Vector3 const & b )
+	{
+		return Vector3(
+		 T( 0.5 * ( a.x + b.x ) ),
+		 T( 0.5 * ( a.y + b.y ) ),
+		 T( 0.5 * ( a.z + b.z ) )
+		);
+	}
+
+	// Center of Three Vector3s
+	friend
+	inline
+	Vector3
+	cen( Vector3 const & a, Vector3 const & b, Vector3 const & c )
+	{
+		static long double const third( 1.0 / 3.0 );
+		return Vector3(
+		 T( third * ( a.x + b.x + c.x ) ),
+		 T( third * ( a.y + b.y + c.y ) ),
+		 T( third * ( a.z + b.z + c.z ) )
+		);
+	}
+
+	// Center of Four Vector3s
+	friend
+	inline
+	Vector3
+	cen( Vector3 const & a, Vector3 const & b, Vector3 const & c, Vector3 const & d )
+	{
+		return Vector3(
+		 T( 0.25 * ( a.x + b.x + c.x + d.x ) ),
+		 T( 0.25 * ( a.y + b.y + c.y + d.y ) ),
+		 T( 0.25 * ( a.z + b.z + c.z + d.z ) )
+		);
+	}
+
+	// Projected Normal to a Vector3
 	inline
 	Vector3
 	projected_normal( Vector3 const & v ) const
@@ -1367,7 +1411,7 @@ public: // Generators
 		return Vector3( x - ( c * v.x ), y - ( c * v.y ), z - ( c * v.z ) );
 	}
 
-	// Projected in Direction of a Vector3
+	// Projected onto a Vector3
 	inline
 	Vector3
 	projected_parallel( Vector3 const & v ) const
@@ -1611,14 +1655,6 @@ public: // Friends: Comparison
 	}
 
 	// Not Equal Length?
-	inline
-	bool
-	not_equal_length( Vector3 const & v )
-	{
-		return ( length_squared() != v.length_squared() );
-	}
-
-	// Not Equal Length?
 	friend
 	inline
 	bool
@@ -1666,59 +1702,6 @@ public: // Friends
 		 ( a.y * b.z ) - ( a.z * b.y ),
 		 ( a.z * b.x ) - ( a.x * b.z ),
 		 ( a.x * b.y ) - ( a.y * b.x )
-		);
-	}
-
-	// Midpoint of Two Vector3s
-	friend
-	inline
-	Vector3
-	mid( Vector3 const & a, Vector3 const & b )
-	{
-		return Vector3(
-		 T( 0.5 * ( a.x + b.x ) ),
-		 T( 0.5 * ( a.y + b.y ) ),
-		 T( 0.5 * ( a.z + b.z ) )
-		);
-	}
-
-	// Center of Two Vector3s
-	friend
-	inline
-	Vector3
-	cen( Vector3 const & a, Vector3 const & b )
-	{
-		return Vector3(
-		 T( 0.5 * ( a.x + b.x ) ),
-		 T( 0.5 * ( a.y + b.y ) ),
-		 T( 0.5 * ( a.z + b.z ) )
-		);
-	}
-
-	// Center of Three Vector3s
-	friend
-	inline
-	Vector3
-	cen( Vector3 const & a, Vector3 const & b, Vector3 const & c )
-	{
-		static long double const third( 1.0 / 3.0 );
-		return Vector3(
-		 T( third * ( a.x + b.x + c.x ) ),
-		 T( third * ( a.y + b.y + c.y ) ),
-		 T( third * ( a.z + b.z + c.z ) )
-		);
-	}
-
-	// Center of Four Vector3s
-	friend
-	inline
-	Vector3
-	cen( Vector3 const & a, Vector3 const & b, Vector3 const & c, Vector3 const & d )
-	{
-		return Vector3(
-		 T( 0.25 * ( a.x + b.x + c.x + d.x ) ),
-		 T( 0.25 * ( a.y + b.y + c.y + d.y ) ),
-		 T( 0.25 * ( a.z + b.z + c.z + d.z ) )
 		);
 	}
 
@@ -1808,15 +1791,6 @@ private: // Methods
 	{
 		static T const Two_Pi( T( 2 ) * std::acos( -1.0 ) );
 		return ( t >= T( 0 ) ? t : Two_Pi + t );
-	}
-
-	// Max of Three Values
-	inline
-	static
-	T const &
-	max3( T const & a, T const & b, T const & c )
-	{
-		return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 	}
 
 public: // Data

--- a/third_party/ObjexxFCL/tst/unit/Array.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array.unit.cc
@@ -51,6 +51,15 @@ TEST( ArrayTest, Construction2DIndexRangeInitializerList )
 			EXPECT_EQ( k, r( i, j ) );
 		}
 	}
+	int v( 0 );
+	for ( auto const e : r ) {
+		EXPECT_EQ( ++v, e );
+	}
+	v = 10;
+	for ( auto & e : r ) {
+		e = ++v;
+		EXPECT_EQ( v, e );
+	}
 }
 
 TEST( ArrayTest, Construction2DDifferentValueType )

--- a/third_party/ObjexxFCL/tst/unit/Array1.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array1.unit.cc
@@ -105,6 +105,10 @@ TEST( Array1Test, ConstructionInitializerListOnlyInt )
 	EXPECT_EQ( 1.0, r( 1 ) );
 	EXPECT_EQ( 2.0, r( 2 ) );
 	EXPECT_EQ( 3.0, r( 3 ) );
+	int v( 0 );
+	for ( auto const e : r ) {
+		EXPECT_EQ( ++v, e );
+	}
 }
 
 TEST( Array1Test, ConstructionInitializerListOnlyUnsigned )

--- a/third_party/ObjexxFCL/tst/unit/Array2.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array2.unit.cc
@@ -1206,6 +1206,15 @@ TEST( Array2Test, AssignArithmeticArgument )
 	EXPECT_TRUE( eq( Array2D_int( 2, 3, 11 ), A1 ) );
 }
 
+TEST( Array2Test, RangeBasedFor )
+{
+	Array2D_int A( 2, 3, { 1, 2, 3, 4, 5, 6 } );
+	int v( 0 );
+	for ( auto const e : A ) {
+		EXPECT_EQ( ++v, e );
+	}
+}
+
 TEST( Array2Test, SubscriptTail )
 {
 	Array2D_double A1( 2, 3, { 1.1, 1.2, 1.3, 2.1, 2.2, 2.3 } );

--- a/third_party/ObjexxFCL/tst/unit/Array3.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array3.unit.cc
@@ -108,6 +108,15 @@ TEST( Array3Test, ConstructIndexes )
 	EXPECT_FALSE( A.initializer_active() );
 }
 
+TEST( Array3Test, RangeBasedFor )
+{
+	Array3D_int A( 2, 2, 2, { 1, 2, 3, 4, 5, 6, 7, 8 } );
+	int v( 0 );
+	for ( auto const e : A ) {
+		EXPECT_EQ( ++v, e );
+	}
+}
+
 TEST( Array3Test, Subscript )
 {
 	Array3D_int A( 2, 2, 2, {

--- a/third_party/ObjexxFCL/tst/unit/Array4.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array4.unit.cc
@@ -125,6 +125,15 @@ TEST( Array4Test, ConstructIndexes )
 	EXPECT_FALSE( A.initializer_active() );
 }
 
+TEST( Array4Test, RangeBasedFor )
+{
+	Array4D_int A( 2, 2, 2, 2, { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } );
+	int v( 0 );
+	for ( auto const e : A ) {
+		EXPECT_EQ( ++v, e );
+	}
+}
+
 TEST( Array4Test, Subscript )
 {
 	Array4D_int A( 2, 2, 2, 2, {

--- a/third_party/ObjexxFCL/tst/unit/Array5.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array5.unit.cc
@@ -142,6 +142,16 @@ TEST( Array5Test, ConstructIndexes )
 	EXPECT_FALSE( A.initializer_active() );
 }
 
+TEST( Array5Test, RangeBasedFor )
+{
+	Array5D_int A( 2, 2, 2, 2, 2 );
+	int v( 0 );
+	for ( auto & e : A ) {
+		e = ++v;
+		EXPECT_EQ( v, e );
+	}
+}
+
 TEST( Array5Test, Subscript )
 {
 	Array5D_int A( 2, 2, 2, 2, 2, {

--- a/third_party/ObjexxFCL/tst/unit/Array6.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array6.unit.cc
@@ -159,6 +159,16 @@ TEST( Array6Test, ConstructIndexes )
 	EXPECT_FALSE( A.initializer_active() );
 }
 
+TEST( Array6Test, RangeBasedFor )
+{
+	Array6D_int A( 2, 2, 2, 2, 2, 2 );
+	int v( 0 );
+	for ( auto & e : A ) {
+		e = ++v;
+		EXPECT_EQ( v, e );
+	}
+}
+
 TEST( Array6Test, Subscript )
 {
 	Array6D_int A( 2, 2, 2, 2, 2, 2, {

--- a/third_party/ObjexxFCL/tst/unit/Vector2.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Vector2.unit.cc
@@ -211,13 +211,7 @@ TEST( Vector2Test, Comparisons )
 
 	// Test length relations
 	EXPECT_TRUE( ! equal_length( v, w ) );
-	EXPECT_TRUE( ! v.equal_length( w ) );
 	EXPECT_TRUE( not_equal_length( v, w ) );
-	EXPECT_TRUE( v.not_equal_length( w ) );
-	EXPECT_TRUE( v.longer( w ) );
-	EXPECT_TRUE( ! v.shorter( w ) );
-	EXPECT_TRUE( v.longer_or_equal( w ) );
-	EXPECT_TRUE( ! v.shorter_or_equal( w ) );
 }
 
 TEST( Vector2Test, Generators )

--- a/third_party/ObjexxFCL/tst/unit/Vector3.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Vector3.unit.cc
@@ -252,13 +252,7 @@ TEST( Vector3Test, Comparisons )
 
 	// Test length relations
 	EXPECT_TRUE( ! equal_length( v, w ) );
-	EXPECT_TRUE( ! v.equal_length( w ) );
 	EXPECT_TRUE( not_equal_length( v, w ) );
-	EXPECT_TRUE( v.not_equal_length( w ) );
-	EXPECT_TRUE( v.longer( w ) );
-	EXPECT_TRUE( ! v.shorter( w ) );
-	EXPECT_TRUE( v.longer_or_equal( w ) );
-	EXPECT_TRUE( ! v.shorter_or_equal( w ) );
 }
 
 TEST( Vector3Test, Generators )


### PR DESCRIPTION
Iterators were added to the ObjexxFCL Array types to allow use in some standard library algorithms and the new range-based for loops. These are just linear memory traversal ordered so with the current row-major Arrays this means traversing in "row" (last index fastest) order.

Some refinements to the ObjexxFCL Vector2 and Vector3 APIs were made to avoid potentially confusing in-place modifier methods that aren't needed for performance with decent compiler RVO.
