### PR TITLE
Fix broken links in documentation

### DIFF
--- a/doc/src/docs/Acknowledgements/Acknowledgements.md
+++ b/doc/src/docs/Acknowledgements/Acknowledgements.md
@@ -12,7 +12,7 @@ Portions of the EnergyPlus™ software package have been developed and copyright
 
 Portions of the EnergyPlus weather processor were developed by US Department of Energy, Office of Building Technologies.
 
-Portions of the input processing, output processing, weather processor, BLAST Translator were developed by US Army Corps of Engineers, Construction Engineering Research Laboratories, 2902 Newmark Drive, Champaign IL  61821. [www.cecer.army.mil](http://www.cecer.army.mil)
+Portions of the input processing, output processing, weather processor, BLAST Translator were developed by US Army Corps of Engineers, Construction Engineering Research Laboratories, 2902 Newmark Drive, Champaign IL  61821. [http://www.erdc.usace.army.mil/Locations/ConstructionEngineeringResearchLaboratory.aspx](http://www.erdc.usace.army.mil/Locations/ConstructionEngineeringResearchLaboratory.aspx)
 
 Portions of this software package were developed for Ernest Orlando Lawrence Berkeley National Laboratory and Florida Solar Energy Center by Linda Lawrie of DHL Consulting.
 

--- a/doc/src/docs/AuxiliaryPrograms/AuxiliaryPrograms.md
+++ b/doc/src/docs/AuxiliaryPrograms/AuxiliaryPrograms.md
@@ -3818,7 +3818,7 @@ Weather data for Israel locations developed by Faculty of Civil and Environmenta
 
 RMY Australia Representative Meteorological Year Climate Files Developed for the Australia Greenhouse Office for use in complying with Building Code of Australia. These data are licensed through ACADS BSG Ltd for use by EnergyPlus users. For use in any other formats, users must contact ACADS BSG Ltd for licensing information.
 
-The RMY data are © 2006 Commonwealth of Australia, Department of the Environment and Water Resources, Australia Greenhouse Office, Canberra, ACT, Australia. [www.greenhouse.gov.au/buildings/code.html](http://www.greenhouse.gov.au/buildings/code.html) All intellectual property rights reserved.
+The RMY data are © 2006 Commonwealth of Australia, Department of the Environment and Water Resources, Australia Greenhouse Office, Canberra, ACT, Australia. [www.greenhouse.gov.au/buildings/code.html](https://web.archive.org/web/20070608213812/http://www.greenhouse.gov.au/buildings/code.html) (URL has since been removed, so replaced with a link on The Internet Archive from 2007.)  All intellectual property rights reserved.
 
 ### Iranian Typical Meteorological Year (ITMY)
 


### PR DESCRIPTION
Fixes #5064 
Fixes the 2 actual bad links found in the docs.  The third link wasn't bad, just had a long timeout.
