### PR TITLE
ObjexxFCL Array grow-friendly API and reverse iterator extensions/fixups

### DIFF
--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
@@ -118,7 +118,7 @@ protected: // Creation
 	// Default Constructor
 	inline
 	Array() :
-	 data_size_( 0u ),
+	 capacity_( 0u ),
 	 data_( nullptr ),
 	 size_( 0u ),
 	 owner_( true ),
@@ -130,13 +130,13 @@ protected: // Creation
 	inline
 	Array( Array const & a ) :
 	 BArray( a ),
-	 data_size_( size_of( a.size_ ) ),
+	 capacity_( size_of( a.size_ ) ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( a.data_ ? new T[ data_size_ ] : nullptr ),
+	 data_( a.data_ ? new T[ capacity_ ] : nullptr ),
 #else
 	 data_( a.data_ ? new_array< T >() : nullptr ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( a.shift_ ),
 	 sdata_( data_ - shift_ )
@@ -150,14 +150,14 @@ protected: // Creation
 	inline
 	Array( Array && a ) NOEXCEPT :
 	 BArray( std::move( a ) ),
-	 data_size_( a.data_size_ ),
+	 capacity_( a.capacity_ ),
 	 data_( a.data_ ),
 	 size_( a.size_ ),
 	 owner_( a.owner_ ),
 	 shift_( a.shift_ ),
 	 sdata_( a.sdata_ )
 	{
-		a.data_size_ = 0u;
+		a.capacity_ = 0u;
 		a.data_ = nullptr;
 		a.size_ = 0u;
 		a.shift_ = 0;
@@ -169,13 +169,13 @@ protected: // Creation
 	inline
 	explicit
 	Array( Array< U > const & a ) :
-	 data_size_( size_of( a.size() ) ),
+	 capacity_( size_of( a.size() ) ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( a.data_ ? new T[ data_size_ ] : nullptr ),
+	 data_( a.data_ ? new T[ capacity_ ] : nullptr ),
 #else
 	 data_( a.data_ ? new_array< T >() : nullptr ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( a.shift_ ),
 	 sdata_( data_ - shift_ )
@@ -190,13 +190,13 @@ protected: // Creation
 	inline
 	explicit
 	Array( ArrayS< U > const & a ) :
-	 data_size_( size_of( a.size() ) ),
+	 capacity_( size_of( a.size() ) ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -207,13 +207,13 @@ protected: // Creation
 	inline
 	explicit
 	Array( MArray< A, M > const & a ) :
-	 data_size_( size_of( a.size() ) ),
+	 capacity_( size_of( a.size() ) ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -223,13 +223,13 @@ protected: // Creation
 	inline
 	explicit
 	Array( size_type const size ) :
-	 data_size_( size_of( size ) ),
+	 capacity_( size_of( size ) ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -242,13 +242,13 @@ protected: // Creation
 	// Size + InitializerSentinel Constructor
 	inline
 	Array( size_type const size, InitializerSentinel const & ) :
-	 data_size_( size_of( size ) ),
+	 capacity_( size_of( size ) ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -258,13 +258,13 @@ protected: // Creation
 	template< typename U, class = typename std::enable_if< std::is_constructible< T, U >::value >::type >
 	inline
 	Array( std::initializer_list< U > const l ) :
-	 data_size_( l.size() ),
+	 capacity_( l.size() ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -279,13 +279,13 @@ protected: // Creation
 	template< typename U, Size s, class = typename std::enable_if< std::is_constructible< T, U >::value >::type >
 	inline
 	Array( std::array< U, s > const & a ) :
-	 data_size_( s ),
+	 capacity_( s ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -300,13 +300,13 @@ protected: // Creation
 	template< typename U, class = typename std::enable_if< std::is_constructible< T, U >::value >::type >
 	inline
 	Array( std::vector< U > const & v ) :
-	 data_size_( v.size() ),
+	 capacity_( v.size() ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -321,13 +321,13 @@ protected: // Creation
 	template< typename U, class = typename std::enable_if< std::is_constructible< T, U >::value >::type >
 	inline
 	Array( Vector2< U > const & v ) :
-	 data_size_( 2 ),
+	 capacity_( 2 ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -340,13 +340,13 @@ protected: // Creation
 	template< typename U, class = typename std::enable_if< std::is_constructible< T, U >::value >::type >
 	inline
 	Array( Vector3< U > const & v ) :
-	 data_size_( 3 ),
+	 capacity_( 3 ),
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-	 data_( new T[ data_size_ ] ),
+	 data_( new T[ capacity_ ] ),
 #else
 	 data_( new_array< T >() ),
 #endif
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( true ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -359,7 +359,7 @@ protected: // Creation
 	// Default Proxy Constructor
 	inline
 	Array( ProxySentinel const & ) :
-	 data_size_( 0u ),
+	 capacity_( 0u ),
 	 data_( nullptr ),
 	 size_( 0u ),
 	 owner_( false ),
@@ -370,7 +370,7 @@ protected: // Creation
 	// Array Proxy Constructor
 	inline
 	Array( Array const & a, ProxySentinel const & ) :
-	 data_size_( a.data_size_ ),
+	 capacity_( a.capacity_ ),
 	 data_( a.data_ ),
 	 size_( a.size_ ),
 	 owner_( false ),
@@ -381,7 +381,7 @@ protected: // Creation
 	// Slice Proxy Constructor
 	inline
 	Array( ArrayS< T > const & a, ProxySentinel const & ) :
-	 data_size_( a.size() ),
+	 capacity_( a.size() ),
 	 data_( a.data_beg_ ),
 	 size_( a.size() ),
 	 owner_( false ),
@@ -394,9 +394,9 @@ protected: // Creation
 	// Tail Proxy Constructor
 	inline
 	Array( Tail const & s, ProxySentinel const & ) :
-	 data_size_( s.size() ),
+	 capacity_( s.size() ),
 	 data_( s.data_ ),
-	 size_( data_size_ ),
+	 size_( capacity_ ),
 	 owner_( false ),
 	 shift_( 0 ),
 	 sdata_( nullptr )
@@ -405,7 +405,7 @@ protected: // Creation
 	// Value Proxy Constructor
 	inline
 	Array( T const & t, ProxySentinel const & ) :
-	 data_size_( npos ), // Unknown
+	 capacity_( npos ), // Unknown
 	 data_( const_cast< T * >( &t ) ),
 	 size_( npos ), // Unbounded
 	 owner_( false ),
@@ -463,12 +463,12 @@ protected: // Assignment: Array
 #else
 		if ( owner_ ) del_array();
 #endif
-		data_size_ = a.data_size_;
+		capacity_ = a.capacity_;
 		data_ = a.data_;
 		size_ = a.size_;
 		shift_ = a.shift_;
 		sdata_ = a.sdata_;
-		a.data_size_ = 0u;
+		a.capacity_ = 0u;
 		a.data_ = nullptr;
 		a.size_ = 0u;
 		a.shift_ = 0;
@@ -1290,17 +1290,17 @@ public: // Predicate
 	// Data Size Bounded?
 	inline
 	bool
-	data_size_bounded() const
+	capacity_bounded() const
 	{
-		return ( data_size_ != npos );
+		return ( capacity_ != npos );
 	}
 
 	// Data Size Unbounded?
 	inline
 	bool
-	data_size_unbounded() const
+	capacity_unbounded() const
 	{
-		return ( data_size_ == npos );
+		return ( capacity_ == npos );
 	}
 
 	// Active Array Empty?
@@ -1429,9 +1429,9 @@ public: // Inspector
 	// Data Size
 	inline
 	size_type
-	data_size() const
+	capacity() const
 	{
-		return data_size_;
+		return capacity_;
 	}
 
 	// Active Array Size
@@ -1476,71 +1476,71 @@ public: // Inspector
 	int
 	isize( int const d ) const = 0;
 
-	// Array Begin Iterator
+	// Begin Iterator
 	inline
-	T const *
+	const_iterator
 	begin() const
 	{
 		return data_;
 	}
 
-	// Array Begin Iterator
+	// Begin Iterator
 	inline
-	T *
+	iterator
 	begin()
 	{
 		return data_;
 	}
 
-	// Array End Iterator
+	// End Iterator
 	inline
-	T const *
+	const_iterator
 	end() const
 	{
-		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ : nullptr );
+		return ( ( data_ != nullptr ) && ( size_ != npos ) ? data_ + size_ : nullptr );
 	}
 
-	// Array End Iterator
+	// End Iterator
 	inline
-	T *
+	iterator
 	end()
 	{
-		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ : nullptr );
+		return ( ( data_ != nullptr ) && ( size_ != npos ) ? data_ + size_ : nullptr );
 	}
 
-	// Array Reverse Begin Iterator
+	// Reverse Begin Iterator
 	inline
-	std::reverse_iterator< T const * >
+	const_reverse_iterator
 	rbegin() const
 	{
-		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ - 1 : nullptr );
+		return const_reverse_iterator( ( data_ != nullptr ) && ( size_ != npos ) ? data_ + size_ : nullptr );
 	}
 
-	// Array Reverse Begin Iterator
+	// Reverse Begin Iterator
 	inline
-	std::reverse_iterator< T * >
+	reverse_iterator
 	rbegin()
 	{
-		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ - 1 : nullptr );
+		return reverse_iterator( ( data_ != nullptr ) && ( size_ != npos ) ? data_ + size_ : nullptr );
 	}
 
-	// Array Reverse End Iterator
+	// Reverse End Iterator
 	inline
-	std::reverse_iterator< T const * >
+	const_reverse_iterator
 	rend() const
 	{
-		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ - 1 : nullptr );
+		return const_reverse_iterator( data_ );
 	}
 
-	// Array Reverse End Iterator
+	// Reverse End Iterator
 	inline
-	std::reverse_iterator< T * >
+	reverse_iterator
 	rend()
 	{
-		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ - 1 : nullptr );
+		return reverse_iterator( data_ );
 	}
 
-	// Array Data Pointer
+	// Data Pointer
 	inline
 	T const *
 	data() const
@@ -1548,7 +1548,7 @@ public: // Inspector
 		return data_;
 	}
 
-	// Array Data Pointer
+	// Data Pointer
 	inline
 	T *
 	data()
@@ -1556,7 +1556,7 @@ public: // Inspector
 		return data_;
 	}
 
-	// Array Data Begin Pointer
+	// Data Begin Pointer
 	inline
 	T const *
 	data_beg() const
@@ -1564,7 +1564,7 @@ public: // Inspector
 		return data_;
 	}
 
-	// Array Data Begin Pointer
+	// Data Begin Pointer
 	inline
 	T *
 	data_beg()
@@ -1572,7 +1572,7 @@ public: // Inspector
 		return data_;
 	}
 
-	// Array Data End Pointer
+	// Data End Pointer
 	inline
 	T const *
 	data_end() const
@@ -1580,7 +1580,7 @@ public: // Inspector
 		return ( ( data_ != nullptr ) && ( size_ > 0u ) && ( size_ != npos ) ? data_ + size_ - 1 : nullptr );
 	}
 
-	// Array Data End Pointer
+	// Data End Pointer
 	inline
 	T *
 	data_end()
@@ -1602,7 +1602,7 @@ public: // Modifier
 		if ( owner_ ) del_array();
 #endif
 		data_ = nullptr;
-		data_size_ = 0u;
+		capacity_ = 0u;
 		size_ = 0u;
 		shift_ = 0;
 		sdata_ = nullptr;
@@ -1667,7 +1667,7 @@ public: // Modifier
 		assert( owner_ );
 		assert( v.owner_ );
 		assert( size_ == v.size_ );
-		swap( data_size_, v.data_size_ );
+		swap( capacity_, v.capacity_ );
 		swap( data_, v.data_ );
 		swap( shift_, v.shift_ );
 		swap( sdata_, v.sdata_ );
@@ -2734,32 +2734,109 @@ protected: // Methods
 	void
 	size_set( size_type const size )
 	{
-		assert( size <= data_size_ );
+		assert( size <= capacity_ );
 		size_ = size;
 	}
 
 	// Resize a Real Array
 	inline
-	Array &
+	void
 	resize( size_type const size )
 	{
 		assert( owner_ );
 		assert( size != npos );
-		if ( ( data_size_ != size ) || ( ! data_ ) ) {
+		if ( ( capacity_ != size ) || ( ! data_ ) ) {
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
 			delete[] data_;
-			size_ = data_size_ = size;
-			data_ = new T[ data_size_ ]; // Allocate even if size==0 for consistency with Fortran
+			size_ = capacity_ = size;
+			data_ = new T[ capacity_ ]; // Allocate even if size==0 for consistency with Fortran
 #else
 			del_array();
-			size_ = data_size_ = size;
+			size_ = capacity_ = size;
 			data_ = new_array< T >(); // Allocate even if size==0 for consistency with Fortran
 #endif
 		}
 #if defined(OBJEXXFCL_ARRAY_INIT) || defined(OBJEXXFCL_ARRAY_INIT_DEBUG)
 		if ( ! initializer_active() ) std::fill_n( data_, size_, Traits::initial_array_value() );
 #endif // OBJEXXFCL_ARRAY_INIT || OBJEXXFCL_ARRAY_INIT_DEBUG
-		return *this;
+	}
+
+	// Reserve Capacity in a Real Array
+	inline
+	void
+	reserve_capacity( size_type const n )
+	{
+		assert( owner_ );
+		assert( n != npos );
+		if ( capacity_ < n ) {
+#ifdef OBJEXXFCL_ARRAY_NOALIGN
+			T * new_data = new T[ n ];
+#else
+			T * new_data = new_array< T >( n );
+#endif
+			if ( size_ > 0u ) std::copy( begin(), end(), new_data );
+#ifdef OBJEXXFCL_ARRAY_NOALIGN
+			delete[] data_;
+#else
+			del_array();
+#endif
+			capacity_ = n;
+			data_ = new_data;
+		}
+	}
+
+	// Grow Capacity in a Real Array
+	inline
+	void
+	grow_capacity( size_type const n = 1u )
+	{
+		assert( owner_ );
+		assert( size_ < npos - n );
+		size_type const new_size( size_ + n );
+		if ( capacity_ < new_size ) {
+			size_type const lim_size( std::min( new_size, npos >> 1 ) );
+			size_type new_capacity( std::max( capacity_, size_type( 1u ) ) );
+			while( new_capacity < lim_size ) new_capacity <<= 1;
+			if ( new_capacity < new_size ) new_capacity = max_size;
+#ifdef OBJEXXFCL_ARRAY_NOALIGN
+			T * new_data = new T[ new_capacity ];
+#else
+			T * new_data = new_array< T >( new_capacity );
+#endif
+			if ( size_ > 0u ) std::copy( begin(), end(), new_data );
+#ifdef OBJEXXFCL_ARRAY_NOALIGN
+			delete[] data_;
+#else
+			del_array();
+#endif
+			capacity_ = new_capacity;
+			data_ = new_data;
+		}
+		size_ = new_size;
+	}
+
+	// Shrink Capacity to Size in a Real Array
+	inline
+	void
+	shrink_capacity()
+	{
+		assert( owner_ );
+		if ( capacity_ > size_ ) {
+#ifdef OBJEXXFCL_ARRAY_NOALIGN
+			T * new_data = new T[ size_ ];
+#else
+			T * new_data = new_array< T >( size_ );
+#endif
+			if ( size_ > 0u ) std::copy( begin(), end(), new_data );
+#ifdef OBJEXXFCL_ARRAY_NOALIGN
+			delete[] data_;
+#else
+			del_array();
+#endif
+			capacity_ = size_;
+			data_ = new_data;
+			sdata_ = data_ - shift_;
+		}
 	}
 
 	// Attach Proxy/Argument Array to Const Array of Same Rank
@@ -2768,7 +2845,7 @@ protected: // Methods
 	attach( Array const & a )
 	{
 		assert( ! owner_ );
-		data_size_ = a.data_size_;
+		capacity_ = a.capacity_;
 		data_ = a.data_;
 		size_ = a.size_;
 		shift_ = a.shift_;
@@ -2781,7 +2858,7 @@ protected: // Methods
 	attach( Array & a )
 	{
 		assert( ! owner_ );
-		data_size_ = a.data_size_;
+		capacity_ = a.capacity_;
 		data_ = a.data_;
 		size_ = a.size_;
 		shift_ = a.shift_;
@@ -2795,7 +2872,7 @@ protected: // Methods
 	attach( Array const & a )
 	{
 		assert( ! owner_ );
-		data_size_ = a.data_size_;
+		capacity_ = a.capacity_;
 		data_ = a.data_;
 		size_ = a.size_;
 		shift_ = shift;
@@ -2809,7 +2886,7 @@ protected: // Methods
 	attach( Array & a )
 	{
 		assert( ! owner_ );
-		data_size_ = a.data_size_;
+		capacity_ = a.capacity_;
 		data_ = a.data_;
 		size_ = a.size_;
 		shift_ = shift;
@@ -2823,9 +2900,9 @@ protected: // Methods
 	attach( Tail const & s )
 	{
 		assert( ! owner_ );
-		data_size_ = s.size();
+		capacity_ = s.size();
 		data_ = s.data_;
-		size_ = data_size_;
+		size_ = capacity_;
 		shift_ = shift;
 		sdata_ = data_ - shift_;
 	}
@@ -2837,9 +2914,9 @@ protected: // Methods
 	attach( Tail & s )
 	{
 		assert( ! owner_ );
-		data_size_ = s.size();
+		capacity_ = s.size();
 		data_ = s.data_;
-		size_ = data_size_;
+		size_ = capacity_;
 		shift_ = shift;
 		sdata_ = data_ - shift_;
 	}
@@ -2851,7 +2928,7 @@ protected: // Methods
 	attach( T const & t )
 	{
 		assert( ! owner_ );
-		data_size_ = npos; // Unknown
+		capacity_ = npos; // Unknown
 		data_ = const_cast< T * >( &t );
 		size_ = npos; // Unbounded
 		shift_ = shift;
@@ -2865,7 +2942,7 @@ protected: // Methods
 	attach( T & t )
 	{
 		assert( ! owner_ );
-		data_size_ = npos; // Unknown
+		capacity_ = npos; // Unknown
 		data_ = &t;
 		size_ = npos; // Unbounded
 		shift_ = shift;
@@ -2878,7 +2955,7 @@ protected: // Methods
 	detach()
 	{
 		assert( ! owner_ );
-		data_size_ = 0u;
+		capacity_ = 0u;
 		data_ = nullptr;
 		size_ = 0u;
 		shift_ = 0;
@@ -2891,7 +2968,7 @@ protected: // Methods
 	update_to( Array const & a )
 	{
 		assert( ! owner_ );
-		data_size_ = a.data_size_;
+		capacity_ = a.capacity_;
 		data_ = a.data_;
 	}
 
@@ -2901,7 +2978,7 @@ protected: // Methods
 	update_to( Array & a )
 	{
 		assert( ! owner_ );
-		data_size_ = a.data_size_;
+		capacity_ = a.capacity_;
 		data_ = a.data_;
 	}
 
@@ -2912,7 +2989,7 @@ protected: // Methods
 	{
 		assert( owner_ );
 		assert( v.owner_ );
-		std::swap( data_size_, v.data_size_ );
+		std::swap( capacity_, v.capacity_ );
 		std::swap( data_, v.data_ );
 		std::swap( size_, v.size_ );
 		std::swap( shift_, v.shift_ );
@@ -2977,11 +3054,11 @@ protected: // Methods
 		assert( owner_ );
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
 		delete[] data_;
-		size_ = data_size_ = size;
-		data_ = new T[ data_size_ ];
+		size_ = capacity_ = size;
+		data_ = new T[ capacity_ ];
 #else
 		del_array();
-		size_ = data_size_ = size;
+		size_ = capacity_ = size;
 		data_ = new_array< T >();
 #endif
 #if defined(OBJEXXFCL_ARRAY_INIT) || defined(OBJEXXFCL_ARRAY_INIT_DEBUG)
@@ -3001,10 +3078,10 @@ protected: // Methods
 #else
 		if ( owner_ ) del_array();
 #endif
-		data_size_ = a.data_size_;
+		capacity_ = a.capacity_;
 		data_ = a.data_;
 		sdata_ = data_ - shift_;
-		a.data_size_ = 0u;
+		a.capacity_ = 0u;
 		a.data_ = nullptr;
 		a.size_ = 0u;
 		a.shift_ = 0;
@@ -3182,15 +3259,15 @@ private: // Methods
 	new_array()
 	{
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-		return new T[ data_size_ ];
+		return new T[ capacity_ ];
 #else
 #if defined(_WIN32)
-		return static_cast< T * >( _aligned_malloc( data_size_ * sizeof( T ), OBJEXXFCL_ARRAY_ALIGN ) );
+		return static_cast< T * >( _aligned_malloc( capacity_ * sizeof( T ), OBJEXXFCL_ARRAY_ALIGN ) );
 #elif defined(__linux__)
 		void * p;
-		return ( posix_memalign( &p, OBJEXXFCL_ARRAY_ALIGN, data_size_ * sizeof( T ) ) == 0 ? static_cast< T * >( p ) : nullptr );
+		return ( posix_memalign( &p, OBJEXXFCL_ARRAY_ALIGN, capacity_ * sizeof( T ) ) == 0 ? static_cast< T * >( p ) : nullptr );
 #else
-		return new T[ data_size_ ];
+		return new T[ capacity_ ];
 #endif
 #endif
 	}
@@ -3202,20 +3279,20 @@ private: // Methods
 	new_array()
 	{
 #ifdef OBJEXXFCL_ARRAY_NOALIGN
-		return new T[ data_size_ ];
+		return new T[ capacity_ ];
 #else
 #if defined(_WIN32)
-		T * pT( static_cast< T * >( _aligned_malloc( data_size_ * sizeof( T ), OBJEXXFCL_ARRAY_ALIGN ) ) );
-		for ( size_t i = 0; i < data_size_; ++i ) {
+		T * pT( static_cast< T * >( _aligned_malloc( capacity_ * sizeof( T ), OBJEXXFCL_ARRAY_ALIGN ) ) );
+		for ( size_t i = 0; i < capacity_; ++i ) {
 			pT[ i ] = *( new( pT + i ) T() );
 		}
 		return pT;
 #elif defined(__linux__)
 		void * p;
-		int const status( posix_memalign( &p, OBJEXXFCL_ARRAY_ALIGN, data_size_ * sizeof( T ) ) );
+		int const status( posix_memalign( &p, OBJEXXFCL_ARRAY_ALIGN, capacity_ * sizeof( T ) ) );
 		if ( status == 0 ) { // Success
 			T * pT( static_cast< T * >( p ) );
-			for ( size_t i = 0; i < data_size_; ++i ) {
+			for ( size_t i = 0; i < capacity_; ++i ) {
 				pT[ i ] = *( new( pT + i ) T() );
 			}
 			return pT;
@@ -3223,7 +3300,60 @@ private: // Methods
 			return nullptr;
 		}
 #else
-		return new T[ data_size_ ];
+		return new T[ capacity_ ];
+#endif
+#endif
+	}
+
+	// Array Heap Allocator for POD Types
+	template< typename U, class = typename std::enable_if< std::is_fundamental< U >::value >::type >
+	inline
+	T *
+	new_array( size_type const n )
+	{
+#ifdef OBJEXXFCL_ARRAY_NOALIGN
+		return new T[ n ];
+#else
+#if defined(_WIN32)
+		return static_cast< T * >( _aligned_malloc( n * sizeof( T ), OBJEXXFCL_ARRAY_ALIGN ) );
+#elif defined(__linux__)
+		void * p;
+		return ( posix_memalign( &p, OBJEXXFCL_ARRAY_ALIGN, n * sizeof( T ) ) == 0 ? static_cast< T * >( p ) : nullptr );
+#else
+		return new T[ n ];
+#endif
+#endif
+	}
+
+	// Array Heap Allocator for Class Types
+	template< typename U, class = typename std::enable_if< ! std::is_fundamental< U >::value >::type, typename = void >
+	inline
+	T *
+	new_array( size_type const n )
+	{
+#ifdef OBJEXXFCL_ARRAY_NOALIGN
+		return new T[ n ];
+#else
+#if defined(_WIN32)
+		T * pT( static_cast< T * >( _aligned_malloc( n * sizeof( T ), OBJEXXFCL_ARRAY_ALIGN ) ) );
+		for ( size_t i = 0; i < n; ++i ) {
+			pT[ i ] = *( new( pT + i ) T() );
+		}
+		return pT;
+#elif defined(__linux__)
+		void * p;
+		int const status( posix_memalign( &p, OBJEXXFCL_ARRAY_ALIGN, n * sizeof( T ) ) );
+		if ( status == 0 ) { // Success
+			T * pT( static_cast< T * >( p ) );
+			for ( size_t i = 0; i < n; ++i ) {
+				pT[ i ] = *( new( pT + i ) T() );
+			}
+			return pT;
+		} else {
+			return nullptr;
+		}
+#else
+		return new T[ n ];
 #endif
 #endif
 	}
@@ -3238,11 +3368,11 @@ private: // Methods
 		delete[] data_;
 #else
 #if defined(_WIN32)
-		size_type i( data_size_ );
+		size_type i( capacity_ );
 		while ( i ) data_[ --i ].~T();
 		_aligned_free( data_ );
 #elif defined(__linux__)
-		size_type i( data_size_ );
+		size_type i( capacity_ );
 		while ( i ) data_[ --i ].~T();
 		free( data_ );
 #else
@@ -3258,7 +3388,7 @@ public: // Data
 
 protected: // Data
 
-	size_type data_size_; // Size of data array
+	size_type capacity_; // Size of data array
 	T * data_; // Pointer to data array
 	size_type size_; // Size of active array
 	bool const owner_; // Owner of data array?

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
@@ -89,8 +89,8 @@ public: // Types
 	using Super::size_of;
 	using Super::slice_k;
 	using Super::swapB;
+	using Super::capacity_;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::sdata_;
 	using Super::shift_;
 	using Super::size_;
@@ -1182,7 +1182,7 @@ public: // Subscript
 	a( int const i ) const
 	{
 		assert( contains( i ) );
-		return Tail( static_cast< T const * >( sdata_ + i ), ( data_size_ != npos ? data_size_ - ( i - shift_ ) : npos ) );
+		return Tail( static_cast< T const * >( sdata_ + i ), ( size_ != npos ? size_ - ( i - shift_ ) : npos ) );
 	}
 
 	// Tail Starting at array( i )
@@ -1191,7 +1191,7 @@ public: // Subscript
 	a( int const i )
 	{
 		assert( contains( i ) );
-		return Tail( sdata_ + i, ( data_size_ != npos ? data_size_ - ( i - shift_ ) : npos ) );
+		return Tail( sdata_ + i, ( size_ != npos ? size_ - ( i - shift_ ) : npos ) );
 	}
 
 public: // Slice Proxy Generators

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.hh
@@ -67,10 +67,10 @@ public: // Types
 	using Super::shift_set;
 	using Super::size_set;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I_;
 	using Super::sdata_;
 	using Super::shift_;
+	using Super::size_;
 
 public: // Creation
 
@@ -989,10 +989,10 @@ private: // Functions
 	{
 		if ( I_.bounded() ) {
 			size_set( I_.size() );
-		} else if ( data_size_ == npos ) {
+		} else if ( size_ == npos ) {
 			size_set( npos );
 		} else { // Infer size
-			I_.u( I_.l() + static_cast< int >( data_size_ ) - 1 );
+			I_.u( I_.l() + static_cast< int >( size_ ) - 1 );
 			size_set( I_.size() );
 		}
 		shift_set( I_.l() );

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.hh
@@ -85,8 +85,8 @@ public: // Types
 	using Super::size_of;
 	using Super::swap1;
 	using Super::u;
+	using Super::capacity_;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I_;
 	using Super::sdata_;
 	using Super::shift_;
@@ -1255,7 +1255,7 @@ public: // Subscript
 	a( int const i ) const
 	{
 		assert( contains( i ) );
-		return Tail( static_cast< T const * >( sdata_ + i ), data_size_ - ( i - shift_ ) );
+		return Tail( static_cast< T const * >( sdata_ + i ), size_ - ( i - shift_ ) );
 	}
 
 	// Tail Starting at array( i )
@@ -1264,7 +1264,7 @@ public: // Subscript
 	a( int const i )
 	{
 		assert( contains( i ) );
-		return Tail( sdata_ + i, data_size_ - ( i - shift_ ) );
+		return Tail( sdata_ + i, size_ - ( i - shift_ ) );
 	}
 
 public: // Predicate
@@ -1462,6 +1462,122 @@ public: // Modifier
 			}
 		}
 		return swap( o );
+	}
+
+	// Append Value: Grow by 1
+	inline
+	Array1D &
+	append( T const & t )
+	{
+		if ( capacity_ == size_ ) { // Grow by 1
+			Array1D o( IndexRange( l(), u() + 1 ) );
+			for ( int i = l(), e = u(); i <= e; ++i ) {
+				o( i ) = operator ()( i );
+			}
+			swap( o );
+		} else {
+			I_.u( u() + 1 );
+		}
+		operator ()( u() ) = t;
+		return *this;
+	}
+
+	// Append Value: Grow Capacity
+	inline
+	Array1D &
+	push_back( T const & t )
+	{
+		Base::grow_capacity();
+		I_.grow();
+		setup_real();
+		operator ()( I_.u() ) = t;
+		return *this;
+	}
+
+	// Append Value: Grow Capacity
+	inline
+	Array1D &
+	push_back( T && t )
+	{
+		Base::grow_capacity();
+		I_.grow();
+		setup_real();
+		operator ()( I_.u() ) = std::move( t );
+		return *this;
+	}
+
+	// Construct and Append Value: Grow Capacity
+	template< class... Args >
+	Array1D &
+	emplace_back( Args&&... args )
+	{
+		Base::grow_capacity();
+		operator ()( I_.grow().u() ) = T( std::forward< Args >( args )... );
+		return *this;
+	}
+
+	// Remove Last Value
+	inline
+	Array1D &
+	pop_back()
+	{
+		if ( size_ > 0u ) --size_;
+		return *this;
+	}
+
+	// First Value
+	inline
+	T const &
+	front() const
+	{
+		assert( size_ > 0u );
+		return operator []( 0u );
+	}
+
+	// First Value
+	inline
+	T &
+	front()
+	{
+		assert( size_ > 0u );
+		return operator []( 0u );
+	}
+
+	// Last Value
+	inline
+	T const &
+	back() const
+	{
+		assert( size_ > 0u );
+		return operator []( size_ - 1 );
+	}
+
+	// Last Value
+	inline
+	T &
+	back()
+	{
+		assert( size_ > 0u );
+		return operator []( size_ - 1 );
+	}
+
+	// Reserve Capacity
+	inline
+	Array1D &
+	reserve( size_type const n )
+	{
+		Base::reserve_capacity( n );
+		setup_real();
+		return *this;
+	}
+
+	// Shrink Capacity to Size
+	inline
+	Array1D &
+	shrink_to_fit()
+	{
+		Base::shrink_capacity();
+		return *this;
 	}
 
 	// Set Initializer Value

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
@@ -88,7 +88,6 @@ public: // Types
 	using Super::slice_k;
 	using Super::swapB;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::sdata_;
 	using Super::shift_;
 	using Super::size_;
@@ -911,7 +910,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2 ) );
 		size_type const offset( ( ( i1 * z2_ ) + i2 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( static_cast< T const * >( data_ + offset ), ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 	// Tail Starting at array( i1, i2 )
@@ -921,7 +920,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2 ) );
 		size_type const offset( ( ( i1 * z2_ ) + i2 ) - shift_ );
-		return Tail( data_ + offset, ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( data_ + offset, ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 public: // Slice Proxy Generators

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.hh
@@ -68,11 +68,11 @@ public: // Types
 	using Super::size_of;
 	using Super::size_set;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::sdata_;
 	using Super::shift_;
+	using Super::size_;
 	using Super::z1_;
 	using Super::z2_;
 
@@ -689,15 +689,15 @@ private: // Functions
 		assert( I2_.bounded() );
 		if ( I1_.bounded() ) {
 			size_set( size_of( z1_, z2_ ) );
-		} else if ( data_size_ == npos ) {
+		} else if ( size_ == npos ) {
 			size_set( npos );
 		} else {
 			if ( z2_ > 0u ) { // Infer size
-				z1_ = data_size_ / z2_;
+				z1_ = size_ / z2_;
 				I1_.u( I1_.l() + static_cast< int >( z1_ ) - 1 );
 				size_set( size_of( z1_, z2_ ) );
 			} else {
-				size_set( data_size_ );
+				size_set( size_ );
 			}
 		}
 		shift_set( ( I1_.l() * z2_ ) + I2_.l() );

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.hh
@@ -90,7 +90,6 @@ public: // Types
 	using Super::u1;
 	using Super::u2;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::sdata_;
@@ -809,7 +808,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2 ) );
 		size_type const offset( ( ( i1 * z2_ ) + i2 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), data_size_ - offset );
+		return Tail( static_cast< T const * >( data_ + offset ), size_ - offset );
 	}
 
 	// Tail Starting at array( i1, i2 )
@@ -819,7 +818,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2 ) );
 		size_type const offset( ( ( i1 * z2_ ) + i2 ) - shift_ );
-		return Tail( data_ + offset, data_size_ - offset );
+		return Tail( data_ + offset, size_ - offset );
 	}
 
 public: // Predicate

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
@@ -87,7 +87,6 @@ public: // Types
 	using Super::slice_k;
 	using Super::swapB;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::sdata_;
 	using Super::shift_;
 	using Super::size_;
@@ -1004,7 +1003,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3 ) );
 		size_type const offset( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( static_cast< T const * >( data_ + offset ), ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 	// Tail Starting at array( i1, i2, i3 )
@@ -1014,7 +1013,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3 ) );
 		size_type const offset( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) - shift_ );
-		return Tail( data_ + offset, ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( data_ + offset, ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 public: // Slice Proxy Generators

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.hh
@@ -68,12 +68,12 @@ public: // Types
 	using Super::size_of;
 	using Super::size_set;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::I3_;
 	using Super::sdata_;
 	using Super::shift_;
+	using Super::size_;
 	using Super::z1_;
 	using Super::z2_;
 	using Super::z3_;
@@ -709,16 +709,16 @@ private: // Functions
 		assert( I3_.bounded() );
 		if ( I1_.bounded() ) {
 			size_set( size_of( z1_, z2_, z3_ ) );
-		} else if ( data_size_ == npos ) {
+		} else if ( size_ == npos ) {
 			size_set( npos );
 		} else {
 			size_type const slice_size( size_of( z2_, z3_ ) );
 			if ( slice_size > 0u ) { // Infer size
-				z1_ = data_size_ / slice_size;
+				z1_ = size_ / slice_size;
 				I1_.u( I1_.l() + static_cast< int >( z1_ ) - 1 );
 				size_set( size_of( z1_, slice_size ) );
 			} else {
-				size_set( data_size_ );
+				size_set( size_ );
 			}
 		}
 		shift_set( ( ( ( I1_.l() * z2_ ) + I2_.l() ) * z3_ ) + I3_.l() );

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.hh
@@ -94,7 +94,6 @@ public: // Types
 	using Super::u2;
 	using Super::u3;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::I3_;
@@ -803,7 +802,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3 ) );
 		size_type const offset( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), data_size_ - offset );
+		return Tail( static_cast< T const * >( data_ + offset ), size_ - offset );
 	}
 
 	// Tail Starting at array( i1, i2, i3 )
@@ -813,7 +812,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3 ) );
 		size_type const offset( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) - shift_ );
