### PR TITLE
Cleanup bad 8.2 to 8.3 transition comments for slab object

### DIFF
--- a/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
@@ -369,8 +369,9 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
               CASE('SITE:GROUNDDOMAIN')
                 ! Object rename
                 nodiff=.false.
-                CALL GetNewObjectDefInIDD(ObjectName,NwNumArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
+                ! objectname needs to be udpated before the GetNewObject call
                 ObjectName = 'Site:GroundDomain:Slab'
+                CALL GetNewObjectDefInIDD(ObjectName,NwNumArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
                 OutArgs(1:CurArgs)=InArgs(1:CurArgs)
                 
               CASE('GROUNDHEATEXCHANGER:VERTICAL')

--- a/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
@@ -369,6 +369,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
               CASE('SITE:GROUNDDOMAIN')
                 ! Object rename
                 nodiff=.false.
+                CALL GetNewObjectDefInIDD(ObjectName,NwNumArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
                 ObjectName = 'Site:GroundDomain:Slab'
                 OutArgs(1:CurArgs)=InArgs(1:CurArgs)
                 


### PR DESCRIPTION
Fixes #5074

@mmatts Are you able to build (Fortran) Transition 8.2 to 8.3, and run `Transition-V8-2-0-to-V8-3-0 <filename>` where filename is an **8.2** file with `Site:GroundDomain` in it?  
