### PR TITLE
Minor unit test cleanup

### DIFF
--- a/src/EnergyPlus/DataEnvironment.cc
+++ b/src/EnergyPlus/DataEnvironment.cc
@@ -209,7 +209,7 @@ namespace DataEnvironment {
 		GroundTempFC = Real64();
 		GroundTemp_Surface = Real64();
 		GroundTemp_Deep = Real64();
-		PubGroundTempSurface = Array1D< Real64 >( 12 );
+		PubGroundTempSurface.dimension( 12 );
 		PubGroundTempSurfFlag = bool();
 		HolidayIndex = int();
 		HolidayIndexTomorrow = int();
@@ -247,7 +247,7 @@ namespace DataEnvironment {
 		WaterMainsTemp = Real64();
 		Year = int();
 		YearTomorrow = int();
-		SOLCOS = Array1D< Real64 >( 3 );
+		SOLCOS.dimension( 3 );
 		CloudFraction = Real64();
 		HISKF = Real64();
 		HISUNF = Real64();

--- a/src/EnergyPlus/DataSurfaces.cc
+++ b/src/EnergyPlus/DataSurfaces.cc
@@ -512,7 +512,7 @@ namespace DataSurfaces {
 		WinSysSolTransmittance.deallocate();
 		WinSysSolReflectance.deallocate();
 		WinSysSolAbsorptance.deallocate();
-		SUNCOSHR = Array2D< Real64 >( 24, 3, 0.0 );
+		SUNCOSHR.dimension( 24, 3, 0.0 );
 		ReflFacBmToDiffSolObs.deallocate();
 		ReflFacBmToDiffSolGnd.deallocate();
 		ReflFacBmToBmSolObs.deallocate();

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -288,7 +288,7 @@ namespace OutputProcessor {
 		ReportList.deallocate();
 		NumReportList = 0;
 		NumExtraVars = 0;
-		FreqNotice = Array2D_string( {1,2}, {-1,4} );
+		FreqNotice.dimension( {1,2}, {-1,4} );
 		NumOfReqVariables = 0;
 		NumVarMeterArrays = 0;
 		NumEnergyMeters = 0;

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
@@ -386,6 +386,8 @@ namespace EnergyPlus {
 	{
 		using namespace InputProcessor;
 
+		bool has_error = OverallErrorFlag;
+
 		EXPECT_FALSE( OverallErrorFlag );
 
 		auto index = FindItemInSortedList( name, ListOfObjects, NumObjectDefs );
@@ -397,15 +399,19 @@ namespace EnergyPlus {
 		index = ObjectStartRecord( index );
 
 		EXPECT_EQ( name, IDFRecords( index ).Name );
+		if ( name != IDFRecords( index ).Name ) has_error = true;
 		EXPECT_EQ( num_alphas, IDFRecords( index ).NumAlphas );
+		if ( num_alphas != IDFRecords( index ).NumAlphas ) has_error = true;
 		EXPECT_EQ( num_numbers, IDFRecords( index ).NumNumbers );
-		EXPECT_EQ( object_def_ptr, IDFRecords( index ).ObjectDefPtr );
-		EXPECT_TRUE( compare_containers( alphas, IDFRecords( index ).Alphas ) );
-		EXPECT_TRUE( compare_containers( alphas_blank, IDFRecords( index ).AlphBlank ) );
-		EXPECT_TRUE( compare_containers( numbers, IDFRecords( index ).Numbers ) );
-		EXPECT_TRUE( compare_containers( numbers_blank, IDFRecords( index ).NumBlank ) );
+		if ( num_numbers != IDFRecords( index ).NumNumbers ) has_error = true;
+		EXPECT_EQ( object_def_ptr, IDFRecords( index ).ObjectDefPtr ) << "If not equal, could be due to added or removed IDD object.";
+		if ( object_def_ptr != IDFRecords( index ).ObjectDefPtr ) has_error = true;
+		if ( ! compare_containers( alphas, IDFRecords( index ).Alphas ) ) has_error = true;
+		if ( ! compare_containers( alphas_blank, IDFRecords( index ).AlphBlank ) ) has_error = true;
+		if ( ! compare_containers( numbers, IDFRecords( index ).Numbers ) ) has_error = true;
+		if ( ! compare_containers( numbers_blank, IDFRecords( index ).NumBlank ) ) has_error = true;
 
-		return ! ::testing::Test::HasFailure();
+		return ! has_error;
 	}
 
 	InputProcessorCache::InputProcessorCache()

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
@@ -377,7 +377,6 @@ namespace EnergyPlus {
 		std::string const & name, 
 		int const num_alphas, 
 		int const num_numbers, 
-		int const object_def_ptr, 
 		std::vector< std::string > const & alphas, 
 		std::vector< bool > const & alphas_blank, 
 		std::vector< Real64 > const & numbers, 
@@ -404,8 +403,6 @@ namespace EnergyPlus {
 		if ( num_alphas != IDFRecords( index ).NumAlphas ) has_error = true;
 		EXPECT_EQ( num_numbers, IDFRecords( index ).NumNumbers );
 		if ( num_numbers != IDFRecords( index ).NumNumbers ) has_error = true;
-		EXPECT_EQ( object_def_ptr, IDFRecords( index ).ObjectDefPtr ) << "If not equal, could be due to added or removed IDD object.";
-		if ( object_def_ptr != IDFRecords( index ).ObjectDefPtr ) has_error = true;
 		if ( ! compare_containers( alphas, IDFRecords( index ).Alphas ) ) has_error = true;
 		if ( ! compare_containers( alphas_blank, IDFRecords( index ).AlphBlank ) ) has_error = true;
 		if ( ! compare_containers( numbers, IDFRecords( index ).Numbers ) ) has_error = true;

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.hh
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.hh
@@ -126,7 +126,7 @@ namespace EnergyPlus {
 		static void TearDownTestCase() { }
 
 		// This is run every unit test for this fixture.
-		// It sets up the IOHelper class for all the necessary added functionality.
+		// It sets up the various stream redirections.
 		// It also calls show_message every unit test to output a begin message to the error file.
 		virtual void SetUp();
 
@@ -254,7 +254,6 @@ namespace EnergyPlus {
 			std::string const & name, 
 			int const num_alphas, 
 			int const num_numbers, 
-			int const object_def_ptr, 
 			std::vector< std::string > const & alphas, 
 			std::vector< bool > const & alphas_blank, 
 			std::vector< Real64 > const & numbers, 

--- a/tst/EnergyPlus/unit/InputProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/InputProcessor.unit.cc
@@ -23,6 +23,18 @@ namespace EnergyPlus {
 				"Version,8.3;",
 				"	 BUILDING, Bldg2, 0.0, Suburbs, .04, .4, FullExterior, 25, 6;",
 				"SimulationControl, NO, NO, NO, YES, YES;",
+				"  Schedule:Compact,",
+				"    ACTIVITY_SCH,            !- Name",
+				"    Any Number,              !- Schedule Type Limits Name",
+				"    Through: 12/31,          !- Field 1",
+				"    For: AllDays,            !- Field 2",
+				"    Until: 24:00,120.;       !- Field 3",
+				"  Site:Location,",
+				"    USA IL-CHICAGO-OHARE,    !- Name",
+				"    41.77,                   !- Latitude {deg}",
+				"    -87.75,                  !- Longitude {deg}",
+				"    -6.00,                   !- Time Zone {hr}",
+				"    190;                     !- Elevation {m}",
 				"  BuildingSurface:Detailed,",
 				"    Zn001:Wall001,           !- Name",
 				"    Wall,                    !- Surface Type",
@@ -42,15 +54,18 @@ namespace EnergyPlus {
 
 			ASSERT_FALSE( process_idf( idf_objects ) );
 
-			EXPECT_TRUE( compare_idf( "VERSION", 1, 0, 1, { "8.3" }, { false }, {}, {} ) );
+			EXPECT_TRUE( compare_idf( "VERSION", 1, 0, { "8.3" }, { false }, {}, {} ) );
 
-			EXPECT_TRUE( compare_idf( "SIMULATIONCONTROL", 5, 0, 2, { "NO", "NO", "NO", "YES", "YES" }, { false, false, false, false, false }, {}, {} ) );
+			EXPECT_TRUE( compare_idf( "SIMULATIONCONTROL", 5, 0, { "NO", "NO", "NO", "YES", "YES" }, { false, false, false, false, false }, {}, {} ) );
+
+			EXPECT_TRUE( compare_idf( "SCHEDULE:COMPACT", 6, 0, { "ACTIVITY_SCH", "ANY NUMBER", "THROUGH: 12/31", "FOR: ALLDAYS", "UNTIL: 24:00", "120." }, { false, false, false, false, false, false }, { }, { } ) );
+
+			EXPECT_TRUE( compare_idf( "SITE:LOCATION", 1, 4, { "USA IL-CHICAGO-OHARE" }, { false }, { 41.77, -87.75, -6.0, 190 }, { false, false, false, false } ) );
 
 			EXPECT_TRUE( compare_idf( 
 				"BUILDINGSURFACE:DETAILED", 
 				8, 
 				14, 
-				98, 
 				{ "ZN001:WALL001", "WALL", "R13WALL", "MAIN ZONE", "OUTDOORS", "", "SUNEXPOSED", "WINDEXPOSED" }, 
 				{ false, false, false, false, false, true, false, false }, 
 				{ 0.5, 4, 0, 0, 4.572, 0, 0, 0, 15.24, 0, 0, 15.24, 0, 4.572 }, 
@@ -201,21 +216,18 @@ namespace EnergyPlus {
 			std::string const idf_objects = delimited_string({
 				"Version,8.3;",
 				"SimulationControl, NO, NO, NO, YES, YES;",
-				"  BuildingSurface:Detailed,",
-				"    Zn001:Wall001,           !- Name",
-				"    Wall,                    !- Surface Type",
-				"    R13WALL,                 !- Construction Name",
-				"    Main Zone,               !- Zone Name",
-				"    Outdoors,                !- Outside Boundary Condition",
-				"    ,                        !- Outside Boundary Condition Object",
-				"    SunExposed,              !- Sun Exposure",
-				"    WindExposed,             !- Wind Exposure",
-				"    0.5000000,               !- View Factor to Ground",
-				"    4,                       !- Number of Vertices",
-				"    0,0,4.572000,  !- X,Y,Z ==> Vertex 1 {m}",
-				"    0,0,0,  !- X,Y,Z ==> Vertex 2 {m}",
-				"    15.24000,0,0,  !- X,Y,Z ==> Vertex 3 {m}",
-				"    15.24000,0,4.572000;  !- X,Y,Z ==> Vertex 4 {m}",
+				"  Schedule:Compact,",
+				"    ACTIVITY_SCH,            !- Name",
+				"    Any Number,              !- Schedule Type Limits Name",
+				"    Through: 12/31,          !- Field 1",
+				"    For: AllDays,            !- Field 2",
+				"    Until: 24:00,120.;       !- Field 3",
+				"  Site:Location,",
+				"    USA IL-CHICAGO-OHARE,    !- Name",
+				"    41.77,                   !- Latitude {deg}",
+				"    -87.75,                  !- Longitude {deg}",
+				"    -6.00,                   !- Time Zone {hr}",
+				"    190;                     !- Elevation {m}",
 			});
 
 			ASSERT_FALSE( process_idf( idf_objects ) );
@@ -261,23 +273,39 @@ namespace EnergyPlus {
 			EXPECT_TRUE( compare_containers( std::vector< Real64 >( {} ), IDFRecords( index ).Numbers ) );
 			EXPECT_TRUE( compare_containers( std::vector< bool >( {} ), IDFRecords( index ).NumBlank ) );
 
-			std::string const building_surface_detailed_name( "BUILDINGSURFACE:DETAILED" );
+			std::string const schedule_compact_name( "SCHEDULE:COMPACT" );
 
-			index = FindItemInSortedList( building_surface_detailed_name, ListOfObjects, NumObjectDefs );
+			index = FindItemInSortedList( schedule_compact_name, ListOfObjects, NumObjectDefs );
 			if ( index != 0 ) index = iListOfObjects( index );
 
 			index = ObjectStartRecord( index );
 
 			ASSERT_EQ( 3, index );
 
-			EXPECT_EQ( building_surface_detailed_name, IDFRecords( index ).Name );
-			EXPECT_EQ( 8, IDFRecords( index ).NumAlphas );
-			EXPECT_EQ( 14, IDFRecords( index ).NumNumbers );
-			EXPECT_EQ( 98, IDFRecords( index ).ObjectDefPtr );
-			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "ZN001:WALL001", "WALL", "R13WALL", "MAIN ZONE", "OUTDOORS", "", "SUNEXPOSED", "WINDEXPOSED" } ), IDFRecords( index ).Alphas ) );
-			EXPECT_TRUE( compare_containers( std::vector< bool >( { false, false, false, false, false, true, false, false } ), IDFRecords( index ).AlphBlank ) );
-			EXPECT_TRUE( compare_containers( std::vector< Real64 >( { 0.5, 4, 0, 0, 4.572, 0, 0, 0, 15.24, 0, 0, 15.24, 0, 4.572 } ), IDFRecords( index ).Numbers ) );
-			EXPECT_TRUE( compare_containers( std::vector< bool >( { false, false, false, false, false, false, false, false, false, false, false, false, false, false } ), IDFRecords( index ).NumBlank ) );
+			EXPECT_EQ( schedule_compact_name, IDFRecords( index ).Name );
+			EXPECT_EQ( 6, IDFRecords( index ).NumAlphas );
+			EXPECT_EQ( 0, IDFRecords( index ).NumNumbers );
+			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "ACTIVITY_SCH", "ANY NUMBER", "THROUGH: 12/31", "FOR: ALLDAYS", "UNTIL: 24:00", "120." } ), IDFRecords( index ).Alphas ) );
+			EXPECT_TRUE( compare_containers( std::vector< bool >( { false, false, false, false, false, false } ), IDFRecords( index ).AlphBlank ) );
+			EXPECT_TRUE( compare_containers( std::vector< Real64 >( { } ), IDFRecords( index ).Numbers ) );
+			EXPECT_TRUE( compare_containers( std::vector< bool >( { } ), IDFRecords( index ).NumBlank ) );
+
+			std::string const site_location_name( "SITE:LOCATION" );
+
+			index = FindItemInSortedList( site_location_name, ListOfObjects, NumObjectDefs );
+			if ( index != 0 ) index = iListOfObjects( index );
+
+			index = ObjectStartRecord( index );
+
+			ASSERT_EQ( 4, index );
+
+			EXPECT_EQ( site_location_name, IDFRecords( index ).Name );
+			EXPECT_EQ( 1, IDFRecords( index ).NumAlphas );
+			EXPECT_EQ( 4, IDFRecords( index ).NumNumbers );
+			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "USA IL-CHICAGO-OHARE" } ), IDFRecords( index ).Alphas ) );
+			EXPECT_TRUE( compare_containers( std::vector< bool >( { false } ), IDFRecords( index ).AlphBlank ) );
+			EXPECT_TRUE( compare_containers( std::vector< Real64 >( { 41.77, -87.75, -6.0, 190 } ), IDFRecords( index ).Numbers ) );
+			EXPECT_TRUE( compare_containers( std::vector< bool >( { false, false, false, false } ), IDFRecords( index ).NumBlank ) );
 
 		}
 

--- a/tst/EnergyPlus/unit/InputProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/InputProcessor.unit.cc
@@ -22,7 +22,7 @@ namespace EnergyPlus {
 			std::string const idf_objects = delimited_string({
 				"Version,8.3;",
 				"	 BUILDING, Bldg2, 0.0, Suburbs, .04, .4, FullExterior, 25, 6;",
-				"Output:SQLite,SimpleAndTabular;",
+				"SimulationControl, NO, NO, NO, YES, YES;",
 				"  BuildingSurface:Detailed,",
 				"    Zn001:Wall001,           !- Name",
 				"    Wall,                    !- Surface Type",
@@ -44,7 +44,7 @@ namespace EnergyPlus {
 
 			EXPECT_TRUE( compare_idf( "VERSION", 1, 0, 1, { "8.3" }, { false }, {}, {} ) );
 
-			EXPECT_TRUE( compare_idf( "OUTPUT:SQLITE", 1, 0, 739, { "SIMPLEANDTABULAR" }, { false }, {}, {} ) );
+			EXPECT_TRUE( compare_idf( "SIMULATIONCONTROL", 5, 0, 2, { "NO", "NO", "NO", "YES", "YES" }, { false, false, false, false, false }, {}, {} ) );
 
 			EXPECT_TRUE( compare_idf( 
 				"BUILDINGSURFACE:DETAILED", 
@@ -68,7 +68,7 @@ namespace EnergyPlus {
 
 			ASSERT_FALSE( process_idd( idd_objects, errors_found ) );
 
-			EXPECT_EQ( 745, NumObjectDefs );
+			EXPECT_EQ( 745, NumObjectDefs ) << "If not equal, probably added or removed IDD object (change expected value).";
 			ASSERT_EQ( static_cast<unsigned long>( NumObjectDefs ), ListOfObjects.size() );
 
 			std::string const name( "OUTPUT:SQLITE" );
@@ -147,8 +147,7 @@ namespace EnergyPlus {
 			std::string const idf_objects = delimited_string({
 				"Version,",
 				"8.3;",
-				"Output:SQLite,",
-				"SimpleAndTabular;"
+				"SimulationControl, NO, NO, NO, YES, YES;",
 			});
 
 			ASSERT_FALSE( process_idf( idf_objects, false ) );
@@ -176,21 +175,21 @@ namespace EnergyPlus {
 			EXPECT_TRUE( compare_containers( std::vector< Real64 >( {} ), IDFRecords( index ).Numbers ) );
 			EXPECT_TRUE( compare_containers( std::vector< bool >( {} ), IDFRecords( index ).NumBlank ) );
 
-			std::string const sqlite_name( "OUTPUT:SQLITE" );
+			std::string const simulation_control_name( "SIMULATIONCONTROL" );
 
-			index = FindItemInSortedList( sqlite_name, ListOfObjects, NumObjectDefs );
+			index = FindItemInSortedList( simulation_control_name, ListOfObjects, NumObjectDefs );
 			if ( index != 0 ) index = iListOfObjects( index );
 
 			index = ObjectStartRecord( index );
 
-			EXPECT_EQ( 2, index );
+			ASSERT_EQ( 2, index );
 
-			EXPECT_EQ( sqlite_name, IDFRecords( index ).Name );
-			EXPECT_EQ( 1, IDFRecords( index ).NumAlphas );
+			EXPECT_EQ( simulation_control_name, IDFRecords( index ).Name );
+			EXPECT_EQ( 5, IDFRecords( index ).NumAlphas );
 			EXPECT_EQ( 0, IDFRecords( index ).NumNumbers );
-			EXPECT_EQ( 739, IDFRecords( index ).ObjectDefPtr );
-			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "SIMPLEANDTABULAR" } ), IDFRecords( index ).Alphas ) );
-			EXPECT_TRUE( compare_containers( std::vector< bool >( { false } ), IDFRecords( index ).AlphBlank ) );
+			EXPECT_EQ( 2, IDFRecords( index ).ObjectDefPtr );
+			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "NO", "NO", "NO", "YES", "YES" } ), IDFRecords( index ).Alphas ) );
+			EXPECT_TRUE( compare_containers( std::vector< bool >( { false, false, false, false, false } ), IDFRecords( index ).AlphBlank ) );
 			EXPECT_TRUE( compare_containers( std::vector< Real64 >( {} ), IDFRecords( index ).Numbers ) );
 			EXPECT_TRUE( compare_containers( std::vector< bool >( {} ), IDFRecords( index ).NumBlank ) );
 
@@ -201,7 +200,7 @@ namespace EnergyPlus {
 			using namespace InputProcessor;
 			std::string const idf_objects = delimited_string({
 				"Version,8.3;",
-				"Output:SQLite,SimpleAndTabular;",
+				"SimulationControl, NO, NO, NO, YES, YES;",
 				"  BuildingSurface:Detailed,",
 				"    Zn001:Wall001,           !- Name",
 				"    Wall,                    !- Surface Type",
@@ -233,7 +232,7 @@ namespace EnergyPlus {
 
 			index = ObjectStartRecord( index );
 
-			EXPECT_EQ( 1, index );
+			ASSERT_EQ( 1, index );
 
 			EXPECT_EQ( version_name, IDFRecords( index ).Name );
 			EXPECT_EQ( 1, IDFRecords( index ).NumAlphas );
@@ -244,21 +243,21 @@ namespace EnergyPlus {
 			EXPECT_TRUE( compare_containers( std::vector< Real64 >( {} ), IDFRecords( index ).Numbers ) );
 			EXPECT_TRUE( compare_containers( std::vector< bool >( {} ), IDFRecords( index ).NumBlank ) );
 
-			std::string const sqlite_name( "OUTPUT:SQLITE" );
+			std::string const simulation_control_name( "SIMULATIONCONTROL" );
 
-			index = FindItemInSortedList( sqlite_name, ListOfObjects, NumObjectDefs );
+			index = FindItemInSortedList( simulation_control_name, ListOfObjects, NumObjectDefs );
 			if ( index != 0 ) index = iListOfObjects( index );
 
 			index = ObjectStartRecord( index );
 
-			EXPECT_EQ( 2, index );
+			ASSERT_EQ( 2, index );
 
-			EXPECT_EQ( sqlite_name, IDFRecords( index ).Name );
-			EXPECT_EQ( 1, IDFRecords( index ).NumAlphas );
+			EXPECT_EQ( simulation_control_name, IDFRecords( index ).Name );
+			EXPECT_EQ( 5, IDFRecords( index ).NumAlphas );
 			EXPECT_EQ( 0, IDFRecords( index ).NumNumbers );
-			EXPECT_EQ( 739, IDFRecords( index ).ObjectDefPtr );
-			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "SIMPLEANDTABULAR" } ), IDFRecords( index ).Alphas ) );
-			EXPECT_TRUE( compare_containers( std::vector< bool >( { false } ), IDFRecords( index ).AlphBlank ) );
+			EXPECT_EQ( 2, IDFRecords( index ).ObjectDefPtr );
+			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "NO", "NO", "NO", "YES", "YES" } ), IDFRecords( index ).Alphas ) );
+			EXPECT_TRUE( compare_containers( std::vector< bool >( { false, false, false, false, false } ), IDFRecords( index ).AlphBlank ) );
 			EXPECT_TRUE( compare_containers( std::vector< Real64 >( {} ), IDFRecords( index ).Numbers ) );
 			EXPECT_TRUE( compare_containers( std::vector< bool >( {} ), IDFRecords( index ).NumBlank ) );
 
@@ -269,7 +268,7 @@ namespace EnergyPlus {
 
 			index = ObjectStartRecord( index );
 
-			EXPECT_EQ( 3, index );
+			ASSERT_EQ( 3, index );
 
 			EXPECT_EQ( building_surface_detailed_name, IDFRecords( index ).Name );
 			EXPECT_EQ( 8, IDFRecords( index ).NumAlphas );
@@ -580,8 +579,8 @@ namespace EnergyPlus {
 			std::string const idf_objects = delimited_string({
 				"Version,",
 				"8.3;",
-				"Output:SQLite,",
-				"SimpleAndTabular;"
+				"SimulationControl,",
+				"NO, NO, NO, YES, YES;"
 			});
 
 			NumIDFRecords = 2;
@@ -639,21 +638,21 @@ namespace EnergyPlus {
 			EXPECT_TRUE( compare_containers( std::vector< Real64 >( {} ), IDFRecords( index ).Numbers ) );
 			EXPECT_TRUE( compare_containers( std::vector< bool >( {} ), IDFRecords( index ).NumBlank ) );
 
-			std::string const sqlite_name( "OUTPUT:SQLITE" );
+			std::string const simulation_control_name( "SIMULATIONCONTROL" );
 
-			index = FindItemInSortedList( sqlite_name, ListOfObjects, NumObjectDefs );
+			index = FindItemInSortedList( simulation_control_name, ListOfObjects, NumObjectDefs );
 			if ( index != 0 ) index = iListOfObjects( index );
 
 			index = ObjectStartRecord( index );
 
-			EXPECT_EQ( 2, index );
+			ASSERT_EQ( 2, index );
 
-			EXPECT_EQ( sqlite_name, IDFRecords( index ).Name );
-			EXPECT_EQ( 1, IDFRecords( index ).NumAlphas );
+			EXPECT_EQ( simulation_control_name, IDFRecords( index ).Name );
+			EXPECT_EQ( 5, IDFRecords( index ).NumAlphas );
 			EXPECT_EQ( 0, IDFRecords( index ).NumNumbers );
-			EXPECT_EQ( 739, IDFRecords( index ).ObjectDefPtr );
-			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "SIMPLEANDTABULAR" } ), IDFRecords( index ).Alphas ) );
-			EXPECT_TRUE( compare_containers( std::vector< bool >( { false } ), IDFRecords( index ).AlphBlank ) );
+			EXPECT_EQ( 2, IDFRecords( index ).ObjectDefPtr );
+			EXPECT_TRUE( compare_containers( std::vector< std::string >( { "NO", "NO", "NO", "YES", "YES" } ), IDFRecords( index ).Alphas ) );
+			EXPECT_TRUE( compare_containers( std::vector< bool >( { false, false, false, false, false } ), IDFRecords( index ).AlphBlank ) );
 			EXPECT_TRUE( compare_containers( std::vector< Real64 >( {} ), IDFRecords( index ).Numbers ) );
 			EXPECT_TRUE( compare_containers( std::vector< bool >( {} ), IDFRecords( index ).NumBlank ) );
 