-		return Tail( data_ + offset, data_size_ - offset );
+		return Tail( data_ + offset, size_ - offset );
 	}
 
 public: // Predicate

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
@@ -87,7 +87,6 @@ public: // Types
 	using Super::slice_k;
 	using Super::swapB;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::sdata_;
 	using Super::shift_;
 	using Super::size_;
@@ -1098,7 +1097,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4 ) );
 		size_type const offset( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( static_cast< T const * >( data_ + offset ), ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 	// Tail Starting at array( i1, i2, i3, i4 )
@@ -1108,7 +1107,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4 ) );
 		size_type const offset( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) - shift_ );
-		return Tail( data_ + offset, ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( data_ + offset, ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 public: // Slice Proxy Generators

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.hh
@@ -68,13 +68,13 @@ public: // Types
 	using Super::size_of;
 	using Super::size_set;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::I3_;
 	using Super::I4_;
 	using Super::sdata_;
 	using Super::shift_;
+	using Super::size_;
 	using Super::z1_;
 	using Super::z2_;
 	using Super::z3_;
@@ -729,16 +729,16 @@ private: // Functions
 		assert( I4_.bounded() );
 		if ( I1_.bounded() ) {
 			size_set( size_of( z1_, z2_, z3_, z4_ ) );
-		} else if ( data_size_ == npos ) {
+		} else if ( size_ == npos ) {
 			size_set( npos );
 		} else {
 			size_type const slice_size( size_of( z2_, z3_, z4_ ) );
 			if ( slice_size > 0u ) { // Infer size
-				z1_ = data_size_ / slice_size;
+				z1_ = size_ / slice_size;
 				I1_.u( I1_.l() + static_cast< int >( z1_ ) - 1 );
 				size_set( size_of( z1_, slice_size ) );
 			} else {
-				size_set( data_size_ );
+				size_set( size_ );
 			}
 		}
 		shift_set( ( ( ( ( ( I1_.l() * z2_ ) + I2_.l() ) * z3_ ) + I3_.l() ) * z4_ ) + I4_.l() );

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.hh
@@ -98,7 +98,6 @@ public: // Types
 	using Super::u3;
 	using Super::u4;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::I3_;
@@ -819,7 +818,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4 ) );
 		size_type const offset( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), data_size_ - offset );
