### PR TITLE
Remove rc from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 *.obj
 *.orig
 *.pdb
-*.rc
 *.res
 *.so
 *.so.*


### PR DESCRIPTION
It seems the rc file is needed on Windows in some cases, but I'm not sure since I don't use Windows.

If it turns out we should remove this from gitignore, and everything is fine, then this fixes #5044 
