### PR TITLE
Add Transition Rules for HVACTemplate Plant Loop Objects

### DIFF
--- a/src/Transition/CreateNewIDFUsingRulesV8_2_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_2_0.f90
@@ -380,7 +380,57 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 else
                   OutArgs(19)=InArgs(19) ! Redundant, but clear
                 endif
-              
+
+              CASE('HVACTEMPLATE:PLANT:CHILLEDWATERLOOP')
+                nodiff=.false.
+                CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
+                ! assign the entire contents of IN to OUT to start
+                OutArgs=InArgs
+                ! then check the value of 32, the chw loop load distribution type and make a decision:
+                if (SameString(InArgs(32), "SEQUENTIAL")) then
+                  OutArgs(32)="SequentialLoad"
+                elseif (SameString(InArgs(32), "UNIFORM")) then
+                  OutArgs(32)="UniformLoad"
+                else
+                  OutArgs(32)=InArgs(32) ! Redundant, but clear
+                endif
+                ! then check the value of 33, the cond loop load distribution type and make a decision:
+                if (SameString(InArgs(33), "SEQUENTIAL")) then
+                  OutArgs(33)="SequentialLoad"
+                elseif (SameString(InArgs(33), "UNIFORM")) then
+                  OutArgs(33)="UniformLoad"
+                else
+                  OutArgs(33)=InArgs(33) ! Redundant, but clear
+                endif
+
+              CASE('HVACTEMPLATE:PLANT:HOTWATERLOOP')
+                nodiff=.false.
+                CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
+                ! assign the entire contents of IN to OUT to start
+                OutArgs=InArgs
+                ! then check the value of 21, the load distribution type and make a decision:
+                if (SameString(InArgs(21), "SEQUENTIAL")) then
+                  OutArgs(21)="SequentialLoad"
+                elseif (SameString(InArgs(21), "UNIFORM")) then
+                  OutArgs(21)="UniformLoad"
+                else
+                  OutArgs(21)=InArgs(21) ! Redundant, but clear
+                endif
+
+              CASE('HVACTEMPLATE:PLANT:MIXEDWATERLOOP')
+                nodiff=.false.
+                CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
+                ! assign the entire contents of IN to OUT to start
+                OutArgs=InArgs
+                ! then check the value of 17, the load distribution type and make a decision:
+                if (SameString(InArgs(17), "SEQUENTIAL")) then
+                  OutArgs(17)="SequentialLoad"
+                elseif (SameString(InArgs(17), "UNIFORM")) then
+                  OutArgs(17)="UniformLoad"
+                else
+                  OutArgs(17)=InArgs(17) ! Redundant, but clear
+                endif
+
               CASE('SIZING:SYSTEM')
                 nodiff = .false.
                 CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)

--- a/src/Transition/CreateNewIDFUsingRulesV8_4_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_4_0.f90
@@ -344,7 +344,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
               SELECT CASE (MakeUPPERCase(TRIM(IDFRecords(Num)%Name)))
 
               CASE ('VERSION')
-                IF ((InArgs(1)(1:3)) == '8.3' .and. ArgFile) THEN
+                IF ((InArgs(1)(1:3)) == sVersionNum .and. ArgFile) THEN
                   CALL ShowWarningError('File is already at latest version.  No new diff file made.',Auditf)
                   CLOSE(diflfn,STATUS='DELETE')
                   LatestVersion=.true.
@@ -355,8 +355,60 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 nodiff=.false.
 
     !!!    Changes for this version
-              !CASE('SOMETHING')
-                
+
+              ! This was actually missed in the 8.1 to 8.2 transition, so it is included here as a redundancy
+              CASE('HVACTEMPLATE:PLANT:CHILLEDWATERLOOP')
+                nodiff=.false.
+                CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
+                ! assign the entire contents of IN to OUT to start
+                OutArgs=InArgs
+                ! then check the value of 32, the chw loop load distribution type and make a decision:
+                if (SameString(InArgs(32), "SEQUENTIAL")) then
+                  OutArgs(32)="SequentialLoad"
+                elseif (SameString(InArgs(32), "UNIFORM")) then
+                  OutArgs(32)="UniformLoad"
+                else
+                  OutArgs(32)=InArgs(32) ! Redundant, but clear
+                endif
+                ! then check the value of 33, the cond loop load distribution type and make a decision:
+                if (SameString(InArgs(33), "SEQUENTIAL")) then
+                  OutArgs(33)="SequentialLoad"
+                elseif (SameString(InArgs(33), "UNIFORM")) then
+                  OutArgs(33)="UniformLoad"
+                else
+                  OutArgs(33)=InArgs(33) ! Redundant, but clear
+                endif
+
+              ! This was actually missed in the 8.1 to 8.2 transition, so it is included here as a redundancy
+              CASE('HVACTEMPLATE:PLANT:HOTWATERLOOP')
+                nodiff=.false.
+                CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
+                ! assign the entire contents of IN to OUT to start
+                OutArgs=InArgs
+                ! then check the value of 21, the load distribution type and make a decision:
+                if (SameString(InArgs(21), "SEQUENTIAL")) then
+                  OutArgs(21)="SequentialLoad"
+                elseif (SameString(InArgs(21), "UNIFORM")) then
+                  OutArgs(21)="UniformLoad"
+                else
+                  OutArgs(21)=InArgs(21) ! Redundant, but clear
+                endif
+
+              ! This was actually missed in the 8.1 to 8.2 transition, so it is included here as a redundancy
+              CASE('HVACTEMPLATE:PLANT:MIXEDWATERLOOP')
+                nodiff=.false.
+                CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
+                ! assign the entire contents of IN to OUT to start
+                OutArgs=InArgs
+                ! then check the value of 17, the load distribution type and make a decision:
+                if (SameString(InArgs(17), "SEQUENTIAL")) then
+                  OutArgs(17)="SequentialLoad"
+                elseif (SameString(InArgs(17), "UNIFORM")) then
+                  OutArgs(17)="UniformLoad"
+                else
+                  OutArgs(17)=InArgs(17) ! Redundant, but clear
+                endif
+
     !!!   Changes for report variables, meters, tables -- update names
               CASE('OUTPUT:VARIABLE')
                 CALL GetNewObjectDefInIDD(ObjectName,NwNumArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)