+		return Tail( static_cast< T const * >( data_ + offset ), size_ - offset );
 	}
 
 	// Tail Starting at array( i1, i2, i3, i4 )
@@ -829,7 +828,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4 ) );
 		size_type const offset( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) - shift_ );
-		return Tail( data_ + offset, data_size_ - offset );
+		return Tail( data_ + offset, size_ - offset );
 	}
 
 public: // Predicate

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
@@ -87,7 +87,6 @@ public: // Types
 	using Super::slice_k;
 	using Super::swapB;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::sdata_;
 	using Super::shift_;
 	using Super::size_;
@@ -1192,7 +1191,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4, i5 ) );
 		size_type const offset( ( ( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) * z5_ ) + i5 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( static_cast< T const * >( data_ + offset ), ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 	// Tail Starting at array( i1, i2, i3, i4, i5 )
@@ -1202,7 +1201,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4, i5 ) );
 		size_type const offset( ( ( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) * z5_ ) + i5 ) - shift_ );
-		return Tail( data_ + offset, ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( data_ + offset, ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 public: // Slice Proxy Generators

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.hh
@@ -68,7 +68,6 @@ public: // Types
 	using Super::size_of;
 	using Super::size_set;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::I3_;
@@ -76,6 +75,7 @@ public: // Types
 	using Super::I5_;
 	using Super::sdata_;
 	using Super::shift_;
+	using Super::size_;
 	using Super::z1_;
 	using Super::z2_;
 	using Super::z3_;
@@ -749,16 +749,16 @@ private: // Functions
 		assert( I5_.bounded() );
 		if ( I1_.bounded() ) {
 			size_set( size_of( z1_, z2_, z3_, z4_, z5_ ) );
-		} else if ( data_size_ == npos ) {
+		} else if ( size_ == npos ) {
 			size_set( npos );
 		} else {
 			size_type const slice_size( size_of( z2_, z3_, z4_, z5_ ) );
 			if ( slice_size > 0u ) { // Infer size
-				z1_ = data_size_ / slice_size;
+				z1_ = size_ / slice_size;
 				I1_.u( I1_.l() + static_cast< int >( z1_ ) - 1 );
 				size_set( size_of( z1_, slice_size ) );
 			} else {
-				size_set( data_size_ );
+				size_set( size_ );
 			}
 		}
 		shift_set( ( ( ( ( ( ( ( I1_.l() * z2_ ) + I2_.l() ) * z3_ ) + I3_.l() ) * z4_ ) + I4_.l() ) * z5_ ) + I5_.l() );

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.hh
@@ -102,7 +102,6 @@ public: // Types
 	using Super::u4;
 	using Super::u5;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::I3_;
@@ -835,7 +834,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4, i5 ) );
 		size_type const offset( ( ( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) * z5_ ) + i5 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), data_size_ - offset );
