### PR TITLE
Fixes KindOfSim not being reset after calling FD Ground Temp Model.

### DIFF
--- a/src/EnergyPlus/GroundTemperatureModeling/FiniteDifferenceGroundTemperatureModel.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/FiniteDifferenceGroundTemperatureModel.cc
@@ -161,6 +161,7 @@ namespace EnergyPlus {
 
 		// Save current environment so we can revert back when done
 		int Envrn_reset = Envrn;
+		int KindOfSim_reset = KindOfSim;
 		int TimeStep_reset = TimeStep;
 		int HourOfDay_reset = HourOfDay;
 		bool BeginEnvrnFlag_reset = BeginEnvrnFlag;
@@ -303,6 +304,7 @@ namespace EnergyPlus {
 		// Reset Envrionment when done reading data
 		--NumOfEnvrn; // May need better way of eliminating the extra envrionment that was added to read the data
 		--TotRunPers;
+		KindOfSim = KindOfSim_reset;
 		RPReadAllWeatherData = false;
 		Environment.redimension( NumOfEnvrn );
 		RunPeriodInput.redimension( TotRunPers );


### PR DESCRIPTION
@shorowit found that the Table outputs were not being written after running the FD model. This corrects that issue.
