### PR TITLE
Fix controller mechanical ventilation array bounds error

### DIFF
--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -217,6 +217,28 @@ namespace MixedAir {
 		bool InitOAControllerOneTimeFlag( true );
 		bool InitOAControllerSetPointCheckFlag( true );
 		bool InitOAControllerSetUpAirLoopHVACVariables( true );
+		Array1D_string DesignSpecOAObjName; // name of the design specification outdoor air object
+		Array1D_int DesignSpecOAObjIndex; // index of the design specification outdoor air object
+		Array1D_string VentMechZoneName; // Zone or Zone List to apply mechanical ventilation rate
+		Array1D< Real64 > VentMechZoneOAAreaRate; // Mechanical ventilation rate (m3/s/m2) for zone or zone list
+		Array1D< Real64 > VentMechZoneOAPeopleRate; // Mechanical ventilation rate (m3/s/person) for zone or zone list
+		Array1D< Real64 > VentMechZoneOAFlow; // Mechanical ventilation rate (m3/s/person) for zone or zone list
+		Array1D< Real64 > VentMechZoneOAACH; // Mechanical ventilation rate (m3/s/person) for zone or zone list
+
+		Array1D< Real64 > VentMechZoneADEffCooling; // Zone air distribution effectiveness in cooling mode
+		// for each zone or zone list
+		Array1D< Real64 > VentMechZoneADEffHeating; // Zone air distribution effectiveness in heating mode
+		// for each zone or zone list
+		Array1D_int VentMechZoneADEffSchPtr; // Pointer to the zone air distribution effectiveness schedule
+		// for each zone or zone list
+		Array1D_string VentMechZoneADEffSchName; // Zone air distribution effectiveness
+		//  schedule name for each zone or zone list
+
+		Array1D< Real64 > VentMechZoneSecondaryRecirculation; // Zone air secondary recirculation ratio
+		//  for each zone or zone list
+		Array1D_string DesignSpecZoneADObjName; // name of the design specification zone air
+		//  distribution object for each zone or zone list
+		Array1D_int DesignSpecZoneADObjIndex; // index of the design specification zone air distribution object
 	}
 	//SUBROUTINE SPECIFICATIONS FOR MODULE MixedAir
 	// Driver/Manager Routines
@@ -307,6 +329,21 @@ namespace MixedAir {
 		OAController.deallocate();
 		OAMixer.deallocate();
 		VentilationMechanical.deallocate();
+		VentMechZoneName.deallocate();
+		DesignSpecOAObjName.deallocate();
+		DesignSpecOAObjIndex.deallocate();
+		VentMechZoneOAFlow.deallocate();
+		VentMechZoneOAACH.deallocate();
+		VentMechZoneOAAreaRate.deallocate();
+		VentMechZoneOAPeopleRate.deallocate();
+		VentMechZoneADEffSchName.deallocate();
+		VentMechZoneADEffCooling.deallocate();
+		VentMechZoneADEffHeating.deallocate();
+		VentMechZoneADEffSchPtr.deallocate();
+		VentMechZoneADEffSchName.deallocate();
+		VentMechZoneSecondaryRecirculation.deallocate();
+		DesignSpecZoneADObjName.deallocate();
+		DesignSpecZoneADObjIndex.deallocate();
 	}
 
 	void