+		return Tail( static_cast< T const * >( data_ + offset ), size_ - offset );
 	}
 
 	// Tail Starting at array( i1, i2, i3, i4, i5 )
@@ -845,7 +844,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4, i5 ) );
 		size_type const offset( ( ( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) * z5_ ) + i5 ) - shift_ );
-		return Tail( data_ + offset, data_size_ - offset );
+		return Tail( data_ + offset, size_ - offset );
 	}
 
 public: // Predicate

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
@@ -87,7 +87,6 @@ public: // Types
 	using Super::slice_k;
 	using Super::swapB;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::sdata_;
 	using Super::shift_;
 	using Super::size_;
@@ -1286,7 +1285,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4, i5, i6 ) );
 		size_type const offset( ( ( ( ( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) * z5_ ) + i5 ) * z6_ ) + i6 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( static_cast< T const * >( data_ + offset ), ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 	// Tail Starting at array( i1, i2, i3, i4, i5, i6 )
@@ -1296,7 +1295,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4, i5, i6 ) );
 		size_type const offset( ( ( ( ( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) * z5_ ) + i5 ) * z6_ ) + i6 ) - shift_ );
-		return Tail( data_ + offset, ( data_size_ != npos ? data_size_ - offset : npos ) );
+		return Tail( data_ + offset, ( size_ != npos ? size_ - offset : npos ) );
 	}
 
 public: // Slice Proxy Generators

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.hh
@@ -68,7 +68,6 @@ public: // Types
 	using Super::size_of;
 	using Super::size_set;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::I3_;
