### PR TITLE
ObjexxFCL::IndexRange::clean_u change to elim GCC 4.8 overflow warning

### DIFF
--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.hh
@@ -566,12 +566,7 @@ private: // Methods
 	int
 	clean_u( int const u )
 	{
-		if ( l_ > u ) {
-			l_ = 1; // Changes lower index: Side effect
-			return 0;
-		} else {
-			return u;
-		}
+		return std::max( u, l_ - 1 );
 	}
 
 public: // Data


### PR DESCRIPTION
This eliminates a false positive warning related to integer overflow in GCC 4.8 release builds that is caused by inlining when an optimization must assume no overflow. The warning is not present with GCC 4.9 or 5.1.
