### PR TITLE
Change transition source to configure

### DIFF
--- a/src/Transition/CMakeLists.txt
+++ b/src/Transition/CMakeLists.txt
@@ -99,10 +99,10 @@ LIST(GET VERSIONS ${ii} OLD_VERSION)
 LIST(GET VERSIONS ${i} NEW_VERSION)
 
 # for newer files, we actually configure the file, for older versions we just copy the file over
-IF( EXISTS "${CMAKE_SOURCE_DIR}/src/Transition/CreateNewIDFUsingRulesV${NEW_VERSION}.f90.in" ) 
-  CONFIGURE_FILE( "${CMAKE_SOURCE_DIR}/src/Transition/CreateNewIDFUsingRulesV${NEW_VERSION}.f90.in" "${CMAKE_CURRENT_BINARY_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" )
+IF( EXISTS "${CMAKE_SOURCE_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90.in" ) 
+  CONFIGURE_FILE( "${CMAKE_SOURCE_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90.in" "${CMAKE_CURRENT_BINARY_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" )
 ELSE()
-  CONFIGURE_FILE( "${CMAKE_SOURCE_DIR}/src/Transition/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" "${CMAKE_CURRENT_BINARY_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" COPYONLY)
+  CONFIGURE_FILE( "${CMAKE_SOURCE_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" "${CMAKE_CURRENT_BINARY_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" COPYONLY)
 ENDIF()
 
 # then create all the binaries using just the Transition source and the appropriate version of the main sub

--- a/src/Transition/CMakeLists.txt
+++ b/src/Transition/CMakeLists.txt
@@ -98,10 +98,17 @@ math(EXPR ii "${i} - 1")
 LIST(GET VERSIONS ${ii} OLD_VERSION)
 LIST(GET VERSIONS ${i} NEW_VERSION)
 
+# for newer files, we actually configure the file, for older versions we just copy the file over
+IF( EXISTS "${CMAKE_SOURCE_DIR}/src/Transition/CreateNewIDFUsingRulesV${NEW_VERSION}.f90.in" ) 
+  CONFIGURE_FILE( "${CMAKE_SOURCE_DIR}/src/Transition/CreateNewIDFUsingRulesV${NEW_VERSION}.f90.in" "${CMAKE_CURRENT_BINARY_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" )
+ELSE()
+  CONFIGURE_FILE( "${CMAKE_SOURCE_DIR}/src/Transition/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" "${CMAKE_CURRENT_BINARY_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90" COPYONLY)
+ENDIF()
+
 # then create all the binaries using just the Transition source and the appropriate version of the main sub
 SET(SRC
   Transition.f90
-  CreateNewIDFUsingRulesV${NEW_VERSION}.f90
+  "${CMAKE_CURRENT_BINARY_DIR}/CreateNewIDFUsingRulesV${NEW_VERSION}.f90"
 )
 
 STRING( REPLACE _ - OLD-VERSION ${OLD_VERSION} )

--- a/src/Transition/CreateNewIDFUsingRulesV8_4_0.f90.in
+++ b/src/Transition/CreateNewIDFUsingRulesV8_4_0.f90.in
@@ -12,7 +12,7 @@ SUBROUTINE SetThisVersionVariables()
       VersionNum=8.4
       sVersionNum='8.4'
       IDDFileNameWithPath=TRIM(ProgramPath)//'V8-3-0-Energy+.idd'
-      NewIDDFileNameWithPath=TRIM(ProgramPath)//'V8-4-0-Energy+.idd'
+      NewIDDFileNameWithPath=TRIM(ProgramPath)//'V${CMAKE_VERSION_MAJOR}-${CMAKE_VERSION_MINOR}-${CMAKE_VERSION_PATCH}-Energy+.idd'
       RepVarFileNameWithPath=TRIM(ProgramPath)//'Report Variables 8-3-0 to 8-4-0.csv'
 END SUBROUTINE
 


### PR DESCRIPTION
@mjwitte This changes the transition source so that it is configured to find the proper IDD name (iteration-numbered).  This won't have much of an effect at all on major releases, just for iteration work.  I built this and ran locally and it appears to search for the expected IDDs which I **purposely** didn't create.

Here is the 8.1 to 8.2 version that I didn't touch:

```
$ ./Transition-V8-1-0-to-V8-2-0 
 Transition Starting
 Conversion 8.1 => 8.2
 **  Fatal  ** Energy+.idd missing. Program terminates. Fullname=V8-1-0-Energy+.idd
 ************* Conversion Terminated--Fatal Error Detected. 0 Warning; 0 Severe Errors
 Error messages saved on .VCperr
 Processing Old IDD -- V8-1-0-Energy+.idd
 **  Fatal  ** Energy+.idd missing. Program terminates. Fullname=V8-2-0-Energy+.idd
 ************* Conversion Terminated--Fatal Error Detected. 0 Warning; 0 Severe Errors
 Error messages saved on .VCperr
 Processing New IDD -- V8-2-0-Energy+.idd
```

Here is the 8.3 to **current** version:

```
$ ./Transition-V8-3-0-to-V8-4-0 
 Transition Starting
 Conversion 8.3 => 8.4
 **  Fatal  ** Energy+.idd missing. Program terminates. Fullname=V8-3-0-Energy+.idd
 ************* Conversion Terminated--Fatal Error Detected. 0 Warning; 0 Severe Errors
 Error messages saved on .VCperr
 Processing Old IDD -- V8-3-0-Energy+.idd
 **  Fatal  ** Energy+.idd missing. Program terminates. Fullname=V8-3-4-Energy+.idd
 ************* Conversion Terminated--Fatal Error Detected. 0 Warning; 0 Severe Errors
 Error messages saved on .VCperr
 Processing New IDD -- V8-3-4-Energy+.idd
```

@mjwitte What would you like from me for verification?  Or merge away...