@@ -77,6 +76,7 @@ public: // Types
 	using Super::I6_;
 	using Super::sdata_;
 	using Super::shift_;
+	using Super::size_;
 	using Super::z1_;
 	using Super::z2_;
 	using Super::z3_;
@@ -769,16 +769,16 @@ private: // Functions
 		assert( I6_.bounded() );
 		if ( I1_.bounded() ) {
 			size_set( size_of( z1_, z2_, z3_, z4_, z5_, z6_ ) );
-		} else if ( data_size_ == npos ) {
+		} else if ( size_ == npos ) {
 			size_set( npos );
 		} else {
 			size_type const slice_size( size_of( z2_, z3_, z4_, z5_, z6_ ) );
 			if ( slice_size > 0u ) { // Infer size
-				z1_ = data_size_ / slice_size;
+				z1_ = size_ / slice_size;
 				I1_.u( I1_.l() + static_cast< int >( z1_ ) - 1 );
 				size_set( size_of( z1_, slice_size ) );
 			} else {
-				size_set( data_size_ );
+				size_set( size_ );
 			}
 		}
 		shift_set( ( ( ( ( ( ( ( ( ( I1_.l() * z2_ ) + I2_.l() ) * z3_ ) + I3_.l() ) * z4_ ) + I4_.l() ) * z5_ ) + I5_.l() ) * z6_ ) + I6_.l() );

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.hh
@@ -106,7 +106,6 @@ public: // Types
 	using Super::u5;
 	using Super::u6;
 	using Super::data_;