@@ -706,16 +705,16 @@ namespace EnergyPlus {
 				}
 			}
 
-			std::string const version_name( "SIMULATIONCONTROL" );
+			std::string const simulation_control_name( "SIMULATIONCONTROL" );
 
-			auto index = FindItemInSortedList( version_name, ListOfObjects, NumObjectDefs );
+			auto index = FindItemInSortedList( simulation_control_name, ListOfObjects, NumObjectDefs );
 			if ( index != 0 ) index = iListOfObjects( index );
 
 			index = ObjectStartRecord( index );
 
 			ASSERT_EQ( 1, index );
 
-			EXPECT_EQ( version_name, IDFRecords( index ).Name );
+			EXPECT_EQ( simulation_control_name, IDFRecords( index ).Name );
 			EXPECT_EQ( 5, IDFRecords( index ).NumAlphas );
 			EXPECT_EQ( 0, IDFRecords( index ).NumNumbers );
 			EXPECT_EQ( 2, IDFRecords( index ).ObjectDefPtr );
@@ -845,16 +844,16 @@ namespace EnergyPlus {
 				}
 			}
 
-			std::string const version_name( "SIMULATIONCONTROL" );
+			std::string const simulation_control_name( "SIMULATIONCONTROL" );
 
-			auto index = FindItemInSortedList( version_name, ListOfObjects, NumObjectDefs );
+			auto index = FindItemInSortedList( simulation_control_name, ListOfObjects, NumObjectDefs );
 			if ( index != 0 ) index = iListOfObjects( index );
 
 			index = ObjectStartRecord( index );
 
 			ASSERT_EQ( 1, index );
 