@@ -1258,29 +1295,6 @@ namespace MixedAir {
 		static int Num( 0 ); // Index used to loop through controllers in list
 		static int SysNum( 0 ); // Index used to loop through OA systems
 		static Real64 DesSupplyVolFlowRate( 0.0 ); // Temporary variable for design supply volumetric flow rate for air loop (m3/s)
-		Array1D_string DesignSpecOAObjName; // name of the design specification outdoor air object
-		Array1D_int DesignSpecOAObjIndex; // index of the design specification outdoor air object
-		Array1D_string VentMechZoneName; // Zone or Zone List to apply mechanical ventilation rate
-		Array1D< Real64 > VentMechZoneOAAreaRate; // Mechanical ventilation rate (m3/s/m2) for zone or zone list
-		Array1D< Real64 > VentMechZoneOAPeopleRate; // Mechanical ventilation rate (m3/s/person) for zone or zone list
-		Array1D< Real64 > VentMechZoneOAFlow; // Mechanical ventilation rate (m3/s/person) for zone or zone list
-		Array1D< Real64 > VentMechZoneOAACH; // Mechanical ventilation rate (m3/s/person) for zone or zone list
-
-		Array1D< Real64 > VentMechZoneADEffCooling; // Zone air distribution effectiveness in cooling mode
-		// for each zone or zone list
-		Array1D< Real64 > VentMechZoneADEffHeating; // Zone air distribution effectiveness in heating mode
-		// for each zone or zone list
-		Array1D_int VentMechZoneADEffSchPtr; // Pointer to the zone air distribution effectiveness schedule
-		// for each zone or zone list
-		Array1D_string VentMechZoneADEffSchName; // Zone air distribution effectiveness
-		//  schedule name for each zone or zone list
-
-		Array1D< Real64 > VentMechZoneSecondaryRecirculation; // Zone air secondary recirculation ratio
-		//  for each zone or zone list
-		Array1D_string DesignSpecZoneADObjName; // name of the design specification zone air
-		//  distribution object for each zone or zone list
-		Array1D_int DesignSpecZoneADObjIndex; // index of the design specification zone air distribution object
-
 		static int ObjIndex( 0 );
 		static int EquipListIndex( 0 );
 		static int EquipNum( 0 );

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -3192,8 +3192,13 @@ namespace MixedAir {
 						ZoneNum = vent_mech.Zone( ZoneIndex );
 
 						// ZoneIntGain(ZoneNum)%NOFOCC is the number of occupants of a zone at each time step, already counting the occupant schedule
-						int OAFlowMethod = OARequirements( vent_mech.ZoneDesignSpecOAObjIndex( ZoneIndex ) ).OAFlowMethod;
-						if ( OAFlowMethod == OAFlowPPer || OAFlowMethod == OAFlowSum || OAFlowMethod == OAFlowMax ) {
+						if( vent_mech.ZoneDesignSpecOAObjIndex(ZoneIndex) > 0 ) {
+							int OAFlowMethod = OARequirements( vent_mech.ZoneDesignSpecOAObjIndex( ZoneIndex ) ).OAFlowMethod;
+							if ( OAFlowMethod == OAFlowPPer || OAFlowMethod == OAFlowSum || OAFlowMethod == OAFlowMax ) {
+								TotalPeopleOAFlow += ZoneIntGain( ZoneNum ).NOFOCC * Zone( ZoneNum ).Multiplier * Zone( ZoneNum ).ListMultiplier * vent_mech.ZoneOAPeopleRate( ZoneIndex );
+							}
+						} else {
+							// use default value if design specification object is missing
 							TotalPeopleOAFlow += ZoneIntGain( ZoneNum ).NOFOCC * Zone( ZoneNum ).Multiplier * Zone( ZoneNum ).ListMultiplier * vent_mech.ZoneOAPeopleRate( ZoneIndex );
 						}
 					}
@@ -3711,7 +3716,7 @@ namespace MixedAir {
 								ZoneOABZ = 0.0;
 							}}
 						} else {
-							ZoneOABZ = 0.0;
+							ZoneOABZ = ZoneOAPeople;
 						}
 
 						if ( VentilationMechanical( VentMechObjectNum ).SystemOAMethod == SOAM_ZoneSum ) {

--- a/tst/EnergyPlus/unit/MixedAir.unit.cc
+++ b/tst/EnergyPlus/unit/MixedAir.unit.cc
@@ -7,9 +7,12 @@
 #include <EnergyPlus/MixedAir.hh>
 #include <EnergyPlus/DataContaminantBalance.hh>
 #include <EnergyPlus/DataAirLoop.hh>
+#include <EnergyPlus/DataGlobals.hh>
 #include <EnergyPlus/DataSizing.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
+#include <EnergyPlus/HeatBalanceManager.hh>
 #include <EnergyPlus/ScheduleManager.hh>
+#include <EnergyPlus/SizingManager.hh>
 #include <EnergyPlus/DataEnvironment.hh>
 #include <EnergyPlus/DataZoneEquipment.hh>
 #include <EnergyPlus/DataLoopNode.hh>
@@ -28,6 +31,8 @@ using namespace EnergyPlus::DataEnvironment;
 using namespace EnergyPlus::DataZoneEquipment;
 using namespace EnergyPlus::DataLoopNode;
 using namespace EnergyPlus::DataZoneEnergyDemands;
+using namespace EnergyPlus::HeatBalanceManager;
+using namespace EnergyPlus::SizingManager;
 
 namespace EnergyPlus {
 
@@ -242,16 +247,136 @@ namespace EnergyPlus {
 		EXPECT_NEAR( 0.0194359, OAController( 1 ).OAMassFlow, 0.00001 );
 		EXPECT_NEAR( 0.009527, OAController( 1 ).MinOAFracLimit, 0.00001 );
 
-		People.deallocate( );
-		AirLoopControlInfo.deallocate( );
-		OARequirements.deallocate( );
-		ZoneAirDistribution.deallocate( );
-		Zone.deallocate( );
-		AirLoopFlow.deallocate( );
-		ZoneAirCO2.deallocate( );
-		ZoneCO2GainFromPeople.deallocate( );
-		ZoneEquipConfig.deallocate( );
-		Node.deallocate( );
-		ZoneSysEnergyDemand.deallocate( );
+		ZoneAirCO2.deallocate();
+		ZoneCO2GainFromPeople.deallocate();
+	}
+
+	TEST_F( HVACFixture, MissingDesignOccupancyTest )
+	{
+
+		bool ErrorsFound( false );
+		
+		std::string const idf_objects = delimited_string( {
+			"Version,8.3;",
+
+			"Zone,",
+			"  WEST ZONE,              !- Name",
+			"  0,                      !- Direction of Relative North{ deg }",
+			"  0,                      !- X Origin{ m }",
+			"  0,                      !- Y Origin{ m }",
+			"  0,                      !- Z Origin{ m }",
+			"  1,                      !- Type",
+			"  1,                      !- Multiplier",
+			"  autocalculate,          !- Ceiling Height{ m }",
+			"  autocalculate;          !- Volume{ m3 }",
+
+			"Sizing:Zone,",
+			"  WEST ZONE,              !- Zone or ZoneList Name",
+			"  SupplyAirTemperature,   !- Zone Cooling Design Supply Air Temperature Input Method",
+			"  14,                     !- Zone Cooling Design Supply Air Temperature{ C }",
+			"  ,                       !- Zone Cooling Design Supply Air Temperature Difference{ deltaC }",
+			"  SupplyAirTemperature,   !- Zone Heating Design Supply Air Temperature Input Method",
+			"  40,                     !- Zone Heating Design Supply Air Temperature{ C }",
+			"  ,                       !- Zone Heating Design Supply Air Temperature Difference{ deltaC }",
+			"  0.0085,                 !- Zone Cooling Design Supply Air Humidity Ratio{ kgWater / kgDryAir }",
+			"  0.008,                  !- Zone Heating Design Supply Air Humidity Ratio{ kgWater / kgDryAir }",
+			"  ,                       !- Design Specification Outdoor Air Object Name",
+			"  ,                       !- Zone Heating Sizing Factor",
+			"  ,                       !- Zone Cooling Sizing Factor",
+			"  DesignDay,              !- Cooling Design Air Flow Method",
+			"  0,                      !- Cooling Design Air Flow Rate{ m3 / s }",
+			"  0.000762,               !- Cooling Minimum Air Flow per Zone Floor Area{ m3 / s - m2 }",
+			"  0,                      !- Cooling Minimum Air Flow{ m3 / s }",
+			"  0,                      !- Cooling Minimum Air Flow Fraction",
+			"  DesignDay,              !- Heating Design Air Flow Method",
+			"  0,                      !- Heating Design Air Flow Rate{ m3 / s }",
+			"  0.002032,               !- Heating Maximum Air Flow per Zone Floor Area{ m3 / s - m2 }",
+			"  0.1415762,              !- Heating Maximum Air Flow{ m3 / s }",
+			"  0.3,                    !- Heating Maximum Air Flow Fraction",
+			"  West Zone Design Spec Zone Air Dist; !- Design Specification Zone Air Distribution Object Name",
+
+			"  OutdoorAir:Node,",
+			"    Outside Air Inlet Node; !- Name",
+			"  Schedule:Constant,",
+			"    VentSchedule,           !- Name",
+			"     ,                      !- Schedule Type Limits Name",
+			"     1;                     !- Hourly value",
+			"  Schedule:Constant,",
+			"    ZoneADEffSch,           !- Name",
+			"     ,                      !- Schedule Type Limits Name",
+			"     1;                     !- Hourly value",
+			"  Schedule:Constant,",
+			"    OAFractionSched,        !- Name",
+			"     ,                      !- Schedule Type Limits Name",
+			"     1;                     !- Hourly value",
+			"  Schedule:Constant,",
+			"    CO2AvailSchedule,       !- Name",
+			"     ,                      !- Schedule Type Limits Name",
+			"     1.0;                   !- Hourly value",
+
+			"  Controller:OutdoorAir,",
+			"    OA Controller 1,        !- Name",
+			"    Relief Air Outlet Node, !- Relief Air Outlet Node Name",
+			"    Outdoor Air Mixer Inlet Node, !- Return Air Node Name",
+			"    Mixed Air Node,         !- Mixed Air Node Name",
+			"    Outside Air Inlet Node, !- Actuator Node Name",
+			"    0.0,                    !- Minimum Outdoor Air Flow Rate{ m3 / s }",
+			"    1.7,                    !- Maximum Outdoor Air Flow Rate{ m3 / s }",
+			"    NoEconomizer,           !- Economizer Control Type",
+			"    ModulateFlow,           !- Economizer Control Action Type",
+			"    ,                       !- Economizer Maximum Limit Dry - Bulb Temperature{ C }",
+			"    ,                       !- Economizer Maximum Limit Enthalpy{ J / kg }",
+			"    ,                       !- Economizer Maximum Limit Dewpoint Temperature{ C }",
+			"    ,                       !- Electronic Enthalpy Limit Curve Name",
+			"    ,                       !- Economizer Minimum Limit Dry - Bulb Temperature{ C }",
+			"    NoLockout,              !- Lockout Type",
+			"    FixedMinimum,           !- Minimum Limit Type",
+			"    OAFractionSched,        !- Minimum Outdoor Air Schedule Name",
+			"    ,                       !- Minimum Fraction of Outdoor Air Schedule Name",
+			"    ,                       !- Maximum Fraction of Outdoor Air Schedule Name",
+			"    DCVObject;              !- Mechanical Ventilation Controller Name",
+
+			"  Controller:MechanicalVentilation,",
+			"    DCVObject, !- Name",
+			"    VentSchedule, !- Availability Schedule Name",
+			"    Yes, !- Demand Controlled Ventilation",
+			"    ZoneSum, !- System Outdoor Air Method",
+			"     , !- Zone Maximum Outdoor Air Fraction{ dimensionless }",
+			"    WEST ZONE, !- Zone 1 Name",
+			"    , !- Design Specification Outdoor Air Object Name 1",
+			"    West Zone Design Spec Zone Air Dist; !- Design Specification Zone Air Distribution Object Name 1",
+
+			"DesignSpecification:ZoneAirDistribution,",
+			"  West Zone Design Spec Zone Air Dist, !- Name",
+			"  1, !- Zone Air Distribution Effectiveness in Cooling Mode{ dimensionless }",
+			"  1; !- Zone Air Distribution Effectiveness in Heating Mode{ dimensionless }",
+		} );
+
+
+		ASSERT_FALSE( process_idf( idf_objects ) );
+
+		AirLoopControlInfo.allocate( 1 );
+		AirLoopControlInfo( 1 ).LoopFlowRateSet = true;
+		OARequirements.allocate( 1 );
+		ZoneAirDistribution.allocate( 1 );
+		ZoneAirDistribution( 1 ).Name = "CM DSZAD WEST ZONE";
+		ZoneAirDistribution( 1 ).ZoneADEffSchPtr = 4;
+
+		AirLoopFlow.allocate( 1 );
+		AirLoopFlow( 1 ).OAFrac = 0.01; // DataAirLoop variable (AirloopHVAC)
+		AirLoopFlow( 1 ).OAMinFrac = 0.01; // DataAirLoop variable (AirloopHVAC)
+
+		GetZoneData( ErrorsFound ); // read zone data
+		EXPECT_FALSE( ErrorsFound ); // expect no errors
+		GetZoneAirDistribution();
+		GetZoneSizingInput();
+		DataGlobals::DoZoneSizing = true;
+		GetOAControllerInputs();
+
+		EXPECT_EQ( 0.00944, VentilationMechanical( 1 ).ZoneOAPeopleRate( 1 ) );
+		EXPECT_EQ( 0.00, VentilationMechanical( 1 ).ZoneOAAreaRate( 1 ) );
+		EXPECT_EQ( 0.00, VentilationMechanical( 1 ).ZoneOAFlow( 1 ) );
+		EXPECT_EQ( 0.00, VentilationMechanical( 1 ).ZoneOAACH( 1 ) );
+
 	}
 }


### PR DESCRIPTION
…DesignSpecificationOutdoorAir-objects

1) Corrects crash when DesignSpecification:OutdoorAir object is missing from Controller:MechanicalVentilation.
2) Uses default OA flow per person when DesignSpecification:OutdoorAir object is missing