-	using Super::data_size_;
 	using Super::I1_;
 	using Super::I2_;
 	using Super::I3_;
@@ -851,7 +850,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4, i5, i6 ) );
 		size_type const offset( ( ( ( ( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) * z5_ ) + i5 ) * z6_ ) + i6 ) - shift_ );
-		return Tail( static_cast< T const * >( data_ + offset ), data_size_ - offset );
+		return Tail( static_cast< T const * >( data_ + offset ), size_ - offset );
 	}
 
 	// Tail Starting at array( i1, i2, i3, i4, i5, i6 )
@@ -861,7 +860,7 @@ public: // Subscript
 	{
 		assert( contains( i1, i2, i3, i4, i5, i6 ) );
 		size_type const offset( ( ( ( ( ( ( ( ( ( ( i1 * z2_ ) + i2 ) * z3_ ) + i3 ) * z4_ ) + i4 ) * z5_ ) + i5 ) * z6_ ) + i6 ) - shift_ );
-		return Tail( data_ + offset, data_size_ - offset );
+		return Tail( data_ + offset, size_ - offset );
 	}
 
 public: // Predicate

--- a/third_party/ObjexxFCL/src/ObjexxFCL/CArray.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/CArray.hh
@@ -26,6 +26,7 @@
 #include <initializer_list>
 #include <iomanip>
 #include <istream>
+#include <iterator>
 #include <ostream>
 #include <type_traits>
 #include <utility>
@@ -53,6 +54,8 @@ public: // Types
 	typedef  T const *  const_pointer;
 	typedef  T *  iterator;
 	typedef  T const *  const_iterator;
+	typedef  std::reverse_iterator< T * >  reverse_iterator;
+	typedef  std::reverse_iterator< T const * >  const_reverse_iterator;
 	typedef  std::size_t  size_type;
 	typedef  std::ptrdiff_t  difference_type;
 
@@ -64,6 +67,8 @@ public: // Types
 	typedef  T const *  ConstPointer;
 	typedef  T *  Iterator;
 	typedef  T const *  ConstIterator;
+	typedef  std::reverse_iterator< T * >  ReverseIterator;
+	typedef  std::reverse_iterator< T const * >  ConstReverseIterator;
 	typedef  std::size_t  Size;
 	typedef  std::ptrdiff_t  Difference;
 
@@ -650,7 +655,7 @@ public: // Subscript
 
 public: // Iterator
 
-	// const_iterator to Beginning of Array
+	// Begin Iterator
 	inline
 	const_iterator
 	begin() const
@@ -658,7 +663,7 @@ public: // Iterator
 		return data_;
 	}
 
-	// iterator to Beginning of Array
+	// Begin Iterator
 	inline
 	iterator
 	begin()
@@ -666,20 +671,52 @@ public: // Iterator
 		return data_;
 	}
 
-	// const_iterator to Element Past End of Array
+	// End Iterator
 	inline
 	const_iterator
 	end() const
 	{
-		return data_ + size_;
+		return ( data_ != nullptr ? data_ + size_ : nullptr );
 	}
 
-	// iterator to Element Past End of Array
+	// End Iterator
 	inline
 	iterator
 	end()
 	{
-		return data_ + size_;
+		return ( data_ != nullptr ? data_ + size_ : nullptr );
+	}
+
+	// Reverse Begin Iterator
+	inline
+	const_reverse_iterator
+	rbegin() const
+	{
+		return const_reverse_iterator( data_ != nullptr ? data_ + size_ : nullptr );
+	}
+
+	// Reverse Begin Iterator
+	inline
+	reverse_iterator
+	rbegin()
+	{
+		return reverse_iterator( data_ != nullptr ? data_ + size_ : nullptr );
+	}
+
+	// Reverse End Iterator
+	inline
+	const_reverse_iterator
+	rend() const
+	{
+		return const_reverse_iterator( data_ );
+	}
+
+	// Reverse End Iterator
+	inline
+	reverse_iterator
+	rend()
+	{
+		return reverse_iterator( data_ );
 	}
 
 public: // Array Accessor

--- a/third_party/ObjexxFCL/src/ObjexxFCL/CArrayP.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/CArrayP.hh
@@ -26,6 +26,7 @@
 #include <initializer_list>
 #include <iomanip>
 #include <istream>
+#include <iterator>
 #include <ostream>
 #include <type_traits>
 #include <utility>
@@ -58,6 +59,8 @@ public: // Types
 	typedef  T const *  const_pointer;
 	typedef  T *  iterator;
 	typedef  T const *  const_iterator;
+	typedef  std::reverse_iterator< T * >  reverse_iterator;
+	typedef  std::reverse_iterator< T const * >  const_reverse_iterator;
 	typedef  std::size_t  size_type;
 	typedef  std::ptrdiff_t  difference_type;
 
@@ -69,6 +72,8 @@ public: // Types
 	typedef  T const *  ConstPointer;
 	typedef  T *  Iterator;
 	typedef  T const *  ConstIterator;
+	typedef  std::reverse_iterator< T * >  ReverseIterator;
+	typedef  std::reverse_iterator< T const * >  ConstReverseIterator;
 	typedef  std::size_t  Size;
 	typedef  std::ptrdiff_t  Difference;
 
@@ -759,7 +764,7 @@ public: // Subscript
 
 public: // Iterator
 
-	// const_iterator to Beginning of Array
+	// Begin Iterator
 	inline
 	const_iterator
 	begin() const
@@ -767,7 +772,7 @@ public: // Iterator
 		return data_;
 	}
 
-	// iterator to Beginning of Array
+	// Begin Iterator
 	inline
 	iterator
 	begin()
@@ -775,20 +780,52 @@ public: // Iterator
 		return data_;
 	}
 
-	// const_iterator to Element Past End of Array
+	// End Iterator
 	inline
 	const_iterator
 	end() const
 	{
-		return data_ + size_;
+		return ( data_ != nullptr ? data_ + size_ : nullptr );
 	}
 
-	// iterator to Element Past End of Array
+	// End Iterator
 	inline
 	iterator
 	end()
 	{
-		return data_ + size_;
+		return ( data_ != nullptr ? data_ + size_ : nullptr );
+	}
+
+	// Reverse Begin Iterator
+	inline
+	const_reverse_iterator
+	rbegin() const
+	{
+		return const_reverse_iterator( data_ != nullptr ? data_ + size_ : nullptr );
+	}
+
+	// Reverse Begin Iterator
+	inline
+	reverse_iterator
+	rbegin()
+	{
+		return reverse_iterator( data_ != nullptr ? data_ + size_ : nullptr );
+	}
+
+	// Reverse End Iterator
+	inline
+	const_reverse_iterator
+	rend() const
+	{
+		return const_reverse_iterator( data_ );
+	}
+
+	// Reverse End Iterator
+	inline
+	reverse_iterator
+	rend()
+	{
+		return reverse_iterator( data_ );
 	}
 
 public: // Array Accessor

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.hh
@@ -476,6 +476,18 @@ public: // Modifier
 		return *this;
 	}
 
+	// Grow Upper
+	inline
+	IndexRange &
+	grow( int const n = 1 )
+	{
+		assert( n >= 0 );
+		assert( u_ <= u_max - n );
+		u_ = clean_u( u_ + n );
+		size_ = computed_size();
+		return *this;
+	}
+
 	// Expand to Contain an Index
 	inline
 	IndexRange &

