### PR TITLE
Add HotWater preheat coil as valid type in HVACTemplate systems

### DIFF
--- a/doc/src/docs/InputOutputReference/02-HVACTemplates.md
+++ b/doc/src/docs/InputOutputReference/02-HVACTemplates.md
@@ -4446,6 +4446,8 @@ Enter the parasitic electric load associated with the gas heating operation, suc
 
 The preheat coil is located in the outdoor air stream, upstream of the outdoor air mixing box and tempers the outdoor air. If no preheat coil is used in the VAV system, then the option “none” should be specified here. Otherwise this indicates the type of preheat coil. It is unlikely that both a heating coil and a preheat coil would be used at the same time. The choices for this field are
 
+- HotWater
+
 - Electric
 
 - Gas
@@ -5405,6 +5407,8 @@ Enter the parasitic electric load associated with the gas heating operation, suc
 
 The preheat coil is located in the outdoor air stream, upstream of the outdoor air mixing box and tempers the outdoor air. If no preheat coil is used in the constant volume system, then the option “none” should be specified here. Otherwise this indicates the type of preheat coil. It is unlikely that both a heating coil and a preheat coil would be used at the same time. The choices for this field are
 
+- HotWater
+
 - Electric
 
 - Gas
@@ -5979,6 +5983,8 @@ Enter the parasitic electric load associated with the gas heating operation, suc
 #### Field: Preheat Coil Type
 
 The preheat coil is located in the outdoor air stream, upstream of the outdoor air mixing box and tempers the outdoor air. If no preheat coil is used in the constant volume system, then the option “none” should be specified here. Otherwise this indicates the type of preheat coil. It is unlikely that both a heating coil and a preheat coil would be used at the same time. The choices for this field are
+
+- HotWater
 
 - Electric
 

--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -27903,6 +27903,7 @@ HVACTemplate:System:VAV,
       \default 0.0
   A9, \field Preheat Coil Type
       \type choice
+      \key  HotWater
       \key  Electric
       \key  Gas
       \key  None
@@ -28665,6 +28666,7 @@ HVACTemplate:System:ConstantVolume,
       \default 0.0
  A14, \field Preheat Coil Type
       \type choice
+      \key  HotWater
       \key  Electric
       \key  Gas
       \key  None
@@ -29134,6 +29136,7 @@ HVACTemplate:System:DualDuct,
       \default 0.0
  A17, \field Preheat Coil Type
       \type choice
+      \key  HotWater
       \key  Electric
       \key  Gas
       \key  None


### PR DESCRIPTION
Addresses #4890 and #4097 
The code for HVACTemplate systems with hotwater preheat has been present in expandobjects, but it was not a valid choice in the IDD, nor was it mentioned in the I/O Ref.  This pull request addresses the idd and documentation.  Testing of all the preheat coil types in HVACTemplate:System:VAV, ConstantVolume, and DualDuct revealed two new issues, one in HVACDiagram #4912 and one in EnergyPlus #4910 .