--- a/testfiles/5ZoneAirCooledWithCoupledInGradeSlab.idf
+++ b/testfiles/5ZoneAirCooledWithCoupledInGradeSlab.idf
@@ -2807,7 +2807,7 @@
     HW Demand Outlet Node,   !- Demand Side Outlet Node Name
     Heating Demand Side Branches,  !- Demand Side Branch List Name
     Heating Demand Side Connectors,  !- Demand Side Connector List Name
-    Sequential;              !- Load Distribution Scheme
+    SequentialLoad;          !- Load Distribution Scheme
 
   SetpointManager:Scheduled,
     Hot Water Loop Setpoint Manager,  !- Name
@@ -3133,7 +3133,7 @@
     CW Demand Outlet Node,   !- Demand Side Outlet Node Name
     Cooling Demand Side Branches,  !- Demand Side Branch List Name
     Cooling Demand Side Connectors,  !- Demand Side Connector List Name
-    SEQUENTIAL,              !- Load Distribution Scheme
+    SequentialLoad,          !- Load Distribution Scheme
     CW Avail List;           !- Availability Manager List Name
 
   AvailabilityManagerAssignmentList,

--- a/testfiles/5ZoneWaterCooled_BaseboardScalableSizing.idf
+++ b/testfiles/5ZoneWaterCooled_BaseboardScalableSizing.idf
@@ -3397,7 +3397,7 @@
     HW Demand Outlet Node,   !- Demand Side Outlet Node Name
     Heating Demand Side Branches,  !- Demand Side Branch List Name
     Heating Demand Side Connectors,  !- Demand Side Connector List Name
-    Sequential;              !- Load Distribution Scheme
+    SequentialLoad;          !- Load Distribution Scheme
 
   PlantLoop,
     Chilled Water Loop,      !- Name
@@ -3418,7 +3418,7 @@
     CW Demand Outlet Node,   !- Demand Side Outlet Node Name
     Cooling Demand Side Branches,  !- Demand Side Branch List Name
     Cooling Demand Side Connectors,  !- Demand Side Connector List Name
-    Sequential;              !- Load Distribution Scheme
+    SequentialLoad;          !- Load Distribution Scheme
 
 !-   ===========  ALL OBJECTS IN CLASS: CONDENSERLOOP ===========
 
@@ -3441,7 +3441,7 @@
     Condenser Demand Outlet Node,  !- Demand Side Outlet Node Name
     Condenser Demand Side Branches,  !- Condenser Demand Side Branch List Name
     Condenser Demand Side Connectors,  !- Condenser Demand Side Connector List Name
-    Sequential;              !- Load Distribution Scheme
+    SequentialLoad;          !- Load Distribution Scheme
 
   SetpointManager:FollowOutdoorAirTemperature,
     MyCondenserControl,      !- Name

--- a/testfiles/AbsorptionChiller_Macro.imf
+++ b/testfiles/AbsorptionChiller_Macro.imf
@@ -969,7 +969,7 @@
     Condenser Demand Outlet Node,  !- Demand Side Outlet Node Name
     Condenser Demand Side Branches,  !- Condenser Demand Side Branch List Name
     Condenser Demand Side Connectors,  !- Condenser Demand Side Connector List Name
-    Sequential;              !- Load Distribution Scheme
+    SequentialLoad;          !- Load Distribution Scheme
 
   SetpointManager:FollowOutdoorAirTemperature,
     MyCondenserControl,      !- Name


### PR DESCRIPTION
These were missed in the v8.1 to v8.2 transition rules.  I went ahead and added the rules to the v8.1 to v8.2 transition source so that anyone bringing up <= 8.1 files with the latest transition binaries will get the fix.  In addition, for those that have already transtiioned from 8.1 to 8.2+, I added the rules to the 8.3 to 8.4 transition tool, so that they will also receive the transition.   This does not cause a problem with double-applying since it is just a rename and checks the existing value and only replaces if necessary.

I tested this from an 8.1 file and an 8.3 file and both binaries work as expected.  I went ahead and updated some example files that missed this transition previously as well.

This fixes two issues: 
- #4493 
- #4830 

And these two Pivotal tickets should be accepted upon merge:
- [98107102](https://www.pivotaltracker.com/story/show/98107102)
- [98106952](https://www.pivotaltracker.com/story/show/98106952)
