### PR TITLE
Fix non-legacy prefix for sqlite error files.

### DIFF
--- a/src/EnergyPlus/CommandLineInterface.cc
+++ b/src/EnergyPlus/CommandLineInterface.cc
@@ -327,7 +327,8 @@ ProcessArgs(int argc, const char * argv[])
 	outputSszTabFileName = outputFilePrefix + sszSuffix + ".tab";
 	outputSszTxtFileName = outputFilePrefix + sszSuffix + ".txt";
 	outputAdsFileName = outputFilePrefix + adsSuffix + ".out";
-	outputSqliteErrFileName = dirPathName + sqliteSuffix + ".err";
+	if (suffixType == "L" || suffixType == "l") outputSqliteErrFileName = dirPathName + sqliteSuffix + ".err";
+	else outputSqliteErrFileName = outputFilePrefix + sqliteSuffix + ".err";
 	outputScreenCsvFileName = outputFilePrefix + screenSuffix + ".csv";
 	outputDelightInFileName = "eplusout.delightin";
 	outputDelightOutFileName = "eplusout.delightout";

--- a/src/EnergyPlus/CommandLineInterface.cc
+++ b/src/EnergyPlus/CommandLineInterface.cc
@@ -327,8 +327,12 @@ ProcessArgs(int argc, const char * argv[])
 	outputSszTabFileName = outputFilePrefix + sszSuffix + ".tab";
 	outputSszTxtFileName = outputFilePrefix + sszSuffix + ".txt";
 	outputAdsFileName = outputFilePrefix + adsSuffix + ".out";
-	if (suffixType == "L" || suffixType == "l") outputSqliteErrFileName = dirPathName + sqliteSuffix + ".err";
-	else outputSqliteErrFileName = outputFilePrefix + sqliteSuffix + ".err";
+	if (suffixType == "L" || suffixType == "l") {
+		outputSqliteErrFileName = dirPathName + sqliteSuffix + ".err";
+	}
+	else {
+		outputSqliteErrFileName = outputFilePrefix + sqliteSuffix + ".err";
+	}
 	outputScreenCsvFileName = outputFilePrefix + screenSuffix + ".csv";
 	outputDelightInFileName = "eplusout.delightin";
 	outputDelightOutFileName = "eplusout.delightout";


### PR DESCRIPTION
The legacy file name scheme creates a file called 'sqlite.err' which does not use the typical file name prefix of 'eplus'. The other naming schemes also didn't use a prefix, but this resulted in files named 'Sqlite.err' and '-sqlite.err', which are not internally consistent within their respective schemes. Now these will be 'prefixSqlite.err' (consistent with the old shell script naming) and 'prefix-sqlite.err'.