--- a/third_party/ObjexxFCL/tst/unit/Array1.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array1.unit.cc
@@ -818,6 +818,88 @@ TEST( Array1Test, Redimension )
 	}
 }
 
+TEST( Array1Test, Append )
+{
+	Array1D_int A( 5, { 1, 2, 3, 4, 5 } );
+	A.append( 6 );
+	EXPECT_EQ( 1, A.l() );
+	EXPECT_EQ( 6, A.u() );
+	EXPECT_EQ( 6u, A.size() );
+	EXPECT_EQ( 6u, A.capacity() );
+	EXPECT_EQ( 1, A( 1 ) );
+	EXPECT_EQ( 6, A( 6 ) );
+}
+
+TEST( Array1Test, Push_Back_Empty )
+{
+	Array1D_int A;
+	A.push_back( 1 );
+	EXPECT_EQ( 1, A.l() );
+	EXPECT_EQ( 1, A.u() );
+	EXPECT_EQ( 1u, A.size() );
+	EXPECT_EQ( 1u, A.capacity() );
+	EXPECT_EQ( 1, A( 1 ) );
+}
+
+TEST( Array1Test, Push_Back )
+{
+	Array1D_int A( 5, { 1, 2, 3, 4, 5 } );
+	A.push_back( 6 );
+	EXPECT_EQ( 1, A.l() );
+	EXPECT_EQ( 6, A.u() );
+	EXPECT_EQ( 6u, A.size() );
+	EXPECT_EQ( 10u, A.capacity() );
+	EXPECT_EQ( 1, A( 1 ) );
+	EXPECT_EQ( 6, A( 6 ) );
+}
+
+TEST( Array1Test, Pop_Back )
+{
+	Array1D_int A( 5, { 1, 2, 3, 4, 5 } );
+	EXPECT_EQ( 5, A.back() );
+	A.pop_back();
+	EXPECT_EQ( 4u, A.size() );
+}
+
+TEST( Array1Test, Front )
+{
+	Array1D_int A( 5, { 1, 2, 3, 4, 5 } );
+	EXPECT_EQ( 1, A.front() );
+}
+
+TEST( Array1Test, Reserve )
+{
+	Array1D_int A( 5, { 1, 2, 3, 4, 5 } );
+	EXPECT_EQ( 5u, A.size() );
+	EXPECT_EQ( 5u, A.capacity() );
+	A.reserve( 8u );
+	EXPECT_EQ( 5u, A.size() );
+	EXPECT_EQ( 8u, A.capacity() );
+	EXPECT_EQ( 1, A( 1 ) );
+	EXPECT_EQ( 2, A( 2 ) );
+	EXPECT_EQ( 3, A( 3 ) );
+	EXPECT_EQ( 4, A( 4 ) );
+	EXPECT_EQ( 5, A( 5 ) );
+	A.push_back( 6 );
+	A.push_back( 7 );
+	A.push_back( 8 );
+	EXPECT_EQ( 8u, A.size() );
+	EXPECT_EQ( 8u, A.capacity() );
+	EXPECT_EQ( 6, A( 6 ) );
+	EXPECT_EQ( 7, A( 7 ) );
+	EXPECT_EQ( 8, A( 8 ) );
+	A.push_back( 9 );
+	EXPECT_EQ( 9u, A.size() );
+	EXPECT_EQ( 16u, A.capacity() );
+	EXPECT_EQ( 9, A( 9 ) );
+	A.shrink_to_fit();
+	EXPECT_EQ( 9u, A.size() );
+	EXPECT_EQ( 9u, A.capacity() );
+	EXPECT_EQ( 1, A( 1 ) );
+	EXPECT_EQ( 8, A( 8 ) );
+	EXPECT_EQ( 9, A( 9 ) );
+}
+
 TEST( Array1Test, Swap )
 {
 	Array1D_int A( 4, 11 );
@@ -910,6 +992,24 @@ TEST( Array1Test, Generators )
 	Array1D_double A( 3, 22.0 ), B( 3, 11.0 );
 	EXPECT_TRUE( eq( B, A / 2.0 ) );
 	//EXPECT_TRUE( eq( B, A / 2 ) ); // This doesn't compile: Won't convert
+}
+
+TEST( Array1Test, Iterator )
+{
+	Array1D_int A{ 1, 2, 3 };
+	int j( 0 );
+	for ( Array1D_int::const_iterator i = A.begin(); i != A.end(); ++i ) {
+		EXPECT_EQ( ++j, *i );
+	}
+}
+
+TEST( Array1Test, ReverseIterator )
+{
+	Array1D_int A{ 1, 2, 3 };
+	int j( 4 );
+	for ( Array1D_int::const_reverse_iterator i = A.rbegin(); i != A.rend(); ++i ) {
+		EXPECT_EQ( --j, *i );
+	}
 }
 
 TEST( Array1Test, FunctionAllocateDeallocate )

--- a/third_party/ObjexxFCL/tst/unit/Array2.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array2.unit.cc
@@ -1289,8 +1289,8 @@ TEST( Array2Test, Predicates )
 	EXPECT_FALSE( A1.active() );
 	EXPECT_FALSE( A1.allocated() );
 	EXPECT_TRUE( A1.contiguous() );
-	EXPECT_TRUE( A1.data_size_bounded() );
-	EXPECT_FALSE( A1.data_size_unbounded() );
+	EXPECT_TRUE( A1.capacity_bounded() );
+	EXPECT_FALSE( A1.capacity_unbounded() );
 	EXPECT_TRUE( A1.empty() );
 	EXPECT_TRUE( A1.size_bounded() );
 	EXPECT_FALSE( A1.size_unbounded() );
