### PR TITLE
ObjexxFCL Update for Visual C++ 2015 and Intel C++ 2016 Compatibility

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -40,29 +40,36 @@ IF ( MSVC AND NOT ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" ) ) # Visual C++
 ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" ) # g++/Clang
     option(ENABLE_THREAD_SANITIZER "Enable thread sanitizer testing in gcc/clang" FALSE)
     set(LINKER_FLAGS "")
-    if(ENABLE_THREAD_SANITIZER)
-      ADD_CXX_DEFINITIONS(-fsanitize=thread )
-      add_definitions(-ggdb -fno-omit-frame-pointer)
+    if (ENABLE_THREAD_SANITIZER)
+      ADD_CXX_DEFINITIONS("-fsanitize=thread")
+      ADD_DEFINITIONS("-ggdb -fno-omit-frame-pointer")
       set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=thread -ggdb")
     endif()
 
     option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer testing in gcc/clang" FALSE)
-    if(ENABLE_ADDRESS_SANITIZER)
-      ADD_CXX_DEFINITIONS(-fsanitize=address)
-      add_definitions(-ggdb -fno-omit-frame-pointer)
+    if (ENABLE_ADDRESS_SANITIZER)
+      ADD_CXX_DEFINITIONS("-fsanitize=address")
+      ADD_DEFINITIONS("-ggdb -fno-omit-frame-pointer")
       set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=address -ggdb")
     endif()
 
+    option(ENABLE_MEMORY_SANITIZER "Enable reads of unintialized memory sanitizer testing in gcc/clang" FALSE)
+    if (ENABLE_MEMORY_SANITIZER)
+      ADD_CXX_DEFINITIONS("-fsanitize=memory")
+      ADD_DEFINITIONS("-ggdb -fno-omit-frame-pointer")
+      set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=memory -ggdb")
+    endif()
+
     option(ENABLE_UNDEFINED_SANITIZER "Enable undefined behavior sanitizer testing in gcc/clang" FALSE)
-    if(ENABLE_UNDEFINED_SANITIZER)
-      ADD_CXX_DEFINITIONS(-fsanitize=undefined )
-      add_definitions(-ggdb -fno-omit-frame-pointer)
+    if (ENABLE_UNDEFINED_SANITIZER)
+      ADD_CXX_DEFINITIONS("-fsanitize=undefined")
+      ADD_DEFINITIONS("-ggdb -fno-omit-frame-pointer")
       set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=undefined -ggdb")
     endif()
 
     option(ENABLE_COVERAGE "Enable Coverage Reporting in GCC" FALSE)
-    if(ENABLE_COVERAGE)
-      add_definitions(--coverage -O0)
+    if (ENABLE_COVERAGE)
+      ADD_DEFINITIONS("--coverage -O0")
       set(LINKER_FLAGS "${LINKER_FLAGS} --coverage")
     endif()
 
@@ -71,7 +78,7 @@ ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
     if(CMAKE_HOST_UNIX)
       if(NOT APPLE)
         set(LINKER_FLAGS "${LINKER_FLAGS} -pthread")
-        add_definitions(-pthread)
+        ADD_DEFINITIONS("-pthread")
       endif()
     endif()
 
@@ -86,7 +93,7 @@ ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
     ADD_CXX_DEFINITIONS("-ffor-scope")
     ADD_CXX_DEFINITIONS("-Wall -Wextra") # Turn on warnings
     ADD_CXX_DEFINITIONS("-Wno-unknown-pragmas")
-    if( CMAKE_COMPILER_IS_GNUCXX ) # g++
+    if ( CMAKE_COMPILER_IS_GNUCXX ) # g++
       ADD_CXX_DEFINITIONS("-Wno-unused-but-set-parameter -Wno-unused-but-set-variable") # Suppress unused-but-set warnings until more serious ones are addressed
       ADD_CXX_DEFINITIONS("-Wno-maybe-uninitialized")
     elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
@@ -98,7 +105,7 @@ ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
       ADD_CXX_DEBUG_DEFINITIONS("-ffloat-store") # Improve debug run solution stability
       ADD_CXX_DEBUG_DEFINITIONS("-fsignaling-nans") # Disable optimizations that may have concealed NaN behavior
       ADD_CXX_DEBUG_DEFINITIONS("-D_GLIBCXX_DEBUG") # Standard container debug mode (bounds checking, ...)
-    endif ()
+    endif()
 
   ADD_CXX_DEBUG_DEFINITIONS("-ggdb") # Produces debugging information specifically for gdb
 
@@ -107,6 +114,7 @@ ELSEIF ( WIN32 AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
     # Disabled Warnings: Enable some of these as more serious warnings are addressed
     #   177 Variable declared but never referenced
     #   488 Template parameter not used ...
+    #   809 Exception specification consistency warnings that fire in gtest code
     #   869 Parameter never referenced
     #  1786 Use of deprecated items
     #  2259 Non-pointer conversions may lose significant bits
@@ -119,7 +127,7 @@ ELSEIF ( WIN32 AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
     ADD_CXX_DEFINITIONS("/Qcxx-features") # Enables standard C++ features without disabling Microsoft extensions
     ADD_CXX_DEFINITIONS("/Wall") # Enable "all" warnings
     ADD_CXX_DEFINITIONS("/Wp64") # 64-bit warnings
-    ADD_CXX_DEFINITIONS("/Qdiag-disable:177,488,869,1786,2259,3280,11074,11075") # Disable warnings listed above
+    ADD_CXX_DEFINITIONS("/Qdiag-disable:177,488,809,869,1786,2259,3280,11074,11075") # Disable warnings listed above
     ADD_CXX_DEFINITIONS("/DNOMINMAX") # Avoid build errors due to STL/Windows min-max conflicts
     ADD_CXX_DEFINITIONS("/DWIN32_LEAN_AND_MEAN") # Excludes rarely used services and headers from compilation
 
@@ -151,6 +159,7 @@ ELSEIF ( UNIX AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
     # Disabled Warnings: Enable some of these as more serious warnings are addressed
     #   177 Variable declared but never referenced
     #   488 Template parameter not used ...
+    #   809 Exception specification consistency warnings that fire in gtest code
     #   869 Parameter never referenced
     #  1786 Use of deprecated items
     #  2259 Non-pointer conversions may lose significant bits
@@ -162,7 +171,7 @@ ELSEIF ( UNIX AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
     ADD_CXX_DEFINITIONS("-std=c++11") # Specify C++11 language
     ADD_CXX_DEFINITIONS("-Wall") # Enable "all" warnings
     ADD_CXX_DEFINITIONS("-Wp64") # 64-bit warnings
-    ADD_CXX_DEFINITIONS("-diag-disable:177,488,869,1786,2259,3280,11074,11075") # Disable warnings listed above
+    ADD_CXX_DEFINITIONS("-diag-disable:177,488,809,869,1786,2259,3280,11074,11075") # Disable warnings listed above
 
     IF(NOT APPLE)
       ADD_CXX_DEFINITIONS(-pthread)

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
@@ -1712,16 +1712,6 @@ public: // Modifier
 		return *this;
 	}
 
-	// Assign Default Value to all Elements
-	inline
-	virtual
-	Array &
-	to_default()
-	{
-		if ( data_ ) std::fill_n( data_, size_, Traits::initial_array_value() );
-		return *this;
-	}
-
 	// Assign Zero to all Elements
 	//  Can't be virtual (for covariant return) or will try to instantiate for all value types
 	inline

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
@@ -1594,15 +1594,6 @@ public: // Modifier
 		return *this;
 	}
 
-	// Assign Default Value to all Elements
-	inline
-	Array1 &
-	to_default()
-	{
-		Super::to_default();
-		return *this;
-	}
-
 	// Normalize to Unit Length
 	inline
 	Array1 &

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
@@ -1292,15 +1292,6 @@ public: // Modifier
 		return *this;
 	}
 
-	// Assign Default Value to all Elements
-	inline
-	Array2 &
-	to_default()
-	{
-		Super::to_default();
-		return *this;
-	}
-
 	// Set to the Identity Matrix
 	inline
 	Array2 &

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
@@ -1483,15 +1483,6 @@ public: // Modifier
 		return *this;
 	}
 
-	// Assign Default Value to all Elements
-	inline
-	Array3 &
-	to_default()
-	{
-		Super::to_default();
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
@@ -1850,15 +1850,6 @@ public: // Modifier
 		return *this;
 	}
 
-	// Assign Default Value to all Elements
-	inline
-	Array4 &
-	to_default()
-	{
-		Super::to_default();
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
@@ -2535,15 +2535,6 @@ public: // Modifier
 		return *this;
 	}
 
-	// Assign Default Value to all Elements
-	inline
-	Array5 &
-	to_default()
-	{
-		Super::to_default();
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
@@ -3766,15 +3766,6 @@ public: // Modifier
 		return *this;
 	}
 
-	// Assign Default Value to all Elements
-	inline
-	Array6 &
-	to_default()
-	{
-		Super::to_default();
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.hh
@@ -1113,17 +1113,6 @@ public: // Inspector
 
 public: // Modifier
 
-	// Assign Default Value to all Elements
-	inline
-	MArray1 &
-	to_default()
-	{
-		for ( int i = 1, e = u(); i <= e; ++i ) {
-			operator ()( i ) = Traits::initial_value();
-		}
-		return *this;
-	}
-
 	// Normalize to Unit Length
 	inline
 	MArray1 &

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.hh
@@ -539,21 +539,6 @@ public: // Inspector
 		return array_.isize2();
 	}
 
-public: // Modifier
-
-	// Assign Default Value to all Elements
-	inline
-	MArray2 &
-	to_default()
-	{
-		for ( int i1 = 1, e1 = u1(); i1 <= e1; ++i1 ) {
-			for ( int i2 = 1, e2 = u2(); i2 <= e2; ++i2 ) {
-				operator ()( i1, i2 ) = Traits::initial_value();
-			}
-		}
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.hh
@@ -623,23 +623,6 @@ public: // Inspector
 		return array_.isize3();
 	}
 
-public: // Modifier
-
-	// Assign Default Value to all Elements
-	inline
-	MArray3 &
-	to_default()
-	{
-		for ( int i1 = 1, e1 = u1(); i1 <= e1; ++i1 ) {
-			for ( int i2 = 1, e2 = u2(); i2 <= e2; ++i2 ) {
-				for ( int i3 = 1, e3 = u3(); i3 <= e3; ++i3 ) {
-					operator ()( i1, i2, i3 ) = Traits::initial_value();
-				}
-			}
-		}
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.hh
@@ -705,25 +705,6 @@ public: // Inspector
 		return array_.isize4();
 	}
 
-public: // Modifier
-
-	// Assign Default Value to all Elements
-	inline
-	MArray4 &
-	to_default()
-	{
-		for ( int i1 = 1, e1 = u1(); i1 <= e1; ++i1 ) {
-			for ( int i2 = 1, e2 = u2(); i2 <= e2; ++i2 ) {
-				for ( int i3 = 1, e3 = u3(); i3 <= e3; ++i3 ) {
-					for ( int i4 = 1, e4 = u4(); i4 <= e4; ++i4 ) {
-						operator ()( i1, i2, i3, i4 ) = Traits::initial_value();
-					}
-				}
-			}
-		}
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.hh
@@ -787,27 +787,6 @@ public: // Inspector
 		return array_.isize5();
 	}
 
-public: // Modifier
-
-	// Assign Default Value to all Elements
-	inline
-	MArray5 &
-	to_default()
-	{
-		for ( int i1 = 1, e1 = u1(); i1 <= e1; ++i1 ) {
-			for ( int i2 = 1, e2 = u2(); i2 <= e2; ++i2 ) {
-				for ( int i3 = 1, e3 = u3(); i3 <= e3; ++i3 ) {
-					for ( int i4 = 1, e4 = u4(); i4 <= e4; ++i4 ) {
-						for ( int i5 = 1, e5 = u5(); i5 <= e5; ++i5 ) {
-							operator ()( i1, i2, i3, i4, i5 ) = Traits::initial_value();
-						}
-					}
-				}
-			}
-		}
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.hh
@@ -869,29 +869,6 @@ public: // Inspector
 		return array_.isize6();
 	}
 
-public: // Modifier
-
-	// Assign Default Value to all Elements
-	inline
-	MArray6 &
-	to_default()
-	{
-		for ( int i1 = 1, e1 = u1(); i1 <= e1; ++i1 ) {
-			for ( int i2 = 1, e2 = u2(); i2 <= e2; ++i2 ) {
-				for ( int i3 = 1, e3 = u3(); i3 <= e3; ++i3 ) {
-					for ( int i4 = 1, e4 = u4(); i4 <= e4; ++i4 ) {
-						for ( int i5 = 1, e5 = u5(); i5 <= e5; ++i5 ) {
-							for ( int i6 = 1, e6 = u6(); i6 <= e6; ++i6 ) {
-								operator ()( i1, i2, i3, i4, i5, i6 ) = Traits::initial_value();
-							}
-						}
-					}
-				}
-			}
-		}
-		return *this;
-	}
-
 public: // MArray Generators
 
 	// Template Helpers

--- a/third_party/ObjexxFCL/src/ObjexxFCL/fmt.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/fmt.cc
@@ -19,6 +19,16 @@
 namespace ObjexxFCL {
 namespace fmt {
 
+// Globals
+fmt::Binary_num_put * binary_num_put( new fmt::Binary_num_put );
+fmt::Exponent_num_put * exponent_num_put( new fmt::Exponent_num_put );
+fmt::Engineering_num_put * engineering_num_put( new fmt::Engineering_num_put );
+fmt::Scientific_num_put * scientific_num_put( new fmt::Scientific_num_put );
+std::locale const binary_locale( std::locale(), binary_num_put );
+std::locale const exponent_locale( std::locale(), exponent_num_put );
+std::locale const engineering_locale( std::locale(), engineering_num_put );
+std::locale const scientific_locale( std::locale(), scientific_num_put );
+
 // Input /////
 
 // Input a Skip from Stream

--- a/third_party/ObjexxFCL/src/ObjexxFCL/fmt.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/fmt.hh
@@ -31,6 +31,7 @@
 #include <iomanip>
 #include <istream>
 #include <limits>
+#include <locale>
 #include <sstream>
 #include <string>
 
@@ -49,6 +50,16 @@ typedef  std::size_t  Size;
 
 // Constants
 static Size const NOSIZE = static_cast< Size >( -1 );
+
+// Globals
+extern fmt::Binary_num_put * binary_num_put;
+extern fmt::Exponent_num_put * exponent_num_put;
+extern fmt::Engineering_num_put * engineering_num_put;
+extern fmt::Scientific_num_put * scientific_num_put;
+extern std::locale const binary_locale;
+extern std::locale const exponent_locale;
+extern std::locale const engineering_locale;
+extern std::locale const scientific_locale;
 
 // Input /////
 
@@ -172,12 +183,11 @@ inline
 std::string
 B( T const & t, Size w = TraitsB< T >::w, Size const m = 0ul )
 {
-	static std::locale const loc( std::locale(), new fmt::Binary_num_put );
 	if ( w == NOSIZE ) w = TraitsB< T >::w;
 	std::ostringstream stream;
 	if ( w > 0ul ) stream << std::setw( m > 0ul ? std::min( m, w ) : w );
 	if ( m > 0ul ) stream << std::setfill( '0' );
-	stream.imbue( loc );
+	stream.imbue( binary_locale );
 	stream << t;
 	return ( w > 0ul ? lpadded( stream.str(), w ) : stream.str() );
 }
@@ -257,15 +267,13 @@ F( std::complex< T > const & c, Size const w = TraitsF< T >::w, Size const d = T
 template< typename T >
 inline
 std::string
-E( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e = TraitsE< T >::e, int const k = 0 )
+E( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size const e = TraitsE< T >::e, int const k = 0 )
 {
-	static auto np( new fmt::Exponent_num_put );
-	static std::locale const loc( std::locale(), np );
 	if ( w == NOSIZE ) w = TraitsE< T >::w;
 	if ( w == 0ul ) return std::string();
-	np->set( d, e, k );
+	exponent_num_put->set( d, e, k );
 	std::ostringstream stream;
-	stream.imbue( loc );
+	stream.imbue( exponent_locale );
 	stream << std::showpoint << std::uppercase << std::setw( w ) << t;
 	return stream.str();
 }
@@ -274,7 +282,7 @@ E( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e
 template< typename T >
 inline
 std::string
-E( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e = TraitsE< T >::e, int const k = 0 )
+E( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size const e = TraitsE< T >::e, int const k = 0 )
 {
 	return '(' + E( c.real(), w, d, e, k ) + ',' + E( c.imag(), w, d, e, k ) + ')';
 }
@@ -283,15 +291,13 @@ E( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = T
 template< typename T >
 inline
 std::string
-D( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e = TraitsE< T >::e, int const k = 0 )
+D( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size const e = TraitsE< T >::e, int const k = 0 )
 {
-	static auto np( new fmt::Exponent_num_put );
-	static std::locale const loc( std::locale(), np );
 	if ( w == NOSIZE ) w = TraitsE< T >::w;
 	if ( w == 0ul ) return std::string();
-	np->set( d, e, k, 'D' );
+	exponent_num_put->set( d, e, k, 'D' );
 	std::ostringstream stream;
-	stream.imbue( loc );
+	stream.imbue( exponent_locale );
 	stream << std::showpoint << std::uppercase << std::setw( w ) << t;
 	return stream.str();
 }
@@ -300,7 +306,7 @@ D( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e
 template< typename T >
 inline
 std::string
-D( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e = TraitsE< T >::e, int const k = 0 )
+D( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size const e = TraitsE< T >::e, int const k = 0 )
 {
 	return '(' + D( c.real(), w, d, e, k ) + ',' + D( c.imag(), w, d, e, k ) + ')';
 }
@@ -309,15 +315,13 @@ D( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = T
 template< typename T >
 inline
 std::string
-EN( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e = TraitsE< T >::e )
+EN( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size const e = TraitsE< T >::e )
 {
-	static auto np( new fmt::Engineering_num_put );
-	static std::locale const loc( std::locale(), np );
 	if ( w == NOSIZE ) w = TraitsE< T >::w;
 	if ( w == 0ul ) return std::string();
-	np->set( d, e );
+	engineering_num_put->set( d, e );
 	std::ostringstream stream;
-	stream.imbue( loc );
+	stream.imbue( engineering_locale );
 	stream << std::showpoint << std::uppercase << std::setw( w ) << t;
 	return stream.str();
 }
@@ -326,7 +330,7 @@ EN( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size 
 template< typename T >
 inline
 std::string
-EN( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e = TraitsE< T >::e )
+EN( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size const e = TraitsE< T >::e )
 {
 	return '(' + EN( c.real(), w, d, e ) + ',' + EN( c.imag(), w, d, e ) + ')';
 }
@@ -335,15 +339,13 @@ EN( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = 
 template< typename T >
 inline
 std::string
-ES( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e = TraitsE< T >::e )
+ES( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size const e = TraitsE< T >::e )
 {
-	static auto np( new fmt::Scientific_num_put );
-	static std::locale const loc( std::locale(), np );
 	if ( w == NOSIZE ) w = TraitsE< T >::w;
 	if ( w == 0ul ) return std::string();
-	np->set( d, e );
+	scientific_num_put->set( d, e );
 	std::ostringstream stream;
-	stream.imbue( loc );
+	stream.imbue( scientific_locale );
 	stream << std::showpoint << std::uppercase << std::setw( w ) << t;
 	return stream.str();
 }
@@ -352,7 +354,7 @@ ES( T const & t, Size w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size 
 template< typename T >
 inline
 std::string
-ES( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size e = TraitsE< T >::e )
+ES( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = TraitsE< T >::d, Size const e = TraitsE< T >::e )
 {
 	return '(' + ES( c.real(), w, d, e ) + ',' + ES( c.imag(), w, d, e ) + ')';
 }
@@ -361,7 +363,7 @@ ES( std::complex< T > const & c, Size const w = TraitsE< T >::w, Size const d = 
 template< typename T >
 inline
 std::string
-G( T const & t, Size w = TraitsG< T >::w, Size const d = TraitsG< T >::d, Size e = TraitsG< T >::e, int const k = 0 )
+G( T const & t, Size w = TraitsG< T >::w, Size const d = TraitsG< T >::d, Size const e = TraitsG< T >::e, int const k = 0 )
 {
 	if ( w == NOSIZE ) w = TraitsG< T >::w;
 	if ( std::numeric_limits< T >::is_integer ) { // Integer

--- a/third_party/ObjexxFCL/src/ObjexxFCL/fmt.manipulators.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/fmt.manipulators.hh
@@ -14,11 +14,13 @@
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 
 // C++ Headers
+#include <algorithm>
 #include <climits>
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
 #include <iomanip>
+#include <locale>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -128,7 +130,7 @@ struct Binary_num_put : std::num_put< char >
 		return binary_do_put( out, str, fill, v );
 	}
 
-private: // Static Methods
+private: // Methods
 
 	inline
 	static
@@ -263,7 +265,7 @@ public: // Custom methods
 		E_ = E;
 	}
 
-private: // Static Methods
+private: // Methods
 
 	inline
 	static
@@ -445,7 +447,7 @@ public: // Custom methods
 		e_ = e;
 	}
 
-private: // Static Methods
+private: // Methods
 
 	inline
 	static
@@ -599,7 +601,7 @@ public: // Custom methods
 		e_ = e;
 	}
 
-private: // Static Methods
+private: // Methods
 
 	inline
 	static

--- a/third_party/ObjexxFCL/tst/unit/Array.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array.unit.cc
@@ -30,7 +30,6 @@ TEST( ArrayTest, DefaultConstruction )
 	EXPECT_EQ( 0u, A.size() );
 	A.zero(); // Now safe against VC Checked Iterators
 	EXPECT_EQ( 0u, A.size() );
-	EXPECT_TRUE( eq( A.to_default(), B ) ); // Now safe against VC Checked Iterators
 }
 
 TEST( ArrayTest, Construction2DIndexRangeInitializerList )

--- a/third_party/ObjexxFCL/tst/unit/Array2.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array2.unit.cc
@@ -1745,26 +1745,6 @@ TEST( Array2Test, ModifierClear )
 	EXPECT_FALSE( A3.initializer_active() );
 }
 
-TEST( Array2Test, ModifierToDefault )
-{
-	// Changes nothing about an empty array
-	Array2D_int A1;
-	A1.to_default();
-	EXPECT_TRUE( eq( Array2D_int(), A1 ) );
-
-	// Zeroes out an uninitialized array
-	Array2D_int A2( 2, 3 );
-	EXPECT_FALSE( A2.initializer_active() );
-	A2.to_default(); // Default value assigned depends on macros
-	EXPECT_FALSE( A2.initializer_active() );
-
-	// Zeroes out (not initializes) an initialized array
-	Array2D_int A3( 2, 3, 31459 );
-	EXPECT_TRUE( A3.initializer_active() );
-	A3.to_default(); // Default value assigned depends on macros
-	EXPECT_TRUE( A3.initializer_active() );
-}
-
 TEST( Array2Test, ModifierZero )
 {
 	// Changes nothing about an empty array

--- a/third_party/ObjexxFCL/tst/unit/Print.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Print.unit.cc
@@ -141,7 +141,11 @@ TEST_F( PrintTest, PrintLD_1E_Big )
 {
 	Print( "*" ) << 8.0e-309; // Intel C++ says this underflows
 #ifdef _MSC_VER // Overflow
+#if _MSC_VER < 1900
 	EXPECT_EQ( "  1.#INF00000000000E-309\n", buf.str() );
+#else
+	EXPECT_EQ( "                infE-309\n", buf.str() );
+#endif
 #else
 	EXPECT_EQ( "  8.000000000000000E-309\n", buf.str() );
 #endif


### PR DESCRIPTION
This adds support for these two new Windows compiler releases. In my quick testing so far, with these changes those compilers seem to work for EnergyPlus. Merging this for the upcoming 8.4 release depends on whether we expect users who do their own builds from release sources will want to use these compilers before the following release.

Visual C++ 2015:
- Format of INF floating point values changed requiring an adjustment to a Print unit test

Intel C++ 2016 (Windows):
- Bug (reported) with static std::locale objects and stream imbue calls worked-around in ObjexxFCL::fmt
- Disabled warning 809 to suppress bogus messages about exception specs for virtual destructors (Intel knows about this and will fix it)

General:
- Dropped the Array::to_default() methods (not used in EnergyPlus) to eliminate issue with builtin type members that aren't initialized in the default constructor (sanitizers would complain about the assignment of an uninitialized value)

CMake:
- A few minor tweaks/fixups in the sanitizer setup
