### PR TITLE
Make "autosize" the default for tube length for ZoneHVAC:LowTemperatureRadiant:*

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -36607,6 +36607,7 @@ ZoneHVAC:LowTemperatureRadiant:VariableFlow,
         \units m
         \minimum> 0
         \autosizable
+        \default autosize
    A5 , \field Temperature Control Type
         \note (Temperature on which unit is controlled)
         \type choice
@@ -36764,6 +36765,7 @@ ZoneHVAC:LowTemperatureRadiant:ConstantFlow,
         \units m
         \minimum> 0
         \autosizable
+        \default autosize
    A5 , \field Temperature Control Type
         \note Temperature used to control system
         \type choice

--- a/src/EnergyPlus/LowTempRadiantSystem.cc
+++ b/src/EnergyPlus/LowTempRadiantSystem.cc
@@ -2212,7 +2212,7 @@ namespace LowTempRadiantSystem {
 					}
 				} else { // Autosize or hard-size with sizing run
 					// assume tube spacing of 15 cm
-					CheckZoneSizing( "ZoneHVAC:LowTemperatureRadiant:VariableFlow", HydrRadSys( RadSysNum ).Name );
+					// CheckZoneSizing( "ZoneHVAC:LowTemperatureRadiant:VariableFlow", HydrRadSys( RadSysNum ).Name );
 					TubeLengthDes = HydrRadSys( RadSysNum ).TotalSurfaceArea / 0.15;
 					if ( IsAutoSize ) {
 						HydrRadSys( RadSysNum ).TubeLength = TubeLengthDes;
@@ -2372,7 +2372,7 @@ namespace LowTempRadiantSystem {
 					}
 				} else {	// Autosize or hard-size with sizing run
 					// assume tube spacing of 15 cm
-					CheckZoneSizing( "ZoneHVAC:LowTemperatureRadiant:ConstantFlow", CFloRadSys( RadSysNum ).Name );
+					// CheckZoneSizing( "ZoneHVAC:LowTemperatureRadiant:ConstantFlow", CFloRadSys( RadSysNum ).Name );
 					TubeLengthDes = CFloRadSys( RadSysNum ).TotalSurfaceArea / 0.15;
 					if (IsAutoSize ) {
 						CFloRadSys( RadSysNum ).TubeLength = TubeLengthDes;


### PR DESCRIPTION
Addresses #4425 
Previously a blank field for Hydronic Tubing Length for ZoneHVAC:LowTemperatureRadiant:\* resulted in zero output (essentially zero tube length) without warning.  This field now defaults to "autosize".
