### PR TITLE
Using correct executable name in shell script

### DIFF
--- a/scripts/runenergyplus.in
+++ b/scripts/runenergyplus.in
@@ -116,7 +116,7 @@ esac
 
 HEADER="=============== EnergyPlus ================="
 # Name of executable
-PRG_N=EnergyPlus
+PRG_N=energyplus
 # Name of ExpandObjects executable
 PRG_X=ExpandObjects
 # Name of EPMacro executable


### PR DESCRIPTION
The `runenergyplus` shell script wasn't pointing to the `energyplus` executable anymore. This fixes that.

@shorowit 