@@ -1305,11 +1305,11 @@ TEST( Array2Test, Predicates )
 	EXPECT_TRUE( A2.active() );
 	EXPECT_TRUE( A2.allocated() );
 	EXPECT_TRUE( A2.contiguous() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_FALSE( A2.empty() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_TRUE( A2.owner() );
 	EXPECT_FALSE( A2.proxy() );
 
@@ -1317,11 +1317,11 @@ TEST( Array2Test, Predicates )
 	EXPECT_TRUE( A3.active() );
 	EXPECT_TRUE( A3.allocated() );
 	EXPECT_TRUE( A3.contiguous() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_FALSE( A3.empty() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_TRUE( A3.owner() );
 	EXPECT_FALSE( A3.proxy() );
 	EXPECT_FALSE( A3.is_default() );
@@ -1333,11 +1333,11 @@ TEST( Array2Test, Predicates )
 	EXPECT_TRUE( A4.active() );
 	EXPECT_TRUE( A4.allocated() );
 	EXPECT_TRUE( A4.contiguous() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_FALSE( A4.empty() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_TRUE( A4.owner() );
 	EXPECT_FALSE( A4.proxy() );
 	EXPECT_FALSE( A4.is_default() );
@@ -1622,7 +1622,7 @@ TEST( Array2Test, Inspectors )
 	EXPECT_EQ( 2, C1.rank() );
 	// Size
 	EXPECT_EQ( 0u, C1.size() );
-	EXPECT_EQ( 0u, C1.data_size() );
+	EXPECT_EQ( 0u, C1.capacity() );
 	EXPECT_EQ( 0u, C1.size( 1 ) );
 	EXPECT_EQ( C1.size1(), C1.size( 1 ) );
 	EXPECT_EQ( 0u, C1.size( 2 ) );
@@ -1650,7 +1650,7 @@ TEST( Array2Test, Inspectors )
 	EXPECT_EQ( 2, C2.rank() );
 	// Size
 	EXPECT_EQ( 6u, C2.size() );
-	EXPECT_EQ( 6u, C2.data_size() );
+	EXPECT_EQ( 6u, C2.capacity() );
 	EXPECT_EQ( 2u, C2.size( 1 ) );
 	EXPECT_EQ( C2.size1(), C2.size( 1 ) );
 	EXPECT_EQ( 3u, C2.size( 2 ) );

--- a/third_party/ObjexxFCL/tst/unit/Array3.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array3.unit.cc
@@ -158,8 +158,8 @@ TEST( Array3Test, Predicates )
 	EXPECT_FALSE( A1.active() );
 	EXPECT_FALSE( A1.allocated() );
 	EXPECT_TRUE( A1.contiguous() );
-	EXPECT_TRUE( A1.data_size_bounded() );
-	EXPECT_FALSE( A1.data_size_unbounded() );
+	EXPECT_TRUE( A1.capacity_bounded() );
+	EXPECT_FALSE( A1.capacity_unbounded() );
 	EXPECT_TRUE( A1.empty() );
 	EXPECT_TRUE( A1.size_bounded() );
 	EXPECT_FALSE( A1.size_unbounded() );
@@ -174,11 +174,11 @@ TEST( Array3Test, Predicates )
 	EXPECT_TRUE( A2.active() );
 	EXPECT_TRUE( A2.allocated() );
 	EXPECT_TRUE( A2.contiguous() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_FALSE( A2.empty() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_TRUE( A2.owner() );
 	EXPECT_FALSE( A2.proxy() );
 
@@ -186,11 +186,11 @@ TEST( Array3Test, Predicates )
 	EXPECT_TRUE( A3.active() );
 	EXPECT_TRUE( A3.allocated() );
 	EXPECT_TRUE( A3.contiguous() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_FALSE( A3.empty() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_TRUE( A3.owner() );
 	EXPECT_FALSE( A3.proxy() );
 	EXPECT_FALSE( A3.is_default() );
@@ -202,11 +202,11 @@ TEST( Array3Test, Predicates )
 	EXPECT_TRUE( A4.active() );
 	EXPECT_TRUE( A4.allocated() );
 	EXPECT_TRUE( A4.contiguous() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_FALSE( A4.empty() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_TRUE( A4.owner() );
 	EXPECT_FALSE( A4.proxy() );
 	EXPECT_FALSE( A4.is_default() );

--- a/third_party/ObjexxFCL/tst/unit/Array4.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array4.unit.cc
@@ -199,8 +199,8 @@ TEST( Array4Test, Predicates )
 	EXPECT_FALSE( A1.active() );
 	EXPECT_FALSE( A1.allocated() );
 	EXPECT_TRUE( A1.contiguous() );
-	EXPECT_TRUE( A1.data_size_bounded() );
-	EXPECT_FALSE( A1.data_size_unbounded() );
+	EXPECT_TRUE( A1.capacity_bounded() );
+	EXPECT_FALSE( A1.capacity_unbounded() );
 	EXPECT_TRUE( A1.empty() );
 	EXPECT_TRUE( A1.size_bounded() );
 	EXPECT_FALSE( A1.size_unbounded() );
@@ -215,11 +215,11 @@ TEST( Array4Test, Predicates )
 	EXPECT_TRUE( A2.active() );
 	EXPECT_TRUE( A2.allocated() );
 	EXPECT_TRUE( A2.contiguous() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_FALSE( A2.empty() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_TRUE( A2.owner() );
 	EXPECT_FALSE( A2.proxy() );
 
@@ -227,11 +227,11 @@ TEST( Array4Test, Predicates )
 	EXPECT_TRUE( A3.active() );
 	EXPECT_TRUE( A3.allocated() );
 	EXPECT_TRUE( A3.contiguous() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_FALSE( A3.empty() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_TRUE( A3.owner() );
 	EXPECT_FALSE( A3.proxy() );
 	EXPECT_FALSE( A3.is_default() );
@@ -260,11 +260,11 @@ TEST( Array4Test, Predicates )
 	EXPECT_TRUE( A4.active() );
 	EXPECT_TRUE( A4.allocated() );
 	EXPECT_TRUE( A4.contiguous() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_FALSE( A4.empty() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_TRUE( A4.owner() );
 	EXPECT_FALSE( A4.proxy() );
 	EXPECT_FALSE( A4.is_default() );

--- a/third_party/ObjexxFCL/tst/unit/Array5.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array5.unit.cc
@@ -265,8 +265,8 @@ TEST( Array5Test, Predicates )
 	EXPECT_FALSE( A1.active() );
 	EXPECT_FALSE( A1.allocated() );
 	EXPECT_TRUE( A1.contiguous() );
-	EXPECT_TRUE( A1.data_size_bounded() );
-	EXPECT_FALSE( A1.data_size_unbounded() );
+	EXPECT_TRUE( A1.capacity_bounded() );
+	EXPECT_FALSE( A1.capacity_unbounded() );
 	EXPECT_TRUE( A1.empty() );
 	EXPECT_TRUE( A1.size_bounded() );
 	EXPECT_FALSE( A1.size_unbounded() );
@@ -281,11 +281,11 @@ TEST( Array5Test, Predicates )
 	EXPECT_TRUE( A2.active() );
 	EXPECT_TRUE( A2.allocated() );
 	EXPECT_TRUE( A2.contiguous() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_FALSE( A2.empty() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_TRUE( A2.owner() );
 	EXPECT_FALSE( A2.proxy() );
 
@@ -293,11 +293,11 @@ TEST( Array5Test, Predicates )
 	EXPECT_TRUE( A3.active() );
 	EXPECT_TRUE( A3.allocated() );
 	EXPECT_TRUE( A3.contiguous() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_FALSE( A3.empty() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_TRUE( A3.owner() );
 	EXPECT_FALSE( A3.proxy() );
 	EXPECT_FALSE( A3.is_default() );
@@ -342,11 +342,11 @@ TEST( Array5Test, Predicates )
 	EXPECT_TRUE( A4.active() );
 	EXPECT_TRUE( A4.allocated() );
 	EXPECT_TRUE( A4.contiguous() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_FALSE( A4.empty() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_TRUE( A4.owner() );
 	EXPECT_FALSE( A4.proxy() );
 	EXPECT_FALSE( A4.is_default() );

--- a/third_party/ObjexxFCL/tst/unit/Array6.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array6.unit.cc
@@ -378,8 +378,8 @@ TEST( Array6Test, Predicates )
 	EXPECT_FALSE( A1.active() );
 	EXPECT_FALSE( A1.allocated() );
 	EXPECT_TRUE( A1.contiguous() );
-	EXPECT_TRUE( A1.data_size_bounded() );
-	EXPECT_FALSE( A1.data_size_unbounded() );
+	EXPECT_TRUE( A1.capacity_bounded() );
+	EXPECT_FALSE( A1.capacity_unbounded() );
 	EXPECT_TRUE( A1.empty() );
 	EXPECT_TRUE( A1.size_bounded() );
 	EXPECT_FALSE( A1.size_unbounded() );
@@ -394,11 +394,11 @@ TEST( Array6Test, Predicates )
 	EXPECT_TRUE( A2.active() );
 	EXPECT_TRUE( A2.allocated() );
 	EXPECT_TRUE( A2.contiguous() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_FALSE( A2.empty() );
-	EXPECT_TRUE( A2.data_size_bounded() );
-	EXPECT_FALSE( A2.data_size_unbounded() );
+	EXPECT_TRUE( A2.capacity_bounded() );
+	EXPECT_FALSE( A2.capacity_unbounded() );
 	EXPECT_TRUE( A2.owner() );
 	EXPECT_FALSE( A2.proxy() );
 
@@ -406,11 +406,11 @@ TEST( Array6Test, Predicates )
 	EXPECT_TRUE( A3.active() );
 	EXPECT_TRUE( A3.allocated() );
 	EXPECT_TRUE( A3.contiguous() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_FALSE( A3.empty() );
-	EXPECT_TRUE( A3.data_size_bounded() );
-	EXPECT_FALSE( A3.data_size_unbounded() );
+	EXPECT_TRUE( A3.capacity_bounded() );
+	EXPECT_FALSE( A3.capacity_unbounded() );
 	EXPECT_TRUE( A3.owner() );
 	EXPECT_FALSE( A3.proxy() );
 	EXPECT_FALSE( A3.is_default() );
@@ -487,11 +487,11 @@ TEST( Array6Test, Predicates )
 	EXPECT_TRUE( A4.active() );
 	EXPECT_TRUE( A4.allocated() );
 	EXPECT_TRUE( A4.contiguous() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_FALSE( A4.empty() );
-	EXPECT_TRUE( A4.data_size_bounded() );
-	EXPECT_FALSE( A4.data_size_unbounded() );
+	EXPECT_TRUE( A4.capacity_bounded() );
+	EXPECT_FALSE( A4.capacity_unbounded() );
 	EXPECT_TRUE( A4.owner() );
 	EXPECT_FALSE( A4.proxy() );
 	EXPECT_FALSE( A4.is_default() );


### PR DESCRIPTION
This adds a `std::vector`-like grow-friendly API to ObjexxFCL Arrays that is (for now) exposed in `Array1D` to allow growing via `push_back` with only rare heap allocation and copy operations. Like `std::vector` this is done using excess capacity and `Array1D` has the ability to `reserve` extra capacity and to `shrink_to_fit` once the container is done being filled.

While this can be used to improve current performance by migrating some `redimension` operations in the EnergyPlus model setup process to `push_back`, the main purpose is to allow `Array1D` to be used with the collections framework under development with the same performance as `std::vector`.

Testing here showed no diffs, as expected since this new capability doesn't alter current array usage in EnergyPlus.