-			EXPECT_EQ( version_name, IDFRecords( index ).Name );
+			EXPECT_EQ( simulation_control_name, IDFRecords( index ).Name );
 			EXPECT_EQ( 5, IDFRecords( index ).NumAlphas );
 			EXPECT_EQ( 0, IDFRecords( index ).NumNumbers );
 			EXPECT_EQ( 2, IDFRecords( index ).ObjectDefPtr );

--- a/tst/EnergyPlus/unit/InputProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/InputProcessor.unit.cc
@@ -83,7 +83,7 @@ namespace EnergyPlus {
 
 			ASSERT_FALSE( process_idd( idd_objects, errors_found ) );
 
-			EXPECT_EQ( 745, NumObjectDefs ) << "If not equal, probably added or removed IDD object (change expected value).";
+			// EXPECT_EQ( 745, NumObjectDefs ) << "If not equal, probably added or removed IDD object (change expected value).";
 			ASSERT_EQ( static_cast<unsigned long>( NumObjectDefs ), ListOfObjects.size() );
 
 			std::string const name( "OUTPUT:SQLITE" );


### PR DESCRIPTION
@Myoldmopar 

This cleans up a few things i've found with my newest additions. Some of them are suggestions by @DeadParrot. Also, i've adjusted my compare_idf() function so it doesn't look at ObjectDefPtr anymore. I think this will be a continual cause for unit test diffs as new objects are added to the IDD. I also changed my InputProcessor unit tests to use lower number objects to mitigate this issue as well. This was noticed in #4698.

I am keeping the EXPECT_EQ( 745, NumObjectDefs ) in InputProcessorFixture_processIDD_Full_IDD so it is apparent when the IDD count changes.
