### PR TITLE
Update copyright year...

### DIFF
--- a/src/EnergyPlus/AirflowNetworkBalanceManager.cc
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.cc
@@ -7625,7 +7625,7 @@ namespace AirflowNetworkBalanceManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/AirflowNetworkBalanceManager.hh
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.hh
@@ -291,7 +291,7 @@ namespace AirflowNetworkBalanceManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/AirflowNetworkSolver.cc
+++ b/src/EnergyPlus/AirflowNetworkSolver.cc
@@ -5071,7 +5071,7 @@ Label90: ;
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/AirflowNetworkSolver.hh
+++ b/src/EnergyPlus/AirflowNetworkSolver.hh
@@ -423,7 +423,7 @@ namespace AirflowNetworkSolver {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/BaseboardRadiator.cc
+++ b/src/EnergyPlus/BaseboardRadiator.cc
@@ -1246,7 +1246,7 @@ namespace BaseboardRadiator {
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/BaseboardRadiator.hh
+++ b/src/EnergyPlus/BaseboardRadiator.hh
@@ -268,7 +268,7 @@ namespace BaseboardRadiator {
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/BoilerSteam.cc
+++ b/src/EnergyPlus/BoilerSteam.cc
@@ -1040,7 +1040,7 @@ namespace BoilerSteam {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/BoilerSteam.hh
+++ b/src/EnergyPlus/BoilerSteam.hh
@@ -183,7 +183,7 @@ namespace BoilerSteam {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Boilers.cc
+++ b/src/EnergyPlus/Boilers.cc
@@ -1157,7 +1157,7 @@ namespace Boilers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Boilers.hh
+++ b/src/EnergyPlus/Boilers.hh
@@ -247,7 +247,7 @@ namespace Boilers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/BranchInputManager.cc
+++ b/src/EnergyPlus/BranchInputManager.cc
@@ -3386,7 +3386,7 @@ namespace BranchInputManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/BranchInputManager.hh
+++ b/src/EnergyPlus/BranchInputManager.hh
@@ -480,7 +480,7 @@ namespace BranchInputManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/BranchNodeConnections.cc
+++ b/src/EnergyPlus/BranchNodeConnections.cc
@@ -1988,7 +1988,7 @@ namespace BranchNodeConnections {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/BranchNodeConnections.hh
+++ b/src/EnergyPlus/BranchNodeConnections.hh
@@ -181,7 +181,7 @@ namespace BranchNodeConnections {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ChillerExhaustAbsorption.cc
+++ b/src/EnergyPlus/ChillerExhaustAbsorption.cc
@@ -2052,7 +2052,7 @@ namespace ChillerExhaustAbsorption {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ChillerExhaustAbsorption.hh
+++ b/src/EnergyPlus/ChillerExhaustAbsorption.hh
@@ -369,7 +369,7 @@ namespace ChillerExhaustAbsorption {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ChillerGasAbsorption.cc
+++ b/src/EnergyPlus/ChillerGasAbsorption.cc
@@ -1991,7 +1991,7 @@ namespace ChillerGasAbsorption {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ChillerGasAbsorption.hh
+++ b/src/EnergyPlus/ChillerGasAbsorption.hh
@@ -358,7 +358,7 @@ namespace ChillerGasAbsorption {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CondenserLoopTowers.cc
+++ b/src/EnergyPlus/CondenserLoopTowers.cc
@@ -5921,7 +5921,7 @@ namespace CondenserLoopTowers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CondenserLoopTowers.hh
+++ b/src/EnergyPlus/CondenserLoopTowers.hh
@@ -762,7 +762,7 @@ namespace CondenserLoopTowers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ConductionTransferFunctionCalc.cc
+++ b/src/EnergyPlus/ConductionTransferFunctionCalc.cc
@@ -2182,7 +2182,7 @@ namespace ConductionTransferFunctionCalc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ConductionTransferFunctionCalc.hh
+++ b/src/EnergyPlus/ConductionTransferFunctionCalc.hh
@@ -82,7 +82,7 @@ namespace ConductionTransferFunctionCalc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ConvectionCoefficients.cc
+++ b/src/EnergyPlus/ConvectionCoefficients.cc
@@ -9944,7 +9944,7 @@ namespace ConvectionCoefficients {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ConvectionCoefficients.hh
+++ b/src/EnergyPlus/ConvectionCoefficients.hh
@@ -1214,7 +1214,7 @@ namespace ConvectionCoefficients {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CoolTower.cc
+++ b/src/EnergyPlus/CoolTower.cc
@@ -694,7 +694,7 @@ namespace CoolTower {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CoolTower.hh
+++ b/src/EnergyPlus/CoolTower.hh
@@ -240,7 +240,7 @@ namespace CoolTower {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CostEstimateManager.cc
+++ b/src/EnergyPlus/CostEstimateManager.cc
@@ -853,7 +853,7 @@ namespace CostEstimateManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CostEstimateManager.hh
+++ b/src/EnergyPlus/CostEstimateManager.hh
@@ -36,7 +36,7 @@ namespace CostEstimateManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CrossVentMgr.cc
+++ b/src/EnergyPlus/CrossVentMgr.cc
@@ -931,7 +931,7 @@ namespace CrossVentMgr {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CrossVentMgr.hh
+++ b/src/EnergyPlus/CrossVentMgr.hh
@@ -57,7 +57,7 @@ namespace CrossVentMgr {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -5737,7 +5737,7 @@ Label999: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/CurveManager.hh
+++ b/src/EnergyPlus/CurveManager.hh
@@ -717,7 +717,7 @@ namespace CurveManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DElightManagerF.cc
+++ b/src/EnergyPlus/DElightManagerF.cc
@@ -896,7 +896,7 @@ namespace DElightManagerF {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DElightManagerF.hh
+++ b/src/EnergyPlus/DElightManagerF.hh
@@ -58,7 +58,7 @@ namespace DElightManagerF {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -14009,7 +14009,7 @@ Label50: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DXCoils.hh
+++ b/src/EnergyPlus/DXCoils.hh
@@ -1596,7 +1596,7 @@ namespace DXCoils {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataAirLoop.cc
+++ b/src/EnergyPlus/DataAirLoop.cc
@@ -85,7 +85,7 @@ namespace DataAirLoop {
 	}
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataAirSystems.cc
+++ b/src/EnergyPlus/DataAirSystems.cc
@@ -57,7 +57,7 @@ namespace DataAirSystems {
 	Array1D< ConnectAirSysSubSubComp > AirSysSubSubCompToPlant; // Connections between loops
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataAirflowNetwork.cc
+++ b/src/EnergyPlus/DataAirflowNetwork.cc
@@ -128,7 +128,7 @@ namespace DataAirflowNetwork {
 	bool VAVSystem( false ); // This flag is used to represent a VAV system
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataAirflowNetwork.hh
+++ b/src/EnergyPlus/DataAirflowNetwork.hh
@@ -121,7 +121,7 @@ namespace DataAirflowNetwork {
 	extern bool VAVSystem; // This flag is used to represent a VAV system
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataBSDFWindow.cc
+++ b/src/EnergyPlus/DataBSDFWindow.cc
@@ -77,7 +77,7 @@ namespace DataBSDFWindow {
 	Array1D< BSDFWindowGeomDescr > ComplexWind; // Window geometry structure: set in CalcPerSolarBeam/SolarShading
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataBranchAirLoopPlant.cc
+++ b/src/EnergyPlus/DataBranchAirLoopPlant.cc
@@ -65,7 +65,7 @@ namespace DataBranchAirLoopPlant {
 	//=================================================================================================!
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataBranchNodeConnections.cc
+++ b/src/EnergyPlus/DataBranchNodeConnections.cc
@@ -73,7 +73,7 @@ namespace DataBranchNodeConnections {
 	}
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataComplexFenestration.cc
+++ b/src/EnergyPlus/DataComplexFenestration.cc
@@ -53,7 +53,7 @@ namespace DataComplexFenestration {
 	int const dmMeasuredDeflection( 2 );
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataContaminantBalance.cc
+++ b/src/EnergyPlus/DataContaminantBalance.cc
@@ -132,7 +132,7 @@ namespace DataContaminantBalance {
 	// MODULE VARIABLE DECLARATIONS:
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataConvergParams.cc
+++ b/src/EnergyPlus/DataConvergParams.cc
@@ -95,7 +95,7 @@ namespace DataConvergParams {
 	Array1D< PlantIterationConvergenceStruct > PlantConvergence;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataConversions.cc
+++ b/src/EnergyPlus/DataConversions.cc
@@ -72,7 +72,7 @@ namespace DataConversions {
 	// na
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataCostEstimate.cc
+++ b/src/EnergyPlus/DataCostEstimate.cc
@@ -48,7 +48,7 @@ namespace DataCostEstimate {
 	Array1D< monetaryUnitType > monetaryUnit;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataDElight.cc
+++ b/src/EnergyPlus/DataDElight.cc
@@ -61,7 +61,7 @@ namespace DataDElight {
 	//     permit others to do so.
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataDaylighting.cc
+++ b/src/EnergyPlus/DataDaylighting.cc
@@ -73,7 +73,7 @@ namespace DataDaylighting {
 	Array1D< MapCalcData > IllumMapCalc;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataDaylightingDevices.cc
+++ b/src/EnergyPlus/DataDaylightingDevices.cc
@@ -51,7 +51,7 @@ namespace DataDaylightingDevices {
 	Array1D< ShelfData > Shelf;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataDefineEquip.cc
+++ b/src/EnergyPlus/DataDefineEquip.cc
@@ -59,7 +59,7 @@ namespace DataDefineEquip {
 	Array1D< ZoneAirEquip > AirDistUnit; // Used to specify zone related
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataEnvironment.cc
+++ b/src/EnergyPlus/DataEnvironment.cc
@@ -694,7 +694,7 @@ namespace DataEnvironment {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataEnvironment.hh
+++ b/src/EnergyPlus/DataEnvironment.hh
@@ -262,7 +262,7 @@ namespace DataEnvironment {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataErrorTracking.cc
+++ b/src/EnergyPlus/DataErrorTracking.cc
@@ -92,7 +92,7 @@ namespace DataErrorTracking {
 	Array1D< RecurringErrorData > RecurringErrors;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataGenerators.cc
+++ b/src/EnergyPlus/DataGenerators.cc
@@ -117,7 +117,7 @@ namespace DataGenerators {
 	Array1D< GeneratorDynamicsManagerStruct > GeneratorDynamics;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataGlobalConstants.cc
+++ b/src/EnergyPlus/DataGlobalConstants.cc
@@ -617,7 +617,7 @@ namespace DataGlobalConstants {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataGlobalConstants.hh
+++ b/src/EnergyPlus/DataGlobalConstants.hh
@@ -221,7 +221,7 @@ namespace DataGlobalConstants {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataGlobals.cc
+++ b/src/EnergyPlus/DataGlobals.cc
@@ -283,7 +283,7 @@ namespace DataGlobals {
 	}
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataHVACControllers.cc
+++ b/src/EnergyPlus/DataHVACControllers.cc
@@ -75,7 +75,7 @@ namespace DataHVACControllers {
 	// na
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataHVACGlobals.cc
+++ b/src/EnergyPlus/DataHVACGlobals.cc
@@ -394,7 +394,7 @@ namespace DataHVACGlobals {
 	}
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataHeatBalFanSys.cc
+++ b/src/EnergyPlus/DataHeatBalFanSys.cc
@@ -191,7 +191,7 @@ namespace DataHeatBalFanSys {
 	Array1D< ZoneComfortControlsFangerData > ZoneComfortControlsFanger;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataHeatBalSurface.cc
+++ b/src/EnergyPlus/DataHeatBalSurface.cc
@@ -194,7 +194,7 @@ namespace DataHeatBalSurface {
 	bool InterZoneWindow( false ); // True if there is an interzone window
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataHeatBalance.cc
+++ b/src/EnergyPlus/DataHeatBalance.cc
@@ -1993,7 +1993,7 @@ namespace DataHeatBalance {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataHeatBalance.hh
+++ b/src/EnergyPlus/DataHeatBalance.hh
@@ -5746,7 +5746,7 @@ namespace DataHeatBalance {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataIPShortCuts.cc
+++ b/src/EnergyPlus/DataIPShortCuts.cc
@@ -67,7 +67,7 @@ namespace DataIPShortCuts {
 	}
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataLoopNode.cc
+++ b/src/EnergyPlus/DataLoopNode.cc
@@ -104,7 +104,7 @@ namespace DataLoopNode {
 	}
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataMoistureBalance.cc
+++ b/src/EnergyPlus/DataMoistureBalance.cc
@@ -65,7 +65,7 @@ namespace DataMoistureBalance {
 	Array1D< Real64 > HAirFD; // Air Convection Coefficient
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataMoistureBalanceEMPD.cc
+++ b/src/EnergyPlus/DataMoistureBalanceEMPD.cc
@@ -42,7 +42,7 @@ namespace DataMoistureBalanceEMPD {
 	Array1D< Real64 > MoistEMPDFlux; // Moisture flux at interior surfaces [W]
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataOutputs.cc
+++ b/src/EnergyPlus/DataOutputs.cc
@@ -147,7 +147,7 @@ namespace DataOutputs {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataOutputs.hh
+++ b/src/EnergyPlus/DataOutputs.hh
@@ -81,7 +81,7 @@ namespace DataOutputs {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataPhotovoltaics.cc
+++ b/src/EnergyPlus/DataPhotovoltaics.cc
@@ -86,7 +86,7 @@ namespace DataPhotovoltaics {
 	//     Tel: (608) 274-2577
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataPlant.cc
+++ b/src/EnergyPlus/DataPlant.cc
@@ -970,7 +970,7 @@ namespace DataPlant {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataPlant.hh
+++ b/src/EnergyPlus/DataPlant.hh
@@ -2377,7 +2377,7 @@ namespace DataPlant {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataPlantPipingSystems.cc
+++ b/src/EnergyPlus/DataPlantPipingSystems.cc
@@ -114,7 +114,7 @@ namespace DataPlantPipingSystems {
 	Array1D< PipeSegmentInfo > PipingSystemSegments;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataPrecisionGlobals.cc
+++ b/src/EnergyPlus/DataPrecisionGlobals.cc
@@ -59,7 +59,7 @@ namespace DataPrecisionGlobals {
 	// na
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataReportingFlags.cc
+++ b/src/EnergyPlus/DataReportingFlags.cc
@@ -49,7 +49,7 @@ namespace DataReportingFlags {
 	bool EvenDuringWarmup( false );
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataRoomAirModel.cc
+++ b/src/EnergyPlus/DataRoomAirModel.cc
@@ -250,7 +250,7 @@ namespace DataRoomAirModel {
 	//**********************************************************************************************
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataRootFinder.cc
+++ b/src/EnergyPlus/DataRootFinder.cc
@@ -89,7 +89,7 @@ namespace DataRootFinder {
 	// na
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataRuntimeLanguage.cc
+++ b/src/EnergyPlus/DataRuntimeLanguage.cc
@@ -358,7 +358,7 @@ namespace DataRuntimeLanguage {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataRuntimeLanguage.hh
+++ b/src/EnergyPlus/DataRuntimeLanguage.hh
@@ -725,7 +725,7 @@ namespace DataRuntimeLanguage {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataShadowingCombinations.cc
+++ b/src/EnergyPlus/DataShadowingCombinations.cc
@@ -41,7 +41,7 @@ namespace DataShadowingCombinations {
 	Array1D< ShadowingCombinations > ShadowComb;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataSizing.cc
+++ b/src/EnergyPlus/DataSizing.cc
@@ -365,7 +365,7 @@ namespace DataSizing {
 	}
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataStringGlobals.in.cc
+++ b/src/EnergyPlus/DataStringGlobals.in.cc
@@ -136,7 +136,7 @@ namespace DataStringGlobals {
 	std::string CurrentDateTime; // For printing current date and time at start of run
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataSurfaceColors.cc
+++ b/src/EnergyPlus/DataSurfaceColors.cc
@@ -239,7 +239,7 @@ namespace DataSurfaceColors {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataSurfaceColors.hh
+++ b/src/EnergyPlus/DataSurfaceColors.hh
@@ -62,7 +62,7 @@ namespace DataSurfaceColors {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataSurfaceLists.cc
+++ b/src/EnergyPlus/DataSurfaceLists.cc
@@ -432,7 +432,7 @@ namespace DataSurfaceLists {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataSurfaceLists.hh
+++ b/src/EnergyPlus/DataSurfaceLists.hh
@@ -133,7 +133,7 @@ namespace DataSurfaceLists {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataSurfaces.cc
+++ b/src/EnergyPlus/DataSurfaces.cc
@@ -634,7 +634,7 @@ namespace DataSurfaces {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataSurfaces.hh
+++ b/src/EnergyPlus/DataSurfaces.hh
@@ -2542,7 +2542,7 @@ namespace DataSurfaces {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataSystemVariables.cc
+++ b/src/EnergyPlus/DataSystemVariables.cc
@@ -289,7 +289,7 @@ namespace DataSystemVariables {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataSystemVariables.hh
+++ b/src/EnergyPlus/DataSystemVariables.hh
@@ -120,7 +120,7 @@ namespace DataSystemVariables {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataTimings.cc
+++ b/src/EnergyPlus/DataTimings.cc
@@ -590,7 +590,7 @@ namespace DataTimings {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataTimings.hh
+++ b/src/EnergyPlus/DataTimings.hh
@@ -128,7 +128,7 @@ namespace DataTimings {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataUCSDSharedData.cc
+++ b/src/EnergyPlus/DataUCSDSharedData.cc
@@ -65,7 +65,7 @@ namespace DataUCSDSharedData {
 	Array1D< Real64 > HDoor;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataViewFactorInformation.cc
+++ b/src/EnergyPlus/DataViewFactorInformation.cc
@@ -46,7 +46,7 @@ namespace DataViewFactorInformation {
 	Array1D< ZoneViewFactorInformation > ZoneInfo;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataWater.cc
+++ b/src/EnergyPlus/DataWater.cc
@@ -83,7 +83,7 @@ namespace DataWater {
 	Array1D< GroundwaterWellDataStruct > GroundwaterWell;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataWindowEquivalentLayer.cc
+++ b/src/EnergyPlus/DataWindowEquivalentLayer.cc
@@ -60,7 +60,7 @@ namespace DataWindowEquivalentLayer {
 	Array1D< CFSGAP > CFSGaps;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataZoneControls.cc
+++ b/src/EnergyPlus/DataZoneControls.cc
@@ -91,7 +91,7 @@ namespace DataZoneControls {
 
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataZoneControls.hh
+++ b/src/EnergyPlus/DataZoneControls.hh
@@ -537,7 +537,7 @@ namespace DataZoneControls {
 	extern Array1D< ZoneStagedControls > StageControlledZone;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataZoneEnergyDemands.cc
+++ b/src/EnergyPlus/DataZoneEnergyDemands.cc
@@ -35,7 +35,7 @@ namespace DataZoneEnergyDemands {
 	Array1D< ZoneSystemMoistureDemand > ZoneSysMoistureDemand;
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/DataZoneEquipment.cc
+++ b/src/EnergyPlus/DataZoneEquipment.cc
@@ -1342,7 +1342,7 @@ namespace DataZoneEquipment {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DataZoneEquipment.hh
+++ b/src/EnergyPlus/DataZoneEquipment.hh
@@ -890,7 +890,7 @@ namespace DataZoneEquipment {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DaylightingDevices.cc
+++ b/src/EnergyPlus/DaylightingDevices.cc
@@ -1553,7 +1553,7 @@ namespace DaylightingDevices {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DaylightingDevices.hh
+++ b/src/EnergyPlus/DaylightingDevices.hh
@@ -78,7 +78,7 @@ namespace DaylightingDevices {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DaylightingManager.cc
+++ b/src/EnergyPlus/DaylightingManager.cc
@@ -10048,7 +10048,7 @@ Label903: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DaylightingManager.hh
+++ b/src/EnergyPlus/DaylightingManager.hh
@@ -543,7 +543,7 @@ namespace DaylightingManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DemandManager.cc
+++ b/src/EnergyPlus/DemandManager.cc
@@ -1846,7 +1846,7 @@ namespace DemandManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DemandManager.hh
+++ b/src/EnergyPlus/DemandManager.hh
@@ -298,7 +298,7 @@ namespace DemandManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DesiccantDehumidifiers.cc
+++ b/src/EnergyPlus/DesiccantDehumidifiers.cc
@@ -2827,7 +2827,7 @@ namespace DesiccantDehumidifiers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DesiccantDehumidifiers.hh
+++ b/src/EnergyPlus/DesiccantDehumidifiers.hh
@@ -576,7 +576,7 @@ namespace DesiccantDehumidifiers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DirectAirManager.cc
+++ b/src/EnergyPlus/DirectAirManager.cc
@@ -645,7 +645,7 @@ namespace DirectAirManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DirectAirManager.hh
+++ b/src/EnergyPlus/DirectAirManager.hh
@@ -156,7 +156,7 @@ namespace DirectAirManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DisplacementVentMgr.cc
+++ b/src/EnergyPlus/DisplacementVentMgr.cc
@@ -1027,7 +1027,7 @@ namespace DisplacementVentMgr {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DisplacementVentMgr.hh
+++ b/src/EnergyPlus/DisplacementVentMgr.hh
@@ -53,7 +53,7 @@ namespace DisplacementVentMgr {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DisplayRoutines.cc
+++ b/src/EnergyPlus/DisplayRoutines.cc
@@ -202,7 +202,7 @@ DisplaySimDaysProgress( // This doesn't do anything!
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DisplayRoutines.hh
+++ b/src/EnergyPlus/DisplayRoutines.hh
@@ -29,7 +29,7 @@ DisplaySimDaysProgress(
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DualDuct.cc
+++ b/src/EnergyPlus/DualDuct.cc
@@ -2193,7 +2193,7 @@ namespace DualDuct {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/DualDuct.hh
+++ b/src/EnergyPlus/DualDuct.hh
@@ -371,7 +371,7 @@ namespace DualDuct {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EMSManager.cc
+++ b/src/EnergyPlus/EMSManager.cc
@@ -1995,7 +1995,7 @@ namespace EMSManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EMSManager.hh
+++ b/src/EnergyPlus/EMSManager.hh
@@ -111,7 +111,7 @@ namespace EMSManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EarthTube.cc
+++ b/src/EnergyPlus/EarthTube.cc
@@ -654,7 +654,7 @@ namespace EarthTube {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EarthTube.hh
+++ b/src/EnergyPlus/EarthTube.hh
@@ -252,7 +252,7 @@ namespace EarthTube {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EcoRoofManager.cc
+++ b/src/EnergyPlus/EcoRoofManager.cc
@@ -1036,7 +1036,7 @@ namespace EcoRoofManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EcoRoofManager.hh
+++ b/src/EnergyPlus/EcoRoofManager.hh
@@ -61,7 +61,7 @@ namespace EcoRoofManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EconomicLifeCycleCost.cc
+++ b/src/EnergyPlus/EconomicLifeCycleCost.cc
@@ -2483,7 +2483,7 @@ namespace EconomicLifeCycleCost {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EconomicLifeCycleCost.hh
+++ b/src/EnergyPlus/EconomicLifeCycleCost.hh
@@ -410,7 +410,7 @@ namespace EconomicLifeCycleCost {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EconomicTariff.cc
+++ b/src/EnergyPlus/EconomicTariff.cc
@@ -5723,7 +5723,7 @@ namespace EconomicTariff {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EconomicTariff.hh
+++ b/src/EnergyPlus/EconomicTariff.hh
@@ -1187,7 +1187,7 @@ namespace EconomicTariff {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ElectricBaseboardRadiator.cc
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.cc
@@ -1182,7 +1182,7 @@ namespace ElectricBaseboardRadiator {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ElectricBaseboardRadiator.hh
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.hh
@@ -231,7 +231,7 @@ namespace ElectricBaseboardRadiator {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/EnergyPlusPgm.cc
@@ -51,7 +51,7 @@ EnergyPlusPgm( std::string const & filepath )
 
 	//      NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//      University of California through Ernest Orlando Lawrence Berkeley National Laboratory.  All rights
 	//      reserved.
 

--- a/src/EnergyPlus/EvaporativeCoolers.cc
+++ b/src/EnergyPlus/EvaporativeCoolers.cc
@@ -4167,7 +4167,7 @@ namespace EvaporativeCoolers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EvaporativeCoolers.hh
+++ b/src/EnergyPlus/EvaporativeCoolers.hh
@@ -556,7 +556,7 @@ namespace EvaporativeCoolers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EvaporativeFluidCoolers.cc
+++ b/src/EnergyPlus/EvaporativeFluidCoolers.cc
@@ -2743,7 +2743,7 @@ namespace EvaporativeFluidCoolers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/EvaporativeFluidCoolers.hh
+++ b/src/EnergyPlus/EvaporativeFluidCoolers.hh
@@ -408,7 +408,7 @@ namespace EvaporativeFluidCoolers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ExteriorEnergyUse.cc
+++ b/src/EnergyPlus/ExteriorEnergyUse.cc
@@ -636,7 +636,7 @@ namespace ExteriorEnergyUse {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ExteriorEnergyUse.hh
+++ b/src/EnergyPlus/ExteriorEnergyUse.hh
@@ -185,7 +185,7 @@ namespace ExteriorEnergyUse {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ExternalInterface.cc
+++ b/src/EnergyPlus/ExternalInterface.cc
@@ -2238,7 +2238,7 @@ namespace ExternalInterface {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ExternalInterface.hh
+++ b/src/EnergyPlus/ExternalInterface.hh
@@ -391,7 +391,7 @@ namespace ExternalInterface {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/FanCoilUnits.cc
+++ b/src/EnergyPlus/FanCoilUnits.cc
@@ -2508,7 +2508,7 @@ namespace FanCoilUnits {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/FanCoilUnits.hh
+++ b/src/EnergyPlus/FanCoilUnits.hh
@@ -525,7 +525,7 @@ namespace FanCoilUnits {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Fans.cc
+++ b/src/EnergyPlus/Fans.cc
@@ -3337,7 +3337,7 @@ namespace Fans {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Fans.hh
+++ b/src/EnergyPlus/Fans.hh
@@ -726,7 +726,7 @@ namespace Fans {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/FaultsManager.cc
+++ b/src/EnergyPlus/FaultsManager.cc
@@ -579,7 +579,7 @@ namespace FaultsManager {
 	// *****************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/FaultsManager.hh
+++ b/src/EnergyPlus/FaultsManager.hh
@@ -182,7 +182,7 @@ namespace FaultsManager {
 	// *****************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/FluidCoolers.cc
+++ b/src/EnergyPlus/FluidCoolers.cc
@@ -2128,7 +2128,7 @@ namespace FluidCoolers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/FluidCoolers.hh
+++ b/src/EnergyPlus/FluidCoolers.hh
@@ -315,7 +315,7 @@ namespace FluidCoolers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/FluidProperties.cc
+++ b/src/EnergyPlus/FluidProperties.cc
@@ -6133,7 +6133,7 @@ namespace FluidProperties {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/FluidProperties.hh
+++ b/src/EnergyPlus/FluidProperties.hh
@@ -1085,7 +1085,7 @@ namespace FluidProperties {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Furnaces.cc
+++ b/src/EnergyPlus/Furnaces.cc
@@ -9498,7 +9498,7 @@ namespace Furnaces {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Furnaces.hh
+++ b/src/EnergyPlus/Furnaces.hh
@@ -910,7 +910,7 @@ namespace Furnaces {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -3431,7 +3431,7 @@ namespace General {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/General.hh
+++ b/src/EnergyPlus/General.hh
@@ -385,7 +385,7 @@ namespace General {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/GeneralRoutines.cc
+++ b/src/EnergyPlus/GeneralRoutines.cc
@@ -2051,7 +2051,7 @@ TestReturnAirPathIntegrity(
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/GeneralRoutines.hh
+++ b/src/EnergyPlus/GeneralRoutines.hh
@@ -125,7 +125,7 @@ TestReturnAirPathIntegrity(
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/GlobalNames.cc
+++ b/src/EnergyPlus/GlobalNames.cc
@@ -336,7 +336,7 @@ namespace GlobalNames {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/GlobalNames.hh
+++ b/src/EnergyPlus/GlobalNames.hh
@@ -97,7 +97,7 @@ namespace GlobalNames {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/GroundHeatExchangers.cc
+++ b/src/EnergyPlus/GroundHeatExchangers.cc
@@ -2272,7 +2272,7 @@ namespace GroundHeatExchangers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/GroundHeatExchangers.hh
+++ b/src/EnergyPlus/GroundHeatExchangers.hh
@@ -359,7 +359,7 @@ namespace GroundHeatExchangers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACControllers.cc
+++ b/src/EnergyPlus/HVACControllers.cc
@@ -3525,7 +3525,7 @@ Label100: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACControllers.hh
+++ b/src/EnergyPlus/HVACControllers.hh
@@ -637,7 +637,7 @@ namespace HVACControllers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACCooledBeam.cc
+++ b/src/EnergyPlus/HVACCooledBeam.cc
@@ -1257,7 +1257,7 @@ namespace HVACCooledBeam {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACCooledBeam.hh
+++ b/src/EnergyPlus/HVACCooledBeam.hh
@@ -298,7 +298,7 @@ namespace HVACCooledBeam {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACDXSystem.cc
+++ b/src/EnergyPlus/HVACDXSystem.cc
@@ -3269,7 +3269,7 @@ namespace HVACDXSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACDXSystem.hh
+++ b/src/EnergyPlus/HVACDXSystem.hh
@@ -515,7 +515,7 @@ namespace HVACDXSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 
@@ -545,7 +545,7 @@ namespace HVACDXSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACDuct.cc
+++ b/src/EnergyPlus/HVACDuct.cc
@@ -430,7 +430,7 @@ namespace HVACDuct {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACDuct.hh
+++ b/src/EnergyPlus/HVACDuct.hh
@@ -85,7 +85,7 @@ namespace HVACDuct {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACHXAssistedCoolingCoil.cc
+++ b/src/EnergyPlus/HVACHXAssistedCoolingCoil.cc
@@ -1910,7 +1910,7 @@ namespace HVACHXAssistedCoolingCoil {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACHXAssistedCoolingCoil.hh
+++ b/src/EnergyPlus/HVACHXAssistedCoolingCoil.hh
@@ -301,7 +301,7 @@ namespace HVACHXAssistedCoolingCoil {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACInterfaceManager.cc
+++ b/src/EnergyPlus/HVACInterfaceManager.cc
@@ -1328,7 +1328,7 @@ namespace HVACInterfaceManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACInterfaceManager.hh
+++ b/src/EnergyPlus/HVACInterfaceManager.hh
@@ -190,7 +190,7 @@ namespace HVACInterfaceManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -2641,7 +2641,7 @@ namespace HVACManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACManager.hh
+++ b/src/EnergyPlus/HVACManager.hh
@@ -71,7 +71,7 @@ namespace HVACManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
@@ -3623,7 +3623,7 @@ namespace HVACMultiSpeedHeatPump {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.hh
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.hh
@@ -738,7 +738,7 @@ namespace HVACMultiSpeedHeatPump {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACSingleDuctInduc.cc
+++ b/src/EnergyPlus/HVACSingleDuctInduc.cc
@@ -1406,7 +1406,7 @@ namespace HVACSingleDuctInduc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACSingleDuctInduc.hh
+++ b/src/EnergyPlus/HVACSingleDuctInduc.hh
@@ -305,7 +305,7 @@ namespace HVACSingleDuctInduc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACStandAloneERV.cc
+++ b/src/EnergyPlus/HVACStandAloneERV.cc
@@ -2026,7 +2026,7 @@ namespace HVACStandAloneERV {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACStandAloneERV.hh
+++ b/src/EnergyPlus/HVACStandAloneERV.hh
@@ -340,7 +340,7 @@ namespace HVACStandAloneERV {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACUnitaryBypassVAV.cc
+++ b/src/EnergyPlus/HVACUnitaryBypassVAV.cc
@@ -3229,7 +3229,7 @@ namespace HVACUnitaryBypassVAV {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACUnitaryBypassVAV.hh
+++ b/src/EnergyPlus/HVACUnitaryBypassVAV.hh
@@ -705,7 +705,7 @@ namespace HVACUnitaryBypassVAV {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -12332,7 +12332,7 @@ namespace HVACUnitarySystem {
 // *****************************************************************************
 	//     NOTICE
 	
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of CalIFornia through Ernest OrlanDO Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	

--- a/src/EnergyPlus/HVACUnitarySystem.hh
+++ b/src/EnergyPlus/HVACUnitarySystem.hh
@@ -1617,7 +1617,7 @@ namespace HVACUnitarySystem {
 	// *****************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of CalIFornia through Ernest OrlanDO Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
@@ -6095,7 +6095,7 @@ namespace HVACVariableRefrigerantFlow {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.hh
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.hh
@@ -1349,7 +1349,7 @@ namespace HVACVariableRefrigerantFlow {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HWBaseboardRadiator.cc
+++ b/src/EnergyPlus/HWBaseboardRadiator.cc
@@ -1645,7 +1645,7 @@ namespace HWBaseboardRadiator {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HWBaseboardRadiator.hh
+++ b/src/EnergyPlus/HWBaseboardRadiator.hh
@@ -346,7 +346,7 @@ namespace HWBaseboardRadiator {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalFiniteDiffManager.cc
+++ b/src/EnergyPlus/HeatBalFiniteDiffManager.cc
@@ -2364,7 +2364,7 @@ namespace HeatBalFiniteDiffManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalFiniteDiffManager.hh
+++ b/src/EnergyPlus/HeatBalFiniteDiffManager.hh
@@ -382,7 +382,7 @@ namespace HeatBalFiniteDiffManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceAirManager.cc
+++ b/src/EnergyPlus/HeatBalanceAirManager.cc
@@ -3331,7 +3331,7 @@ namespace HeatBalanceAirManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceAirManager.hh
+++ b/src/EnergyPlus/HeatBalanceAirManager.hh
@@ -81,7 +81,7 @@ namespace HeatBalanceAirManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceHAMTManager.cc
+++ b/src/EnergyPlus/HeatBalanceHAMTManager.cc
@@ -1675,7 +1675,7 @@ namespace HeatBalanceHAMTManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     Illinois and The Regents of the University of California through
 	//     Ernest Orlando Lawrence Berkeley National Laboratory.  All rights
 	//     reserved.

--- a/src/EnergyPlus/HeatBalanceHAMTManager.hh
+++ b/src/EnergyPlus/HeatBalanceHAMTManager.hh
@@ -268,7 +268,7 @@ namespace HeatBalanceHAMTManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     Illinois and The Regents of the University of California through
 	//     Ernest Orlando Lawrence Berkeley National Laboratory.  All rights
 	//     reserved.

--- a/src/EnergyPlus/HeatBalanceIntRadExchange.cc
+++ b/src/EnergyPlus/HeatBalanceIntRadExchange.cc
@@ -1433,7 +1433,7 @@ namespace HeatBalanceIntRadExchange {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceIntRadExchange.hh
+++ b/src/EnergyPlus/HeatBalanceIntRadExchange.hh
@@ -102,7 +102,7 @@ namespace HeatBalanceIntRadExchange {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -8046,7 +8046,7 @@ Label1000: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceManager.hh
+++ b/src/EnergyPlus/HeatBalanceManager.hh
@@ -262,7 +262,7 @@ namespace HeatBalanceManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceMovableInsulation.cc
+++ b/src/EnergyPlus/HeatBalanceMovableInsulation.cc
@@ -195,7 +195,7 @@ namespace HeatBalanceMovableInsulation {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceMovableInsulation.hh
+++ b/src/EnergyPlus/HeatBalanceMovableInsulation.hh
@@ -37,7 +37,7 @@ namespace HeatBalanceMovableInsulation {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatBalanceSurfaceManager.cc
+++ b/src/EnergyPlus/HeatBalanceSurfaceManager.cc
@@ -6077,7 +6077,7 @@ GatherComponentLoadsSurfAbsFact()
 
 	//     NOTICE
 	
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	

--- a/src/EnergyPlus/HeatBalanceSurfaceManager.hh
+++ b/src/EnergyPlus/HeatBalanceSurfaceManager.hh
@@ -143,7 +143,7 @@ GatherComponentLoadsSurfAbsFact();
 
 	//     NOTICE
 	
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	

--- a/src/EnergyPlus/HeatRecovery.cc
+++ b/src/EnergyPlus/HeatRecovery.cc
@@ -4894,7 +4894,7 @@ namespace HeatRecovery {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatRecovery.hh
+++ b/src/EnergyPlus/HeatRecovery.hh
@@ -1373,7 +1373,7 @@ namespace HeatRecovery {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatingCoils.cc
+++ b/src/EnergyPlus/HeatingCoils.cc
@@ -3244,7 +3244,7 @@ namespace HeatingCoils {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HeatingCoils.hh
+++ b/src/EnergyPlus/HeatingCoils.hh
@@ -474,7 +474,7 @@ namespace HeatingCoils {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HighTempRadiantSystem.cc
+++ b/src/EnergyPlus/HighTempRadiantSystem.cc
@@ -1472,7 +1472,7 @@ namespace HighTempRadiantSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/HighTempRadiantSystem.hh
+++ b/src/EnergyPlus/HighTempRadiantSystem.hh
@@ -253,7 +253,7 @@ namespace HighTempRadiantSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Humidifiers.cc
+++ b/src/EnergyPlus/Humidifiers.cc
@@ -1325,7 +1325,7 @@ namespace Humidifiers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Humidifiers.hh
+++ b/src/EnergyPlus/Humidifiers.hh
@@ -201,7 +201,7 @@ namespace Humidifiers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/IceThermalStorage.cc
+++ b/src/EnergyPlus/IceThermalStorage.cc
@@ -2503,7 +2503,7 @@ namespace IceThermalStorage {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/IceThermalStorage.hh
+++ b/src/EnergyPlus/IceThermalStorage.hh
@@ -612,7 +612,7 @@ namespace IceThermalStorage {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/InputProcessor.cc
+++ b/src/EnergyPlus/InputProcessor.cc
@@ -6020,7 +6020,7 @@ namespace InputProcessor {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/InputProcessor.hh
+++ b/src/EnergyPlus/InputProcessor.hh
@@ -877,7 +877,7 @@ namespace InputProcessor {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/InternalHeatGains.cc
+++ b/src/EnergyPlus/InternalHeatGains.cc
@@ -5286,7 +5286,7 @@ namespace InternalHeatGains {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/InternalHeatGains.hh
+++ b/src/EnergyPlus/InternalHeatGains.hh
@@ -137,7 +137,7 @@ namespace InternalHeatGains {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/LowTempRadiantSystem.cc
+++ b/src/EnergyPlus/LowTempRadiantSystem.cc
@@ -5011,7 +5011,7 @@ namespace LowTempRadiantSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/LowTempRadiantSystem.hh
+++ b/src/EnergyPlus/LowTempRadiantSystem.hh
@@ -937,7 +937,7 @@ namespace LowTempRadiantSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ManageElectricPower.cc
+++ b/src/EnergyPlus/ManageElectricPower.cc
@@ -3745,7 +3745,7 @@ namespace ManageElectricPower {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ManageElectricPower.hh
+++ b/src/EnergyPlus/ManageElectricPower.hh
@@ -1079,7 +1079,7 @@ namespace ManageElectricPower {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MatrixDataManager.cc
+++ b/src/EnergyPlus/MatrixDataManager.cc
@@ -327,7 +327,7 @@ namespace MatrixDataManager {
 
 	}
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MatrixDataManager.hh
+++ b/src/EnergyPlus/MatrixDataManager.hh
@@ -92,7 +92,7 @@ namespace MatrixDataManager {
 		int & NumCols
 	);
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -6529,7 +6529,7 @@ namespace MixedAir {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MixedAir.hh
+++ b/src/EnergyPlus/MixedAir.hh
@@ -975,7 +975,7 @@ namespace MixedAir {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MixerComponent.cc
+++ b/src/EnergyPlus/MixerComponent.cc
@@ -692,7 +692,7 @@ namespace MixerComponent {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MixerComponent.hh
+++ b/src/EnergyPlus/MixerComponent.hh
@@ -184,7 +184,7 @@ namespace MixerComponent {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MoistureBalanceEMPDManager.cc
+++ b/src/EnergyPlus/MoistureBalanceEMPDManager.cc
@@ -646,7 +646,7 @@ namespace MoistureBalanceEMPDManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MoistureBalanceEMPDManager.hh
+++ b/src/EnergyPlus/MoistureBalanceEMPDManager.hh
@@ -56,7 +56,7 @@ namespace MoistureBalanceEMPDManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MundtSimMgr.cc
+++ b/src/EnergyPlus/MundtSimMgr.cc
@@ -945,7 +945,7 @@ namespace MundtSimMgr {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/MundtSimMgr.hh
+++ b/src/EnergyPlus/MundtSimMgr.hh
@@ -208,7 +208,7 @@ namespace MundtSimMgr {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/NodeInputManager.cc
+++ b/src/EnergyPlus/NodeInputManager.cc
@@ -1351,7 +1351,7 @@ namespace NodeInputManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/NodeInputManager.hh
+++ b/src/EnergyPlus/NodeInputManager.hh
@@ -171,7 +171,7 @@ namespace NodeInputManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/NonZoneEquipmentManager.cc
+++ b/src/EnergyPlus/NonZoneEquipmentManager.cc
@@ -99,7 +99,7 @@ namespace NonZoneEquipmentManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/NonZoneEquipmentManager.hh
+++ b/src/EnergyPlus/NonZoneEquipmentManager.hh
@@ -24,7 +24,7 @@ namespace NonZoneEquipmentManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutAirNodeManager.cc
+++ b/src/EnergyPlus/OutAirNodeManager.cc
@@ -515,7 +515,7 @@ namespace OutAirNodeManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutAirNodeManager.hh
+++ b/src/EnergyPlus/OutAirNodeManager.hh
@@ -51,7 +51,7 @@ namespace OutAirNodeManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutdoorAirUnit.cc
+++ b/src/EnergyPlus/OutdoorAirUnit.cc
@@ -2613,7 +2613,7 @@ namespace OutdoorAirUnit {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutdoorAirUnit.hh
+++ b/src/EnergyPlus/OutdoorAirUnit.hh
@@ -499,7 +499,7 @@ namespace OutdoorAirUnit {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -8179,7 +8179,7 @@ AddToOutputVariableList(
 
 	//     NOTICE
 	
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutputProcessor.hh
+++ b/src/EnergyPlus/OutputProcessor.hh
@@ -1444,7 +1444,7 @@ AddToOutputVariableList(
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutputReportPredefined.cc
+++ b/src/EnergyPlus/OutputReportPredefined.cc
@@ -1995,7 +1995,7 @@ namespace OutputReportPredefined {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutputReportPredefined.hh
+++ b/src/EnergyPlus/OutputReportPredefined.hh
@@ -908,7 +908,7 @@ namespace OutputReportPredefined {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -14248,7 +14248,7 @@ Label900: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutputReportTabular.hh
+++ b/src/EnergyPlus/OutputReportTabular.hh
@@ -1080,7 +1080,7 @@ namespace OutputReportTabular {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutputReports.cc
+++ b/src/EnergyPlus/OutputReports.cc
@@ -2445,7 +2445,7 @@ VRMLOut(
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutputReports.hh
+++ b/src/EnergyPlus/OutputReports.hh
@@ -41,7 +41,7 @@ VRMLOut(
 
 	//     NOTICE
 	
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	

--- a/src/EnergyPlus/OutsideEnergySources.cc
+++ b/src/EnergyPlus/OutsideEnergySources.cc
@@ -749,7 +749,7 @@ namespace OutsideEnergySources {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/OutsideEnergySources.hh
+++ b/src/EnergyPlus/OutsideEnergySources.hh
@@ -178,7 +178,7 @@ namespace OutsideEnergySources {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PackagedTerminalHeatPump.cc
+++ b/src/EnergyPlus/PackagedTerminalHeatPump.cc
@@ -6650,7 +6650,7 @@ namespace PackagedTerminalHeatPump {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PackagedTerminalHeatPump.hh
+++ b/src/EnergyPlus/PackagedTerminalHeatPump.hh
@@ -866,7 +866,7 @@ namespace PackagedTerminalHeatPump {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PackagedThermalStorageCoil.cc
+++ b/src/EnergyPlus/PackagedThermalStorageCoil.cc
@@ -4327,7 +4327,7 @@ namespace PackagedThermalStorageCoil {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PackagedThermalStorageCoil.hh
+++ b/src/EnergyPlus/PackagedThermalStorageCoil.hh
@@ -995,7 +995,7 @@ namespace PackagedThermalStorageCoil {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PhotovoltaicThermalCollectors.cc
+++ b/src/EnergyPlus/PhotovoltaicThermalCollectors.cc
@@ -1348,7 +1348,7 @@ namespace PhotovoltaicThermalCollectors {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PhotovoltaicThermalCollectors.hh
+++ b/src/EnergyPlus/PhotovoltaicThermalCollectors.hh
@@ -210,7 +210,7 @@ namespace PhotovoltaicThermalCollectors {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Photovoltaics.cc
+++ b/src/EnergyPlus/Photovoltaics.cc
@@ -2748,7 +2748,7 @@ namespace Photovoltaics {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Photovoltaics.hh
+++ b/src/EnergyPlus/Photovoltaics.hh
@@ -358,7 +358,7 @@ namespace Photovoltaics {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PipeHeatTransfer.cc
+++ b/src/EnergyPlus/PipeHeatTransfer.cc
@@ -2134,7 +2134,7 @@ namespace PipeHeatTransfer {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PipeHeatTransfer.hh
+++ b/src/EnergyPlus/PipeHeatTransfer.hh
@@ -576,7 +576,7 @@ namespace PipeHeatTransfer {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Pipes.cc
+++ b/src/EnergyPlus/Pipes.cc
@@ -392,7 +392,7 @@ namespace Pipes {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Pipes.hh
+++ b/src/EnergyPlus/Pipes.hh
@@ -127,7 +127,7 @@ namespace Pipes {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantCentralGSHP.cc
+++ b/src/EnergyPlus/PlantCentralGSHP.cc
@@ -3306,7 +3306,7 @@ namespace PlantCentralGSHP {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantCentralGSHP.hh
+++ b/src/EnergyPlus/PlantCentralGSHP.hh
@@ -619,7 +619,7 @@ namespace PlantCentralGSHP {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantChillers.cc
+++ b/src/EnergyPlus/PlantChillers.cc
@@ -7010,7 +7010,7 @@ namespace PlantChillers {
 
 	//     NOTICE
 	
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	

--- a/src/EnergyPlus/PlantChillers.hh
+++ b/src/EnergyPlus/PlantChillers.hh
@@ -748,7 +748,7 @@ namespace PlantChillers {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantCondLoopOperation.cc
+++ b/src/EnergyPlus/PlantCondLoopOperation.cc
@@ -3384,7 +3384,7 @@ namespace PlantCondLoopOperation {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantCondLoopOperation.hh
+++ b/src/EnergyPlus/PlantCondLoopOperation.hh
@@ -227,7 +227,7 @@ namespace PlantCondLoopOperation {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantHeatExchangerFluidToFluid.cc
+++ b/src/EnergyPlus/PlantHeatExchangerFluidToFluid.cc
@@ -1904,7 +1904,7 @@ namespace PlantHeatExchangerFluidToFluid {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantHeatExchangerFluidToFluid.hh
+++ b/src/EnergyPlus/PlantHeatExchangerFluidToFluid.hh
@@ -244,7 +244,7 @@ namespace PlantHeatExchangerFluidToFluid {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantLoadProfile.cc
+++ b/src/EnergyPlus/PlantLoadProfile.cc
@@ -432,7 +432,7 @@ namespace PlantLoadProfile {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantLoadProfile.hh
+++ b/src/EnergyPlus/PlantLoadProfile.hh
@@ -173,7 +173,7 @@ namespace PlantLoadProfile {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantLoopEquip.cc
+++ b/src/EnergyPlus/PlantLoopEquip.cc
@@ -1133,7 +1133,7 @@ namespace PlantLoopEquip {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantLoopEquip.hh
+++ b/src/EnergyPlus/PlantLoopEquip.hh
@@ -26,7 +26,7 @@ namespace PlantLoopEquip {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantLoopSolver.cc
+++ b/src/EnergyPlus/PlantLoopSolver.cc
@@ -2941,7 +2941,7 @@ namespace PlantLoopSolver {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantLoopSolver.hh
+++ b/src/EnergyPlus/PlantLoopSolver.hh
@@ -318,7 +318,7 @@ namespace PlantLoopSolver {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantManager.cc
+++ b/src/EnergyPlus/PlantManager.cc
@@ -4461,7 +4461,7 @@ namespace PlantManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantManager.hh
+++ b/src/EnergyPlus/PlantManager.hh
@@ -309,7 +309,7 @@ namespace PlantManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantPipingSystemsManager.cc
+++ b/src/EnergyPlus/PlantPipingSystemsManager.cc
@@ -9644,7 +9644,7 @@ namespace PlantPipingSystemsManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantPipingSystemsManager.hh
+++ b/src/EnergyPlus/PlantPipingSystemsManager.hh
@@ -1104,7 +1104,7 @@ namespace PlantPipingSystemsManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantPressureSystem.cc
+++ b/src/EnergyPlus/PlantPressureSystem.cc
@@ -1445,7 +1445,7 @@ namespace PlantPressureSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantPressureSystem.hh
+++ b/src/EnergyPlus/PlantPressureSystem.hh
@@ -411,7 +411,7 @@ namespace PlantPressureSystem {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantUtilities.cc
+++ b/src/EnergyPlus/PlantUtilities.cc
@@ -2488,7 +2488,7 @@ namespace PlantUtilities {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantUtilities.hh
+++ b/src/EnergyPlus/PlantUtilities.hh
@@ -216,7 +216,7 @@ namespace PlantUtilities {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantValves.cc
+++ b/src/EnergyPlus/PlantValves.cc
@@ -705,7 +705,7 @@ namespace PlantValves {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PlantValves.hh
+++ b/src/EnergyPlus/PlantValves.hh
@@ -158,7 +158,7 @@ namespace PlantValves {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PollutionModule.cc
+++ b/src/EnergyPlus/PollutionModule.cc
@@ -3679,7 +3679,7 @@ namespace PollutionModule {
 	// *****************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PollutionModule.hh
+++ b/src/EnergyPlus/PollutionModule.hh
@@ -695,7 +695,7 @@ namespace PollutionModule {
 	// *****************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PondGroundHeatExchanger.cc
+++ b/src/EnergyPlus/PondGroundHeatExchanger.cc
@@ -1192,7 +1192,7 @@ namespace PondGroundHeatExchanger {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PondGroundHeatExchanger.hh
+++ b/src/EnergyPlus/PondGroundHeatExchanger.hh
@@ -264,7 +264,7 @@ namespace PondGroundHeatExchanger {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PoweredInductionUnits.cc
+++ b/src/EnergyPlus/PoweredInductionUnits.cc
@@ -1861,7 +1861,7 @@ namespace PoweredInductionUnits {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PoweredInductionUnits.hh
+++ b/src/EnergyPlus/PoweredInductionUnits.hh
@@ -317,7 +317,7 @@ namespace PoweredInductionUnits {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Psychrometrics.cc
+++ b/src/EnergyPlus/Psychrometrics.cc
@@ -1396,7 +1396,7 @@ Label170: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Psychrometrics.hh
+++ b/src/EnergyPlus/Psychrometrics.hh
@@ -1283,7 +1283,7 @@ namespace Psychrometrics {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Pumps.cc
+++ b/src/EnergyPlus/Pumps.cc
@@ -1982,7 +1982,7 @@ namespace Pumps {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/Pumps.hh
+++ b/src/EnergyPlus/Pumps.hh
@@ -509,7 +509,7 @@ namespace Pumps {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PurchasedAirManager.cc
+++ b/src/EnergyPlus/PurchasedAirManager.cc
@@ -2831,7 +2831,7 @@ namespace PurchasedAirManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/PurchasedAirManager.hh
+++ b/src/EnergyPlus/PurchasedAirManager.hh
@@ -642,7 +642,7 @@ namespace PurchasedAirManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RefrigeratedCase.cc
+++ b/src/EnergyPlus/RefrigeratedCase.cc
@@ -12911,7 +12911,7 @@ namespace RefrigeratedCase {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RefrigeratedCase.hh
+++ b/src/EnergyPlus/RefrigeratedCase.hh
@@ -4114,7 +4114,7 @@ namespace RefrigeratedCase {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -2109,7 +2109,7 @@ namespace ReportSizingManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ReportSizingManager.hh
+++ b/src/EnergyPlus/ReportSizingManager.hh
@@ -45,7 +45,7 @@ namespace ReportSizingManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ReturnAirPathManager.cc
+++ b/src/EnergyPlus/ReturnAirPathManager.cc
@@ -291,7 +291,7 @@ namespace ReturnAirPathManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ReturnAirPathManager.hh
+++ b/src/EnergyPlus/ReturnAirPathManager.hh
@@ -39,7 +39,7 @@ namespace ReturnAirPathManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RoomAirModelManager.cc
+++ b/src/EnergyPlus/RoomAirModelManager.cc
@@ -2118,7 +2118,7 @@ namespace RoomAirModelManager {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RoomAirModelManager.hh
+++ b/src/EnergyPlus/RoomAirModelManager.hh
@@ -57,7 +57,7 @@ namespace RoomAirModelManager {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RoomAirModelUserTempPattern.cc
+++ b/src/EnergyPlus/RoomAirModelUserTempPattern.cc
@@ -1158,7 +1158,7 @@ namespace RoomAirModelUserTempPattern {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RoomAirModelUserTempPattern.hh
+++ b/src/EnergyPlus/RoomAirModelUserTempPattern.hh
@@ -94,7 +94,7 @@ namespace RoomAirModelUserTempPattern {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RootFinder.cc
+++ b/src/EnergyPlus/RootFinder.cc
@@ -2833,7 +2833,7 @@ namespace RootFinder {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RootFinder.hh
+++ b/src/EnergyPlus/RootFinder.hh
@@ -204,7 +204,7 @@ namespace RootFinder {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RuntimeLanguageProcessor.cc
+++ b/src/EnergyPlus/RuntimeLanguageProcessor.cc
@@ -4022,7 +4022,7 @@ namespace RuntimeLanguageProcessor {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/RuntimeLanguageProcessor.hh
+++ b/src/EnergyPlus/RuntimeLanguageProcessor.hh
@@ -285,7 +285,7 @@ namespace RuntimeLanguageProcessor {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ScheduleManager.cc
+++ b/src/EnergyPlus/ScheduleManager.cc
@@ -4753,7 +4753,7 @@ namespace ScheduleManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ScheduleManager.hh
+++ b/src/EnergyPlus/ScheduleManager.hh
@@ -401,7 +401,7 @@ namespace ScheduleManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -7995,7 +7995,7 @@ namespace SetPointManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SetPointManager.hh
+++ b/src/EnergyPlus/SetPointManager.hh
@@ -2081,7 +2081,7 @@ namespace SetPointManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SimAirServingZones.cc
+++ b/src/EnergyPlus/SimAirServingZones.cc
@@ -6244,7 +6244,7 @@ namespace SimAirServingZones {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SimAirServingZones.hh
+++ b/src/EnergyPlus/SimAirServingZones.hh
@@ -192,7 +192,7 @@ namespace SimAirServingZones {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SimulationManager.cc
+++ b/src/EnergyPlus/SimulationManager.cc
@@ -2804,7 +2804,7 @@ Resimulate(
 }
 
 //     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 //     and The Regents of the University of California through Ernest Orlando Lawrence
 //     Berkeley National Laboratory.  All rights reserved.
 //     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/SimulationManager.hh
+++ b/src/EnergyPlus/SimulationManager.hh
@@ -90,7 +90,7 @@ Resimulate(
 );
 
 //     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 //     and The Regents of the University of California through Ernest Orlando Lawrence
 //     Berkeley National Laboratory.  All rights reserved.
 //     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -5031,7 +5031,7 @@ namespace SingleDuct {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SingleDuct.hh
+++ b/src/EnergyPlus/SingleDuct.hh
@@ -728,7 +728,7 @@ namespace SingleDuct {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SizingManager.cc
+++ b/src/EnergyPlus/SizingManager.cc
@@ -3318,7 +3318,7 @@ namespace SizingManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SizingManager.hh
+++ b/src/EnergyPlus/SizingManager.hh
@@ -132,7 +132,7 @@ namespace SizingManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SolarCollectors.cc
+++ b/src/EnergyPlus/SolarCollectors.cc
@@ -2311,7 +2311,7 @@ namespace SolarCollectors {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SolarCollectors.hh
+++ b/src/EnergyPlus/SolarCollectors.hh
@@ -576,7 +576,7 @@ namespace SolarCollectors {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SolarReflectionManager.cc
+++ b/src/EnergyPlus/SolarReflectionManager.cc
@@ -1349,7 +1349,7 @@ namespace SolarReflectionManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SolarReflectionManager.hh
+++ b/src/EnergyPlus/SolarReflectionManager.hh
@@ -154,7 +154,7 @@ namespace SolarReflectionManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -10760,7 +10760,7 @@ namespace SolarShading {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SolarShading.hh
+++ b/src/EnergyPlus/SolarShading.hh
@@ -450,7 +450,7 @@ namespace SolarShading {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SortAndStringUtilities.cc
+++ b/src/EnergyPlus/SortAndStringUtilities.cc
@@ -220,7 +220,7 @@ namespace SortAndStringUtilities {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SortAndStringUtilities.hh
+++ b/src/EnergyPlus/SortAndStringUtilities.hh
@@ -46,7 +46,7 @@ namespace SortAndStringUtilities {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SplitterComponent.cc
+++ b/src/EnergyPlus/SplitterComponent.cc
@@ -859,7 +859,7 @@ namespace SplitterComponent {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SplitterComponent.hh
+++ b/src/EnergyPlus/SplitterComponent.hh
@@ -209,7 +209,7 @@ namespace SplitterComponent {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/StandardRatings.cc
+++ b/src/EnergyPlus/StandardRatings.cc
@@ -2653,7 +2653,7 @@ namespace StandardRatings {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/StandardRatings.hh
+++ b/src/EnergyPlus/StandardRatings.hh
@@ -292,7 +292,7 @@ namespace StandardRatings {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SteamBaseboardRadiator.cc
+++ b/src/EnergyPlus/SteamBaseboardRadiator.cc
@@ -1476,7 +1476,7 @@ namespace SteamBaseboardRadiator {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SteamBaseboardRadiator.hh
+++ b/src/EnergyPlus/SteamBaseboardRadiator.hh
@@ -321,7 +321,7 @@ namespace SteamBaseboardRadiator {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SteamCoils.cc
+++ b/src/EnergyPlus/SteamCoils.cc
@@ -2352,7 +2352,7 @@ namespace SteamCoils {
 	// *****************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SteamCoils.hh
+++ b/src/EnergyPlus/SteamCoils.hh
@@ -446,7 +446,7 @@ namespace SteamCoils {
 	// *****************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -10600,7 +10600,7 @@ namespace SurfaceGeometry {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SurfaceGeometry.hh
+++ b/src/EnergyPlus/SurfaceGeometry.hh
@@ -313,7 +313,7 @@ namespace SurfaceGeometry {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SurfaceGroundHeatExchanger.cc
+++ b/src/EnergyPlus/SurfaceGroundHeatExchanger.cc
@@ -1731,7 +1731,7 @@ namespace loc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SurfaceGroundHeatExchanger.hh
+++ b/src/EnergyPlus/SurfaceGroundHeatExchanger.hh
@@ -529,7 +529,7 @@ namespace loc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SwimmingPool.cc
+++ b/src/EnergyPlus/SwimmingPool.cc
@@ -1259,7 +1259,7 @@ namespace SwimmingPool {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SwimmingPool.hh
+++ b/src/EnergyPlus/SwimmingPool.hh
@@ -335,7 +335,7 @@ namespace SwimmingPool {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SystemAvailabilityManager.cc
+++ b/src/EnergyPlus/SystemAvailabilityManager.cc
@@ -4769,7 +4769,7 @@ namespace SystemAvailabilityManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SystemAvailabilityManager.hh
+++ b/src/EnergyPlus/SystemAvailabilityManager.hh
@@ -873,7 +873,7 @@ namespace SystemAvailabilityManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SystemReports.cc
+++ b/src/EnergyPlus/SystemReports.cc
@@ -4713,7 +4713,7 @@ namespace SystemReports {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/SystemReports.hh
+++ b/src/EnergyPlus/SystemReports.hh
@@ -368,7 +368,7 @@ namespace SystemReports {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGArgs.cc
+++ b/src/EnergyPlus/TARCOGArgs.cc
@@ -643,7 +643,7 @@ namespace TARCOGArgs {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGArgs.hh
+++ b/src/EnergyPlus/TARCOGArgs.hh
@@ -146,7 +146,7 @@ namespace TARCOGArgs {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGCommon.cc
+++ b/src/EnergyPlus/TARCOGCommon.cc
@@ -436,7 +436,7 @@ namespace TARCOGCommon {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGCommon.hh
+++ b/src/EnergyPlus/TARCOGCommon.hh
@@ -83,7 +83,7 @@ namespace TARCOGCommon {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGDeflection.cc
+++ b/src/EnergyPlus/TARCOGDeflection.cc
@@ -292,7 +292,7 @@ namespace TARCOGDeflection {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGDeflection.hh
+++ b/src/EnergyPlus/TARCOGDeflection.hh
@@ -66,7 +66,7 @@ namespace TARCOGDeflection {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGGasses90.cc
+++ b/src/EnergyPlus/TARCOGGasses90.cc
@@ -335,7 +335,7 @@ namespace TARCOGGasses90 {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGGasses90.hh
+++ b/src/EnergyPlus/TARCOGGasses90.hh
@@ -101,7 +101,7 @@ namespace TARCOGGasses90 {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGGassesParams.cc
+++ b/src/EnergyPlus/TARCOGGassesParams.cc
@@ -87,7 +87,7 @@ namespace TARCOGGassesParams {
 	//end function GetGasIndex
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/TARCOGMain.cc
+++ b/src/EnergyPlus/TARCOGMain.cc
@@ -737,7 +737,7 @@ namespace TARCOGMain {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGMain.hh
+++ b/src/EnergyPlus/TARCOGMain.hh
@@ -130,7 +130,7 @@ namespace TARCOGMain {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGOutput.cc
+++ b/src/EnergyPlus/TARCOGOutput.cc
@@ -1546,7 +1546,7 @@ namespace TARCOGOutput {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGOutput.hh
+++ b/src/EnergyPlus/TARCOGOutput.hh
@@ -282,7 +282,7 @@ namespace TARCOGOutput {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TARCOGParams.cc
+++ b/src/EnergyPlus/TARCOGParams.cc
@@ -133,7 +133,7 @@ namespace TARCOGParams {
 	Real64 const TemperatureQuessDiff( 1.0 ); // in case outside and inside temperatures are identical
 
 	//     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 	//     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/TarcogShading.cc
+++ b/src/EnergyPlus/TarcogShading.cc
@@ -923,7 +923,7 @@ namespace TarcogShading {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TarcogShading.hh
+++ b/src/EnergyPlus/TarcogShading.hh
@@ -150,7 +150,7 @@ namespace TarcogShading {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ThermalChimney.cc
+++ b/src/EnergyPlus/ThermalChimney.cc
@@ -874,7 +874,7 @@ namespace ThermalChimney {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ThermalChimney.hh
+++ b/src/EnergyPlus/ThermalChimney.hh
@@ -186,7 +186,7 @@ namespace ThermalChimney {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ThermalComfort.cc
+++ b/src/EnergyPlus/ThermalComfort.cc
@@ -2924,7 +2924,7 @@ namespace ThermalComfort {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ThermalComfort.hh
+++ b/src/EnergyPlus/ThermalComfort.hh
@@ -444,7 +444,7 @@ namespace ThermalComfort {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ThermalEN673Calc.cc
+++ b/src/EnergyPlus/ThermalEN673Calc.cc
@@ -498,7 +498,7 @@ namespace ThermalEN673Calc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ThermalEN673Calc.hh
+++ b/src/EnergyPlus/ThermalEN673Calc.hh
@@ -113,7 +113,7 @@ namespace ThermalEN673Calc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ThermalISO15099Calc.cc
+++ b/src/EnergyPlus/ThermalISO15099Calc.cc
@@ -2902,7 +2902,7 @@ namespace ThermalISO15099Calc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ThermalISO15099Calc.hh
+++ b/src/EnergyPlus/ThermalISO15099Calc.hh
@@ -480,7 +480,7 @@ namespace ThermalISO15099Calc {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TranspiredCollector.cc
+++ b/src/EnergyPlus/TranspiredCollector.cc
@@ -1398,7 +1398,7 @@ namespace TranspiredCollector {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/TranspiredCollector.hh
+++ b/src/EnergyPlus/TranspiredCollector.hh
@@ -349,7 +349,7 @@ namespace TranspiredCollector {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UFADManager.cc
+++ b/src/EnergyPlus/UFADManager.cc
@@ -1796,7 +1796,7 @@ namespace UFADManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UFADManager.hh
+++ b/src/EnergyPlus/UFADManager.hh
@@ -61,7 +61,7 @@ namespace UFADManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UnitHeater.cc
+++ b/src/EnergyPlus/UnitHeater.cc
@@ -1711,7 +1711,7 @@ namespace UnitHeater {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UnitHeater.hh
+++ b/src/EnergyPlus/UnitHeater.hh
@@ -329,7 +329,7 @@ namespace UnitHeater {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UnitVentilator.cc
+++ b/src/EnergyPlus/UnitVentilator.cc
@@ -3238,7 +3238,7 @@ namespace UnitVentilator {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UnitVentilator.hh
+++ b/src/EnergyPlus/UnitVentilator.hh
@@ -535,7 +535,7 @@ namespace UnitVentilator {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UserDefinedComponents.cc
+++ b/src/EnergyPlus/UserDefinedComponents.cc
@@ -1997,7 +1997,7 @@ namespace UserDefinedComponents {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UserDefinedComponents.hh
+++ b/src/EnergyPlus/UserDefinedComponents.hh
@@ -609,7 +609,7 @@ namespace UserDefinedComponents {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -1751,7 +1751,7 @@ ShowRecurringErrors()
 }
 
 //     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 //     and The Regents of the University of California through Ernest Orlando Lawrence
 //     Berkeley National Laboratory.  All rights reserved.
 //     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/UtilityRoutines.hh
+++ b/src/EnergyPlus/UtilityRoutines.hh
@@ -219,7 +219,7 @@ void
 ShowRecurringErrors();
 
 //     NOTICE
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 //     and The Regents of the University of California through Ernest Orlando Lawrence
 //     Berkeley National Laboratory.  All rights reserved.
 //     Portions of the EnergyPlus software package have been developed and copyrighted

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -6752,7 +6752,7 @@ namespace VariableSpeedCoils {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/VariableSpeedCoils.hh
+++ b/src/EnergyPlus/VariableSpeedCoils.hh
@@ -1015,7 +1015,7 @@ namespace VariableSpeedCoils {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/VentilatedSlab.cc
+++ b/src/EnergyPlus/VentilatedSlab.cc
@@ -4063,7 +4063,7 @@ namespace VentilatedSlab {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/VentilatedSlab.hh
+++ b/src/EnergyPlus/VentilatedSlab.hh
@@ -769,7 +769,7 @@ namespace VentilatedSlab {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WaterCoils.cc
+++ b/src/EnergyPlus/WaterCoils.cc
@@ -5989,7 +5989,7 @@ Label10: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WaterCoils.hh
+++ b/src/EnergyPlus/WaterCoils.hh
@@ -930,7 +930,7 @@ namespace WaterCoils {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WaterManager.cc
+++ b/src/EnergyPlus/WaterManager.cc
@@ -1799,7 +1799,7 @@ namespace WaterManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WaterManager.hh
+++ b/src/EnergyPlus/WaterManager.hh
@@ -102,7 +102,7 @@ namespace WaterManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WaterThermalTanks.cc
+++ b/src/EnergyPlus/WaterThermalTanks.cc
@@ -10410,7 +10410,7 @@ namespace WaterThermalTanks {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WaterThermalTanks.hh
+++ b/src/EnergyPlus/WaterThermalTanks.hh
@@ -1605,7 +1605,7 @@ namespace WaterThermalTanks {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WaterUse.cc
+++ b/src/EnergyPlus/WaterUse.cc
@@ -1535,7 +1535,7 @@ namespace WaterUse {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WaterUse.hh
+++ b/src/EnergyPlus/WaterUse.hh
@@ -512,7 +512,7 @@ namespace WaterUse {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WeatherManager.cc
+++ b/src/EnergyPlus/WeatherManager.cc
@@ -9483,7 +9483,7 @@ Label9998: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WeatherManager.hh
+++ b/src/EnergyPlus/WeatherManager.hh
@@ -1464,7 +1464,7 @@ namespace WeatherManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindTurbine.cc
+++ b/src/EnergyPlus/WindTurbine.cc
@@ -1004,7 +1004,7 @@ namespace WindTurbine {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindTurbine.hh
+++ b/src/EnergyPlus/WindTurbine.hh
@@ -274,7 +274,7 @@ namespace WindTurbine {
 	//*****************************************************************************************
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindowAC.cc
+++ b/src/EnergyPlus/WindowAC.cc
@@ -1665,7 +1665,7 @@ namespace WindowAC {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindowAC.hh
+++ b/src/EnergyPlus/WindowAC.hh
@@ -342,7 +342,7 @@ namespace WindowAC {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindowComplexManager.cc
+++ b/src/EnergyPlus/WindowComplexManager.cc
@@ -4209,7 +4209,7 @@ namespace WindowComplexManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindowComplexManager.hh
+++ b/src/EnergyPlus/WindowComplexManager.hh
@@ -310,7 +310,7 @@ namespace WindowComplexManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindowEquivalentLayer.cc
+++ b/src/EnergyPlus/WindowEquivalentLayer.cc
@@ -9464,7 +9464,7 @@ namespace WindowEquivalentLayer {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindowEquivalentLayer.hh
+++ b/src/EnergyPlus/WindowEquivalentLayer.hh
@@ -887,7 +887,7 @@ namespace WindowEquivalentLayer {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindowManager.cc
+++ b/src/EnergyPlus/WindowManager.cc
@@ -8866,7 +8866,7 @@ Label99999: ;
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/WindowManager.hh
+++ b/src/EnergyPlus/WindowManager.hh
@@ -541,7 +541,7 @@ namespace WindowManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
@@ -733,7 +733,7 @@ namespace ZoneAirLoopEquipmentManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.hh
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.hh
@@ -65,7 +65,7 @@ namespace ZoneAirLoopEquipmentManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
@@ -2304,7 +2304,7 @@ namespace ZoneContaminantPredictorCorrector {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneContaminantPredictorCorrector.hh
+++ b/src/EnergyPlus/ZoneContaminantPredictorCorrector.hh
@@ -73,7 +73,7 @@ namespace ZoneContaminantPredictorCorrector {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneDehumidifier.cc
+++ b/src/EnergyPlus/ZoneDehumidifier.cc
@@ -1102,7 +1102,7 @@ namespace ZoneDehumidifier {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneDehumidifier.hh
+++ b/src/EnergyPlus/ZoneDehumidifier.hh
@@ -311,7 +311,7 @@ namespace ZoneDehumidifier {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneEquipmentManager.cc
@@ -5021,7 +5021,7 @@ namespace ZoneEquipmentManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneEquipmentManager.hh
+++ b/src/EnergyPlus/ZoneEquipmentManager.hh
@@ -157,7 +157,7 @@ namespace ZoneEquipmentManager {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZonePlenum.cc
+++ b/src/EnergyPlus/ZonePlenum.cc
@@ -1367,7 +1367,7 @@ namespace ZonePlenum {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZonePlenum.hh
+++ b/src/EnergyPlus/ZonePlenum.hh
@@ -373,7 +373,7 @@ namespace ZonePlenum {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -5910,7 +5910,7 @@ namespace ZoneTempPredictorCorrector {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.hh
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.hh
@@ -331,7 +331,7 @@ namespace ZoneTempPredictorCorrector {
 
 	//     NOTICE
 
-	//     Copyright (c) 1996-2014 The Board of Trustees of the University of Illinois
+	//     Copyright (c) 1996-2015 The Board of Trustees of the University of Illinois
 	//     and The Regents of the University of California through Ernest Orlando Lawrence
 	//     Berkeley National Laboratory.  All rights reserved.
 


### PR DESCRIPTION
The year was supposed to be updated to 2015 with #5035, but somehow that didn't happen.  Anyway, this simply updates all 1996-2014 to 1996-2015 in the EnergyPlus source.

@kbenne You OK merging this comment only change assuming CI comes back happy?
