### PR TITLE
Fix AirflowNerwork Error Output to Report Missing Zone

### DIFF
--- a/src/EnergyPlus/AirflowNetworkBalanceManager.cc
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.cc
@@ -1297,7 +1297,7 @@ namespace AirflowNetworkBalanceManager {
 						MultizoneSurfaceData( i ).NodeNums( 2 ) = j;
 					} else {
 						ShowSevereError( RoutineName + CurrentModuleObject + " = " + MultizoneSurfaceData( i ).SurfName );
-						ShowContinueError( "..Zone = " + Zone( Surface( MultizoneSurfaceData( i ).SurfNum ).Zone ).Name + " is not described in AIRFLOWNETWORK:MULTIZONE:ZONE" );
+						ShowContinueError( "..Zone = " + Zone( Surface( n ).Zone ).Name + " is not described in AIRFLOWNETWORK:MULTIZONE:ZONE" );
 						ErrorsFound = true;
 						continue;
 					}

--- a/src/EnergyPlus/AirflowNetworkBalanceManager.cc
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.cc
@@ -1297,7 +1297,7 @@ namespace AirflowNetworkBalanceManager {
 						MultizoneSurfaceData( i ).NodeNums( 2 ) = j;
 					} else {
 						ShowSevereError( RoutineName + CurrentModuleObject + " = " + MultizoneSurfaceData( i ).SurfName );
-						ShowContinueError( "..Zone = " + Zone( Surface( n ).Zone ).Name + " is not described in AIRFLOWNETWORK:MULTIZONE:ZONE" );
+						ShowContinueError("An adjacent zone = " + Zone(Surface(n).Zone).Name + " is not described in AIRFLOWNETWORK:MULTIZONE:ZONE");
 						ErrorsFound = true;
 						continue;
 					}


### PR DESCRIPTION
GetAirflowNetwork input was not reporting the right zone when a zone was found to not have the necessary Multizone:Zone object. The user's file had two thermal zones and one Multizone:Zone object, and the zone that did have the right objects was reported instead of the zone that did not.

Closes #4282 
