### PR TITLE
NOEXCEPT macro fixup for Intel C++ / Consistent friend inline ordering

### DIFF
--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
@@ -1676,8 +1676,8 @@ public: // Modifier
 public: // Comparison: Predicate
 
 	// Array == Value
-	inline
 	friend
+	inline
 	bool
 	eq( Array const & a, T const & t )
 	{
@@ -1690,8 +1690,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == Array
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, Array const & a )
 	{
@@ -1699,8 +1699,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array != Value
-	inline
 	friend
+	inline
 	bool
 	ne( Array const & a, T const & t )
 	{
@@ -1708,8 +1708,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != Array
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, Array const & a )
 	{
@@ -1717,8 +1717,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array < Value
-	inline
 	friend
+	inline
 	bool
 	lt( Array const & a, T const & t )
 	{
@@ -1731,8 +1731,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < Array
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, Array const & a )
 	{
@@ -1745,8 +1745,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array <= Value
-	inline
 	friend
+	inline
 	bool
 	le( Array const & a, T const & t )
 	{
@@ -1759,8 +1759,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= Array
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, Array const & a )
 	{
@@ -1773,8 +1773,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array > Value
-	inline
 	friend
+	inline
 	bool
 	gt( Array const & a, T const & t )
 	{
@@ -1782,8 +1782,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > Array
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, Array const & a )
 	{
@@ -1791,8 +1791,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( Array const & a, T const & t )
 	{
@@ -1800,8 +1800,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= Array
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, Array const & a )
 	{
@@ -1811,8 +1811,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any Array == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array const & a, T const & t )
 	{
@@ -1825,8 +1825,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == Array
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, Array const & a )
 	{
@@ -1834,8 +1834,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Array != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array const & a, T const & t )
 	{
@@ -1843,8 +1843,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != Array
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, Array const & a )
 	{
@@ -1852,8 +1852,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Array < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array const & a, T const & t )
 	{
@@ -1866,8 +1866,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < Array
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, Array const & a )
 	{
@@ -1880,8 +1880,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Array <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( Array const & a, T const & t )
 	{
@@ -1894,8 +1894,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= Array
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, Array const & a )
 	{
@@ -1908,8 +1908,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Array > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array const & a, T const & t )
 	{
@@ -1917,8 +1917,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > Array
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, Array const & a )
 	{
@@ -1926,8 +1926,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Array >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array const & a, T const & t )
 	{
@@ -1935,8 +1935,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= Array
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, Array const & a )
 	{
@@ -1946,8 +1946,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All Array == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array const & a, T const & t )
 	{
@@ -1955,8 +1955,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == Array
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, Array const & a )
 	{
@@ -1964,8 +1964,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Array != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array const & a, T const & t )
 	{
@@ -1973,8 +1973,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != Array
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, Array const & a )
 	{
@@ -1982,8 +1982,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Array < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array const & a, T const & t )
 	{
@@ -1991,8 +1991,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < Array
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, Array const & a )
 	{
@@ -2000,8 +2000,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Array <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( Array const & a, T const & t )
 	{
@@ -2009,8 +2009,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= Array
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, Array const & a )
 	{
@@ -2018,8 +2018,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Array > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array const & a, T const & t )
 	{
@@ -2027,8 +2027,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > Array
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, Array const & a )
 	{
@@ -2036,8 +2036,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Array >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array const & a, T const & t )
 	{
@@ -2045,8 +2045,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= Array
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, Array const & a )
 	{
@@ -2056,8 +2056,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count Array == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array const & a, T const & t )
 	{
@@ -2071,8 +2071,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == Array
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, Array const & a )
 	{
@@ -2080,8 +2080,8 @@ public: // Comparison: Count
 	}
 
 	// Count Array != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array const & a, T const & t )
 	{
@@ -2095,8 +2095,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != Array
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, Array const & a )
 	{
@@ -2104,8 +2104,8 @@ public: // Comparison: Count
 	}
 
 	// Count Array < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array const & a, T const & t )
 	{
@@ -2119,8 +2119,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < Array
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, Array const & a )
 	{
@@ -2128,8 +2128,8 @@ public: // Comparison: Count
 	}
 
 	// Count Array <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array const & a, T const & t )
 	{
@@ -2143,8 +2143,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= Array
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, Array const & a )
 	{
@@ -2152,8 +2152,8 @@ public: // Comparison: Count
 	}
 
 	// Count Array > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array const & a, T const & t )
 	{
@@ -2167,8 +2167,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > Array
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, Array const & a )
 	{
@@ -2176,8 +2176,8 @@ public: // Comparison: Count
 	}
 
 	// Count Array >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array const & a, T const & t )
 	{
@@ -2191,8 +2191,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= Array
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, Array const & a )
 	{
@@ -2202,8 +2202,8 @@ public: // Comparison: Count
 protected: // Comparison: Predicate
 
 	// Array == Array
-	inline
 	friend
+	inline
 	bool
 	eq( Array const & a, Array const & b )
 	{
@@ -2217,8 +2217,8 @@ protected: // Comparison: Predicate
 	}
 
 	// Array != Array
-	inline
 	friend
+	inline
 	bool
 	ne( Array const & a, Array const & b )
 	{
@@ -2226,8 +2226,8 @@ protected: // Comparison: Predicate
 	}
 
 	// Array < Array
-	inline
 	friend
+	inline
 	bool
 	lt( Array const & a, Array const & b )
 	{
@@ -2241,8 +2241,8 @@ protected: // Comparison: Predicate
 	}
 
 	// Array <= Array
-	inline
 	friend
+	inline
 	bool
 	le( Array const & a, Array const & b )
 	{
@@ -2256,8 +2256,8 @@ protected: // Comparison: Predicate
 	}
 
 	// Array > Array
-	inline
 	friend
+	inline
 	bool
 	gt( Array const & a, Array const & b )
 	{
@@ -2265,8 +2265,8 @@ protected: // Comparison: Predicate
 	}
 
 	// Array >= Array
-	inline
 	friend
+	inline
 	bool
 	ge( Array const & a, Array const & b )
 	{
@@ -2276,8 +2276,8 @@ protected: // Comparison: Predicate
 protected: // Comparison: Predicate: Any
 
 	// Any Array == Array
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array const & a, Array const & b )
 	{
@@ -2292,8 +2292,8 @@ protected: // Comparison: Predicate: Any
 	}
 
 	// Any Array != Array
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array const & a, Array const & b )
 	{
@@ -2301,8 +2301,8 @@ protected: // Comparison: Predicate: Any
 	}
 
 	// Any Array < Array
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array const & a, Array const & b )
 	{
@@ -2317,8 +2317,8 @@ protected: // Comparison: Predicate: Any
 	}
 
 	// Any Array <= Array
-	inline
 	friend
+	inline
 	bool
 	any_le( Array const & a, Array const & b )
 	{
@@ -2333,8 +2333,8 @@ protected: // Comparison: Predicate: Any
 	}
 
 	// Any Array > Array
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array const & a, Array const & b )
 	{
@@ -2342,8 +2342,8 @@ protected: // Comparison: Predicate: Any
 	}
 
 	// Any Array >= Array
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array const & a, Array const & b )
 	{
@@ -2353,8 +2353,8 @@ protected: // Comparison: Predicate: Any
 protected: // Comparison: Predicate: All
 
 	// All Array == Array
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array const & a, Array const & b )
 	{
@@ -2362,8 +2362,8 @@ protected: // Comparison: Predicate: All
 	}
 
 	// All Array != Array
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array const & a, Array const & b )
 	{
@@ -2371,8 +2371,8 @@ protected: // Comparison: Predicate: All
 	}
 
 	// All Array < Array
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array const & a, Array const & b )
 	{
@@ -2380,8 +2380,8 @@ protected: // Comparison: Predicate: All
 	}
 
 	// All Array <= Array
-	inline
 	friend
+	inline
 	bool
 	all_le( Array const & a, Array const & b )
 	{
@@ -2389,8 +2389,8 @@ protected: // Comparison: Predicate: All
 	}
 
 	// All Array > Array
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array const & a, Array const & b )
 	{
@@ -2398,8 +2398,8 @@ protected: // Comparison: Predicate: All
 	}
 
 	// All Array >= Array
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array const & a, Array const & b )
 	{
@@ -2409,8 +2409,8 @@ protected: // Comparison: Predicate: All
 protected: // Comparison: Count
 
 	// Count Array == Array
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array const & a, Array const & b )
 	{
@@ -2426,8 +2426,8 @@ protected: // Comparison: Count
 	}
 
 	// Count Array != Array
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array const & a, Array const & b )
 	{
@@ -2443,8 +2443,8 @@ protected: // Comparison: Count
 	}
 
 	// Count Array < Array
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array const & a, Array const & b )
 	{
@@ -2460,8 +2460,8 @@ protected: // Comparison: Count
 	}
 
 	// Count Array <= Array
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array const & a, Array const & b )
 	{
@@ -2477,8 +2477,8 @@ protected: // Comparison: Count
 	}
 
 	// Count Array > Array
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array const & a, Array const & b )
 	{
@@ -2486,8 +2486,8 @@ protected: // Comparison: Count
 	}
 
 	// Count Array >= Array
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array const & a, Array const & b )
 	{
@@ -2497,8 +2497,8 @@ protected: // Comparison: Count
 protected: // Comparison: Elemental
 
 	// Array == Array
-	inline
 	friend
+	inline
 	void
 	eq_elemental( Array const & a, Array const & b, Array< bool > & r )
 	{
@@ -2510,8 +2510,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array != Array
-	inline
 	friend
+	inline
 	void
 	ne_elemental( Array const & a, Array const & b, Array< bool > & r )
 	{
@@ -2523,8 +2523,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array < Array
-	inline
 	friend
+	inline
 	void
 	lt_elemental( Array const & a, Array const & b, Array< bool > & r )
 	{
@@ -2536,8 +2536,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array <= Array
-	inline
 	friend
+	inline
 	void
 	le_elemental( Array const & a, Array const & b, Array< bool > & r )
 	{
@@ -2549,8 +2549,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array > Array
-	inline
 	friend
+	inline
 	void
 	gt_elemental( Array const & a, Array const & b, Array< bool > & r )
 	{
@@ -2562,8 +2562,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array >= Array
-	inline
 	friend
+	inline
 	void
 	ge_elemental( Array const & a, Array const & b, Array< bool > & r )
 	{
@@ -2575,8 +2575,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array == Value
-	inline
 	friend
+	inline
 	void
 	eq_elemental( Array const & a, T const & t, Array< bool > & r )
 	{
@@ -2587,8 +2587,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array != Value
-	inline
 	friend
+	inline
 	void
 	ne_elemental( Array const & a, T const & t, Array< bool > & r )
 	{
@@ -2599,8 +2599,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array < Value
-	inline
 	friend
+	inline
 	void
 	lt_elemental( Array const & a, T const & t, Array< bool > & r )
 	{
@@ -2611,8 +2611,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array <= Value
-	inline
 	friend
+	inline
 	void
 	le_elemental( Array const & a, T const & t, Array< bool > & r )
 	{
@@ -2623,8 +2623,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array > Value
-	inline
 	friend
+	inline
 	void
 	gt_elemental( Array const & a, T const & t, Array< bool > & r )
 	{
@@ -2635,8 +2635,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Array >= Value
-	inline
 	friend
+	inline
 	void
 	ge_elemental( Array const & a, T const & t, Array< bool > & r )
 	{
@@ -2647,8 +2647,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Value == Array
-	inline
 	friend
+	inline
 	void
 	eq_elemental( T const & t, Array const & b, Array< bool > & r )
 	{
@@ -2659,8 +2659,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Value != Array
-	inline
 	friend
+	inline
 	void
 	ne_elemental( T const & t, Array const & b, Array< bool > & r )
 	{
@@ -2671,8 +2671,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Value < Array
-	inline
 	friend
+	inline
 	void
 	lt_elemental( T const & t, Array const & b, Array< bool > & r )
 	{
@@ -2683,8 +2683,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Value <= Array
-	inline
 	friend
+	inline
 	void
 	le_elemental( T const & t, Array const & b, Array< bool > & r )
 	{
@@ -2695,8 +2695,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Value > Array
-	inline
 	friend
+	inline
 	void
 	gt_elemental( T const & t, Array const & b, Array< bool > & r )
 	{
@@ -2707,8 +2707,8 @@ protected: // Comparison: Elemental
 	}
 
 	// Value >= Array
-	inline
 	friend
+	inline
 	void
 	ge_elemental( T const & t, Array const & b, Array< bool > & r )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
@@ -1557,8 +1557,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Array1 == Array1
-	inline
 	friend
+	inline
 	bool
 	eq( Array1 const & a, Array1 const & b )
 	{
@@ -1568,8 +1568,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array1 != Array1
-	inline
 	friend
+	inline
 	bool
 	ne( Array1 const & a, Array1 const & b )
 	{
@@ -1577,8 +1577,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array1 < Array1
-	inline
 	friend
+	inline
 	bool
 	lt( Array1 const & a, Array1 const & b )
 	{
@@ -1588,8 +1588,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array1 <= Array1
-	inline
 	friend
+	inline
 	bool
 	le( Array1 const & a, Array1 const & b )
 	{
@@ -1599,8 +1599,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array1 > Array1
-	inline
 	friend
+	inline
 	bool
 	gt( Array1 const & a, Array1 const & b )
 	{
@@ -1608,8 +1608,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array1 >= Array1
-	inline
 	friend
+	inline
 	bool
 	ge( Array1 const & a, Array1 const & b )
 	{
@@ -1619,8 +1619,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Array1 == Array1
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array1 const & a, Array1 const & b )
 	{
@@ -1630,8 +1630,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array1 != Array1
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array1 const & a, Array1 const & b )
 	{
@@ -1639,8 +1639,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array1 < Array1
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array1 const & a, Array1 const & b )
 	{
@@ -1650,8 +1650,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array1 <= Array1
-	inline
 	friend
+	inline
 	bool
 	any_le( Array1 const & a, Array1 const & b )
 	{
@@ -1661,8 +1661,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array1 > Array1
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array1 const & a, Array1 const & b )
 	{
@@ -1670,8 +1670,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array1 >= Array1
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array1 const & a, Array1 const & b )
 	{
@@ -1681,8 +1681,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// Array1 == Array1
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array1 const & a, Array1 const & b )
 	{
@@ -1690,8 +1690,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array1 != Array1
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array1 const & a, Array1 const & b )
 	{
@@ -1699,8 +1699,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array1 < Array1
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array1 const & a, Array1 const & b )
 	{
@@ -1708,8 +1708,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array1 <= Array1
-	inline
 	friend
+	inline
 	bool
 	all_le( Array1 const & a, Array1 const & b )
 	{
@@ -1717,8 +1717,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array1 > Array1
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array1 const & a, Array1 const & b )
 	{
@@ -1726,8 +1726,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array1 >= Array1
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array1 const & a, Array1 const & b )
 	{
@@ -1737,8 +1737,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Array1 == Array1
-	inline
 	friend
+	inline
 	bool
 	count_eq( Array1 const & a, Array1 const & b )
 	{
@@ -1748,8 +1748,8 @@ public: // Comparison: Count
 	}
 
 	// Array1 != Array1
-	inline
 	friend
+	inline
 	bool
 	count_ne( Array1 const & a, Array1 const & b )
 	{
@@ -1759,8 +1759,8 @@ public: // Comparison: Count
 	}
 
 	// Array1 < Array1
-	inline
 	friend
+	inline
 	bool
 	count_lt( Array1 const & a, Array1 const & b )
 	{
@@ -1770,8 +1770,8 @@ public: // Comparison: Count
 	}
 
 	// Array1 <= Array1
-	inline
 	friend
+	inline
 	bool
 	count_le( Array1 const & a, Array1 const & b )
 	{
@@ -1781,8 +1781,8 @@ public: // Comparison: Count
 	}
 
 	// Array1 > Array1
-	inline
 	friend
+	inline
 	bool
 	count_gt( Array1 const & a, Array1 const & b )
 	{
@@ -1792,8 +1792,8 @@ public: // Comparison: Count
 	}
 
 	// Array1 >= Array1
-	inline
 	friend
+	inline
 	bool
 	count_ge( Array1 const & a, Array1 const & b )
 	{
@@ -1805,8 +1805,8 @@ public: // Comparison: Count
 public: // Comparison: Predicate: Slice
 
 	// Array1 == Array1S
-	inline
 	friend
+	inline
 	bool
 	eq( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1821,8 +1821,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1 != Array1S
-	inline
 	friend
+	inline
 	bool
 	ne( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1830,8 +1830,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1 < Array1S
-	inline
 	friend
+	inline
 	bool
 	lt( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1846,8 +1846,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1 <= Array1S
-	inline
 	friend
+	inline
 	bool
 	le( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1862,8 +1862,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1 > Array1S
-	inline
 	friend
+	inline
 	bool
 	gt( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1878,8 +1878,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1 >= Array1S
-	inline
 	friend
+	inline
 	bool
 	ge( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1894,8 +1894,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1S == Array1
-	inline
 	friend
+	inline
 	bool
 	eq( Array1S< T > const & a, Array1 const & b )
 	{
@@ -1903,8 +1903,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1S != Array1
-	inline
 	friend
+	inline
 	bool
 	ne( Array1S< T > const & a, Array1 const & b )
 	{
@@ -1912,8 +1912,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1S < Array1
-	inline
 	friend
+	inline
 	bool
 	lt( Array1S< T > const & a, Array1 const & b )
 	{
@@ -1921,8 +1921,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1S <= Array1
-	inline
 	friend
+	inline
 	bool
 	le( Array1S< T > const & a, Array1 const & b )
 	{
@@ -1930,8 +1930,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1S > Array1
-	inline
 	friend
+	inline
 	bool
 	gt( Array1S< T > const & a, Array1 const & b )
 	{
@@ -1939,8 +1939,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array1S >= Array1
-	inline
 	friend
+	inline
 	bool
 	ge( Array1S< T > const & a, Array1 const & b )
 	{
@@ -1950,8 +1950,8 @@ public: // Comparison: Predicate: Slice
 public: // Comparison: Predicate: Any: Slice
 
 	// Any Array1 == Array1S
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1966,8 +1966,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1 != Array1S
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1975,8 +1975,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1 < Array1S
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array1 const & a, Array1S< T > const & b )
 	{
@@ -1991,8 +1991,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1 <= Array1S
-	inline
 	friend
+	inline
 	bool
 	any_le( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2007,8 +2007,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1 > Array1S
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2023,8 +2023,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1 >= Array1S
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2039,8 +2039,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1S == Array1
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2048,8 +2048,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1S != Array1
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2057,8 +2057,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1S < Array1
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2066,8 +2066,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1S <= Array1
-	inline
 	friend
+	inline
 	bool
 	any_le( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2075,8 +2075,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1S > Array1
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2084,8 +2084,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array1S >= Array1
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2095,8 +2095,8 @@ public: // Comparison: Predicate: Any: Slice
 public: // Comparison: Predicate: All: Slice
 
 	// All Array1 == Array1S
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2104,8 +2104,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1 != Array1S
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2113,8 +2113,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1 < Array1S
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2122,8 +2122,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1 <= Array1S
-	inline
 	friend
+	inline
 	bool
 	all_le( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2131,8 +2131,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1 > Array1S
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2140,8 +2140,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1 >= Array1S
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2149,8 +2149,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1S == Array1
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2158,8 +2158,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1S != Array1
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2167,8 +2167,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1S < Array1
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2176,8 +2176,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1S <= Array1
-	inline
 	friend
+	inline
 	bool
 	all_le( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2185,8 +2185,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1S > Array1
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2194,8 +2194,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array1S >= Array1
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2205,8 +2205,8 @@ public: // Comparison: Predicate: All: Slice
 public: // Comparison: Count: Slice
 
 	// Count Array1 == Array1S
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2221,8 +2221,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1 != Array1S
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2237,8 +2237,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1 < Array1S
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2253,8 +2253,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1 <= Array1S
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2269,8 +2269,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1 > Array1S
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2285,8 +2285,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1 >= Array1S
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array1 const & a, Array1S< T > const & b )
 	{
@@ -2301,8 +2301,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1S == Array1
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2310,8 +2310,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1S != Array1
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2319,8 +2319,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1S < Array1
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2328,8 +2328,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1S <= Array1
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2337,8 +2337,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1S > Array1
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2346,8 +2346,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array1S >= Array1
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array1S< T > const & a, Array1 const & b )
 	{
@@ -2358,8 +2358,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1 == MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2375,8 +2375,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1 != MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2385,8 +2385,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1 < MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2402,8 +2402,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1 <= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2419,8 +2419,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1 > MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2436,8 +2436,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1 >= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2453,8 +2453,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 == Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2463,8 +2463,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 != Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2473,8 +2473,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 < Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2483,8 +2483,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 <= Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2493,8 +2493,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 > Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2503,8 +2503,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 >= Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2515,8 +2515,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1 == MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2532,8 +2532,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1 != MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2542,8 +2542,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1 < MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2559,8 +2559,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1 <= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2576,8 +2576,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1 > MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2593,8 +2593,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1 >= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2610,8 +2610,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 == Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2620,8 +2620,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 != Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2630,8 +2630,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 < Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2640,8 +2640,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 <= Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2650,8 +2650,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 > Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2660,8 +2660,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 >= Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2672,8 +2672,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1 == MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2682,8 +2682,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1 != MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2692,8 +2692,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1 < MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2702,8 +2702,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1 <= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2712,8 +2712,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1 > MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2722,8 +2722,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1 >= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2732,8 +2732,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 == Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2742,8 +2742,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 != Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2752,8 +2752,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 < Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2762,8 +2762,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 <= Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2772,8 +2772,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 > Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2782,8 +2782,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 >= Array1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2794,8 +2794,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1 == MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2811,8 +2811,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1 != MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2828,8 +2828,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1 < MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2845,8 +2845,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1 <= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2862,8 +2862,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1 > MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2879,8 +2879,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1 >= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array1 const & a, MArray1< A, T > const & b )
 	{
@@ -2896,8 +2896,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 == Array1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2906,8 +2906,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 != Array1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2916,8 +2916,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 < Array1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2926,8 +2926,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 <= Array1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2936,8 +2936,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 > Array1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray1< A, T > const & a, Array1 const & b )
 	{
@@ -2946,8 +2946,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 >= Array1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray1< A, T > const & a, Array1 const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1S.hh
@@ -1362,8 +1362,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( Array1S const & a, Array1S const & b )
 	{
@@ -1376,8 +1376,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( Array1S const & a, Array1S const & b )
 	{
@@ -1385,8 +1385,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( Array1S const & a, Array1S const & b )
 	{
@@ -1399,8 +1399,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( Array1S const & a, Array1S const & b )
 	{
@@ -1413,8 +1413,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( Array1S const & a, Array1S const & b )
 	{
@@ -1422,8 +1422,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( Array1S const & a, Array1S const & b )
 	{
@@ -1431,8 +1431,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice == Value
-	inline
 	friend
+	inline
 	bool
 	eq( Array1S const & a, T const & t )
 	{
@@ -1444,8 +1444,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Value
-	inline
 	friend
+	inline
 	bool
 	ne( Array1S const & a, T const & t )
 	{
@@ -1453,8 +1453,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Value
-	inline
 	friend
+	inline
 	bool
 	lt( Array1S const & a, T const & t )
 	{
@@ -1466,8 +1466,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	le( Array1S const & a, T const & t )
 	{
@@ -1479,8 +1479,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Value
-	inline
 	friend
+	inline
 	bool
 	gt( Array1S const & a, T const & t )
 	{
@@ -1488,8 +1488,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( Array1S const & a, T const & t )
 	{
@@ -1497,8 +1497,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, Array1S const & a )
 	{
@@ -1506,8 +1506,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, Array1S const & a )
 	{
@@ -1515,8 +1515,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, Array1S const & a )
 	{
@@ -1528,8 +1528,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, Array1S const & a )
 	{
@@ -1541,8 +1541,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, Array1S const & a )
 	{
@@ -1550,8 +1550,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, Array1S const & a )
 	{
@@ -1561,8 +1561,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array1S const & a, Array1S const & b )
 	{
@@ -1576,8 +1576,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array1S const & a, Array1S const & b )
 	{
@@ -1585,8 +1585,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array1S const & a, Array1S const & b )
 	{
@@ -1600,8 +1600,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( Array1S const & a, Array1S const & b )
 	{
@@ -1615,8 +1615,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array1S const & a, Array1S const & b )
 	{
@@ -1624,8 +1624,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array1S const & a, Array1S const & b )
 	{
@@ -1633,8 +1633,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array1S const & a, T const & t )
 	{
@@ -1646,8 +1646,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array1S const & a, T const & t )
 	{
@@ -1655,8 +1655,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array1S const & a, T const & t )
 	{
@@ -1668,8 +1668,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( Array1S const & a, T const & t )
 	{
@@ -1681,8 +1681,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array1S const & a, T const & t )
 	{
@@ -1690,8 +1690,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array1S const & a, T const & t )
 	{
@@ -1699,8 +1699,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, Array1S const & a )
 	{
@@ -1708,8 +1708,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, Array1S const & a )
 	{
@@ -1717,8 +1717,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, Array1S const & a )
 	{
@@ -1730,8 +1730,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, Array1S const & a )
 	{
@@ -1743,8 +1743,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, Array1S const & a )
 	{
@@ -1752,8 +1752,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, Array1S const & a )
 	{
@@ -1763,8 +1763,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array1S const & a, Array1S const & b )
 	{
@@ -1772,8 +1772,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array1S const & a, Array1S const & b )
 	{
@@ -1781,8 +1781,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array1S const & a, Array1S const & b )
 	{
@@ -1790,8 +1790,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( Array1S const & a, Array1S const & b )
 	{
@@ -1799,8 +1799,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array1S const & a, Array1S const & b )
 	{
@@ -1808,8 +1808,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array1S const & a, Array1S const & b )
 	{
@@ -1817,8 +1817,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array1S const & a, T const & t )
 	{
@@ -1826,8 +1826,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array1S const & a, T const & t )
 	{
@@ -1835,8 +1835,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array1S const & a, T const & t )
 	{
@@ -1844,8 +1844,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( Array1S const & a, T const & t )
 	{
@@ -1853,8 +1853,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array1S const & a, T const & t )
 	{
@@ -1862,8 +1862,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array1S const & a, T const & t )
 	{
@@ -1871,8 +1871,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, Array1S const & a )
 	{
@@ -1880,8 +1880,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, Array1S const & a )
 	{
@@ -1889,8 +1889,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, Array1S const & a )
 	{
@@ -1898,8 +1898,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, Array1S const & a )
 	{
@@ -1907,8 +1907,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, Array1S const & a )
 	{
@@ -1916,8 +1916,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, Array1S const & a )
 	{
@@ -1927,8 +1927,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count Slice == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array1S const & a, Array1S const & b )
 	{
@@ -1943,8 +1943,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array1S const & a, Array1S const & b )
 	{
@@ -1959,8 +1959,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array1S const & a, Array1S const & b )
 	{
@@ -1975,8 +1975,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array1S const & a, Array1S const & b )
 	{
@@ -1991,8 +1991,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array1S const & a, Array1S const & b )
 	{
@@ -2007,8 +2007,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array1S const & a, Array1S const & b )
 	{
@@ -2023,8 +2023,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array1S const & a, T const & t )
 	{
@@ -2037,8 +2037,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, Array1S const & a )
 	{
@@ -2046,8 +2046,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array1S const & a, T const & t )
 	{
@@ -2060,8 +2060,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, Array1S const & a )
 	{
@@ -2069,8 +2069,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array1S const & a, T const & t )
 	{
@@ -2083,8 +2083,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, Array1S const & a )
 	{
@@ -2092,8 +2092,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array1S const & a, T const & t )
 	{
@@ -2106,8 +2106,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, Array1S const & a )
 	{
@@ -2115,8 +2115,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array1S const & a, T const & t )
 	{
@@ -2129,8 +2129,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, Array1S const & a )
 	{
@@ -2138,8 +2138,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array1S const & a, T const & t )
 	{
@@ -2152,8 +2152,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, Array1S const & a )
 	{
@@ -2164,8 +2164,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1S == MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2179,8 +2179,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1S != MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2189,8 +2189,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1S < MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2204,8 +2204,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1S <= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2219,8 +2219,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1S > MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2234,8 +2234,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array1S >= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2249,8 +2249,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 == Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2259,8 +2259,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 != Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2269,8 +2269,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 < Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2279,8 +2279,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 <= Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2289,8 +2289,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 > Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2299,8 +2299,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray1 >= Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2311,8 +2311,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1S == MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2326,8 +2326,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1S != MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2336,8 +2336,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1S < MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2351,8 +2351,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1S <= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2366,8 +2366,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1S > MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2381,8 +2381,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array1S >= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2396,8 +2396,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 == Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2406,8 +2406,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 != Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2416,8 +2416,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 < Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2426,8 +2426,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 <= Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2436,8 +2436,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 > Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2446,8 +2446,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray1 >= Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2458,8 +2458,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1S == MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2468,8 +2468,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1S != MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2478,8 +2478,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1S < MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2488,8 +2488,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1S <= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2498,8 +2498,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1S > MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2508,8 +2508,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array1S >= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2518,8 +2518,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 == Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2528,8 +2528,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 != Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2538,8 +2538,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 < Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2548,8 +2548,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 <= Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2558,8 +2558,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 > Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2568,8 +2568,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray1 >= Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2580,8 +2580,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1S == MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2596,8 +2596,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1S != MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2612,8 +2612,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1S < MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2628,8 +2628,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1S <= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2644,8 +2644,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1S > MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2660,8 +2660,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array1S >= MArray1
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array1S const & a, MArray1< A, T > const & b )
 	{
@@ -2676,8 +2676,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 == Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2686,8 +2686,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 != Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2696,8 +2696,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 < Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2706,8 +2706,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 <= Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2716,8 +2716,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 > Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray1< A, T > const & a, Array1S const & b )
 	{
@@ -2726,8 +2726,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray1 >= Array1S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray1< A, T > const & a, Array1S const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
@@ -1442,8 +1442,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Array2 == Array2
-	inline
 	friend
+	inline
 	bool
 	eq( Array2 const & a, Array2 const & b )
 	{
@@ -1453,8 +1453,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array2 != Array2
-	inline
 	friend
+	inline
 	bool
 	ne( Array2 const & a, Array2 const & b )
 	{
@@ -1462,8 +1462,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array2 < Array2
-	inline
 	friend
+	inline
 	bool
 	lt( Array2 const & a, Array2 const & b )
 	{
@@ -1473,8 +1473,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array2 <= Array2
-	inline
 	friend
+	inline
 	bool
 	le( Array2 const & a, Array2 const & b )
 	{
@@ -1484,8 +1484,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array2 > Array2
-	inline
 	friend
+	inline
 	bool
 	gt( Array2 const & a, Array2 const & b )
 	{
@@ -1493,8 +1493,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array2 >= Array2
-	inline
 	friend
+	inline
 	bool
 	ge( Array2 const & a, Array2 const & b )
 	{
@@ -1504,8 +1504,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Array2 == Array2
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array2 const & a, Array2 const & b )
 	{
@@ -1515,8 +1515,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array2 != Array2
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array2 const & a, Array2 const & b )
 	{
@@ -1524,8 +1524,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array2 < Array2
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array2 const & a, Array2 const & b )
 	{
@@ -1535,8 +1535,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array2 <= Array2
-	inline
 	friend
+	inline
 	bool
 	any_le( Array2 const & a, Array2 const & b )
 	{
@@ -1546,8 +1546,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array2 > Array2
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array2 const & a, Array2 const & b )
 	{
@@ -1555,8 +1555,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array2 >= Array2
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array2 const & a, Array2 const & b )
 	{
@@ -1566,8 +1566,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// Array2 == Array2
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array2 const & a, Array2 const & b )
 	{
@@ -1575,8 +1575,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array2 != Array2
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array2 const & a, Array2 const & b )
 	{
@@ -1584,8 +1584,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array2 < Array2
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array2 const & a, Array2 const & b )
 	{
@@ -1593,8 +1593,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array2 <= Array2
-	inline
 	friend
+	inline
 	bool
 	all_le( Array2 const & a, Array2 const & b )
 	{
@@ -1602,8 +1602,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array2 > Array2
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array2 const & a, Array2 const & b )
 	{
@@ -1611,8 +1611,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array2 >= Array2
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array2 const & a, Array2 const & b )
 	{
@@ -1622,8 +1622,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Array2 == Array2
-	inline
 	friend
+	inline
 	bool
 	count_eq( Array2 const & a, Array2 const & b )
 	{
@@ -1633,8 +1633,8 @@ public: // Comparison: Count
 	}
 
 	// Array2 != Array2
-	inline
 	friend
+	inline
 	bool
 	count_ne( Array2 const & a, Array2 const & b )
 	{
@@ -1644,8 +1644,8 @@ public: // Comparison: Count
 	}
 
 	// Array2 < Array2
-	inline
 	friend
+	inline
 	bool
 	count_lt( Array2 const & a, Array2 const & b )
 	{
@@ -1655,8 +1655,8 @@ public: // Comparison: Count
 	}
 
 	// Array2 <= Array2
-	inline
 	friend
+	inline
 	bool
 	count_le( Array2 const & a, Array2 const & b )
 	{
@@ -1666,8 +1666,8 @@ public: // Comparison: Count
 	}
 
 	// Array2 > Array2
-	inline
 	friend
+	inline
 	bool
 	count_gt( Array2 const & a, Array2 const & b )
 	{
@@ -1677,8 +1677,8 @@ public: // Comparison: Count
 	}
 
 	// Array2 >= Array2
-	inline
 	friend
+	inline
 	bool
 	count_ge( Array2 const & a, Array2 const & b )
 	{
@@ -1690,8 +1690,8 @@ public: // Comparison: Count
 public: // Comparison: Predicate: Slice
 
 	// Array2 == Array2S
-	inline
 	friend
+	inline
 	bool
 	eq( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1708,8 +1708,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2 != Array2S
-	inline
 	friend
+	inline
 	bool
 	ne( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1717,8 +1717,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2 < Array2S
-	inline
 	friend
+	inline
 	bool
 	lt( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1735,8 +1735,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2 <= Array2S
-	inline
 	friend
+	inline
 	bool
 	le( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1753,8 +1753,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2 > Array2S
-	inline
 	friend
+	inline
 	bool
 	gt( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1771,8 +1771,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2 >= Array2S
-	inline
 	friend
+	inline
 	bool
 	ge( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1789,8 +1789,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2S == Array2
-	inline
 	friend
+	inline
 	bool
 	eq( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1798,8 +1798,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2S != Array2
-	inline
 	friend
+	inline
 	bool
 	ne( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1807,8 +1807,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2S < Array2
-	inline
 	friend
+	inline
 	bool
 	lt( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1816,8 +1816,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2S <= Array2
-	inline
 	friend
+	inline
 	bool
 	le( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1825,8 +1825,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2S > Array2
-	inline
 	friend
+	inline
 	bool
 	gt( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1834,8 +1834,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array2S >= Array2
-	inline
 	friend
+	inline
 	bool
 	ge( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1845,8 +1845,8 @@ public: // Comparison: Predicate: Slice
 public: // Comparison: Predicate: Any: Slice
 
 	// Any Array2 == Array2S
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1863,8 +1863,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2 != Array2S
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1872,8 +1872,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2 < Array2S
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1890,8 +1890,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2 <= Array2S
-	inline
 	friend
+	inline
 	bool
 	any_le( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1908,8 +1908,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2 > Array2S
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1926,8 +1926,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2 >= Array2S
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array2 const & a, Array2S< T > const & b )
 	{
@@ -1944,8 +1944,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2S == Array2
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1953,8 +1953,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2S != Array2
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1962,8 +1962,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2S < Array2
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1971,8 +1971,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2S <= Array2
-	inline
 	friend
+	inline
 	bool
 	any_le( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1980,8 +1980,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2S > Array2
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array2S< T > const & a, Array2 const & b )
 	{
@@ -1989,8 +1989,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array2S >= Array2
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2000,8 +2000,8 @@ public: // Comparison: Predicate: Any: Slice
 public: // Comparison: Predicate: All: Slice
 
 	// All Array2 == Array2S
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2009,8 +2009,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2 != Array2S
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2018,8 +2018,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2 < Array2S
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2027,8 +2027,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2 <= Array2S
-	inline
 	friend
+	inline
 	bool
 	all_le( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2036,8 +2036,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2 > Array2S
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2045,8 +2045,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2 >= Array2S
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2054,8 +2054,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2S == Array2
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2063,8 +2063,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2S != Array2
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2072,8 +2072,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2S < Array2
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2081,8 +2081,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2S <= Array2
-	inline
 	friend
+	inline
 	bool
 	all_le( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2090,8 +2090,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2S > Array2
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2099,8 +2099,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array2S >= Array2
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2110,8 +2110,8 @@ public: // Comparison: Predicate: All: Slice
 public: // Comparison: Count: Slice
 
 	// Count Array2 == Array2S
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2128,8 +2128,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2 != Array2S
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2146,8 +2146,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2 < Array2S
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2164,8 +2164,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2 <= Array2S
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2182,8 +2182,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2 > Array2S
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2200,8 +2200,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2 >= Array2S
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array2 const & a, Array2S< T > const & b )
 	{
@@ -2218,8 +2218,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2S == Array2
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2227,8 +2227,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2S != Array2
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2236,8 +2236,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2S < Array2
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2245,8 +2245,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2S <= Array2
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2254,8 +2254,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2S > Array2
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2263,8 +2263,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array2S >= Array2
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array2S< T > const & a, Array2 const & b )
 	{
@@ -2275,8 +2275,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2 == MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2294,8 +2294,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2 != MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2304,8 +2304,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2 < MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2323,8 +2323,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2 <= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2342,8 +2342,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2 > MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2361,8 +2361,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2 >= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2380,8 +2380,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 == Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2390,8 +2390,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 != Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2400,8 +2400,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 < Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2410,8 +2410,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 <= Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2420,8 +2420,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 > Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2430,8 +2430,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 >= Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2442,8 +2442,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2 == MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2461,8 +2461,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2 != MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2471,8 +2471,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2 < MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2491,8 +2491,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2 <= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2510,8 +2510,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2 > MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2530,8 +2530,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2 >= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2549,8 +2549,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 == Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2559,8 +2559,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 != Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2569,8 +2569,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 < Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2579,8 +2579,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 <= Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2589,8 +2589,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 > Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2599,8 +2599,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 >= Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2611,8 +2611,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2 == MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2621,8 +2621,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2 != MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2631,8 +2631,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2 < MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2641,8 +2641,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2 <= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2651,8 +2651,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2 > MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2661,8 +2661,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2 >= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2671,8 +2671,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 == Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2681,8 +2681,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 != Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2691,8 +2691,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 < Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2701,8 +2701,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 <= Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2711,8 +2711,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 > Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2721,8 +2721,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 >= Array2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2733,8 +2733,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2 == MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2752,8 +2752,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2 != MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2771,8 +2771,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2 < MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2790,8 +2790,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2 <= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2809,8 +2809,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2 > MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2828,8 +2828,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2 >= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array2 const & a, MArray2< A, T > const & b )
 	{
@@ -2847,8 +2847,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 == Array2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2857,8 +2857,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 != Array2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2867,8 +2867,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 < Array2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2877,8 +2877,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 <= Array2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2887,8 +2887,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 > Array2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray2< A, T > const & a, Array2 const & b )
 	{
@@ -2897,8 +2897,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 >= Array2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray2< A, T > const & a, Array2 const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2S.hh
@@ -1040,8 +1040,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( Array2S const & a, Array2S const & b )
 	{
@@ -1056,8 +1056,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( Array2S const & a, Array2S const & b )
 	{
@@ -1065,8 +1065,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( Array2S const & a, Array2S const & b )
 	{
@@ -1081,8 +1081,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( Array2S const & a, Array2S const & b )
 	{
@@ -1097,8 +1097,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( Array2S const & a, Array2S const & b )
 	{
@@ -1106,8 +1106,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( Array2S const & a, Array2S const & b )
 	{
@@ -1115,8 +1115,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice == Value
-	inline
 	friend
+	inline
 	bool
 	eq( Array2S const & a, T const & t )
 	{
@@ -1130,8 +1130,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Value
-	inline
 	friend
+	inline
 	bool
 	ne( Array2S const & a, T const & t )
 	{
@@ -1139,8 +1139,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Value
-	inline
 	friend
+	inline
 	bool
 	lt( Array2S const & a, T const & t )
 	{
@@ -1154,8 +1154,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	le( Array2S const & a, T const & t )
 	{
@@ -1169,8 +1169,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Value
-	inline
 	friend
+	inline
 	bool
 	gt( Array2S const & a, T const & t )
 	{
@@ -1178,8 +1178,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( Array2S const & a, T const & t )
 	{
@@ -1187,8 +1187,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, Array2S const & a )
 	{
@@ -1196,8 +1196,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, Array2S const & a )
 	{
@@ -1205,8 +1205,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, Array2S const & a )
 	{
@@ -1220,8 +1220,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, Array2S const & a )
 	{
@@ -1235,8 +1235,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, Array2S const & a )
 	{
@@ -1244,8 +1244,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, Array2S const & a )
 	{
@@ -1255,8 +1255,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array2S const & a, Array2S const & b )
 	{
@@ -1272,8 +1272,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array2S const & a, Array2S const & b )
 	{
@@ -1281,8 +1281,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array2S const & a, Array2S const & b )
 	{
@@ -1298,8 +1298,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( Array2S const & a, Array2S const & b )
 	{
@@ -1315,8 +1315,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array2S const & a, Array2S const & b )
 	{
@@ -1324,8 +1324,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array2S const & a, Array2S const & b )
 	{
@@ -1333,8 +1333,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array2S const & a, T const & t )
 	{
@@ -1348,8 +1348,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array2S const & a, T const & t )
 	{
@@ -1357,8 +1357,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array2S const & a, T const & t )
 	{
@@ -1372,8 +1372,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( Array2S const & a, T const & t )
 	{
@@ -1387,8 +1387,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array2S const & a, T const & t )
 	{
@@ -1396,8 +1396,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array2S const & a, T const & t )
 	{
@@ -1405,8 +1405,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, Array2S const & a )
 	{
@@ -1414,8 +1414,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, Array2S const & a )
 	{
@@ -1423,8 +1423,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, Array2S const & a )
 	{
@@ -1438,8 +1438,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, Array2S const & a )
 	{
@@ -1453,8 +1453,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, Array2S const & a )
 	{
@@ -1462,8 +1462,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, Array2S const & a )
 	{
@@ -1473,8 +1473,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array2S const & a, Array2S const & b )
 	{
@@ -1482,8 +1482,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array2S const & a, Array2S const & b )
 	{
@@ -1491,8 +1491,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array2S const & a, Array2S const & b )
 	{
@@ -1500,8 +1500,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( Array2S const & a, Array2S const & b )
 	{
@@ -1509,8 +1509,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array2S const & a, Array2S const & b )
 	{
@@ -1518,8 +1518,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array2S const & a, Array2S const & b )
 	{
@@ -1527,8 +1527,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array2S const & a, T const & t )
 	{
@@ -1536,8 +1536,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array2S const & a, T const & t )
 	{
@@ -1545,8 +1545,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array2S const & a, T const & t )
 	{
@@ -1554,8 +1554,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( Array2S const & a, T const & t )
 	{
@@ -1563,8 +1563,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array2S const & a, T const & t )
 	{
@@ -1572,8 +1572,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array2S const & a, T const & t )
 	{
@@ -1581,8 +1581,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, Array2S const & a )
 	{
@@ -1590,8 +1590,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, Array2S const & a )
 	{
@@ -1599,8 +1599,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, Array2S const & a )
 	{
@@ -1608,8 +1608,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, Array2S const & a )
 	{
@@ -1617,8 +1617,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, Array2S const & a )
 	{
@@ -1626,8 +1626,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, Array2S const & a )
 	{
@@ -1637,8 +1637,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count Slice == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array2S const & a, Array2S const & b )
 	{
@@ -1655,8 +1655,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array2S const & a, Array2S const & b )
 	{
@@ -1673,8 +1673,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array2S const & a, Array2S const & b )
 	{
@@ -1691,8 +1691,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array2S const & a, Array2S const & b )
 	{
@@ -1709,8 +1709,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array2S const & a, Array2S const & b )
 	{
@@ -1727,8 +1727,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array2S const & a, Array2S const & b )
 	{
@@ -1745,8 +1745,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array2S const & a, T const & t )
 	{
@@ -1761,8 +1761,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, Array2S const & a )
 	{
@@ -1770,8 +1770,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array2S const & a, T const & t )
 	{
@@ -1786,8 +1786,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, Array2S const & a )
 	{
@@ -1795,8 +1795,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array2S const & a, T const & t )
 	{
@@ -1811,8 +1811,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, Array2S const & a )
 	{
@@ -1820,8 +1820,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array2S const & a, T const & t )
 	{
@@ -1836,8 +1836,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, Array2S const & a )
 	{
@@ -1845,8 +1845,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array2S const & a, T const & t )
 	{
@@ -1861,8 +1861,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, Array2S const & a )
 	{
@@ -1870,8 +1870,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array2S const & a, T const & t )
 	{
@@ -1886,8 +1886,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, Array2S const & a )
 	{
@@ -1898,8 +1898,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2S == MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -1915,8 +1915,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2S != MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -1925,8 +1925,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2S < MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -1942,8 +1942,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2S <= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -1959,8 +1959,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2S > MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -1976,8 +1976,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array2S >= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -1993,8 +1993,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 == Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2003,8 +2003,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 != Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2013,8 +2013,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 < Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2023,8 +2023,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 <= Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2033,8 +2033,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 > Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2043,8 +2043,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray2 >= Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2055,8 +2055,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2S == MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2072,8 +2072,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2S != MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2082,8 +2082,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2S < MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2099,8 +2099,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2S <= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2116,8 +2116,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2S > MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2133,8 +2133,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array2S >= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2150,8 +2150,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 == Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2160,8 +2160,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 != Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2170,8 +2170,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 < Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2180,8 +2180,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 <= Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2190,8 +2190,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 > Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2200,8 +2200,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray2 >= Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2212,8 +2212,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2S == MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2222,8 +2222,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2S != MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2232,8 +2232,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2S < MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2242,8 +2242,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2S <= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2252,8 +2252,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2S > MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2262,8 +2262,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array2S >= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2272,8 +2272,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 == Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2282,8 +2282,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 != Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2292,8 +2292,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 < Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2302,8 +2302,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 <= Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2312,8 +2312,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 > Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2322,8 +2322,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray2 >= Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2334,8 +2334,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2S == MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2352,8 +2352,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2S != MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2370,8 +2370,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2S < MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2388,8 +2388,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2S <= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2406,8 +2406,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2S > MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2424,8 +2424,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array2S >= MArray2
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array2S const & a, MArray2< A, T > const & b )
 	{
@@ -2442,8 +2442,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 == Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2452,8 +2452,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 != Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2462,8 +2462,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 < Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2472,8 +2472,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 <= Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2482,8 +2482,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 > Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray2< A, T > const & a, Array2S const & b )
 	{
@@ -2492,8 +2492,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray2 >= Array2S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray2< A, T > const & a, Array2S const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
@@ -1519,8 +1519,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Array3 == Array3
-	inline
 	friend
+	inline
 	bool
 	eq( Array3 const & a, Array3 const & b )
 	{
@@ -1530,8 +1530,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array3 != Array3
-	inline
 	friend
+	inline
 	bool
 	ne( Array3 const & a, Array3 const & b )
 	{
@@ -1539,8 +1539,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array3 < Array3
-	inline
 	friend
+	inline
 	bool
 	lt( Array3 const & a, Array3 const & b )
 	{
@@ -1550,8 +1550,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array3 <= Array3
-	inline
 	friend
+	inline
 	bool
 	le( Array3 const & a, Array3 const & b )
 	{
@@ -1561,8 +1561,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array3 > Array3
-	inline
 	friend
+	inline
 	bool
 	gt( Array3 const & a, Array3 const & b )
 	{
@@ -1570,8 +1570,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array3 >= Array3
-	inline
 	friend
+	inline
 	bool
 	ge( Array3 const & a, Array3 const & b )
 	{
@@ -1581,8 +1581,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Array3 == Array3
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array3 const & a, Array3 const & b )
 	{
@@ -1592,8 +1592,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array3 != Array3
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array3 const & a, Array3 const & b )
 	{
@@ -1601,8 +1601,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array3 < Array3
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array3 const & a, Array3 const & b )
 	{
@@ -1612,8 +1612,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array3 <= Array3
-	inline
 	friend
+	inline
 	bool
 	any_le( Array3 const & a, Array3 const & b )
 	{
@@ -1623,8 +1623,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array3 > Array3
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array3 const & a, Array3 const & b )
 	{
@@ -1632,8 +1632,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array3 >= Array3
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array3 const & a, Array3 const & b )
 	{
@@ -1643,8 +1643,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// Array3 == Array3
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array3 const & a, Array3 const & b )
 	{
@@ -1652,8 +1652,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array3 != Array3
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array3 const & a, Array3 const & b )
 	{
@@ -1661,8 +1661,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array3 < Array3
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array3 const & a, Array3 const & b )
 	{
@@ -1670,8 +1670,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array3 <= Array3
-	inline
 	friend
+	inline
 	bool
 	all_le( Array3 const & a, Array3 const & b )
 	{
@@ -1679,8 +1679,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array3 > Array3
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array3 const & a, Array3 const & b )
 	{
@@ -1688,8 +1688,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array3 >= Array3
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array3 const & a, Array3 const & b )
 	{
@@ -1699,8 +1699,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Array3 == Array3
-	inline
 	friend
+	inline
 	bool
 	count_eq( Array3 const & a, Array3 const & b )
 	{
@@ -1710,8 +1710,8 @@ public: // Comparison: Count
 	}
 
 	// Array3 != Array3
-	inline
 	friend
+	inline
 	bool
 	count_ne( Array3 const & a, Array3 const & b )
 	{
@@ -1721,8 +1721,8 @@ public: // Comparison: Count
 	}
 
 	// Array3 < Array3
-	inline
 	friend
+	inline
 	bool
 	count_lt( Array3 const & a, Array3 const & b )
 	{
@@ -1732,8 +1732,8 @@ public: // Comparison: Count
 	}
 
 	// Array3 <= Array3
-	inline
 	friend
+	inline
 	bool
 	count_le( Array3 const & a, Array3 const & b )
 	{
@@ -1743,8 +1743,8 @@ public: // Comparison: Count
 	}
 
 	// Array3 > Array3
-	inline
 	friend
+	inline
 	bool
 	count_gt( Array3 const & a, Array3 const & b )
 	{
@@ -1754,8 +1754,8 @@ public: // Comparison: Count
 	}
 
 	// Array3 >= Array3
-	inline
 	friend
+	inline
 	bool
 	count_ge( Array3 const & a, Array3 const & b )
 	{
@@ -1767,8 +1767,8 @@ public: // Comparison: Count
 public: // Comparison: Predicate: Slice
 
 	// Array3 == Array3S
-	inline
 	friend
+	inline
 	bool
 	eq( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1787,8 +1787,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3 != Array3S
-	inline
 	friend
+	inline
 	bool
 	ne( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1796,8 +1796,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3 < Array3S
-	inline
 	friend
+	inline
 	bool
 	lt( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1816,8 +1816,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3 <= Array3S
-	inline
 	friend
+	inline
 	bool
 	le( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1836,8 +1836,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3 > Array3S
-	inline
 	friend
+	inline
 	bool
 	gt( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1856,8 +1856,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3 >= Array3S
-	inline
 	friend
+	inline
 	bool
 	ge( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1876,8 +1876,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3S == Array3
-	inline
 	friend
+	inline
 	bool
 	eq( Array3S< T > const & a, Array3 const & b )
 	{
@@ -1885,8 +1885,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3S != Array3
-	inline
 	friend
+	inline
 	bool
 	ne( Array3S< T > const & a, Array3 const & b )
 	{
@@ -1894,8 +1894,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3S < Array3
-	inline
 	friend
+	inline
 	bool
 	lt( Array3S< T > const & a, Array3 const & b )
 	{
@@ -1903,8 +1903,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3S <= Array3
-	inline
 	friend
+	inline
 	bool
 	le( Array3S< T > const & a, Array3 const & b )
 	{
@@ -1912,8 +1912,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3S > Array3
-	inline
 	friend
+	inline
 	bool
 	gt( Array3S< T > const & a, Array3 const & b )
 	{
@@ -1921,8 +1921,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array3S >= Array3
-	inline
 	friend
+	inline
 	bool
 	ge( Array3S< T > const & a, Array3 const & b )
 	{
@@ -1932,8 +1932,8 @@ public: // Comparison: Predicate: Slice
 public: // Comparison: Predicate: Any: Slice
 
 	// Any Array3 == Array3S
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1952,8 +1952,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3 != Array3S
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1961,8 +1961,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3 < Array3S
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array3 const & a, Array3S< T > const & b )
 	{
@@ -1981,8 +1981,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3 <= Array3S
-	inline
 	friend
+	inline
 	bool
 	any_le( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2001,8 +2001,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3 > Array3S
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2021,8 +2021,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3 >= Array3S
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2041,8 +2041,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3S == Array3
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2050,8 +2050,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3S != Array3
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2059,8 +2059,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3S < Array3
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2068,8 +2068,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3S <= Array3
-	inline
 	friend
+	inline
 	bool
 	any_le( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2077,8 +2077,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3S > Array3
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2086,8 +2086,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array3S >= Array3
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2097,8 +2097,8 @@ public: // Comparison: Predicate: Any: Slice
 public: // Comparison: Predicate: All: Slice
 
 	// All Array3 == Array3S
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2106,8 +2106,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3 != Array3S
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2115,8 +2115,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3 < Array3S
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2124,8 +2124,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3 <= Array3S
-	inline
 	friend
+	inline
 	bool
 	all_le( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2133,8 +2133,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3 > Array3S
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2142,8 +2142,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3 >= Array3S
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2151,8 +2151,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3S == Array3
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2160,8 +2160,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3S != Array3
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2169,8 +2169,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3S < Array3
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2178,8 +2178,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3S <= Array3
-	inline
 	friend
+	inline
 	bool
 	all_le( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2187,8 +2187,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3S > Array3
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2196,8 +2196,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array3S >= Array3
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2207,8 +2207,8 @@ public: // Comparison: Predicate: All: Slice
 public: // Comparison: Count: Slice
 
 	// Count Array3 == Array3S
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2227,8 +2227,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3 != Array3S
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2247,8 +2247,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3 < Array3S
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2267,8 +2267,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3 <= Array3S
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2287,8 +2287,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3 > Array3S
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2307,8 +2307,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3 >= Array3S
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array3 const & a, Array3S< T > const & b )
 	{
@@ -2327,8 +2327,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3S == Array3
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2336,8 +2336,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3S != Array3
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2345,8 +2345,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3S < Array3
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2354,8 +2354,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3S <= Array3
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2363,8 +2363,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3S > Array3
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2372,8 +2372,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array3S >= Array3
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array3S< T > const & a, Array3 const & b )
 	{
@@ -2384,8 +2384,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3 == MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2405,8 +2405,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3 != MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2415,8 +2415,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3 < MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2436,8 +2436,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3 <= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2457,8 +2457,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3 > MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2478,8 +2478,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3 >= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2499,8 +2499,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 == Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2509,8 +2509,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 != Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2519,8 +2519,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 < Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2529,8 +2529,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 <= Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2539,8 +2539,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 > Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2549,8 +2549,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 >= Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2561,8 +2561,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3 == MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2582,8 +2582,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3 != MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2592,8 +2592,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3 < MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2613,8 +2613,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3 <= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2634,8 +2634,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3 > MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2655,8 +2655,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3 >= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2676,8 +2676,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 == Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2686,8 +2686,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 != Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2696,8 +2696,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 < Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2706,8 +2706,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 <= Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2716,8 +2716,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 > Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2726,8 +2726,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 >= Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2738,8 +2738,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3 == MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2748,8 +2748,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3 != MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2758,8 +2758,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3 < MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2768,8 +2768,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3 <= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2778,8 +2778,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3 > MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2788,8 +2788,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3 >= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2798,8 +2798,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 == Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2808,8 +2808,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 != Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2818,8 +2818,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 < Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2828,8 +2828,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 <= Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2838,8 +2838,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 > Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2848,8 +2848,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 >= Array3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2860,8 +2860,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3 == MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2881,8 +2881,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3 != MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2902,8 +2902,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3 < MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2923,8 +2923,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3 <= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2944,8 +2944,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3 > MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2965,8 +2965,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3 >= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array3 const & a, MArray3< A, T > const & b )
 	{
@@ -2986,8 +2986,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 == Array3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -2996,8 +2996,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 != Array3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -3006,8 +3006,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 < Array3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -3016,8 +3016,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 <= Array3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -3026,8 +3026,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 > Array3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray3< A, T > const & a, Array3 const & b )
 	{
@@ -3036,8 +3036,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 >= Array3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray3< A, T > const & a, Array3 const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3S.hh
@@ -1293,8 +1293,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( Array3S const & a, Array3S const & b )
 	{
@@ -1311,8 +1311,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( Array3S const & a, Array3S const & b )
 	{
@@ -1320,8 +1320,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( Array3S const & a, Array3S const & b )
 	{
@@ -1338,8 +1338,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( Array3S const & a, Array3S const & b )
 	{
@@ -1356,8 +1356,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( Array3S const & a, Array3S const & b )
 	{
@@ -1365,8 +1365,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( Array3S const & a, Array3S const & b )
 	{
@@ -1374,8 +1374,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice == Value
-	inline
 	friend
+	inline
 	bool
 	eq( Array3S const & a, T const & t )
 	{
@@ -1391,8 +1391,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Value
-	inline
 	friend
+	inline
 	bool
 	ne( Array3S const & a, T const & t )
 	{
@@ -1400,8 +1400,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Value
-	inline
 	friend
+	inline
 	bool
 	lt( Array3S const & a, T const & t )
 	{
@@ -1417,8 +1417,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	le( Array3S const & a, T const & t )
 	{
@@ -1434,8 +1434,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Value
-	inline
 	friend
+	inline
 	bool
 	gt( Array3S const & a, T const & t )
 	{
@@ -1443,8 +1443,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( Array3S const & a, T const & t )
 	{
@@ -1452,8 +1452,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, Array3S const & a )
 	{
@@ -1461,8 +1461,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, Array3S const & a )
 	{
@@ -1470,8 +1470,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, Array3S const & a )
 	{
@@ -1487,8 +1487,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, Array3S const & a )
 	{
@@ -1504,8 +1504,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, Array3S const & a )
 	{
@@ -1513,8 +1513,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, Array3S const & a )
 	{
@@ -1524,8 +1524,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array3S const & a, Array3S const & b )
 	{
@@ -1543,8 +1543,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array3S const & a, Array3S const & b )
 	{
@@ -1552,8 +1552,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array3S const & a, Array3S const & b )
 	{
@@ -1571,8 +1571,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( Array3S const & a, Array3S const & b )
 	{
@@ -1590,8 +1590,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array3S const & a, Array3S const & b )
 	{
@@ -1599,8 +1599,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array3S const & a, Array3S const & b )
 	{
@@ -1608,8 +1608,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array3S const & a, T const & t )
 	{
@@ -1625,8 +1625,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array3S const & a, T const & t )
 	{
@@ -1634,8 +1634,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array3S const & a, T const & t )
 	{
@@ -1651,8 +1651,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( Array3S const & a, T const & t )
 	{
@@ -1668,8 +1668,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array3S const & a, T const & t )
 	{
@@ -1677,8 +1677,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array3S const & a, T const & t )
 	{
@@ -1686,8 +1686,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, Array3S const & a )
 	{
@@ -1695,8 +1695,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, Array3S const & a )
 	{
@@ -1704,8 +1704,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, Array3S const & a )
 	{
@@ -1721,8 +1721,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, Array3S const & a )
 	{
@@ -1738,8 +1738,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, Array3S const & a )
 	{
@@ -1747,8 +1747,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, Array3S const & a )
 	{
@@ -1758,8 +1758,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array3S const & a, Array3S const & b )
 	{
@@ -1767,8 +1767,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array3S const & a, Array3S const & b )
 	{
@@ -1776,8 +1776,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array3S const & a, Array3S const & b )
 	{
@@ -1785,8 +1785,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( Array3S const & a, Array3S const & b )
 	{
@@ -1794,8 +1794,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array3S const & a, Array3S const & b )
 	{
@@ -1803,8 +1803,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array3S const & a, Array3S const & b )
 	{
@@ -1812,8 +1812,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array3S const & a, T const & t )
 	{
@@ -1821,8 +1821,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array3S const & a, T const & t )
 	{
@@ -1830,8 +1830,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array3S const & a, T const & t )
 	{
@@ -1839,8 +1839,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( Array3S const & a, T const & t )
 	{
@@ -1848,8 +1848,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array3S const & a, T const & t )
 	{
@@ -1857,8 +1857,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array3S const & a, T const & t )
 	{
@@ -1866,8 +1866,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, Array3S const & a )
 	{
@@ -1875,8 +1875,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, Array3S const & a )
 	{
@@ -1884,8 +1884,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, Array3S const & a )
 	{
@@ -1893,8 +1893,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, Array3S const & a )
 	{
@@ -1902,8 +1902,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, Array3S const & a )
 	{
@@ -1911,8 +1911,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, Array3S const & a )
 	{
@@ -1922,8 +1922,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count Slice == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array3S const & a, Array3S const & b )
 	{
@@ -1942,8 +1942,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array3S const & a, Array3S const & b )
 	{
@@ -1962,8 +1962,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array3S const & a, Array3S const & b )
 	{
@@ -1982,8 +1982,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array3S const & a, Array3S const & b )
 	{
@@ -2002,8 +2002,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array3S const & a, Array3S const & b )
 	{
@@ -2022,8 +2022,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array3S const & a, Array3S const & b )
 	{
@@ -2042,8 +2042,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array3S const & a, T const & t )
 	{
@@ -2060,8 +2060,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, Array3S const & a )
 	{
@@ -2069,8 +2069,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array3S const & a, T const & t )
 	{
@@ -2087,8 +2087,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, Array3S const & a )
 	{
@@ -2096,8 +2096,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array3S const & a, T const & t )
 	{
@@ -2114,8 +2114,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, Array3S const & a )
 	{
@@ -2123,8 +2123,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array3S const & a, T const & t )
 	{
@@ -2141,8 +2141,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, Array3S const & a )
 	{
@@ -2150,8 +2150,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array3S const & a, T const & t )
 	{
@@ -2168,8 +2168,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, Array3S const & a )
 	{
@@ -2177,8 +2177,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array3S const & a, T const & t )
 	{
@@ -2195,8 +2195,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, Array3S const & a )
 	{
@@ -2207,8 +2207,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3S == MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2226,8 +2226,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3S != MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2236,8 +2236,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3S < MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2255,8 +2255,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3S <= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2274,8 +2274,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3S > MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2293,8 +2293,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array3S >= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2312,8 +2312,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 == Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2322,8 +2322,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 != Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2332,8 +2332,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 < Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2342,8 +2342,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 <= Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2352,8 +2352,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 > Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2362,8 +2362,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray3 >= Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2374,8 +2374,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3S == MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2393,8 +2393,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3S != MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2403,8 +2403,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3S < MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2422,8 +2422,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3S <= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2441,8 +2441,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3S > MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2460,8 +2460,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array3S >= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2479,8 +2479,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 == Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2489,8 +2489,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 != Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2499,8 +2499,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 < Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2509,8 +2509,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 <= Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2519,8 +2519,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 > Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2529,8 +2529,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray3 >= Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2541,8 +2541,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3S == MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2551,8 +2551,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3S != MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2561,8 +2561,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3S < MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2571,8 +2571,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3S <= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2581,8 +2581,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3S > MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2591,8 +2591,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array3S >= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2601,8 +2601,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 == Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2611,8 +2611,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 != Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2621,8 +2621,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 < Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2631,8 +2631,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 <= Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2641,8 +2641,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 > Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2651,8 +2651,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray3 >= Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2663,8 +2663,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3S == MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2683,8 +2683,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3S != MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2703,8 +2703,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3S < MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2723,8 +2723,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3S <= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2743,8 +2743,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3S > MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2763,8 +2763,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array3S >= MArray3
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array3S const & a, MArray3< A, T > const & b )
 	{
@@ -2783,8 +2783,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 == Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2793,8 +2793,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 != Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2803,8 +2803,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 < Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2813,8 +2813,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 <= Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2823,8 +2823,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 > Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray3< A, T > const & a, Array3S const & b )
 	{
@@ -2833,8 +2833,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray3 >= Array3S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray3< A, T > const & a, Array3S const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
@@ -1886,8 +1886,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Array4 == Array4
-	inline
 	friend
+	inline
 	bool
 	eq( Array4 const & a, Array4 const & b )
 	{
@@ -1897,8 +1897,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array4 != Array4
-	inline
 	friend
+	inline
 	bool
 	ne( Array4 const & a, Array4 const & b )
 	{
@@ -1906,8 +1906,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array4 < Array4
-	inline
 	friend
+	inline
 	bool
 	lt( Array4 const & a, Array4 const & b )
 	{
@@ -1917,8 +1917,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array4 <= Array4
-	inline
 	friend
+	inline
 	bool
 	le( Array4 const & a, Array4 const & b )
 	{
@@ -1928,8 +1928,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array4 > Array4
-	inline
 	friend
+	inline
 	bool
 	gt( Array4 const & a, Array4 const & b )
 	{
@@ -1937,8 +1937,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array4 >= Array4
-	inline
 	friend
+	inline
 	bool
 	ge( Array4 const & a, Array4 const & b )
 	{
@@ -1948,8 +1948,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Array4 == Array4
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array4 const & a, Array4 const & b )
 	{
@@ -1959,8 +1959,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array4 != Array4
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array4 const & a, Array4 const & b )
 	{
@@ -1968,8 +1968,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array4 < Array4
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array4 const & a, Array4 const & b )
 	{
@@ -1979,8 +1979,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array4 <= Array4
-	inline
 	friend
+	inline
 	bool
 	any_le( Array4 const & a, Array4 const & b )
 	{
@@ -1990,8 +1990,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array4 > Array4
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array4 const & a, Array4 const & b )
 	{
@@ -1999,8 +1999,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array4 >= Array4
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array4 const & a, Array4 const & b )
 	{
@@ -2010,8 +2010,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// Array4 == Array4
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array4 const & a, Array4 const & b )
 	{
@@ -2019,8 +2019,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array4 != Array4
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array4 const & a, Array4 const & b )
 	{
@@ -2028,8 +2028,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array4 < Array4
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array4 const & a, Array4 const & b )
 	{
@@ -2037,8 +2037,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array4 <= Array4
-	inline
 	friend
+	inline
 	bool
 	all_le( Array4 const & a, Array4 const & b )
 	{
@@ -2046,8 +2046,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array4 > Array4
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array4 const & a, Array4 const & b )
 	{
@@ -2055,8 +2055,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array4 >= Array4
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array4 const & a, Array4 const & b )
 	{
@@ -2066,8 +2066,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Array4 == Array4
-	inline
 	friend
+	inline
 	bool
 	count_eq( Array4 const & a, Array4 const & b )
 	{
@@ -2077,8 +2077,8 @@ public: // Comparison: Count
 	}
 
 	// Array4 != Array4
-	inline
 	friend
+	inline
 	bool
 	count_ne( Array4 const & a, Array4 const & b )
 	{
@@ -2088,8 +2088,8 @@ public: // Comparison: Count
 	}
 
 	// Array4 < Array4
-	inline
 	friend
+	inline
 	bool
 	count_lt( Array4 const & a, Array4 const & b )
 	{
@@ -2099,8 +2099,8 @@ public: // Comparison: Count
 	}
 
 	// Array4 <= Array4
-	inline
 	friend
+	inline
 	bool
 	count_le( Array4 const & a, Array4 const & b )
 	{
@@ -2110,8 +2110,8 @@ public: // Comparison: Count
 	}
 
 	// Array4 > Array4
-	inline
 	friend
+	inline
 	bool
 	count_gt( Array4 const & a, Array4 const & b )
 	{
@@ -2121,8 +2121,8 @@ public: // Comparison: Count
 	}
 
 	// Array4 >= Array4
-	inline
 	friend
+	inline
 	bool
 	count_ge( Array4 const & a, Array4 const & b )
 	{
@@ -2134,8 +2134,8 @@ public: // Comparison: Count
 public: // Comparison: Predicate: Slice
 
 	// Array4 == Array4S
-	inline
 	friend
+	inline
 	bool
 	eq( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2156,8 +2156,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4 != Array4S
-	inline
 	friend
+	inline
 	bool
 	ne( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2165,8 +2165,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4 < Array4S
-	inline
 	friend
+	inline
 	bool
 	lt( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2187,8 +2187,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4 <= Array4S
-	inline
 	friend
+	inline
 	bool
 	le( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2209,8 +2209,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4 > Array4S
-	inline
 	friend
+	inline
 	bool
 	gt( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2231,8 +2231,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4 >= Array4S
-	inline
 	friend
+	inline
 	bool
 	ge( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2253,8 +2253,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4S == Array4
-	inline
 	friend
+	inline
 	bool
 	eq( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2262,8 +2262,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4S != Array4
-	inline
 	friend
+	inline
 	bool
 	ne( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2271,8 +2271,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4S < Array4
-	inline
 	friend
+	inline
 	bool
 	lt( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2280,8 +2280,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4S <= Array4
-	inline
 	friend
+	inline
 	bool
 	le( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2289,8 +2289,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4S > Array4
-	inline
 	friend
+	inline
 	bool
 	gt( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2298,8 +2298,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array4S >= Array4
-	inline
 	friend
+	inline
 	bool
 	ge( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2309,8 +2309,8 @@ public: // Comparison: Predicate: Slice
 public: // Comparison: Predicate: Any: Slice
 
 	// Any Array4 == Array4S
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2331,8 +2331,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4 != Array4S
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2340,8 +2340,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4 < Array4S
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2362,8 +2362,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4 <= Array4S
-	inline
 	friend
+	inline
 	bool
 	any_le( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2384,8 +2384,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4 > Array4S
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2406,8 +2406,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4 >= Array4S
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2428,8 +2428,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4S == Array4
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2437,8 +2437,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4S != Array4
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2446,8 +2446,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4S < Array4
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2455,8 +2455,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4S <= Array4
-	inline
 	friend
+	inline
 	bool
 	any_le( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2464,8 +2464,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4S > Array4
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2473,8 +2473,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array4S >= Array4
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2484,8 +2484,8 @@ public: // Comparison: Predicate: Any: Slice
 public: // Comparison: Predicate: All: Slice
 
 	// All Array4 == Array4S
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2493,8 +2493,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4 != Array4S
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2502,8 +2502,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4 < Array4S
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2511,8 +2511,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4 <= Array4S
-	inline
 	friend
+	inline
 	bool
 	all_le( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2520,8 +2520,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4 > Array4S
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2529,8 +2529,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4 >= Array4S
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2538,8 +2538,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4S == Array4
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2547,8 +2547,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4S != Array4
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2556,8 +2556,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4S < Array4
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2565,8 +2565,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4S <= Array4
-	inline
 	friend
+	inline
 	bool
 	all_le( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2574,8 +2574,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4S > Array4
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2583,8 +2583,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array4S >= Array4
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2594,8 +2594,8 @@ public: // Comparison: Predicate: All: Slice
 public: // Comparison: Count: Slice
 
 	// Count Array4 == Array4S
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2616,8 +2616,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4 != Array4S
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2638,8 +2638,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4 < Array4S
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2660,8 +2660,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4 <= Array4S
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2682,8 +2682,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4 > Array4S
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2704,8 +2704,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4 >= Array4S
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array4 const & a, Array4S< T > const & b )
 	{
@@ -2726,8 +2726,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4S == Array4
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2735,8 +2735,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4S != Array4
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2744,8 +2744,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4S < Array4
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2753,8 +2753,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4S <= Array4
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2762,8 +2762,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4S > Array4
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2771,8 +2771,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array4S >= Array4
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array4S< T > const & a, Array4 const & b )
 	{
@@ -2783,8 +2783,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4 == MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -2806,8 +2806,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4 != MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -2816,8 +2816,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4 < MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -2839,8 +2839,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4 <= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -2862,8 +2862,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4 > MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -2885,8 +2885,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4 >= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -2908,8 +2908,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 == Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -2918,8 +2918,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 != Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -2928,8 +2928,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 < Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -2938,8 +2938,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 <= Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -2948,8 +2948,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 > Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -2958,8 +2958,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 >= Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -2970,8 +2970,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4 == MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -2993,8 +2993,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4 != MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3003,8 +3003,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4 < MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3026,8 +3026,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4 <= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3049,8 +3049,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4 > MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3072,8 +3072,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4 >= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3095,8 +3095,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 == Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3105,8 +3105,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 != Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3115,8 +3115,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 < Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3125,8 +3125,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 <= Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3135,8 +3135,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 > Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3145,8 +3145,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 >= Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3157,8 +3157,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4 == MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3167,8 +3167,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4 != MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3177,8 +3177,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4 < MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3187,8 +3187,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4 <= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3197,8 +3197,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4 > MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3207,8 +3207,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4 >= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3217,8 +3217,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 == Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3227,8 +3227,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 != Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3237,8 +3237,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 < Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3247,8 +3247,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 <= Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3257,8 +3257,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 > Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3267,8 +3267,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 >= Array4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3279,8 +3279,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4 == MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3302,8 +3302,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4 != MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3325,8 +3325,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4 < MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3348,8 +3348,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4 <= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3371,8 +3371,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4 > MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3394,8 +3394,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4 >= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array4 const & a, MArray4< A, T > const & b )
 	{
@@ -3417,8 +3417,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 == Array4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3427,8 +3427,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 != Array4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3437,8 +3437,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 < Array4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3447,8 +3447,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 <= Array4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3457,8 +3457,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 > Array4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray4< A, T > const & a, Array4 const & b )
 	{
@@ -3467,8 +3467,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 >= Array4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray4< A, T > const & a, Array4 const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4S.hh
@@ -1662,8 +1662,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( Array4S const & a, Array4S const & b )
 	{
@@ -1682,8 +1682,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( Array4S const & a, Array4S const & b )
 	{
@@ -1691,8 +1691,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( Array4S const & a, Array4S const & b )
 	{
@@ -1711,8 +1711,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( Array4S const & a, Array4S const & b )
 	{
@@ -1731,8 +1731,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( Array4S const & a, Array4S const & b )
 	{
@@ -1740,8 +1740,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( Array4S const & a, Array4S const & b )
 	{
@@ -1749,8 +1749,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice == Value
-	inline
 	friend
+	inline
 	bool
 	eq( Array4S const & a, T const & t )
 	{
@@ -1768,8 +1768,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Value
-	inline
 	friend
+	inline
 	bool
 	ne( Array4S const & a, T const & t )
 	{
@@ -1777,8 +1777,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Value
-	inline
 	friend
+	inline
 	bool
 	lt( Array4S const & a, T const & t )
 	{
@@ -1796,8 +1796,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	le( Array4S const & a, T const & t )
 	{
@@ -1815,8 +1815,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Value
-	inline
 	friend
+	inline
 	bool
 	gt( Array4S const & a, T const & t )
 	{
@@ -1824,8 +1824,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( Array4S const & a, T const & t )
 	{
@@ -1833,8 +1833,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, Array4S const & a )
 	{
@@ -1842,8 +1842,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, Array4S const & a )
 	{
@@ -1851,8 +1851,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, Array4S const & a )
 	{
@@ -1870,8 +1870,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, Array4S const & a )
 	{
@@ -1889,8 +1889,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, Array4S const & a )
 	{
@@ -1898,8 +1898,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, Array4S const & a )
 	{
@@ -1909,8 +1909,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array4S const & a, Array4S const & b )
 	{
@@ -1930,8 +1930,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array4S const & a, Array4S const & b )
 	{
@@ -1939,8 +1939,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array4S const & a, Array4S const & b )
 	{
@@ -1960,8 +1960,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( Array4S const & a, Array4S const & b )
 	{
@@ -1981,8 +1981,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array4S const & a, Array4S const & b )
 	{
@@ -1990,8 +1990,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array4S const & a, Array4S const & b )
 	{
@@ -1999,8 +1999,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array4S const & a, T const & t )
 	{
@@ -2018,8 +2018,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array4S const & a, T const & t )
 	{
@@ -2027,8 +2027,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array4S const & a, T const & t )
 	{
@@ -2046,8 +2046,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( Array4S const & a, T const & t )
 	{
@@ -2065,8 +2065,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array4S const & a, T const & t )
 	{
@@ -2074,8 +2074,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array4S const & a, T const & t )
 	{
@@ -2083,8 +2083,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, Array4S const & a )
 	{
@@ -2092,8 +2092,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, Array4S const & a )
 	{
@@ -2101,8 +2101,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, Array4S const & a )
 	{
@@ -2120,8 +2120,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, Array4S const & a )
 	{
@@ -2139,8 +2139,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, Array4S const & a )
 	{
@@ -2148,8 +2148,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, Array4S const & a )
 	{
@@ -2159,8 +2159,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array4S const & a, Array4S const & b )
 	{
@@ -2168,8 +2168,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array4S const & a, Array4S const & b )
 	{
@@ -2177,8 +2177,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array4S const & a, Array4S const & b )
 	{
@@ -2186,8 +2186,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( Array4S const & a, Array4S const & b )
 	{
@@ -2195,8 +2195,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array4S const & a, Array4S const & b )
 	{
@@ -2204,8 +2204,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array4S const & a, Array4S const & b )
 	{
@@ -2213,8 +2213,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array4S const & a, T const & t )
 	{
@@ -2222,8 +2222,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array4S const & a, T const & t )
 	{
@@ -2231,8 +2231,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array4S const & a, T const & t )
 	{
@@ -2240,8 +2240,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( Array4S const & a, T const & t )
 	{
@@ -2249,8 +2249,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array4S const & a, T const & t )
 	{
@@ -2258,8 +2258,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array4S const & a, T const & t )
 	{
@@ -2267,8 +2267,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, Array4S const & a )
 	{
@@ -2276,8 +2276,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, Array4S const & a )
 	{
@@ -2285,8 +2285,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, Array4S const & a )
 	{
@@ -2294,8 +2294,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, Array4S const & a )
 	{
@@ -2303,8 +2303,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, Array4S const & a )
 	{
@@ -2312,8 +2312,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, Array4S const & a )
 	{
@@ -2323,8 +2323,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count Slice == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array4S const & a, Array4S const & b )
 	{
@@ -2345,8 +2345,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array4S const & a, Array4S const & b )
 	{
@@ -2367,8 +2367,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array4S const & a, Array4S const & b )
 	{
@@ -2389,8 +2389,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array4S const & a, Array4S const & b )
 	{
@@ -2411,8 +2411,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array4S const & a, Array4S const & b )
 	{
@@ -2433,8 +2433,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array4S const & a, Array4S const & b )
 	{
@@ -2455,8 +2455,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array4S const & a, T const & t )
 	{
@@ -2475,8 +2475,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, Array4S const & a )
 	{
@@ -2484,8 +2484,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array4S const & a, T const & t )
 	{
@@ -2504,8 +2504,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, Array4S const & a )
 	{
@@ -2513,8 +2513,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array4S const & a, T const & t )
 	{
@@ -2533,8 +2533,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, Array4S const & a )
 	{
@@ -2542,8 +2542,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array4S const & a, T const & t )
 	{
@@ -2562,8 +2562,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, Array4S const & a )
 	{
@@ -2571,8 +2571,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array4S const & a, T const & t )
 	{
@@ -2591,8 +2591,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, Array4S const & a )
 	{
@@ -2600,8 +2600,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array4S const & a, T const & t )
 	{
@@ -2620,8 +2620,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, Array4S const & a )
 	{
@@ -2632,8 +2632,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4S == MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2653,8 +2653,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4S != MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2663,8 +2663,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4S < MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2684,8 +2684,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4S <= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2705,8 +2705,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4S > MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2726,8 +2726,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array4S >= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2747,8 +2747,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 == Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2757,8 +2757,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 != Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2767,8 +2767,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 < Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2777,8 +2777,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 <= Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2787,8 +2787,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 > Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2797,8 +2797,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray4 >= Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2809,8 +2809,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4S == MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2830,8 +2830,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4S != MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2840,8 +2840,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4S < MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2861,8 +2861,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4S <= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2882,8 +2882,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4S > MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2903,8 +2903,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array4S >= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2924,8 +2924,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 == Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2934,8 +2934,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 != Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2944,8 +2944,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 < Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2954,8 +2954,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 <= Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2964,8 +2964,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 > Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2974,8 +2974,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray4 >= Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -2986,8 +2986,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4S == MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -2996,8 +2996,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4S != MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3006,8 +3006,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4S < MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3016,8 +3016,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4S <= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3026,8 +3026,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4S > MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3036,8 +3036,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array4S >= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3046,8 +3046,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 == Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3056,8 +3056,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 != Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3066,8 +3066,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 < Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3076,8 +3076,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 <= Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3086,8 +3086,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 > Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3096,8 +3096,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray4 >= Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3108,8 +3108,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4S == MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3130,8 +3130,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4S != MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3152,8 +3152,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4S < MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3174,8 +3174,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4S <= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3196,8 +3196,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4S > MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3218,8 +3218,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array4S >= MArray4
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array4S const & a, MArray4< A, T > const & b )
 	{
@@ -3240,8 +3240,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 == Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3250,8 +3250,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 != Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3260,8 +3260,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 < Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3270,8 +3270,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 <= Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3280,8 +3280,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 > Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray4< A, T > const & a, Array4S const & b )
 	{
@@ -3290,8 +3290,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray4 >= Array4S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray4< A, T > const & a, Array4S const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
@@ -2571,8 +2571,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Array5 == Array5
-	inline
 	friend
+	inline
 	bool
 	eq( Array5 const & a, Array5 const & b )
 	{
@@ -2582,8 +2582,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array5 != Array5
-	inline
 	friend
+	inline
 	bool
 	ne( Array5 const & a, Array5 const & b )
 	{
@@ -2591,8 +2591,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array5 < Array5
-	inline
 	friend
+	inline
 	bool
 	lt( Array5 const & a, Array5 const & b )
 	{
@@ -2602,8 +2602,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array5 <= Array5
-	inline
 	friend
+	inline
 	bool
 	le( Array5 const & a, Array5 const & b )
 	{
@@ -2613,8 +2613,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array5 > Array5
-	inline
 	friend
+	inline
 	bool
 	gt( Array5 const & a, Array5 const & b )
 	{
@@ -2622,8 +2622,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array5 >= Array5
-	inline
 	friend
+	inline
 	bool
 	ge( Array5 const & a, Array5 const & b )
 	{
@@ -2633,8 +2633,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Array5 == Array5
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array5 const & a, Array5 const & b )
 	{
@@ -2644,8 +2644,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array5 != Array5
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array5 const & a, Array5 const & b )
 	{
@@ -2653,8 +2653,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array5 < Array5
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array5 const & a, Array5 const & b )
 	{
@@ -2664,8 +2664,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array5 <= Array5
-	inline
 	friend
+	inline
 	bool
 	any_le( Array5 const & a, Array5 const & b )
 	{
@@ -2675,8 +2675,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array5 > Array5
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array5 const & a, Array5 const & b )
 	{
@@ -2684,8 +2684,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array5 >= Array5
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array5 const & a, Array5 const & b )
 	{
@@ -2695,8 +2695,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// Array5 == Array5
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array5 const & a, Array5 const & b )
 	{
@@ -2704,8 +2704,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array5 != Array5
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array5 const & a, Array5 const & b )
 	{
@@ -2713,8 +2713,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array5 < Array5
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array5 const & a, Array5 const & b )
 	{
@@ -2722,8 +2722,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array5 <= Array5
-	inline
 	friend
+	inline
 	bool
 	all_le( Array5 const & a, Array5 const & b )
 	{
@@ -2731,8 +2731,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array5 > Array5
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array5 const & a, Array5 const & b )
 	{
@@ -2740,8 +2740,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array5 >= Array5
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array5 const & a, Array5 const & b )
 	{
@@ -2751,8 +2751,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Array5 == Array5
-	inline
 	friend
+	inline
 	bool
 	count_eq( Array5 const & a, Array5 const & b )
 	{
@@ -2762,8 +2762,8 @@ public: // Comparison: Count
 	}
 
 	// Array5 != Array5
-	inline
 	friend
+	inline
 	bool
 	count_ne( Array5 const & a, Array5 const & b )
 	{
@@ -2773,8 +2773,8 @@ public: // Comparison: Count
 	}
 
 	// Array5 < Array5
-	inline
 	friend
+	inline
 	bool
 	count_lt( Array5 const & a, Array5 const & b )
 	{
@@ -2784,8 +2784,8 @@ public: // Comparison: Count
 	}
 
 	// Array5 <= Array5
-	inline
 	friend
+	inline
 	bool
 	count_le( Array5 const & a, Array5 const & b )
 	{
@@ -2795,8 +2795,8 @@ public: // Comparison: Count
 	}
 
 	// Array5 > Array5
-	inline
 	friend
+	inline
 	bool
 	count_gt( Array5 const & a, Array5 const & b )
 	{
@@ -2806,8 +2806,8 @@ public: // Comparison: Count
 	}
 
 	// Array5 >= Array5
-	inline
 	friend
+	inline
 	bool
 	count_ge( Array5 const & a, Array5 const & b )
 	{
@@ -2819,8 +2819,8 @@ public: // Comparison: Count
 public: // Comparison: Predicate: Slice
 
 	// Array5 == Array5S
-	inline
 	friend
+	inline
 	bool
 	eq( Array5 const & a, Array5S< T > const & b )
 	{
@@ -2843,8 +2843,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5 != Array5S
-	inline
 	friend
+	inline
 	bool
 	ne( Array5 const & a, Array5S< T > const & b )
 	{
@@ -2852,8 +2852,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5 < Array5S
-	inline
 	friend
+	inline
 	bool
 	lt( Array5 const & a, Array5S< T > const & b )
 	{
@@ -2876,8 +2876,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5 <= Array5S
-	inline
 	friend
+	inline
 	bool
 	le( Array5 const & a, Array5S< T > const & b )
 	{
@@ -2900,8 +2900,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5 > Array5S
-	inline
 	friend
+	inline
 	bool
 	gt( Array5 const & a, Array5S< T > const & b )
 	{
@@ -2924,8 +2924,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5 >= Array5S
-	inline
 	friend
+	inline
 	bool
 	ge( Array5 const & a, Array5S< T > const & b )
 	{
@@ -2948,8 +2948,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5S == Array5
-	inline
 	friend
+	inline
 	bool
 	eq( Array5S< T > const & a, Array5 const & b )
 	{
@@ -2957,8 +2957,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5S != Array5
-	inline
 	friend
+	inline
 	bool
 	ne( Array5S< T > const & a, Array5 const & b )
 	{
@@ -2966,8 +2966,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5S < Array5
-	inline
 	friend
+	inline
 	bool
 	lt( Array5S< T > const & a, Array5 const & b )
 	{
@@ -2975,8 +2975,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5S <= Array5
-	inline
 	friend
+	inline
 	bool
 	le( Array5S< T > const & a, Array5 const & b )
 	{
@@ -2984,8 +2984,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5S > Array5
-	inline
 	friend
+	inline
 	bool
 	gt( Array5S< T > const & a, Array5 const & b )
 	{
@@ -2993,8 +2993,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array5S >= Array5
-	inline
 	friend
+	inline
 	bool
 	ge( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3004,8 +3004,8 @@ public: // Comparison: Predicate: Slice
 public: // Comparison: Predicate: Any: Slice
 
 	// Any Array5 == Array5S
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3028,8 +3028,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5 != Array5S
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3037,8 +3037,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5 < Array5S
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3061,8 +3061,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5 <= Array5S
-	inline
 	friend
+	inline
 	bool
 	any_le( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3085,8 +3085,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5 > Array5S
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3109,8 +3109,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5 >= Array5S
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3133,8 +3133,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5S == Array5
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3142,8 +3142,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5S != Array5
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3151,8 +3151,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5S < Array5
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3160,8 +3160,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5S <= Array5
-	inline
 	friend
+	inline
 	bool
 	any_le( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3169,8 +3169,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5S > Array5
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3178,8 +3178,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array5S >= Array5
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3189,8 +3189,8 @@ public: // Comparison: Predicate: Any: Slice
 public: // Comparison: Predicate: All: Slice
 
 	// All Array5 == Array5S
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3198,8 +3198,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5 != Array5S
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3207,8 +3207,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5 < Array5S
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3216,8 +3216,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5 <= Array5S
-	inline
 	friend
+	inline
 	bool
 	all_le( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3225,8 +3225,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5 > Array5S
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3234,8 +3234,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5 >= Array5S
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3243,8 +3243,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5S == Array5
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3252,8 +3252,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5S != Array5
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3261,8 +3261,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5S < Array5
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3270,8 +3270,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5S <= Array5
-	inline
 	friend
+	inline
 	bool
 	all_le( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3279,8 +3279,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5S > Array5
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3288,8 +3288,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array5S >= Array5
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3299,8 +3299,8 @@ public: // Comparison: Predicate: All: Slice
 public: // Comparison: Count: Slice
 
 	// Count Array5 == Array5S
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3323,8 +3323,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5 != Array5S
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3347,8 +3347,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5 < Array5S
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3371,8 +3371,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5 <= Array5S
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3395,8 +3395,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5 > Array5S
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3419,8 +3419,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5 >= Array5S
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array5 const & a, Array5S< T > const & b )
 	{
@@ -3443,8 +3443,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5S == Array5
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3452,8 +3452,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5S != Array5
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3461,8 +3461,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5S < Array5
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3470,8 +3470,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5S <= Array5
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3479,8 +3479,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5S > Array5
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3488,8 +3488,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array5S >= Array5
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array5S< T > const & a, Array5 const & b )
 	{
@@ -3500,8 +3500,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5 == MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3525,8 +3525,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5 != MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3535,8 +3535,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5 < MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3560,8 +3560,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5 <= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3585,8 +3585,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5 > MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3610,8 +3610,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5 >= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3635,8 +3635,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 == Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3645,8 +3645,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 != Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3655,8 +3655,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 < Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3665,8 +3665,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 <= Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3675,8 +3675,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 > Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3685,8 +3685,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 >= Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3697,8 +3697,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5 == MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3722,8 +3722,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5 != MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3732,8 +3732,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5 < MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3757,8 +3757,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5 <= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3782,8 +3782,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5 > MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3807,8 +3807,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5 >= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3832,8 +3832,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 == Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3842,8 +3842,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 != Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3852,8 +3852,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 < Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3862,8 +3862,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 <= Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3872,8 +3872,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 > Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3882,8 +3882,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 >= Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3894,8 +3894,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5 == MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3904,8 +3904,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5 != MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3914,8 +3914,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5 < MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3924,8 +3924,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5 <= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3934,8 +3934,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5 > MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3944,8 +3944,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5 >= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -3954,8 +3954,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 == Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3964,8 +3964,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 != Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3974,8 +3974,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 < Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3984,8 +3984,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 <= Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -3994,8 +3994,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 > Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -4004,8 +4004,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 >= Array5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -4016,8 +4016,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5 == MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -4041,8 +4041,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5 != MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -4066,8 +4066,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5 < MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -4091,8 +4091,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5 <= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -4116,8 +4116,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5 > MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -4141,8 +4141,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5 >= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array5 const & a, MArray5< A, T > const & b )
 	{
@@ -4166,8 +4166,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 == Array5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -4176,8 +4176,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 != Array5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -4186,8 +4186,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 < Array5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -4196,8 +4196,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 <= Array5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -4206,8 +4206,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 > Array5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray5< A, T > const & a, Array5 const & b )
 	{
@@ -4216,8 +4216,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 >= Array5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray5< A, T > const & a, Array5 const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5S.hh
@@ -2287,8 +2287,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( Array5S const & a, Array5S const & b )
 	{
@@ -2309,8 +2309,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( Array5S const & a, Array5S const & b )
 	{
@@ -2318,8 +2318,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( Array5S const & a, Array5S const & b )
 	{
@@ -2340,8 +2340,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( Array5S const & a, Array5S const & b )
 	{
@@ -2362,8 +2362,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( Array5S const & a, Array5S const & b )
 	{
@@ -2371,8 +2371,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( Array5S const & a, Array5S const & b )
 	{
@@ -2380,8 +2380,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice == Value
-	inline
 	friend
+	inline
 	bool
 	eq( Array5S const & a, T const & t )
 	{
@@ -2401,8 +2401,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Value
-	inline
 	friend
+	inline
 	bool
 	ne( Array5S const & a, T const & t )
 	{
@@ -2410,8 +2410,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Value
-	inline
 	friend
+	inline
 	bool
 	lt( Array5S const & a, T const & t )
 	{
@@ -2431,8 +2431,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	le( Array5S const & a, T const & t )
 	{
@@ -2452,8 +2452,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Value
-	inline
 	friend
+	inline
 	bool
 	gt( Array5S const & a, T const & t )
 	{
@@ -2461,8 +2461,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( Array5S const & a, T const & t )
 	{
@@ -2470,8 +2470,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, Array5S const & a )
 	{
@@ -2479,8 +2479,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, Array5S const & a )
 	{
@@ -2488,8 +2488,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, Array5S const & a )
 	{
@@ -2509,8 +2509,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, Array5S const & a )
 	{
@@ -2530,8 +2530,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, Array5S const & a )
 	{
@@ -2539,8 +2539,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, Array5S const & a )
 	{
@@ -2550,8 +2550,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array5S const & a, Array5S const & b )
 	{
@@ -2573,8 +2573,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array5S const & a, Array5S const & b )
 	{
@@ -2582,8 +2582,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array5S const & a, Array5S const & b )
 	{
@@ -2605,8 +2605,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( Array5S const & a, Array5S const & b )
 	{
@@ -2628,8 +2628,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array5S const & a, Array5S const & b )
 	{
@@ -2637,8 +2637,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array5S const & a, Array5S const & b )
 	{
@@ -2646,8 +2646,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array5S const & a, T const & t )
 	{
@@ -2667,8 +2667,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array5S const & a, T const & t )
 	{
@@ -2676,8 +2676,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array5S const & a, T const & t )
 	{
@@ -2697,8 +2697,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( Array5S const & a, T const & t )
 	{
@@ -2718,8 +2718,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array5S const & a, T const & t )
 	{
@@ -2727,8 +2727,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array5S const & a, T const & t )
 	{
@@ -2736,8 +2736,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, Array5S const & a )
 	{
@@ -2745,8 +2745,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, Array5S const & a )
 	{
@@ -2754,8 +2754,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, Array5S const & a )
 	{
@@ -2775,8 +2775,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, Array5S const & a )
 	{
@@ -2796,8 +2796,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, Array5S const & a )
 	{
@@ -2805,8 +2805,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, Array5S const & a )
 	{
@@ -2816,8 +2816,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array5S const & a, Array5S const & b )
 	{
@@ -2825,8 +2825,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array5S const & a, Array5S const & b )
 	{
@@ -2834,8 +2834,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array5S const & a, Array5S const & b )
 	{
@@ -2843,8 +2843,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( Array5S const & a, Array5S const & b )
 	{
@@ -2852,8 +2852,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array5S const & a, Array5S const & b )
 	{
@@ -2861,8 +2861,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array5S const & a, Array5S const & b )
 	{
@@ -2870,8 +2870,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array5S const & a, T const & t )
 	{
@@ -2879,8 +2879,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array5S const & a, T const & t )
 	{
@@ -2888,8 +2888,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array5S const & a, T const & t )
 	{
@@ -2897,8 +2897,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( Array5S const & a, T const & t )
 	{
@@ -2906,8 +2906,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array5S const & a, T const & t )
 	{
@@ -2915,8 +2915,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array5S const & a, T const & t )
 	{
@@ -2924,8 +2924,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, Array5S const & a )
 	{
@@ -2933,8 +2933,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, Array5S const & a )
 	{
@@ -2942,8 +2942,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, Array5S const & a )
 	{
@@ -2951,8 +2951,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, Array5S const & a )
 	{
@@ -2960,8 +2960,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, Array5S const & a )
 	{
@@ -2969,8 +2969,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, Array5S const & a )
 	{
@@ -2980,8 +2980,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count Slice == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array5S const & a, Array5S const & b )
 	{
@@ -3004,8 +3004,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array5S const & a, Array5S const & b )
 	{
@@ -3028,8 +3028,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array5S const & a, Array5S const & b )
 	{
@@ -3052,8 +3052,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array5S const & a, Array5S const & b )
 	{
@@ -3076,8 +3076,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array5S const & a, Array5S const & b )
 	{
@@ -3100,8 +3100,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array5S const & a, Array5S const & b )
 	{
@@ -3124,8 +3124,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array5S const & a, T const & t )
 	{
@@ -3146,8 +3146,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, Array5S const & a )
 	{
@@ -3155,8 +3155,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array5S const & a, T const & t )
 	{
@@ -3177,8 +3177,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, Array5S const & a )
 	{
@@ -3186,8 +3186,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array5S const & a, T const & t )
 	{
@@ -3208,8 +3208,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, Array5S const & a )
 	{
@@ -3217,8 +3217,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array5S const & a, T const & t )
 	{
@@ -3239,8 +3239,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, Array5S const & a )
 	{
@@ -3248,8 +3248,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array5S const & a, T const & t )
 	{
@@ -3270,8 +3270,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, Array5S const & a )
 	{
@@ -3279,8 +3279,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array5S const & a, T const & t )
 	{
@@ -3301,8 +3301,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, Array5S const & a )
 	{
@@ -3313,8 +3313,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5S == MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3336,8 +3336,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5S != MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3346,8 +3346,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5S < MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3369,8 +3369,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5S <= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3392,8 +3392,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5S > MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3415,8 +3415,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array5S >= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3438,8 +3438,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 == Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3448,8 +3448,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 != Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3458,8 +3458,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 < Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3468,8 +3468,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 <= Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3478,8 +3478,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 > Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3488,8 +3488,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray5 >= Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3500,8 +3500,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5S == MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3523,8 +3523,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5S != MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3533,8 +3533,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5S < MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3556,8 +3556,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5S <= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3579,8 +3579,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5S > MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3602,8 +3602,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array5S >= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3625,8 +3625,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 == Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3635,8 +3635,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 != Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3645,8 +3645,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 < Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3655,8 +3655,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 <= Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3665,8 +3665,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 > Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3675,8 +3675,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray5 >= Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3687,8 +3687,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5S == MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3697,8 +3697,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5S != MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3707,8 +3707,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5S < MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3717,8 +3717,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5S <= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3727,8 +3727,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5S > MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3737,8 +3737,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array5S >= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3747,8 +3747,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 == Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3757,8 +3757,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 != Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3767,8 +3767,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 < Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3777,8 +3777,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 <= Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3787,8 +3787,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 > Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3797,8 +3797,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray5 >= Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3809,8 +3809,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5S == MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3833,8 +3833,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5S != MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3857,8 +3857,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5S < MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3881,8 +3881,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5S <= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3905,8 +3905,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5S > MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3929,8 +3929,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array5S >= MArray5
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array5S const & a, MArray5< A, T > const & b )
 	{
@@ -3953,8 +3953,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 == Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3963,8 +3963,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 != Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3973,8 +3973,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 < Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3983,8 +3983,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 <= Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -3993,8 +3993,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 > Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray5< A, T > const & a, Array5S const & b )
 	{
@@ -4003,8 +4003,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray5 >= Array5S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray5< A, T > const & a, Array5S const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
@@ -3802,8 +3802,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Array6 == Array6
-	inline
 	friend
+	inline
 	bool
 	eq( Array6 const & a, Array6 const & b )
 	{
@@ -3813,8 +3813,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array6 != Array6
-	inline
 	friend
+	inline
 	bool
 	ne( Array6 const & a, Array6 const & b )
 	{
@@ -3822,8 +3822,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array6 < Array6
-	inline
 	friend
+	inline
 	bool
 	lt( Array6 const & a, Array6 const & b )
 	{
@@ -3833,8 +3833,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array6 <= Array6
-	inline
 	friend
+	inline
 	bool
 	le( Array6 const & a, Array6 const & b )
 	{
@@ -3844,8 +3844,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array6 > Array6
-	inline
 	friend
+	inline
 	bool
 	gt( Array6 const & a, Array6 const & b )
 	{
@@ -3853,8 +3853,8 @@ public: // Comparison: Predicate
 	}
 
 	// Array6 >= Array6
-	inline
 	friend
+	inline
 	bool
 	ge( Array6 const & a, Array6 const & b )
 	{
@@ -3864,8 +3864,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Array6 == Array6
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array6 const & a, Array6 const & b )
 	{
@@ -3875,8 +3875,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array6 != Array6
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array6 const & a, Array6 const & b )
 	{
@@ -3884,8 +3884,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array6 < Array6
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array6 const & a, Array6 const & b )
 	{
@@ -3895,8 +3895,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array6 <= Array6
-	inline
 	friend
+	inline
 	bool
 	any_le( Array6 const & a, Array6 const & b )
 	{
@@ -3906,8 +3906,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array6 > Array6
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array6 const & a, Array6 const & b )
 	{
@@ -3915,8 +3915,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Array6 >= Array6
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array6 const & a, Array6 const & b )
 	{
@@ -3926,8 +3926,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// Array6 == Array6
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array6 const & a, Array6 const & b )
 	{
@@ -3935,8 +3935,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array6 != Array6
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array6 const & a, Array6 const & b )
 	{
@@ -3944,8 +3944,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array6 < Array6
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array6 const & a, Array6 const & b )
 	{
@@ -3953,8 +3953,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array6 <= Array6
-	inline
 	friend
+	inline
 	bool
 	all_le( Array6 const & a, Array6 const & b )
 	{
@@ -3962,8 +3962,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array6 > Array6
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array6 const & a, Array6 const & b )
 	{
@@ -3971,8 +3971,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// Array6 >= Array6
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array6 const & a, Array6 const & b )
 	{
@@ -3982,8 +3982,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Array6 == Array6
-	inline
 	friend
+	inline
 	bool
 	count_eq( Array6 const & a, Array6 const & b )
 	{
@@ -3993,8 +3993,8 @@ public: // Comparison: Count
 	}
 
 	// Array6 != Array6
-	inline
 	friend
+	inline
 	bool
 	count_ne( Array6 const & a, Array6 const & b )
 	{
@@ -4004,8 +4004,8 @@ public: // Comparison: Count
 	}
 
 	// Array6 < Array6
-	inline
 	friend
+	inline
 	bool
 	count_lt( Array6 const & a, Array6 const & b )
 	{
@@ -4015,8 +4015,8 @@ public: // Comparison: Count
 	}
 
 	// Array6 <= Array6
-	inline
 	friend
+	inline
 	bool
 	count_le( Array6 const & a, Array6 const & b )
 	{
@@ -4026,8 +4026,8 @@ public: // Comparison: Count
 	}
 
 	// Array6 > Array6
-	inline
 	friend
+	inline
 	bool
 	count_gt( Array6 const & a, Array6 const & b )
 	{
@@ -4037,8 +4037,8 @@ public: // Comparison: Count
 	}
 
 	// Array6 >= Array6
-	inline
 	friend
+	inline
 	bool
 	count_ge( Array6 const & a, Array6 const & b )
 	{
@@ -4050,8 +4050,8 @@ public: // Comparison: Count
 public: // Comparison: Predicate: Slice
 
 	// Array6 == Array6S
-	inline
 	friend
+	inline
 	bool
 	eq( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4076,8 +4076,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6 != Array6S
-	inline
 	friend
+	inline
 	bool
 	ne( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4085,8 +4085,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6 < Array6S
-	inline
 	friend
+	inline
 	bool
 	lt( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4111,8 +4111,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6 <= Array6S
-	inline
 	friend
+	inline
 	bool
 	le( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4137,8 +4137,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6 > Array6S
-	inline
 	friend
+	inline
 	bool
 	gt( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4163,8 +4163,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6 >= Array6S
-	inline
 	friend
+	inline
 	bool
 	ge( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4189,8 +4189,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6S == Array6
-	inline
 	friend
+	inline
 	bool
 	eq( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4198,8 +4198,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6S != Array6
-	inline
 	friend
+	inline
 	bool
 	ne( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4207,8 +4207,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6S < Array6
-	inline
 	friend
+	inline
 	bool
 	lt( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4216,8 +4216,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6S <= Array6
-	inline
 	friend
+	inline
 	bool
 	le( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4225,8 +4225,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6S > Array6
-	inline
 	friend
+	inline
 	bool
 	gt( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4234,8 +4234,8 @@ public: // Comparison: Predicate: Slice
 	}
 
 	// Array6S >= Array6
-	inline
 	friend
+	inline
 	bool
 	ge( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4245,8 +4245,8 @@ public: // Comparison: Predicate: Slice
 public: // Comparison: Predicate: Any: Slice
 
 	// Any Array6 == Array6S
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4271,8 +4271,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6 != Array6S
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4280,8 +4280,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6 < Array6S
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4306,8 +4306,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6 <= Array6S
-	inline
 	friend
+	inline
 	bool
 	any_le( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4332,8 +4332,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6 > Array6S
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4358,8 +4358,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6 >= Array6S
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4384,8 +4384,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6S == Array6
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4393,8 +4393,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6S != Array6
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4402,8 +4402,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6S < Array6
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4411,8 +4411,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6S <= Array6
-	inline
 	friend
+	inline
 	bool
 	any_le( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4420,8 +4420,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6S > Array6
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4429,8 +4429,8 @@ public: // Comparison: Predicate: Any: Slice
 	}
 
 	// Any Array6S >= Array6
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4440,8 +4440,8 @@ public: // Comparison: Predicate: Any: Slice
 public: // Comparison: Predicate: All: Slice
 
 	// All Array6 == Array6S
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4449,8 +4449,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6 != Array6S
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4458,8 +4458,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6 < Array6S
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4467,8 +4467,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6 <= Array6S
-	inline
 	friend
+	inline
 	bool
 	all_le( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4476,8 +4476,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6 > Array6S
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4485,8 +4485,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6 >= Array6S
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4494,8 +4494,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6S == Array6
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4503,8 +4503,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6S != Array6
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4512,8 +4512,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6S < Array6
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4521,8 +4521,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6S <= Array6
-	inline
 	friend
+	inline
 	bool
 	all_le( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4530,8 +4530,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6S > Array6
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4539,8 +4539,8 @@ public: // Comparison: Predicate: All: Slice
 	}
 
 	// All Array6S >= Array6
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4550,8 +4550,8 @@ public: // Comparison: Predicate: All: Slice
 public: // Comparison: Count: Slice
 
 	// Count Array6 == Array6S
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4576,8 +4576,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6 != Array6S
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4602,8 +4602,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6 < Array6S
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4628,8 +4628,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6 <= Array6S
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4654,8 +4654,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6 > Array6S
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4680,8 +4680,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6 >= Array6S
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array6 const & a, Array6S< T > const & b )
 	{
@@ -4706,8 +4706,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6S == Array6
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4715,8 +4715,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6S != Array6
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4724,8 +4724,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6S < Array6
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4733,8 +4733,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6S <= Array6
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4742,8 +4742,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6S > Array6
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4751,8 +4751,8 @@ public: // Comparison: Count: Slice
 	}
 
 	// Count Array6S >= Array6
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array6S< T > const & a, Array6 const & b )
 	{
@@ -4763,8 +4763,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6 == MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -4790,8 +4790,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6 != MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -4800,8 +4800,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6 < MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -4827,8 +4827,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6 <= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -4854,8 +4854,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6 > MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -4881,8 +4881,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6 >= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -4908,8 +4908,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 == Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -4918,8 +4918,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 != Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -4928,8 +4928,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 < Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -4938,8 +4938,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 <= Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -4948,8 +4948,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 > Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -4958,8 +4958,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 >= Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -4970,8 +4970,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6 == MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -4997,8 +4997,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6 != MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5007,8 +5007,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6 < MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5034,8 +5034,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6 <= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5061,8 +5061,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6 > MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5088,8 +5088,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6 >= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5115,8 +5115,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 == Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5125,8 +5125,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 != Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5135,8 +5135,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 < Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5145,8 +5145,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 <= Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5155,8 +5155,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 > Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5165,8 +5165,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 >= Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5177,8 +5177,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6 == MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5187,8 +5187,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6 != MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5197,8 +5197,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6 < MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5207,8 +5207,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6 <= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5217,8 +5217,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6 > MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5227,8 +5227,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6 >= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5237,8 +5237,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 == Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5247,8 +5247,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 != Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5257,8 +5257,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 < Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5267,8 +5267,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 <= Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5277,8 +5277,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 > Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5287,8 +5287,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 >= Array6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5299,8 +5299,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6 == MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5326,8 +5326,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6 != MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5353,8 +5353,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6 < MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5380,8 +5380,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6 <= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5407,8 +5407,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6 > MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5434,8 +5434,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6 >= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array6 const & a, MArray6< A, T > const & b )
 	{
@@ -5461,8 +5461,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 == Array6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5471,8 +5471,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 != Array6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5481,8 +5481,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 < Array6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5491,8 +5491,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 <= Array6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5501,8 +5501,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 > Array6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray6< A, T > const & a, Array6 const & b )
 	{
@@ -5511,8 +5511,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 >= Array6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray6< A, T > const & a, Array6 const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6S.hh
@@ -3456,8 +3456,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( Array6S const & a, Array6S const & b )
 	{
@@ -3480,8 +3480,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( Array6S const & a, Array6S const & b )
 	{
@@ -3489,8 +3489,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( Array6S const & a, Array6S const & b )
 	{
@@ -3513,8 +3513,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( Array6S const & a, Array6S const & b )
 	{
@@ -3537,8 +3537,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( Array6S const & a, Array6S const & b )
 	{
@@ -3546,8 +3546,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( Array6S const & a, Array6S const & b )
 	{
@@ -3555,8 +3555,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice == Value
-	inline
 	friend
+	inline
 	bool
 	eq( Array6S const & a, T const & t )
 	{
@@ -3578,8 +3578,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice != Value
-	inline
 	friend
+	inline
 	bool
 	ne( Array6S const & a, T const & t )
 	{
@@ -3587,8 +3587,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice < Value
-	inline
 	friend
+	inline
 	bool
 	lt( Array6S const & a, T const & t )
 	{
@@ -3610,8 +3610,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	le( Array6S const & a, T const & t )
 	{
@@ -3633,8 +3633,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice > Value
-	inline
 	friend
+	inline
 	bool
 	gt( Array6S const & a, T const & t )
 	{
@@ -3642,8 +3642,8 @@ public: // Comparison: Predicate
 	}
 
 	// Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( Array6S const & a, T const & t )
 	{
@@ -3651,8 +3651,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == Slice
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, Array6S const & a )
 	{
@@ -3660,8 +3660,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != Slice
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, Array6S const & a )
 	{
@@ -3669,8 +3669,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < Slice
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, Array6S const & a )
 	{
@@ -3692,8 +3692,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, Array6S const & a )
 	{
@@ -3715,8 +3715,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > Slice
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, Array6S const & a )
 	{
@@ -3724,8 +3724,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, Array6S const & a )
 	{
@@ -3735,8 +3735,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array6S const & a, Array6S const & b )
 	{
@@ -3760,8 +3760,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array6S const & a, Array6S const & b )
 	{
@@ -3769,8 +3769,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array6S const & a, Array6S const & b )
 	{
@@ -3794,8 +3794,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( Array6S const & a, Array6S const & b )
 	{
@@ -3819,8 +3819,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array6S const & a, Array6S const & b )
 	{
@@ -3828,8 +3828,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array6S const & a, Array6S const & b )
 	{
@@ -3837,8 +3837,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array6S const & a, T const & t )
 	{
@@ -3860,8 +3860,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array6S const & a, T const & t )
 	{
@@ -3869,8 +3869,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array6S const & a, T const & t )
 	{
@@ -3892,8 +3892,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( Array6S const & a, T const & t )
 	{
@@ -3915,8 +3915,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array6S const & a, T const & t )
 	{
@@ -3924,8 +3924,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array6S const & a, T const & t )
 	{
@@ -3933,8 +3933,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == Slice
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, Array6S const & a )
 	{
@@ -3942,8 +3942,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != Slice
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, Array6S const & a )
 	{
@@ -3951,8 +3951,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < Slice
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, Array6S const & a )
 	{
@@ -3974,8 +3974,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, Array6S const & a )
 	{
@@ -3997,8 +3997,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > Slice
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, Array6S const & a )
 	{
@@ -4006,8 +4006,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, Array6S const & a )
 	{
@@ -4017,8 +4017,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All Slice == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array6S const & a, Array6S const & b )
 	{
@@ -4026,8 +4026,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array6S const & a, Array6S const & b )
 	{
@@ -4035,8 +4035,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array6S const & a, Array6S const & b )
 	{
@@ -4044,8 +4044,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( Array6S const & a, Array6S const & b )
 	{
@@ -4053,8 +4053,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array6S const & a, Array6S const & b )
 	{
@@ -4062,8 +4062,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array6S const & a, Array6S const & b )
 	{
@@ -4071,8 +4071,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array6S const & a, T const & t )
 	{
@@ -4080,8 +4080,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array6S const & a, T const & t )
 	{
@@ -4089,8 +4089,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array6S const & a, T const & t )
 	{
@@ -4098,8 +4098,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( Array6S const & a, T const & t )
 	{
@@ -4107,8 +4107,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array6S const & a, T const & t )
 	{
@@ -4116,8 +4116,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Slice >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array6S const & a, T const & t )
 	{
@@ -4125,8 +4125,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == Slice
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, Array6S const & a )
 	{
@@ -4134,8 +4134,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != Slice
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, Array6S const & a )
 	{
@@ -4143,8 +4143,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < Slice
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, Array6S const & a )
 	{
@@ -4152,8 +4152,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= Slice
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, Array6S const & a )
 	{
@@ -4161,8 +4161,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > Slice
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, Array6S const & a )
 	{
@@ -4170,8 +4170,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= Slice
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, Array6S const & a )
 	{
@@ -4181,8 +4181,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count Slice == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array6S const & a, Array6S const & b )
 	{
@@ -4207,8 +4207,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array6S const & a, Array6S const & b )
 	{
@@ -4233,8 +4233,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array6S const & a, Array6S const & b )
 	{
@@ -4259,8 +4259,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array6S const & a, Array6S const & b )
 	{
@@ -4285,8 +4285,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array6S const & a, Array6S const & b )
 	{
@@ -4311,8 +4311,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array6S const & a, Array6S const & b )
 	{
@@ -4337,8 +4337,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array6S const & a, T const & t )
 	{
@@ -4361,8 +4361,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == Slice
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, Array6S const & a )
 	{
@@ -4370,8 +4370,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array6S const & a, T const & t )
 	{
@@ -4394,8 +4394,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, Array6S const & a )
 	{
@@ -4403,8 +4403,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array6S const & a, T const & t )
 	{
@@ -4427,8 +4427,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < Slice
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, Array6S const & a )
 	{
@@ -4436,8 +4436,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array6S const & a, T const & t )
 	{
@@ -4460,8 +4460,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, Array6S const & a )
 	{
@@ -4469,8 +4469,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array6S const & a, T const & t )
 	{
@@ -4493,8 +4493,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > Slice
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, Array6S const & a )
 	{
@@ -4502,8 +4502,8 @@ public: // Comparison: Count
 	}
 
 	// Count Slice >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array6S const & a, T const & t )
 	{
@@ -4526,8 +4526,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= Slice
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, Array6S const & a )
 	{
@@ -4538,8 +4538,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6S == MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4563,8 +4563,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6S != MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4573,8 +4573,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6S < MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4598,8 +4598,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6S <= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4623,8 +4623,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6S > MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4648,8 +4648,8 @@ public: // Comparison: Predicate: MArray
 
 	// Array6S >= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4673,8 +4673,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 == Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	eq( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4683,8 +4683,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 != Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ne( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4693,8 +4693,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 < Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	lt( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4703,8 +4703,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 <= Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	le( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4713,8 +4713,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 > Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	gt( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4723,8 +4723,8 @@ public: // Comparison: Predicate: MArray
 
 	// MArray6 >= Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	ge( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4735,8 +4735,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6S == MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4760,8 +4760,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6S != MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4770,8 +4770,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6S < MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4795,8 +4795,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6S <= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4820,8 +4820,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6S > MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4845,8 +4845,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any Array6S >= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4870,8 +4870,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 == Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4880,8 +4880,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 != Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4890,8 +4890,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 < Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4900,8 +4900,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 <= Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4910,8 +4910,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 > Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4920,8 +4920,8 @@ public: // Comparison: Predicate: Any: MArray
 
 	// Any MArray6 >= Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -4932,8 +4932,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6S == MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4942,8 +4942,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6S != MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4952,8 +4952,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6S < MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4962,8 +4962,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6S <= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4972,8 +4972,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6S > MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4982,8 +4982,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All Array6S >= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -4992,8 +4992,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 == Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5002,8 +5002,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 != Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5012,8 +5012,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 < Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5022,8 +5022,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 <= Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5032,8 +5032,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 > Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5042,8 +5042,8 @@ public: // Comparison: Predicate: All: MArray
 
 	// All MArray6 >= Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5054,8 +5054,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6S == MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -5080,8 +5080,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6S != MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -5106,8 +5106,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6S < MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -5132,8 +5132,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6S <= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -5158,8 +5158,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6S > MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -5184,8 +5184,8 @@ public: // Comparison: Count: MArray
 
 	// Count Array6S >= MArray6
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( Array6S const & a, MArray6< A, T > const & b )
 	{
@@ -5210,8 +5210,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 == Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5220,8 +5220,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 != Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5230,8 +5230,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 < Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5240,8 +5240,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 <= Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5250,8 +5250,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 > Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray6< A, T > const & a, Array6S const & b )
 	{
@@ -5260,8 +5260,8 @@ public: // Comparison: Count: MArray
 
 	// Count MArray6 >= Array6S
 	template< class A >
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray6< A, T > const & a, Array6S const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Cstring.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Cstring.hh
@@ -426,8 +426,8 @@ public: // Modifier
 	}
 
 	// swap( Cstring, Cstring )
-	inline
 	friend
+	inline
 	void
 	swap( Cstring & s, Cstring & t )
 	{
@@ -479,8 +479,8 @@ public: // Subscript
 public: // Concatenation
 
 	// Cstring + Cstring
-	inline
 	friend
+	inline
 	Cstring
 	operator +( Cstring const & s, Cstring const & t )
 	{
@@ -493,8 +493,8 @@ public: // Concatenation
 	}
 
 	// Cstring + cstring
-	inline
 	friend
+	inline
 	Cstring
 	operator +( Cstring const & s, c_cstring const t )
 	{
@@ -507,8 +507,8 @@ public: // Concatenation
 	}
 
 	// cstring + Cstring
-	inline
 	friend
+	inline
 	Cstring
 	operator +( c_cstring const s, Cstring const & t )
 	{
@@ -521,8 +521,8 @@ public: // Concatenation
 	}
 
 	// Cstring + std::string
-	inline
 	friend
+	inline
 	Cstring
 	operator +( Cstring const & s, std::string const & t )
 	{
@@ -535,8 +535,8 @@ public: // Concatenation
 	}
 
 	// Cstring + char
-	inline
 	friend
+	inline
 	Cstring
 	operator +( Cstring const & s, char const c )
 	{
@@ -548,8 +548,8 @@ public: // Concatenation
 	}
 
 	// char + Cstring
-	inline
 	friend
+	inline
 	Cstring
 	operator +( char const c, Cstring const & t )
 	{
@@ -629,8 +629,8 @@ public: // Generator
 public: // Comparison
 
 	// Cstring == Cstring
-	inline
 	friend
+	inline
 	bool
 	operator ==( Cstring const & s, Cstring const & t )
 	{
@@ -638,8 +638,8 @@ public: // Comparison
 	}
 
 	// Cstring != Cstring
-	inline
 	friend
+	inline
 	bool
 	operator !=( Cstring const & s, Cstring const & t )
 	{
@@ -647,8 +647,8 @@ public: // Comparison
 	}
 
 	// Cstring == cstring
-	inline
 	friend
+	inline
 	bool
 	operator ==( Cstring const & s, c_cstring const t )
 	{
@@ -656,8 +656,8 @@ public: // Comparison
 	}
 
 	// cstring == Cstring
-	inline
 	friend
+	inline
 	bool
 	operator ==( c_cstring const t, Cstring const & s )
 	{
@@ -665,8 +665,8 @@ public: // Comparison
 	}
 
 	// Cstring != cstring
-	inline
 	friend
+	inline
 	bool
 	operator !=( Cstring const & s, c_cstring const t )
 	{
@@ -674,8 +674,8 @@ public: // Comparison
 	}
 
 	// cstring != Cstring
-	inline
 	friend
+	inline
 	bool
 	operator !=( c_cstring const t, Cstring const & s )
 	{
@@ -683,8 +683,8 @@ public: // Comparison
 	}
 
 	// Cstring == std::string
-	inline
 	friend
+	inline
 	bool
 	operator ==( Cstring const & s, std::string const & t )
 	{
@@ -692,8 +692,8 @@ public: // Comparison
 	}
 
 	// std::string == Cstring
-	inline
 	friend
+	inline
 	bool
 	operator ==( std::string const & t, Cstring const & s )
 	{
@@ -701,8 +701,8 @@ public: // Comparison
 	}
 
 	// Cstring != std::string
-	inline
 	friend
+	inline
 	bool
 	operator !=( Cstring const & s, std::string const & t )
 	{
@@ -710,8 +710,8 @@ public: // Comparison
 	}
 
 	// std::string != Cstring
-	inline
 	friend
+	inline
 	bool
 	operator !=( std::string const & t, Cstring const & s )
 	{
@@ -719,8 +719,8 @@ public: // Comparison
 	}
 
 	// Cstring == char
-	inline
 	friend
+	inline
 	bool
 	operator ==( Cstring const & s, char const c )
 	{
@@ -728,8 +728,8 @@ public: // Comparison
 	}
 
 	// char == Cstring
-	inline
 	friend
+	inline
 	bool
 	operator ==( char const c, Cstring const & s )
 	{
@@ -737,8 +737,8 @@ public: // Comparison
 	}
 
 	// Cstring != char
-	inline
 	friend
+	inline
 	bool
 	operator !=( Cstring const & s, char const c )
 	{
@@ -746,8 +746,8 @@ public: // Comparison
 	}
 
 	// char != Cstring
-	inline
 	friend
+	inline
 	bool
 	operator !=( char const c, Cstring const & s )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexSlice.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexSlice.hh
@@ -586,8 +586,8 @@ public: // Modifier
 public: // Friend
 
 	// Swap
-	inline
 	friend
+	inline
 	void
 	swap( IndexSlice & a, IndexSlice & b )
 	{
@@ -597,8 +597,8 @@ public: // Friend
 public: // Comparison
 
 	// IndexSlice == IndexSlice
-	inline
 	friend
+	inline
 	bool
 	operator ==( IndexSlice const & I, IndexSlice const & J )
 	{
@@ -606,8 +606,8 @@ public: // Comparison
 	}
 
 	// IndexSlice != IndexSlice
-	inline
 	friend
+	inline
 	bool
 	operator !=( IndexSlice const & I, IndexSlice const & J )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.hh
@@ -1061,8 +1061,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// MArray1 == MArray1
-	inline
 	friend
+	inline
 	bool
 	eq( MArray1 const & a, MArray1 const & b )
 	{
@@ -1076,8 +1076,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 != MArray1
-	inline
 	friend
+	inline
 	bool
 	ne( MArray1 const & a, MArray1 const & b )
 	{
@@ -1085,8 +1085,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 < MArray1
-	inline
 	friend
+	inline
 	bool
 	lt( MArray1 const & a, MArray1 const & b )
 	{
@@ -1100,8 +1100,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 <= MArray1
-	inline
 	friend
+	inline
 	bool
 	le( MArray1 const & a, MArray1 const & b )
 	{
@@ -1115,8 +1115,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 > MArray1
-	inline
 	friend
+	inline
 	bool
 	gt( MArray1 const & a, MArray1 const & b )
 	{
@@ -1124,8 +1124,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 >= MArray1
-	inline
 	friend
+	inline
 	bool
 	ge( MArray1 const & a, MArray1 const & b )
 	{
@@ -1133,8 +1133,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 == Value
-	inline
 	friend
+	inline
 	bool
 	eq( MArray1 const & a, T const & t )
 	{
@@ -1145,8 +1145,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 != Value
-	inline
 	friend
+	inline
 	bool
 	ne( MArray1 const & a, T const & t )
 	{
@@ -1154,8 +1154,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 < Value
-	inline
 	friend
+	inline
 	bool
 	lt( MArray1 const & a, T const & t )
 	{
@@ -1167,8 +1167,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 <= Value
-	inline
 	friend
+	inline
 	bool
 	le( MArray1 const & a, T const & t )
 	{
@@ -1180,8 +1180,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 > Value
-	inline
 	friend
+	inline
 	bool
 	gt( MArray1 const & a, T const & t )
 	{
@@ -1189,8 +1189,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray1 >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( MArray1 const & a, T const & t )
 	{
@@ -1198,8 +1198,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == MArray1
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, MArray1 const & a )
 	{
@@ -1207,8 +1207,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != MArray1
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, MArray1 const & a )
 	{
@@ -1216,8 +1216,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < MArray1
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, MArray1 const & a )
 	{
@@ -1229,8 +1229,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= MArray1
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, MArray1 const & a )
 	{
@@ -1242,8 +1242,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > MArray1
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, MArray1 const & a )
 	{
@@ -1251,8 +1251,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= MArray1
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, MArray1 const & a )
 	{
@@ -1262,8 +1262,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any MArray1 == MArray1
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray1 const & a, MArray1 const & b )
 	{
@@ -1277,8 +1277,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 != MArray1
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray1 const & a, MArray1 const & b )
 	{
@@ -1286,8 +1286,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 < MArray1
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray1 const & a, MArray1 const & b )
 	{
@@ -1301,8 +1301,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 <= MArray1
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray1 const & a, MArray1 const & b )
 	{
@@ -1316,8 +1316,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 > MArray1
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray1 const & a, MArray1 const & b )
 	{
@@ -1325,8 +1325,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 >= MArray1
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray1 const & a, MArray1 const & b )
 	{
@@ -1334,8 +1334,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray1 const & a, T const & t )
 	{
@@ -1347,8 +1347,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray1 const & a, T const & t )
 	{
@@ -1356,8 +1356,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray1 const & a, T const & t )
 	{
@@ -1369,8 +1369,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray1 const & a, T const & t )
 	{
@@ -1382,8 +1382,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray1 const & a, T const & t )
 	{
@@ -1391,8 +1391,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray1 >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray1 const & a, T const & t )
 	{
@@ -1400,8 +1400,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == MArray1
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, MArray1 const & a )
 	{
@@ -1409,8 +1409,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != MArray1
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, MArray1 const & a )
 	{
@@ -1418,8 +1418,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < MArray1
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, MArray1 const & a )
 	{
@@ -1431,8 +1431,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= MArray1
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, MArray1 const & a )
 	{
@@ -1444,8 +1444,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > MArray1
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, MArray1 const & a )
 	{
@@ -1453,8 +1453,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= MArray1
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, MArray1 const & a )
 	{
@@ -1464,8 +1464,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All MArray1 == MArray1
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray1 const & a, MArray1 const & b )
 	{
@@ -1473,8 +1473,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 != MArray1
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray1 const & a, MArray1 const & b )
 	{
@@ -1482,8 +1482,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 < MArray1
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray1 const & a, MArray1 const & b )
 	{
@@ -1491,8 +1491,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 <= MArray1
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray1 const & a, MArray1 const & b )
 	{
@@ -1500,8 +1500,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 > MArray1
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray1 const & a, MArray1 const & b )
 	{
@@ -1509,8 +1509,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 >= MArray1
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray1 const & a, MArray1 const & b )
 	{
@@ -1518,8 +1518,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray1 const & a, T const & t )
 	{
@@ -1527,8 +1527,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray1 const & a, T const & t )
 	{
@@ -1536,8 +1536,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray1 const & a, T const & t )
 	{
@@ -1545,8 +1545,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray1 const & a, T const & t )
 	{
@@ -1554,8 +1554,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray1 const & a, T const & t )
 	{
@@ -1563,8 +1563,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray1 >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray1 const & a, T const & t )
 	{
@@ -1572,8 +1572,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == MArray1
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, MArray1 const & a )
 	{
@@ -1581,8 +1581,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != MArray1
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, MArray1 const & a )
 	{
@@ -1590,8 +1590,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < MArray1
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, MArray1 const & a )
 	{
@@ -1599,8 +1599,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= MArray1
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, MArray1 const & a )
 	{
@@ -1608,8 +1608,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > MArray1
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, MArray1 const & a )
 	{
@@ -1617,8 +1617,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= MArray1
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, MArray1 const & a )
 	{
@@ -1628,8 +1628,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count MArray1 == MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray1 const & a, MArray1 const & b )
 	{
@@ -1644,8 +1644,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 != MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray1 const & a, MArray1 const & b )
 	{
@@ -1660,8 +1660,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 < MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray1 const & a, MArray1 const & b )
 	{
@@ -1676,8 +1676,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 <= MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray1 const & a, MArray1 const & b )
 	{
@@ -1692,8 +1692,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 > MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray1 const & a, MArray1 const & b )
 	{
@@ -1708,8 +1708,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 >= MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray1 const & a, MArray1 const & b )
 	{
@@ -1724,8 +1724,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray1 const & a, T const & t )
 	{
@@ -1738,8 +1738,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, MArray1 const & a )
 	{
@@ -1747,8 +1747,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray1 const & a, T const & t )
 	{
@@ -1761,8 +1761,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, MArray1 const & a )
 	{
@@ -1770,8 +1770,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray1 const & a, T const & t )
 	{
@@ -1784,8 +1784,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, MArray1 const & a )
 	{
@@ -1793,8 +1793,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray1 const & a, T const & t )
 	{
@@ -1807,8 +1807,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, MArray1 const & a )
 	{
@@ -1816,8 +1816,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray1 const & a, T const & t )
 	{
@@ -1830,8 +1830,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, MArray1 const & a )
 	{
@@ -1839,8 +1839,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray1 >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray1 const & a, T const & t )
 	{
@@ -1853,8 +1853,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= MArray1
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, MArray1 const & a )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.hh
@@ -581,8 +581,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// MArray2 == MArray2
-	inline
 	friend
+	inline
 	bool
 	eq( MArray2 const & a, MArray2 const & b )
 	{
@@ -598,8 +598,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 != MArray2
-	inline
 	friend
+	inline
 	bool
 	ne( MArray2 const & a, MArray2 const & b )
 	{
@@ -607,8 +607,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 < MArray2
-	inline
 	friend
+	inline
 	bool
 	lt( MArray2 const & a, MArray2 const & b )
 	{
@@ -624,8 +624,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 <= MArray2
-	inline
 	friend
+	inline
 	bool
 	le( MArray2 const & a, MArray2 const & b )
 	{
@@ -641,8 +641,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 > MArray2
-	inline
 	friend
+	inline
 	bool
 	gt( MArray2 const & a, MArray2 const & b )
 	{
@@ -650,8 +650,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 >= MArray2
-	inline
 	friend
+	inline
 	bool
 	ge( MArray2 const & a, MArray2 const & b )
 	{
@@ -659,8 +659,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 == Value
-	inline
 	friend
+	inline
 	bool
 	eq( MArray2 const & a, T const & t )
 	{
@@ -674,8 +674,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 != Value
-	inline
 	friend
+	inline
 	bool
 	ne( MArray2 const & a, T const & t )
 	{
@@ -683,8 +683,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 < Value
-	inline
 	friend
+	inline
 	bool
 	lt( MArray2 const & a, T const & t )
 	{
@@ -699,8 +699,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 <= Value
-	inline
 	friend
+	inline
 	bool
 	le( MArray2 const & a, T const & t )
 	{
@@ -715,8 +715,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 > Value
-	inline
 	friend
+	inline
 	bool
 	gt( MArray2 const & a, T const & t )
 	{
@@ -724,8 +724,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray2 >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( MArray2 const & a, T const & t )
 	{
@@ -733,8 +733,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == MArray2
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, MArray2 const & a )
 	{
@@ -742,8 +742,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != MArray2
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, MArray2 const & a )
 	{
@@ -751,8 +751,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < MArray2
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, MArray2 const & a )
 	{
@@ -767,8 +767,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= MArray2
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, MArray2 const & a )
 	{
@@ -783,8 +783,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > MArray2
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, MArray2 const & a )
 	{
@@ -792,8 +792,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= MArray2
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, MArray2 const & a )
 	{
@@ -803,8 +803,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any MArray2 == MArray2
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray2 const & a, MArray2 const & b )
 	{
@@ -820,8 +820,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 != MArray2
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray2 const & a, MArray2 const & b )
 	{
@@ -829,8 +829,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 < MArray2
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray2 const & a, MArray2 const & b )
 	{
@@ -846,8 +846,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 <= MArray2
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray2 const & a, MArray2 const & b )
 	{
@@ -863,8 +863,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 > MArray2
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray2 const & a, MArray2 const & b )
 	{
@@ -872,8 +872,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 >= MArray2
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray2 const & a, MArray2 const & b )
 	{
@@ -881,8 +881,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray2 const & a, T const & t )
 	{
@@ -896,8 +896,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray2 const & a, T const & t )
 	{
@@ -905,8 +905,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray2 const & a, T const & t )
 	{
@@ -920,8 +920,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray2 const & a, T const & t )
 	{
@@ -935,8 +935,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray2 const & a, T const & t )
 	{
@@ -944,8 +944,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray2 >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray2 const & a, T const & t )
 	{
@@ -953,8 +953,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == MArray2
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, MArray2 const & a )
 	{
@@ -962,8 +962,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != MArray2
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, MArray2 const & a )
 	{
@@ -971,8 +971,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < MArray2
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, MArray2 const & a )
 	{
@@ -986,8 +986,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= MArray2
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, MArray2 const & a )
 	{
@@ -1001,8 +1001,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > MArray2
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, MArray2 const & a )
 	{
@@ -1010,8 +1010,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= MArray2
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, MArray2 const & a )
 	{
@@ -1021,8 +1021,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All MArray2 == MArray2
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray2 const & a, MArray2 const & b )
 	{
@@ -1030,8 +1030,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 != MArray2
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray2 const & a, MArray2 const & b )
 	{
@@ -1039,8 +1039,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 < MArray2
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray2 const & a, MArray2 const & b )
 	{
@@ -1048,8 +1048,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 <= MArray2
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray2 const & a, MArray2 const & b )
 	{
@@ -1057,8 +1057,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 > MArray2
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray2 const & a, MArray2 const & b )
 	{
@@ -1066,8 +1066,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 >= MArray2
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray2 const & a, MArray2 const & b )
 	{
@@ -1075,8 +1075,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray2 const & a, T const & t )
 	{
@@ -1084,8 +1084,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray2 const & a, T const & t )
 	{
@@ -1093,8 +1093,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray2 const & a, T const & t )
 	{
@@ -1102,8 +1102,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray2 const & a, T const & t )
 	{
@@ -1111,8 +1111,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray2 const & a, T const & t )
 	{
@@ -1120,8 +1120,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray2 >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray2 const & a, T const & t )
 	{
@@ -1129,8 +1129,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == MArray2
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, MArray2 const & a )
 	{
@@ -1138,8 +1138,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != MArray2
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, MArray2 const & a )
 	{
@@ -1147,8 +1147,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < MArray2
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, MArray2 const & a )
 	{
@@ -1156,8 +1156,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= MArray2
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, MArray2 const & a )
 	{
@@ -1165,8 +1165,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > MArray2
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, MArray2 const & a )
 	{
@@ -1174,8 +1174,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= MArray2
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, MArray2 const & a )
 	{
@@ -1185,8 +1185,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count MArray2 == MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray2 const & a, MArray2 const & b )
 	{
@@ -1203,8 +1203,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 != MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray2 const & a, MArray2 const & b )
 	{
@@ -1221,8 +1221,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 < MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray2 const & a, MArray2 const & b )
 	{
@@ -1239,8 +1239,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 <= MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray2 const & a, MArray2 const & b )
 	{
@@ -1257,8 +1257,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 > MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray2 const & a, MArray2 const & b )
 	{
@@ -1275,8 +1275,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 >= MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray2 const & a, MArray2 const & b )
 	{
@@ -1293,8 +1293,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray2 const & a, T const & t )
 	{
@@ -1309,8 +1309,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, MArray2 const & a )
 	{
@@ -1318,8 +1318,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray2 const & a, T const & t )
 	{
@@ -1334,8 +1334,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, MArray2 const & a )
 	{
@@ -1343,8 +1343,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray2 const & a, T const & t )
 	{
@@ -1359,8 +1359,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, MArray2 const & a )
 	{
@@ -1368,8 +1368,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray2 const & a, T const & t )
 	{
@@ -1384,8 +1384,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, MArray2 const & a )
 	{
@@ -1393,8 +1393,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray2 const & a, T const & t )
 	{
@@ -1409,8 +1409,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, MArray2 const & a )
 	{
@@ -1418,8 +1418,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray2 >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray2 const & a, T const & t )
 	{
@@ -1434,8 +1434,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= MArray2
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, MArray2 const & a )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.hh
@@ -667,8 +667,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// MArray3 == MArray3
-	inline
 	friend
+	inline
 	bool
 	eq( MArray3 const & a, MArray3 const & b )
 	{
@@ -686,8 +686,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 != MArray3
-	inline
 	friend
+	inline
 	bool
 	ne( MArray3 const & a, MArray3 const & b )
 	{
@@ -695,8 +695,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 < MArray3
-	inline
 	friend
+	inline
 	bool
 	lt( MArray3 const & a, MArray3 const & b )
 	{
@@ -714,8 +714,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 <= MArray3
-	inline
 	friend
+	inline
 	bool
 	le( MArray3 const & a, MArray3 const & b )
 	{
@@ -733,8 +733,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 > MArray3
-	inline
 	friend
+	inline
 	bool
 	gt( MArray3 const & a, MArray3 const & b )
 	{
@@ -742,8 +742,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 >= MArray3
-	inline
 	friend
+	inline
 	bool
 	ge( MArray3 const & a, MArray3 const & b )
 	{
@@ -751,8 +751,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 == Value
-	inline
 	friend
+	inline
 	bool
 	eq( MArray3 const & a, T const & t )
 	{
@@ -768,8 +768,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 != Value
-	inline
 	friend
+	inline
 	bool
 	ne( MArray3 const & a, T const & t )
 	{
@@ -777,8 +777,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 < Value
-	inline
 	friend
+	inline
 	bool
 	lt( MArray3 const & a, T const & t )
 	{
@@ -795,8 +795,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 <= Value
-	inline
 	friend
+	inline
 	bool
 	le( MArray3 const & a, T const & t )
 	{
@@ -813,8 +813,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 > Value
-	inline
 	friend
+	inline
 	bool
 	gt( MArray3 const & a, T const & t )
 	{
@@ -822,8 +822,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray3 >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( MArray3 const & a, T const & t )
 	{
@@ -831,8 +831,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == MArray3
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, MArray3 const & a )
 	{
@@ -840,8 +840,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != MArray3
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, MArray3 const & a )
 	{
@@ -849,8 +849,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < MArray3
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, MArray3 const & a )
 	{
@@ -867,8 +867,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= MArray3
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, MArray3 const & a )
 	{
@@ -885,8 +885,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > MArray3
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, MArray3 const & a )
 	{
@@ -894,8 +894,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= MArray3
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, MArray3 const & a )
 	{
@@ -905,8 +905,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any MArray3 == MArray3
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray3 const & a, MArray3 const & b )
 	{
@@ -924,8 +924,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 != MArray3
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray3 const & a, MArray3 const & b )
 	{
@@ -933,8 +933,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 < MArray3
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray3 const & a, MArray3 const & b )
 	{
@@ -952,8 +952,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 <= MArray3
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray3 const & a, MArray3 const & b )
 	{
@@ -971,8 +971,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 > MArray3
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray3 const & a, MArray3 const & b )
 	{
@@ -980,8 +980,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 >= MArray3
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray3 const & a, MArray3 const & b )
 	{
@@ -989,8 +989,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray3 const & a, T const & t )
 	{
@@ -1006,8 +1006,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray3 const & a, T const & t )
 	{
@@ -1015,8 +1015,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray3 const & a, T const & t )
 	{
@@ -1032,8 +1032,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray3 const & a, T const & t )
 	{
@@ -1049,8 +1049,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray3 const & a, T const & t )
 	{
@@ -1058,8 +1058,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray3 >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray3 const & a, T const & t )
 	{
@@ -1067,8 +1067,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == MArray3
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, MArray3 const & a )
 	{
@@ -1076,8 +1076,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != MArray3
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, MArray3 const & a )
 	{
@@ -1085,8 +1085,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < MArray3
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, MArray3 const & a )
 	{
@@ -1102,8 +1102,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= MArray3
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, MArray3 const & a )
 	{
@@ -1119,8 +1119,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > MArray3
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, MArray3 const & a )
 	{
@@ -1128,8 +1128,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= MArray3
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, MArray3 const & a )
 	{
@@ -1139,8 +1139,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All MArray3 == MArray3
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray3 const & a, MArray3 const & b )
 	{
@@ -1148,8 +1148,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 != MArray3
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray3 const & a, MArray3 const & b )
 	{
@@ -1157,8 +1157,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 < MArray3
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray3 const & a, MArray3 const & b )
 	{
@@ -1166,8 +1166,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 <= MArray3
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray3 const & a, MArray3 const & b )
 	{
@@ -1175,8 +1175,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 > MArray3
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray3 const & a, MArray3 const & b )
 	{
@@ -1184,8 +1184,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 >= MArray3
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray3 const & a, MArray3 const & b )
 	{
@@ -1193,8 +1193,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray3 const & a, T const & t )
 	{
@@ -1202,8 +1202,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray3 const & a, T const & t )
 	{
@@ -1211,8 +1211,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray3 const & a, T const & t )
 	{
@@ -1220,8 +1220,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray3 const & a, T const & t )
 	{
@@ -1229,8 +1229,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray3 const & a, T const & t )
 	{
@@ -1238,8 +1238,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray3 >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray3 const & a, T const & t )
 	{
@@ -1247,8 +1247,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == MArray3
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, MArray3 const & a )
 	{
@@ -1256,8 +1256,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != MArray3
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, MArray3 const & a )
 	{
@@ -1265,8 +1265,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < MArray3
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, MArray3 const & a )
 	{
@@ -1274,8 +1274,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= MArray3
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, MArray3 const & a )
 	{
@@ -1283,8 +1283,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > MArray3
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, MArray3 const & a )
 	{
@@ -1292,8 +1292,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= MArray3
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, MArray3 const & a )
 	{
@@ -1303,8 +1303,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count MArray3 == MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray3 const & a, MArray3 const & b )
 	{
@@ -1323,8 +1323,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 != MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray3 const & a, MArray3 const & b )
 	{
@@ -1343,8 +1343,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 < MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray3 const & a, MArray3 const & b )
 	{
@@ -1363,8 +1363,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 <= MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray3 const & a, MArray3 const & b )
 	{
@@ -1383,8 +1383,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 > MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray3 const & a, MArray3 const & b )
 	{
@@ -1403,8 +1403,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 >= MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray3 const & a, MArray3 const & b )
 	{
@@ -1423,8 +1423,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray3 const & a, T const & t )
 	{
@@ -1441,8 +1441,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, MArray3 const & a )
 	{
@@ -1450,8 +1450,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray3 const & a, T const & t )
 	{
@@ -1468,8 +1468,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, MArray3 const & a )
 	{
@@ -1477,8 +1477,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray3 const & a, T const & t )
 	{
@@ -1495,8 +1495,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, MArray3 const & a )
 	{
@@ -1504,8 +1504,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray3 const & a, T const & t )
 	{
@@ -1522,8 +1522,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, MArray3 const & a )
 	{
@@ -1531,8 +1531,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray3 const & a, T const & t )
 	{
@@ -1549,8 +1549,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, MArray3 const & a )
 	{
@@ -1558,8 +1558,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray3 >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray3 const & a, T const & t )
 	{
@@ -1576,8 +1576,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= MArray3
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, MArray3 const & a )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.hh
@@ -751,8 +751,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// MArray4 == MArray4
-	inline
 	friend
+	inline
 	bool
 	eq( MArray4 const & a, MArray4 const & b )
 	{
@@ -772,8 +772,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 != MArray4
-	inline
 	friend
+	inline
 	bool
 	ne( MArray4 const & a, MArray4 const & b )
 	{
@@ -781,8 +781,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 < MArray4
-	inline
 	friend
+	inline
 	bool
 	lt( MArray4 const & a, MArray4 const & b )
 	{
@@ -802,8 +802,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 <= MArray4
-	inline
 	friend
+	inline
 	bool
 	le( MArray4 const & a, MArray4 const & b )
 	{
@@ -823,8 +823,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 > MArray4
-	inline
 	friend
+	inline
 	bool
 	gt( MArray4 const & a, MArray4 const & b )
 	{
@@ -832,8 +832,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 >= MArray4
-	inline
 	friend
+	inline
 	bool
 	ge( MArray4 const & a, MArray4 const & b )
 	{
@@ -841,8 +841,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 == Value
-	inline
 	friend
+	inline
 	bool
 	eq( MArray4 const & a, T const & t )
 	{
@@ -860,8 +860,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 != Value
-	inline
 	friend
+	inline
 	bool
 	ne( MArray4 const & a, T const & t )
 	{
@@ -869,8 +869,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 < Value
-	inline
 	friend
+	inline
 	bool
 	lt( MArray4 const & a, T const & t )
 	{
@@ -889,8 +889,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 <= Value
-	inline
 	friend
+	inline
 	bool
 	le( MArray4 const & a, T const & t )
 	{
@@ -909,8 +909,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 > Value
-	inline
 	friend
+	inline
 	bool
 	gt( MArray4 const & a, T const & t )
 	{
@@ -918,8 +918,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray4 >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( MArray4 const & a, T const & t )
 	{
@@ -927,8 +927,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == MArray4
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, MArray4 const & a )
 	{
@@ -936,8 +936,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != MArray4
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, MArray4 const & a )
 	{
@@ -945,8 +945,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < MArray4
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, MArray4 const & a )
 	{
@@ -965,8 +965,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= MArray4
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, MArray4 const & a )
 	{
@@ -985,8 +985,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > MArray4
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, MArray4 const & a )
 	{
@@ -994,8 +994,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= MArray4
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, MArray4 const & a )
 	{
@@ -1005,8 +1005,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any MArray4 == MArray4
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray4 const & a, MArray4 const & b )
 	{
@@ -1026,8 +1026,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 != MArray4
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray4 const & a, MArray4 const & b )
 	{
@@ -1035,8 +1035,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 < MArray4
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray4 const & a, MArray4 const & b )
 	{
@@ -1056,8 +1056,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 <= MArray4
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray4 const & a, MArray4 const & b )
 	{
@@ -1077,8 +1077,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 > MArray4
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray4 const & a, MArray4 const & b )
 	{
@@ -1086,8 +1086,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 >= MArray4
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray4 const & a, MArray4 const & b )
 	{
@@ -1095,8 +1095,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray4 const & a, T const & t )
 	{
@@ -1114,8 +1114,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray4 const & a, T const & t )
 	{
@@ -1123,8 +1123,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray4 const & a, T const & t )
 	{
@@ -1142,8 +1142,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray4 const & a, T const & t )
 	{
@@ -1161,8 +1161,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray4 const & a, T const & t )
 	{
@@ -1170,8 +1170,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray4 >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray4 const & a, T const & t )
 	{
@@ -1179,8 +1179,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == MArray4
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, MArray4 const & a )
 	{
@@ -1188,8 +1188,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != MArray4
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, MArray4 const & a )
 	{
@@ -1197,8 +1197,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < MArray4
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, MArray4 const & a )
 	{
@@ -1216,8 +1216,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= MArray4
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, MArray4 const & a )
 	{
@@ -1235,8 +1235,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > MArray4
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, MArray4 const & a )
 	{
@@ -1244,8 +1244,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= MArray4
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, MArray4 const & a )
 	{
@@ -1255,8 +1255,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All MArray4 == MArray4
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray4 const & a, MArray4 const & b )
 	{
@@ -1264,8 +1264,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 != MArray4
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray4 const & a, MArray4 const & b )
 	{
@@ -1273,8 +1273,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 < MArray4
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray4 const & a, MArray4 const & b )
 	{
@@ -1282,8 +1282,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 <= MArray4
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray4 const & a, MArray4 const & b )
 	{
@@ -1291,8 +1291,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 > MArray4
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray4 const & a, MArray4 const & b )
 	{
@@ -1300,8 +1300,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 >= MArray4
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray4 const & a, MArray4 const & b )
 	{
@@ -1309,8 +1309,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray4 const & a, T const & t )
 	{
@@ -1318,8 +1318,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray4 const & a, T const & t )
 	{
@@ -1327,8 +1327,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray4 const & a, T const & t )
 	{
@@ -1336,8 +1336,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray4 const & a, T const & t )
 	{
@@ -1345,8 +1345,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray4 const & a, T const & t )
 	{
@@ -1354,8 +1354,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray4 >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray4 const & a, T const & t )
 	{
@@ -1363,8 +1363,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == MArray4
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, MArray4 const & a )
 	{
@@ -1372,8 +1372,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != MArray4
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, MArray4 const & a )
 	{
@@ -1381,8 +1381,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < MArray4
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, MArray4 const & a )
 	{
@@ -1390,8 +1390,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= MArray4
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, MArray4 const & a )
 	{
@@ -1399,8 +1399,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > MArray4
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, MArray4 const & a )
 	{
@@ -1408,8 +1408,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= MArray4
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, MArray4 const & a )
 	{
@@ -1419,8 +1419,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count MArray4 == MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray4 const & a, MArray4 const & b )
 	{
@@ -1441,8 +1441,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 != MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray4 const & a, MArray4 const & b )
 	{
@@ -1463,8 +1463,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 < MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray4 const & a, MArray4 const & b )
 	{
@@ -1485,8 +1485,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 <= MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray4 const & a, MArray4 const & b )
 	{
@@ -1507,8 +1507,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 > MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray4 const & a, MArray4 const & b )
 	{
@@ -1529,8 +1529,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 >= MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray4 const & a, MArray4 const & b )
 	{
@@ -1551,8 +1551,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray4 const & a, T const & t )
 	{
@@ -1571,8 +1571,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, MArray4 const & a )
 	{
@@ -1580,8 +1580,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray4 const & a, T const & t )
 	{
@@ -1600,8 +1600,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, MArray4 const & a )
 	{
@@ -1609,8 +1609,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray4 const & a, T const & t )
 	{
@@ -1629,8 +1629,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, MArray4 const & a )
 	{
@@ -1638,8 +1638,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray4 const & a, T const & t )
 	{
@@ -1658,8 +1658,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, MArray4 const & a )
 	{
@@ -1667,8 +1667,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray4 const & a, T const & t )
 	{
@@ -1687,8 +1687,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, MArray4 const & a )
 	{
@@ -1696,8 +1696,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray4 >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray4 const & a, T const & t )
 	{
@@ -1716,8 +1716,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= MArray4
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, MArray4 const & a )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.hh
@@ -835,8 +835,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// MArray5 == MArray5
-	inline
 	friend
+	inline
 	bool
 	eq( MArray5 const & a, MArray5 const & b )
 	{
@@ -858,8 +858,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 != MArray5
-	inline
 	friend
+	inline
 	bool
 	ne( MArray5 const & a, MArray5 const & b )
 	{
@@ -867,8 +867,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 < MArray5
-	inline
 	friend
+	inline
 	bool
 	lt( MArray5 const & a, MArray5 const & b )
 	{
@@ -890,8 +890,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 <= MArray5
-	inline
 	friend
+	inline
 	bool
 	le( MArray5 const & a, MArray5 const & b )
 	{
@@ -913,8 +913,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 > MArray5
-	inline
 	friend
+	inline
 	bool
 	gt( MArray5 const & a, MArray5 const & b )
 	{
@@ -922,8 +922,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 >= MArray5
-	inline
 	friend
+	inline
 	bool
 	ge( MArray5 const & a, MArray5 const & b )
 	{
@@ -931,8 +931,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 == Value
-	inline
 	friend
+	inline
 	bool
 	eq( MArray5 const & a, T const & t )
 	{
@@ -952,8 +952,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 != Value
-	inline
 	friend
+	inline
 	bool
 	ne( MArray5 const & a, T const & t )
 	{
@@ -961,8 +961,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 < Value
-	inline
 	friend
+	inline
 	bool
 	lt( MArray5 const & a, T const & t )
 	{
@@ -983,8 +983,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 <= Value
-	inline
 	friend
+	inline
 	bool
 	le( MArray5 const & a, T const & t )
 	{
@@ -1005,8 +1005,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 > Value
-	inline
 	friend
+	inline
 	bool
 	gt( MArray5 const & a, T const & t )
 	{
@@ -1014,8 +1014,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray5 >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( MArray5 const & a, T const & t )
 	{
@@ -1023,8 +1023,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == MArray5
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, MArray5 const & a )
 	{
@@ -1032,8 +1032,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != MArray5
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, MArray5 const & a )
 	{
@@ -1041,8 +1041,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < MArray5
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, MArray5 const & a )
 	{
@@ -1063,8 +1063,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= MArray5
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, MArray5 const & a )
 	{
@@ -1085,8 +1085,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > MArray5
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, MArray5 const & a )
 	{
@@ -1094,8 +1094,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= MArray5
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, MArray5 const & a )
 	{
@@ -1105,8 +1105,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any MArray5 == MArray5
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray5 const & a, MArray5 const & b )
 	{
@@ -1128,8 +1128,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 != MArray5
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray5 const & a, MArray5 const & b )
 	{
@@ -1137,8 +1137,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 < MArray5
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray5 const & a, MArray5 const & b )
 	{
@@ -1160,8 +1160,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 <= MArray5
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray5 const & a, MArray5 const & b )
 	{
@@ -1183,8 +1183,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 > MArray5
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray5 const & a, MArray5 const & b )
 	{
@@ -1192,8 +1192,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 >= MArray5
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray5 const & a, MArray5 const & b )
 	{
@@ -1201,8 +1201,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray5 const & a, T const & t )
 	{
@@ -1222,8 +1222,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray5 const & a, T const & t )
 	{
@@ -1231,8 +1231,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray5 const & a, T const & t )
 	{
@@ -1252,8 +1252,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray5 const & a, T const & t )
 	{
@@ -1273,8 +1273,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray5 const & a, T const & t )
 	{
@@ -1282,8 +1282,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray5 >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray5 const & a, T const & t )
 	{
@@ -1291,8 +1291,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == MArray5
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, MArray5 const & a )
 	{
@@ -1300,8 +1300,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != MArray5
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, MArray5 const & a )
 	{
@@ -1309,8 +1309,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < MArray5
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, MArray5 const & a )
 	{
@@ -1330,8 +1330,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= MArray5
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, MArray5 const & a )
 	{
@@ -1351,8 +1351,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > MArray5
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, MArray5 const & a )
 	{
@@ -1360,8 +1360,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= MArray5
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, MArray5 const & a )
 	{
@@ -1371,8 +1371,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All MArray5 == MArray5
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray5 const & a, MArray5 const & b )
 	{
@@ -1380,8 +1380,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 != MArray5
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray5 const & a, MArray5 const & b )
 	{
@@ -1389,8 +1389,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 < MArray5
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray5 const & a, MArray5 const & b )
 	{
@@ -1398,8 +1398,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 <= MArray5
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray5 const & a, MArray5 const & b )
 	{
@@ -1407,8 +1407,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 > MArray5
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray5 const & a, MArray5 const & b )
 	{
@@ -1416,8 +1416,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 >= MArray5
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray5 const & a, MArray5 const & b )
 	{
@@ -1425,8 +1425,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray5 const & a, T const & t )
 	{
@@ -1434,8 +1434,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray5 const & a, T const & t )
 	{
@@ -1443,8 +1443,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray5 const & a, T const & t )
 	{
@@ -1452,8 +1452,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray5 const & a, T const & t )
 	{
@@ -1461,8 +1461,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray5 const & a, T const & t )
 	{
@@ -1470,8 +1470,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray5 >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray5 const & a, T const & t )
 	{
@@ -1479,8 +1479,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == MArray5
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, MArray5 const & a )
 	{
@@ -1488,8 +1488,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != MArray5
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, MArray5 const & a )
 	{
@@ -1497,8 +1497,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < MArray5
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, MArray5 const & a )
 	{
@@ -1506,8 +1506,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= MArray5
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, MArray5 const & a )
 	{
@@ -1515,8 +1515,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > MArray5
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, MArray5 const & a )
 	{
@@ -1524,8 +1524,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= MArray5
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, MArray5 const & a )
 	{
@@ -1535,8 +1535,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count MArray5 == MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray5 const & a, MArray5 const & b )
 	{
@@ -1559,8 +1559,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 != MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray5 const & a, MArray5 const & b )
 	{
@@ -1583,8 +1583,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 < MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray5 const & a, MArray5 const & b )
 	{
@@ -1607,8 +1607,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 <= MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray5 const & a, MArray5 const & b )
 	{
@@ -1631,8 +1631,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 > MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray5 const & a, MArray5 const & b )
 	{
@@ -1655,8 +1655,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 >= MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray5 const & a, MArray5 const & b )
 	{
@@ -1679,8 +1679,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray5 const & a, T const & t )
 	{
@@ -1701,8 +1701,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, MArray5 const & a )
 	{
@@ -1710,8 +1710,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray5 const & a, T const & t )
 	{
@@ -1732,8 +1732,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, MArray5 const & a )
 	{
@@ -1741,8 +1741,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray5 const & a, T const & t )
 	{
@@ -1763,8 +1763,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, MArray5 const & a )
 	{
@@ -1772,8 +1772,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray5 const & a, T const & t )
 	{
@@ -1794,8 +1794,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, MArray5 const & a )
 	{
@@ -1803,8 +1803,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray5 const & a, T const & t )
 	{
@@ -1825,8 +1825,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, MArray5 const & a )
 	{
@@ -1834,8 +1834,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray5 >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray5 const & a, T const & t )
 	{
@@ -1856,8 +1856,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= MArray5
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, MArray5 const & a )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.hh
@@ -919,8 +919,8 @@ public: // MArray Generators
 public: // Comparison: Predicate
 
 	// MArray6 == MArray6
-	inline
 	friend
+	inline
 	bool
 	eq( MArray6 const & a, MArray6 const & b )
 	{
@@ -944,8 +944,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 != MArray6
-	inline
 	friend
+	inline
 	bool
 	ne( MArray6 const & a, MArray6 const & b )
 	{
@@ -953,8 +953,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 < MArray6
-	inline
 	friend
+	inline
 	bool
 	lt( MArray6 const & a, MArray6 const & b )
 	{
@@ -979,8 +979,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 <= MArray6
-	inline
 	friend
+	inline
 	bool
 	le( MArray6 const & a, MArray6 const & b )
 	{
@@ -1004,8 +1004,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 > MArray6
-	inline
 	friend
+	inline
 	bool
 	gt( MArray6 const & a, MArray6 const & b )
 	{
@@ -1013,8 +1013,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 >= MArray6
-	inline
 	friend
+	inline
 	bool
 	ge( MArray6 const & a, MArray6 const & b )
 	{
@@ -1022,8 +1022,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 == Value
-	inline
 	friend
+	inline
 	bool
 	eq( MArray6 const & a, T const & t )
 	{
@@ -1045,8 +1045,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 != Value
-	inline
 	friend
+	inline
 	bool
 	ne( MArray6 const & a, T const & t )
 	{
@@ -1054,8 +1054,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 < Value
-	inline
 	friend
+	inline
 	bool
 	lt( MArray6 const & a, T const & t )
 	{
@@ -1078,8 +1078,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 <= Value
-	inline
 	friend
+	inline
 	bool
 	le( MArray6 const & a, T const & t )
 	{
@@ -1102,8 +1102,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 > Value
-	inline
 	friend
+	inline
 	bool
 	gt( MArray6 const & a, T const & t )
 	{
@@ -1111,8 +1111,8 @@ public: // Comparison: Predicate
 	}
 
 	// MArray6 >= Value
-	inline
 	friend
+	inline
 	bool
 	ge( MArray6 const & a, T const & t )
 	{
@@ -1120,8 +1120,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value == MArray6
-	inline
 	friend
+	inline
 	bool
 	eq( T const & t, MArray6 const & a )
 	{
@@ -1129,8 +1129,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value != MArray6
-	inline
 	friend
+	inline
 	bool
 	ne( T const & t, MArray6 const & a )
 	{
@@ -1138,8 +1138,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value < MArray6
-	inline
 	friend
+	inline
 	bool
 	lt( T const & t, MArray6 const & a )
 	{
@@ -1162,8 +1162,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value <= MArray6
-	inline
 	friend
+	inline
 	bool
 	le( T const & t, MArray6 const & a )
 	{
@@ -1186,8 +1186,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value > MArray6
-	inline
 	friend
+	inline
 	bool
 	gt( T const & t, MArray6 const & a )
 	{
@@ -1195,8 +1195,8 @@ public: // Comparison: Predicate
 	}
 
 	// Value >= MArray6
-	inline
 	friend
+	inline
 	bool
 	ge( T const & t, MArray6 const & a )
 	{
@@ -1206,8 +1206,8 @@ public: // Comparison: Predicate
 public: // Comparison: Predicate: Any
 
 	// Any MArray6 == MArray6
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray6 const & a, MArray6 const & b )
 	{
@@ -1231,8 +1231,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 != MArray6
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray6 const & a, MArray6 const & b )
 	{
@@ -1240,8 +1240,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 < MArray6
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray6 const & a, MArray6 const & b )
 	{
@@ -1265,8 +1265,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 <= MArray6
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray6 const & a, MArray6 const & b )
 	{
@@ -1290,8 +1290,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 > MArray6
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray6 const & a, MArray6 const & b )
 	{
@@ -1299,8 +1299,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 >= MArray6
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray6 const & a, MArray6 const & b )
 	{
@@ -1308,8 +1308,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 == Value
-	inline
 	friend
+	inline
 	bool
 	any_eq( MArray6 const & a, T const & t )
 	{
@@ -1331,8 +1331,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 != Value
-	inline
 	friend
+	inline
 	bool
 	any_ne( MArray6 const & a, T const & t )
 	{
@@ -1340,8 +1340,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 < Value
-	inline
 	friend
+	inline
 	bool
 	any_lt( MArray6 const & a, T const & t )
 	{
@@ -1363,8 +1363,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 <= Value
-	inline
 	friend
+	inline
 	bool
 	any_le( MArray6 const & a, T const & t )
 	{
@@ -1386,8 +1386,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 > Value
-	inline
 	friend
+	inline
 	bool
 	any_gt( MArray6 const & a, T const & t )
 	{
@@ -1395,8 +1395,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any MArray6 >= Value
-	inline
 	friend
+	inline
 	bool
 	any_ge( MArray6 const & a, T const & t )
 	{
@@ -1404,8 +1404,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value == MArray6
-	inline
 	friend
+	inline
 	bool
 	any_eq( T const & t, MArray6 const & a )
 	{
@@ -1413,8 +1413,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value != MArray6
-	inline
 	friend
+	inline
 	bool
 	any_ne( T const & t, MArray6 const & a )
 	{
@@ -1422,8 +1422,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value < MArray6
-	inline
 	friend
+	inline
 	bool
 	any_lt( T const & t, MArray6 const & a )
 	{
@@ -1445,8 +1445,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value <= MArray6
-	inline
 	friend
+	inline
 	bool
 	any_le( T const & t, MArray6 const & a )
 	{
@@ -1468,8 +1468,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value > MArray6
-	inline
 	friend
+	inline
 	bool
 	any_gt( T const & t, MArray6 const & a )
 	{
@@ -1477,8 +1477,8 @@ public: // Comparison: Predicate: Any
 	}
 
 	// Any Value >= MArray6
-	inline
 	friend
+	inline
 	bool
 	any_ge( T const & t, MArray6 const & a )
 	{
@@ -1488,8 +1488,8 @@ public: // Comparison: Predicate: Any
 public: // Comparison: Predicate: All
 
 	// All MArray6 == MArray6
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray6 const & a, MArray6 const & b )
 	{
@@ -1497,8 +1497,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 != MArray6
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray6 const & a, MArray6 const & b )
 	{
@@ -1506,8 +1506,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 < MArray6
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray6 const & a, MArray6 const & b )
 	{
@@ -1515,8 +1515,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 <= MArray6
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray6 const & a, MArray6 const & b )
 	{
@@ -1524,8 +1524,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 > MArray6
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray6 const & a, MArray6 const & b )
 	{
@@ -1533,8 +1533,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 >= MArray6
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray6 const & a, MArray6 const & b )
 	{
@@ -1542,8 +1542,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 == Value
-	inline
 	friend
+	inline
 	bool
 	all_eq( MArray6 const & a, T const & t )
 	{
@@ -1551,8 +1551,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 != Value
-	inline
 	friend
+	inline
 	bool
 	all_ne( MArray6 const & a, T const & t )
 	{
@@ -1560,8 +1560,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 < Value
-	inline
 	friend
+	inline
 	bool
 	all_lt( MArray6 const & a, T const & t )
 	{
@@ -1569,8 +1569,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 <= Value
-	inline
 	friend
+	inline
 	bool
 	all_le( MArray6 const & a, T const & t )
 	{
@@ -1578,8 +1578,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 > Value
-	inline
 	friend
+	inline
 	bool
 	all_gt( MArray6 const & a, T const & t )
 	{
@@ -1587,8 +1587,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All MArray6 >= Value
-	inline
 	friend
+	inline
 	bool
 	all_ge( MArray6 const & a, T const & t )
 	{
@@ -1596,8 +1596,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value == MArray6
-	inline
 	friend
+	inline
 	bool
 	all_eq( T const & t, MArray6 const & a )
 	{
@@ -1605,8 +1605,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value != MArray6
-	inline
 	friend
+	inline
 	bool
 	all_ne( T const & t, MArray6 const & a )
 	{
@@ -1614,8 +1614,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value < MArray6
-	inline
 	friend
+	inline
 	bool
 	all_lt( T const & t, MArray6 const & a )
 	{
@@ -1623,8 +1623,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value <= MArray6
-	inline
 	friend
+	inline
 	bool
 	all_le( T const & t, MArray6 const & a )
 	{
@@ -1632,8 +1632,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value > MArray6
-	inline
 	friend
+	inline
 	bool
 	all_gt( T const & t, MArray6 const & a )
 	{
@@ -1641,8 +1641,8 @@ public: // Comparison: Predicate: All
 	}
 
 	// All Value >= MArray6
-	inline
 	friend
+	inline
 	bool
 	all_ge( T const & t, MArray6 const & a )
 	{
@@ -1652,8 +1652,8 @@ public: // Comparison: Predicate: All
 public: // Comparison: Count
 
 	// Count MArray6 == MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray6 const & a, MArray6 const & b )
 	{
@@ -1678,8 +1678,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 != MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray6 const & a, MArray6 const & b )
 	{
@@ -1704,8 +1704,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 < MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray6 const & a, MArray6 const & b )
 	{
@@ -1730,8 +1730,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 <= MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray6 const & a, MArray6 const & b )
 	{
@@ -1756,8 +1756,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 > MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray6 const & a, MArray6 const & b )
 	{
@@ -1782,8 +1782,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 >= MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray6 const & a, MArray6 const & b )
 	{
@@ -1808,8 +1808,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 == Value
-	inline
 	friend
+	inline
 	size_type
 	count_eq( MArray6 const & a, T const & t )
 	{
@@ -1832,8 +1832,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value == MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_eq( T const & t, MArray6 const & a )
 	{
@@ -1841,8 +1841,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 != Value
-	inline
 	friend
+	inline
 	size_type
 	count_ne( MArray6 const & a, T const & t )
 	{
@@ -1865,8 +1865,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value != MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_ne( T const & t, MArray6 const & a )
 	{
@@ -1874,8 +1874,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 < Value
-	inline
 	friend
+	inline
 	size_type
 	count_lt( MArray6 const & a, T const & t )
 	{
@@ -1898,8 +1898,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value < MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_lt( T const & t, MArray6 const & a )
 	{
@@ -1907,8 +1907,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 <= Value
-	inline
 	friend
+	inline
 	size_type
 	count_le( MArray6 const & a, T const & t )
 	{
@@ -1931,8 +1931,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value <= MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_le( T const & t, MArray6 const & a )
 	{
@@ -1940,8 +1940,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 > Value
-	inline
 	friend
+	inline
 	size_type
 	count_gt( MArray6 const & a, T const & t )
 	{
@@ -1964,8 +1964,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value > MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_gt( T const & t, MArray6 const & a )
 	{
@@ -1973,8 +1973,8 @@ public: // Comparison: Count
 	}
 
 	// Count MArray6 >= Value
-	inline
 	friend
+	inline
 	size_type
 	count_ge( MArray6 const & a, T const & t )
 	{
@@ -1997,8 +1997,8 @@ public: // Comparison: Count
 	}
 
 	// Count Value >= MArray6
-	inline
 	friend
+	inline
 	size_type
 	count_ge( T const & t, MArray6 const & a )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Optional.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Optional.hh
@@ -224,8 +224,8 @@ public: // Modifiers
 public: // Comparison
 
 	// Optional == Optional
-	inline
 	friend
+	inline
 	bool
 	operator ==( Optional const & a, Optional const & b )
 	{
@@ -233,8 +233,8 @@ public: // Comparison
 	}
 
 	// Optional != Optional
-	inline
 	friend
+	inline
 	bool
 	operator !=( Optional const & a, Optional const & b )
 	{
@@ -242,8 +242,8 @@ public: // Comparison
 	}
 
 	// Optional == Value
-	inline
 	friend
+	inline
 	bool
 	operator ==( Optional const & a, T const & b )
 	{
@@ -251,8 +251,8 @@ public: // Comparison
 	}
 
 	// Optional != Value
-	inline
 	friend
+	inline
 	bool
 	operator !=( Optional const & a, T const & b )
 	{
@@ -260,8 +260,8 @@ public: // Comparison
 	}
 
 	// Value == Optional
-	inline
 	friend
+	inline
 	bool
 	operator ==( T const & a, Optional const & b )
 	{
@@ -269,8 +269,8 @@ public: // Comparison
 	}
 
 	// Value != Optional
-	inline
 	friend
+	inline
 	bool
 	operator !=( T const & a, Optional const & b )
 	{
@@ -448,8 +448,8 @@ public: // Modifiers
 public: // Comparison
 
 	// Optional == Optional
-	inline
 	friend
+	inline
 	bool
 	operator ==( Optional const & a, Optional const & b )
 	{
@@ -457,8 +457,8 @@ public: // Comparison
 	}
 
 	// Optional != Optional
-	inline
 	friend
+	inline
 	bool
 	operator !=( Optional const & a, Optional const & b )
 	{
@@ -466,8 +466,8 @@ public: // Comparison
 	}
 
 	// Optional == Value
-	inline
 	friend
+	inline
 	bool
 	operator ==( Optional const & a, T const & b )
 	{
@@ -475,8 +475,8 @@ public: // Comparison
 	}
 
 	// Optional != Value
-	inline
 	friend
+	inline
 	bool
 	operator !=( Optional const & a, T const & b )
 	{
@@ -484,8 +484,8 @@ public: // Comparison
 	}
 
 	// Value == Optional
-	inline
 	friend
+	inline
 	bool
 	operator ==( T const & a, Optional const & b )
 	{
@@ -493,8 +493,8 @@ public: // Comparison
 	}
 
 	// Value != Optional
-	inline
 	friend
+	inline
 	bool
 	operator !=( T const & a, Optional const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Reference.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Reference.hh
@@ -315,8 +315,8 @@ public: // Modifiers
 public: // Comparison
 
 	// Reference == Reference
-	inline
 	friend
+	inline
 	bool
 	operator ==( Reference const & a, Reference const & b )
 	{
@@ -325,8 +325,8 @@ public: // Comparison
 	}
 
 	// Reference != Reference
-	inline
 	friend
+	inline
 	bool
 	operator !=( Reference const & a, Reference const & b )
 	{
@@ -335,8 +335,8 @@ public: // Comparison
 	}
 
 	// Reference == Value
-	inline
 	friend
+	inline
 	bool
 	operator ==( Reference const & a, T const & b )
 	{
@@ -345,8 +345,8 @@ public: // Comparison
 	}
 
 	// Reference != Value
-	inline
 	friend
+	inline
 	bool
 	operator !=( Reference const & a, T const & b )
 	{
@@ -355,8 +355,8 @@ public: // Comparison
 	}
 
 	// Value == Reference
-	inline
 	friend
+	inline
 	bool
 	operator ==( T const & a, Reference const & b )
 	{
@@ -365,8 +365,8 @@ public: // Comparison
 	}
 
 	// Value != Reference
-	inline
 	friend
+	inline
 	bool
 	operator !=( T const & a, Reference const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Required.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Required.hh
@@ -210,8 +210,8 @@ public: // Properties
 public: // Comparison
 
 	// Required == Required
-	inline
 	friend
+	inline
 	bool
 	operator ==( Required const & a, Required const & b )
 	{
@@ -219,8 +219,8 @@ public: // Comparison
 	}
 
 	// Required != Required
-	inline
 	friend
+	inline
 	bool
 	operator !=( Required const & a, Required const & b )
 	{
@@ -228,8 +228,8 @@ public: // Comparison
 	}
 
 	// Required == Value
-	inline
 	friend
+	inline
 	bool
 	operator ==( Required const & a, T const & b )
 	{
@@ -237,8 +237,8 @@ public: // Comparison
 	}
 
 	// Required != Value
-	inline
 	friend
+	inline
 	bool
 	operator !=( Required const & a, T const & b )
 	{
@@ -246,8 +246,8 @@ public: // Comparison
 	}
 
 	// Value == Required
-	inline
 	friend
+	inline
 	bool
 	operator ==( T const & a, Required const & b )
 	{
@@ -255,8 +255,8 @@ public: // Comparison
 	}
 
 	// Value != Required
-	inline
 	friend
+	inline
 	bool
 	operator !=( T const & a, Required const & b )
 	{
@@ -424,8 +424,8 @@ public: // Properties
 public: // Comparison
 
 	// Required == Required
-	inline
 	friend
+	inline
 	bool
 	operator ==( Required const & a, Required const & b )
 	{
@@ -433,8 +433,8 @@ public: // Comparison
 	}
 
 	// Required != Required
-	inline
 	friend
+	inline
 	bool
 	operator !=( Required const & a, Required const & b )
 	{
@@ -442,8 +442,8 @@ public: // Comparison
 	}
 
 	// Required == Value
-	inline
 	friend
+	inline
 	bool
 	operator ==( Required const & a, T const & b )
 	{
@@ -451,8 +451,8 @@ public: // Comparison
 	}
 
 	// Required != Value
-	inline
 	friend
+	inline
 	bool
 	operator !=( Required const & a, T const & b )
 	{
@@ -460,8 +460,8 @@ public: // Comparison
 	}
 
 	// Value == Required
-	inline
 	friend
+	inline
 	bool
 	operator ==( T const & a, Required const & b )
 	{
@@ -469,8 +469,8 @@ public: // Comparison
 	}
 
 	// Value != Required
-	inline
 	friend
+	inline
 	bool
 	operator !=( T const & a, Required const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/byte.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/byte.hh
@@ -189,8 +189,8 @@ public: // Math
 	}
 
 	// byte + byte
-	inline
 	friend
+	inline
 	byte
 	operator +( byte const & i, byte const & j )
 	{
@@ -198,8 +198,8 @@ public: // Math
 	}
 
 	// byte - byte
-	inline
 	friend
+	inline
 	byte
 	operator -( byte const & i, byte const & j )
 	{
@@ -207,8 +207,8 @@ public: // Math
 	}
 
 	// byte * byte
-	inline
 	friend
+	inline
 	byte
 	operator *( byte const & i, byte const & j )
 	{
@@ -216,8 +216,8 @@ public: // Math
 	}
 
 	// byte / byte
-	inline
 	friend
+	inline
 	byte
 	operator /( byte const & i, byte const & j )
 	{
@@ -295,8 +295,8 @@ public: // Bitwise Logical
 	}
 
 	// byte & byte
-	inline
 	friend
+	inline
 	byte
 	operator &( byte const & i, byte const & j )
 	{
@@ -304,8 +304,8 @@ public: // Bitwise Logical
 	}
 
 	// byte | byte
-	inline
 	friend
+	inline
 	byte
 	operator |( byte const & i, byte const & j )
 	{
@@ -313,8 +313,8 @@ public: // Bitwise Logical
 	}
 
 	// byte ^ byte
-	inline
 	friend
+	inline
 	byte
 	operator ^( byte const & i, byte const & j )
 	{
@@ -324,8 +324,8 @@ public: // Bitwise Logical
 public: // Comparison
 
 	// byte == byte
-	inline
 	friend
+	inline
 	bool
 	operator ==( byte const & i, byte const & j )
 	{
@@ -333,8 +333,8 @@ public: // Comparison
 	}
 
 	// byte != byte
-	inline
 	friend
+	inline
 	bool
 	operator !=( byte const & i, byte const & j )
 	{
@@ -342,8 +342,8 @@ public: // Comparison
 	}
 
 	// byte < byte
-	inline
 	friend
+	inline
 	bool
 	operator <( byte const & i, byte const & j )
 	{
@@ -351,8 +351,8 @@ public: // Comparison
 	}
 
 	// byte <= byte
-	inline
 	friend
+	inline
 	bool
 	operator <=( byte const & i, byte const & j )
 	{
@@ -360,8 +360,8 @@ public: // Comparison
 	}
 
 	// byte > byte
-	inline
 	friend
+	inline
 	bool
 	operator >( byte const & i, byte const & j )
 	{
@@ -369,8 +369,8 @@ public: // Comparison
 	}
 
 	// byte >= byte
-	inline
 	friend
+	inline
 	bool
 	operator >=( byte const & i, byte const & j )
 	{
@@ -380,8 +380,8 @@ public: // Comparison
 public: // I/O
 
 	// Stream >> byte
-	inline
 	friend
+	inline
 	std::istream &
 	operator >>( std::istream & stream, byte & b )
 	{
@@ -394,8 +394,8 @@ public: // I/O
 	}
 
 	// Stream << byte
-	inline
 	friend
+	inline
 	std::ostream &
 	operator <<( std::ostream & stream, byte const & b )
 	{

--- a/third_party/ObjexxFCL/src/ObjexxFCL/noexcept.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/noexcept.hh
@@ -13,7 +13,7 @@
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
+#if defined(_MSC_VER) && _MSC_VER < 1900 && !defined(__INTEL_COMPILER)
 #define NOEXCEPT throw()
 #else
 #define NOEXCEPT noexcept

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ubyte.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ubyte.hh
@@ -224,8 +224,8 @@ public: // Math
 	}
 
 	// ubyte + ubyte
-	inline
 	friend
+	inline
 	ubyte
 	operator +( ubyte const & i, ubyte const & j )
 	{
@@ -233,8 +233,8 @@ public: // Math
 	}
 
 	// ubyte - ubyte
-	inline
 	friend
+	inline
 	ubyte
 	operator -( ubyte const & i, ubyte const & j )
 	{
@@ -242,8 +242,8 @@ public: // Math
 	}
 
 	// ubyte * ubyte
-	inline
 	friend
+	inline
 	ubyte
 	operator *( ubyte const & i, ubyte const & j )
 	{
@@ -251,8 +251,8 @@ public: // Math
 	}
 
 	// ubyte / ubyte
-	inline
 	friend
+	inline
 	ubyte
 	operator /( ubyte const & i, ubyte const & j )
 	{
@@ -330,8 +330,8 @@ public: // Bitwise Logical
 	}
 
 	// ubyte & ubyte
-	inline
 	friend
+	inline
 	ubyte
 	operator &( ubyte const & i, ubyte const & j )
 	{
@@ -339,8 +339,8 @@ public: // Bitwise Logical
 	}
 
 	// ubyte | ubyte
-	inline
 	friend
+	inline
 	ubyte
 	operator |( ubyte const & i, ubyte const & j )
 	{
@@ -348,8 +348,8 @@ public: // Bitwise Logical
 	}
 
 	// ubyte ^ ubyte
-	inline
 	friend
+	inline
 	ubyte
 	operator ^( ubyte const & i, ubyte const & j )
 	{
@@ -359,8 +359,8 @@ public: // Bitwise Logical
 public: // Comparison
 
 	// ubyte == ubyte
-	inline
 	friend
+	inline
 	bool
 	operator ==( ubyte const & i, ubyte const & j )
 	{
@@ -368,8 +368,8 @@ public: // Comparison
 	}
 
 	// ubyte != ubyte
-	inline
 	friend
+	inline
 	bool
 	operator !=( ubyte const & i, ubyte const & j )
 	{
@@ -377,8 +377,8 @@ public: // Comparison
 	}
 
 	// ubyte < ubyte
-	inline
 	friend
+	inline
 	bool
 	operator <( ubyte const & i, ubyte const & j )
 	{
@@ -386,8 +386,8 @@ public: // Comparison
 	}
 
 	// ubyte <= ubyte
-	inline
 	friend
+	inline
 	bool
 	operator <=( ubyte const & i, ubyte const & j )
 	{
@@ -395,8 +395,8 @@ public: // Comparison
 	}
 
 	// ubyte > ubyte
-	inline
 	friend
+	inline
 	bool
 	operator >( ubyte const & i, ubyte const & j )
 	{
@@ -404,8 +404,8 @@ public: // Comparison
 	}
 
 	// ubyte >= ubyte
-	inline
 	friend
+	inline
 	bool
 	operator >=( ubyte const & i, ubyte const & j )
 	{
@@ -415,8 +415,8 @@ public: // Comparison
 public: // I/O
 
 	// Stream >> ubyte
-	inline
 	friend
+	inline
 	std::istream &
 	operator >>( std::istream & stream, ubyte & b )
 	{
@@ -429,8 +429,8 @@ public: // I/O
 	}
 
 	// Stream << ubyte
-	inline
 	friend
+	inline
 	std::ostream &
 	operator <<( std::ostream & stream, ubyte const & b )
 	{


### PR DESCRIPTION
This fixes the NOEXCEPT macro (needed because Visual C++ 2013 doesn't have noexcept) for Intel C++ on Windows (which does have noexcept).

(Also puts friend inline qualifiers in consistent order.)

Should have zero impact on results.
