### PR TITLE
Reduce testing runtime for basement simulation files

### DIFF
--- a/cmake/RunSimulation.cmake
+++ b/cmake/RunSimulation.cmake
@@ -59,6 +59,8 @@ endif()
 
 if(BUILD_FORTRAN)
 
+  set(ENV{CI_BASEMENT_NUMYEARS} "2")
+
   # Parametric preprocessor next
   string(FIND "${IDF_CONTENT}" "Parametric:" PAR_RESULT)
   if ( "${PAR_RESULT}" GREATER -1 )

--- a/src/Basement/3DBasementHT.f90
+++ b/src/Basement/3DBasementHT.f90
@@ -971,6 +971,11 @@ IMPLICIT NONE
      REAL(r64),DIMENSION(3)              :: NumArray  !numeric data
      CHARACTER *3 RUNID
 
+     INTEGER :: EnvVarNumYearsStringLength
+     CHARACTER * 4 :: EnvVarNumYearsString
+     INTEGER :: EnvVarNumYears
+     INTEGER :: EnvVarNumYearsStatus
+
      ! Set defaults
      SimParams%F=.1d0
      SimParams%IYRS=15
@@ -1003,6 +1008,25 @@ IMPLICIT NONE
        SimParams%F=.1d0
      ENDIF
      SimParams%IYRS =NumArray(2)
+     
+     ! Override with environment variable for quicker testing
+     CALL GET_ENVIRONMENT_VARIABLE("CI_BASEMENT_NUMYEARS", EnvVarNumYearsString, EnvVarNumYearsStringLength, EnvVarNumYearsStatus)
+     SELECT CASE (EnvVarNumYearsStatus)
+     CASE (-1)
+       ! environment variable exists, but too big to fit in the string; ignoring
+     CASE (1)
+       ! environment variable does not exist, move along
+     CASE (2)
+       ! no environment variables, what?
+     CASE (0)
+       ! good, got a nice value, try to read it into the integer
+       READ(EnvVarNumYearsString, '(I4)', IOSTAT=EnvVarNumYearsStatus) EnvVarNumYears
+       ! if it worked, assign the value, if not just ignore and move on
+       IF (EnvVarNumYearsStatus == 0) THEN
+         SimParams%IYRS = EnvVarNumYears
+       END IF
+     END SELECT
+          
      IF (SimParams%IYRS <= 0.d0) THEN
        CALL ShowSevereError('GetSimParams: Entered "IYRS: Maximum number of yearly iterations:" '//  &
           'choice is not valid.'//  &


### PR DESCRIPTION
The CI testing time is _dominated_ by the basement runtime.  The other X hundred example files finish, then for a long time the basement file churns away.  In some cases on debug builds, it even hits the 1 hour timeout and fails, leaving CI in an artificial warn state.  

This change doesn't affect the example file at all, it simply adds an environment variable within the basement code that limits the number of years to simulate the basement.  For our CI regression testing, we don't care that it doesn't reach the 10 year convergence.

I tested this out and it was substantially better.  There will be regressions in the basement files, yes.  But once this commit is merged into develop, there won't be any diffs in the future.  

I foresee this to be easy to merge in.  @mjwitte do you have any thoughts?  I already know that @mbadams5 likes this :smile:.  @kbenne any thoughts on the CMake way I did this?  A better way?
