### PR TITLE
Revert "#5252 Tin Discrepancy New VRF Model"

### DIFF
--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -5764,7 +5764,6 @@ namespace DXCoils {
 		Real64 SupEnth;
 		Real64 OutTemp;
 		Real64 OutAirFrac;
-		Real64 CoilInTemp;
 		Real64 VolFlowRate;
 		Real64 CoolCapAtPeak;
 		Real64 TotCapTempModFac;
@@ -6052,8 +6051,7 @@ namespace DXCoils {
 					FieldNum = 1;
 					TempSize = DXCoil( DXCoilNum ).RatedTotCap( Mode );
 					SizingString = DXCoilNumericFields( DXCoilNum ).PerfMode( Mode ).FieldNames( FieldNum ) + " [W]";
-					CoilInTemp = ZoneSizingRunDone ? FinalZoneSizing ( CurZoneEqNum ).DesCoolCoilInTemp : 26;
-					CalcVRFCoilCapModFac( 0, _, CompName, CoilInTemp, _, _, _, DataTotCapCurveValue);
+					CalcVRFCoilCapModFac( 0, _, CompName, FinalZoneSizing ( CurZoneEqNum ).DesCoolCoilInTemp, _, _, _, DataTotCapCurveValue);
 				} else {
 					SizingMethod = CoolingCapacitySizing;
 					CompName = DXCoil( DXCoilNum ).Name;
@@ -14419,12 +14417,12 @@ Label50: ;
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Xiufeng Pang, LBNL
 		//       DATE WRITTEN   Jan 2013
-		//       MODIFIED       Nov 2015, RP Zhang, LBNL 
+		//       MODIFIED       Jul 2015, RP Zhang, LBNL 
 		//       RE-ENGINEERED  na
 
 		// PURPOSE OF THIS SUBROUTINE:
 		// 		Calculates the air-side performance of a direct-expansion, air-cooled
-		// 		VRF terminal unit cooling coil, for the VRF_FluidTCtrl model.
+		// 		VRF terminal unit cooling coil, for the new VRF model.
 
 		// METHODOLOGY EMPLOYED:
 		// 		This subroutine is derived from CalcVRFCoolingCoil, and implements the new VRF model for FluidTCtrl.
@@ -14438,12 +14436,10 @@ Label50: ;
 		using DataHVACGlobals::HPWHCrankcaseDBTemp;
 		using DataHVACGlobals::TimeStepSys;
 		using DataHVACGlobals::SysTimeElapsed;
-		using DataWater::WaterStorage;
 		using General::TrimSigDigits;
 		using General::RoundSigDigits;
 		using General::CreateSysTimeIntervalString;
-		using HVACVariableRefrigerantFlow::OACompOnMassFlow;
-		using HVACVariableRefrigerantFlow::OACompOffMassFlow;    
+		using DataWater::WaterStorage;
 		using namespace DataZoneEnergyDemands;
 		using namespace HVACVariableRefrigerantFlow;
 
@@ -14463,6 +14459,7 @@ Label50: ;
 		// (average flow if cycling fan, full flow if constant fan)
 		Real64 VolFlowperRatedTotCap; // Air volume flow rate divided by rated total cooling capacity [m3/s-W] (adjusted for bypass)
 		Real64 TotCap; // gross total cooling capacity at off-rated conditions [W]
+		Real64 InletAirWetBulbC; // wetbulb temperature of inlet air [C]
 		Real64 InletAirDryBulbTemp; // inlet air dry bulb temperature [C]
 		Real64 InletAirEnthalpy; // inlet air enthalpy [J/kg]
 		Real64 InletAirHumRat; // inlet air humidity ratio [kg/kg]
@@ -14473,8 +14470,10 @@ Label50: ;
 		Real64 CBF; // coil bypass factor at off rated conditions
 		Real64 A0; // NTU * air mass flow rate, used in CBF calculation
 		Real64 hDelta; // Change in air enthalpy across the cooling coil [J/kg]
-		Real64 hADP; // Apparatus dew point enthalpy [J/kg]
-		Real64 hTinwADP; // Enthalpy at inlet dry-bulb and wADP [J/kg]
+		Real64 hTinwout; // Enthalpy at inlet dry-bulb and outlet humidity ratio [J/kg]
+		Real64 FullLoadOutAirEnth; // outlet full load enthalpy [J/kg]
+		Real64 FullLoadOutAirHumRat; // outlet humidity ratio at full load
+		Real64 FullLoadOutAirTemp; // outlet air temperature at full load [C]
 		Real64 PLF; // Part load factor, accounts for thermal lag at compressor startup, used in power calculation
 		Real64 CondInletTemp; // Condenser inlet temperature (C). Outdoor dry-bulb temp for air-cooled condenser.
 		// Outdoor Wetbulb +(1 - effectiveness)*(outdoor drybulb - outdoor wetbulb) for evap condenser.
@@ -14491,8 +14490,6 @@ Label50: ;
 		Real64 OutdoorWetBulb; // Outdoor wet-bulb temperature at condenser (C)
 		Real64 OutdoorHumRat; // Outdoor humidity ratio at condenser (kg/kg)
 		Real64 OutdoorPressure; // Outdoor barometric pressure at condenser (Pa)
-		Real64 tADP; // Apparatus dew point temperature [C]
-		Real64 wADP; // Apparatus dew point humidity ratio [kg/kg]
 
 		static Real64 CurrentEndTime( 0.0 ); // end time of time step for current simulation time step
 		static Real64 MinAirHumRat( 0.0 ); // minimum of the inlet air humidity ratio and the outlet air humidity ratio
@@ -14503,11 +14500,13 @@ Label50: ;
 		Real64 ADiff; // Used for exponential
 		
 		// Followings for VRF FluidTCtrl Only 
-		Real64 QCoilReq; // Coil load (W)
-		Real64 FanSpdRatio; // Fan speed ratio           
-		Real64 AirMassFlowMin; // Min air mass flow rate due to OA requirement [kg/s]   
+		Real64 QZnReqSenCoolingLoad; // Zone required cooling load (W)   
+		Real64 FanSpdRatio; // Fan speed ratio            
+		Real64 TcoilIn; // Air temperature at the inlet of the coil (C)                
+		Real64 HcoilIn; // Air enthalpy at the inlet of the coil (kJ/kg) 
 		Real64 ActualSH; // Super heating degrees (C)               
 		Real64 ActualSC; // Sub cooling degrees (C)                 
+		int OperatingMode; // Coil operation mode: 0 for cooling, 1 for heating, 2 for neither cooling nor heating             
 
 		// If Performance mode not present, then set to 1.  Used only by Multimode/Multispeed DX coil (otherwise mode = 1)
 		if ( present( PerfMode ) ) {
@@ -14637,25 +14636,14 @@ Label50: ;
 		DXCoil( DXCoilNum ).PrintLowOutTempMessage = false;
 
 		if ( ( AirMassFlow > 0.0 ) && ( GetCurrentScheduleValue( DXCoil( DXCoilNum ).SchedPtr ) > 0.0 ) && ( PartLoadRatio > 0.0 ) && ( CompOp == On ) ) { // for cycling fan, reset mass flow to full on rate
-			
+			InletAirWetBulbC = PsyTwbFnTdbWPb( InletAirDryBulbTemp, InletAirHumRat, OutdoorPressure );
+			AirVolumeFlowRate = AirMassFlow / PsyRhoAirFnPbTdbW( OutdoorPressure, InletAirDryBulbTemp, InletAirHumRat );
+			VolFlowperRatedTotCap = AirVolumeFlowRate / DXCoil( DXCoilNum ).RatedTotCap( Mode );
+
 			if ( DXCoil( DXCoilNum ).RatedTotCap( Mode ) <= 0.0 ) {
 				ShowFatalError( DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Rated total cooling capacity is zero or less." );
 			}
 
-			TotCap = DXCoil( DXCoilNum ).RatedTotCap( Mode );
-			QCoilReq = -PartLoadRatio * TotCap;
-			if( PartLoadRatio == 0.0 ){
-				AirMassFlowMin = OACompOffMassFlow;
-			} else {
-				AirMassFlowMin = OACompOnMassFlow;
-			}
-			
-			// Call ControlVRFIUCoil to calculate: (1) FanSpdRatio, (2) coil inlet/outlet conditions, and (3) SH/SC
-			ControlVRFIUCoil( DXCoilNum, QCoilReq, DXCoil( DXCoilNum ).InletAirTemp, DXCoil( DXCoilNum ).InletAirHumRat, DXCoil( DXCoilNum ).EvaporatingTemp, AirMassFlowMin, FanSpdRatio, OutletAirHumRat, OutletAirTemp, OutletAirEnthalpy, ActualSH, ActualSC );
-			AirMassFlow = FanSpdRatio * DXCoil( DXCoilNum ).RatedAirMassFlowRate( Mode );
-			
-			AirVolumeFlowRate = AirMassFlow / PsyRhoAirFnPbTdbW( OutdoorPressure, InletAirDryBulbTemp, InletAirHumRat );
-			VolFlowperRatedTotCap = AirVolumeFlowRate / DXCoil( DXCoilNum ).RatedTotCap( Mode );
 			// VolFlowperRatedTotCap was checked at the initialization step
 			// No need to check VolFlowperRatedTotCap at the simulation
 			// New VRF_FluidTCtrl model implements VAV fan which can vary air flow rate during simulation
@@ -14696,38 +14684,13 @@ Label50: ;
 			//  Get total capacity modifying factor (function of temperature) for off-rated conditions
 			//  InletAirHumRat may be modified in this ADP/BF loop, use temporary varible for calculations
 			InletAirHumRatTemp = InletAirHumRat;
+			// No need to differentiate between curve types, single-independent curve will just use first variable
+			// (as long as the first independent variable is the same for both curve types)
 			
-					
-			// Calculate apparatus dew point conditions using TotCap and CBF
-			hDelta = TotCap / AirMassFlow;
-			// there is an issue here with using CBF to calculate the ADP enthalpy.
-			// at low loads the bypass factor increases significantly.
-			hADP = InletAirEnthalpy - hDelta / ( 1.0 - CBF );
-			tADP = PsyTsatFnHPb( hADP, OutdoorPressure, RoutineName );
-			//  Eventually inlet air conditions will be used in DX Coil, these lines are commented out and marked with this comment line
-			//  tADP = PsyTsatFnHPb(hADP,InletAirPressure)
-			wADP = min( InletAirHumRat, PsyWFnTdbH( tADP, hADP, RoutineName ) );
-			hTinwADP = PsyHFnTdbW( InletAirDryBulbTemp, wADP );
-			if ( ( InletAirEnthalpy - hADP ) > 1.e-10 ) {
-				SHR = min( ( hTinwADP - hADP ) / ( InletAirEnthalpy - hADP ), 1.0 );
-			} else {
-				SHR = 1.0;
-			}
-					
 			if ( DXCoil( DXCoilNum ).PLFFPLR( Mode ) > 0 && CompCycRatio < 1.0 ) {
 				PLF = CurveValue( DXCoil( DXCoilNum ).PLFFPLR( Mode ), CompCycRatio ); // Calculate part-load factor
 			} else {
 				PLF = 1.0;
-			}
-
-			if ( PLF < 0.7 ) {
-				if ( DXCoil( DXCoilNum ).ErrIndex2 == 0 ) {
-					ShowWarningMessage( "The PLF curve value for the DX cooling coil " + DXCoil( DXCoilNum ).Name + " =" + RoundSigDigits( PLF, 3 ) + " for part-load ratio =" + RoundSigDigits( PartLoadRatio, 3 ) );
-					ShowContinueErrorTimeStamp( "PLF curve values must be >= 0.7. PLF has been reset to 0.7 and simulation is continuing." );
-					ShowContinueError( "Check the IO reference manual for PLF curve guidance [Coil:Cooling:DX:SingleSpeed]." );
-				}
-				ShowRecurringWarningErrorAtEnd( DXCoil( DXCoilNum ).Name + ", DX cooling coil PLF curve < 0.7 warning continues...", DXCoil( DXCoilNum ).ErrIndex2, PLF, PLF );
-				PLF = 0.7;
 			}
 
 			DXCoil( DXCoilNum ).PartLoadRatio = PartLoadRatio;
@@ -14748,51 +14711,73 @@ Label50: ;
 			// If cycling fan, send coil part-load fraction to on/off fan via HVACDataGlobals
 			if ( FanOpMode == CycFanCycCoil ) OnOffFanPartLoadFraction = PLF;
 
+			//  Calculate full load output conditions
+			SHR = 1.0;
+			TotCap = 0.0;
+			hDelta = 0.0;
+			FullLoadOutAirEnth = InletAirEnthalpy - TotCap / AirMassFlow;
+			hTinwout = InletAirEnthalpy - ( 1.0 - SHR ) * hDelta;
+			if ( SHR < 1.0 ) {
+				FullLoadOutAirHumRat = PsyWFnTdbH( InletAirDryBulbTemp, hTinwout );
+			} else {
+				FullLoadOutAirHumRat = InletAirHumRat;
+			}
+			FullLoadOutAirTemp = PsyTdbFnHW( FullLoadOutAirEnth, FullLoadOutAirHumRat );
+
 			// Check for saturation error and modify temperature at constant enthalpy
-			if ( OutletAirTemp < PsyTsatFnHPb( OutletAirEnthalpy, OutdoorPressure ) ) {
-				OutletAirTemp = PsyTsatFnHPb( OutletAirEnthalpy, OutdoorPressure );
-				//  Eventually inlet air conditions will be used in DX Coil, these lines are commented out and marked with this comment line
-				//   IF(FullLoadOutAirTemp .LT. PsyTsatFnHPb(FullLoadOutAirEnth,InletAirPressure)) THEN
-				//    FullLoadOutAirTemp = PsyTsatFnHPb(FullLoadOutAirEnth,InletAirPressure)
-				OutletAirHumRat = PsyWFnTdbH( OutletAirTemp, OutletAirEnthalpy );
+			if ( FullLoadOutAirTemp < PsyTsatFnHPb( FullLoadOutAirEnth, OutdoorPressure ) ) {
+				FullLoadOutAirTemp = PsyTsatFnHPb( FullLoadOutAirEnth, OutdoorPressure );
+				FullLoadOutAirHumRat = PsyWFnTdbH( FullLoadOutAirTemp, FullLoadOutAirEnth );
 			}
 
 			// Store actual outlet conditions when DX coil is ON for use in heat recovery module
-			DXCoilFullLoadOutAirTemp( DXCoilNum ) = OutletAirTemp;
-			DXCoilFullLoadOutAirHumRat( DXCoilNum ) = OutletAirHumRat;
+			DXCoilFullLoadOutAirTemp( DXCoilNum ) = FullLoadOutAirTemp;
+			DXCoilFullLoadOutAirHumRat( DXCoilNum ) = FullLoadOutAirHumRat;
 
-			// Add warning message for cold cooling coil (OutletAirTemp < 2 C)
-			if ( OutletAirTemp < 2.0 && ! FirstHVACIteration && ! WarmupFlag ) {
+			// Add warning message for cold cooling coil (FullLoadOutAirTemp < 2 C)
+			if ( FullLoadOutAirTemp < 2.0 && ! FirstHVACIteration && ! WarmupFlag ) {
 				DXCoil( DXCoilNum ).PrintLowOutTempMessage = true;
-				DXCoil( DXCoilNum ).FullLoadOutAirTempLast = OutletAirTemp;
+				DXCoil( DXCoilNum ).FullLoadOutAirTempLast = FullLoadOutAirTemp;
 				if ( DXCoil( DXCoilNum ).LowOutletTempIndex == 0 ) {
 					DXCoil( DXCoilNum ).FullLoadInletAirTempLast = InletAirDryBulbTemp;
-					DXCoil( DXCoilNum ).LowOutTempBuffer1 = DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = " + RoundSigDigits( OutletAirTemp, 2 ) + " C.";
+					DXCoil( DXCoilNum ).LowOutTempBuffer1 = DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = " + RoundSigDigits( FullLoadOutAirTemp, 2 ) + " C.";
 					DXCoil( DXCoilNum ).LowOutTempBuffer2 = " ...Occurrence info = " + EnvironmentName + ", " + CurMnDy + " " + CreateSysTimeIntervalString();
 				}
 			}
+
+			int ZoneIndex = VRFTU( DXCoil( DXCoilNum ).VRFIUPtr ).ZoneNum;  // Index of the zone that the coil serves
+			QZnReqSenCoolingLoad = -1.0 * ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToCoolingSP;
 			
+			if( QZnReqSenCoolingLoad > 0.0) {
+			// There is cooling load			
+				OperatingMode = 0;				
+				// The following function calculates: (1) FanSpdRatio, (2) coil inlet/outlet conditions, and (3) SH/SC
+				CalcVRFIUAirFlow( ZoneIndex, OperatingMode, DXCoil( DXCoilNum ).EvaporatingTemp, DXCoilNum, DXCoilNum, true, FanSpdRatio, OutletAirHumRat, 
+								OutletAirTemp, OutletAirEnthalpy, HcoilIn, TcoilIn, ActualSH, ActualSC );				
+			} else {
+			// There is no cooling load
+				OutletAirTemp = DXCoil(DXCoilNum).InletAirTemp;
+				OutletAirHumRat = DXCoil(DXCoilNum).InletAirHumRat;
+				OutletAirEnthalpy = DXCoil(DXCoilNum).InletAirEnthalpy;
+				HcoilIn = DXCoil(DXCoilNum).InletAirEnthalpy;
+				TcoilIn = DXCoil(DXCoilNum).InletAirTemp;
+				ActualSH = 998.0;
+				ActualSC = 998.0;
+			}
 			
-			// Coil total cooling 
-			DXCoil( DXCoilNum ).TotalCoolingEnergyRate = AirMassFlow * ( InletAirEnthalpy - OutletAirEnthalpy );
+			DXCoil( DXCoilNum ).TotalCoolingEnergyRate = AirMassFlow * ( HcoilIn - OutletAirEnthalpy );
 			
-			// Coil sensible cooling 
 			MinAirHumRat = min( InletAirHumRat, OutletAirHumRat );
-			DXCoil( DXCoilNum ).SensCoolingEnergyRate = AirMassFlow * 1005.0 * ( InletAirDryBulbTemp - OutletAirTemp );
+			DXCoil( DXCoilNum ).SensCoolingEnergyRate = AirMassFlow * 1005.0 * ( TcoilIn - OutletAirTemp );
 			//  Don't let sensible capacity be greater than total capacity
 			if ( DXCoil( DXCoilNum ).SensCoolingEnergyRate > DXCoil( DXCoilNum ).TotalCoolingEnergyRate ) {
 				DXCoil( DXCoilNum ).SensCoolingEnergyRate = DXCoil( DXCoilNum ).TotalCoolingEnergyRate;
 			}
-			
-			// Coil latent cooling 
 			DXCoil( DXCoilNum ).LatCoolingEnergyRate = DXCoil( DXCoilNum ).TotalCoolingEnergyRate - DXCoil( DXCoilNum ).SensCoolingEnergyRate;
-			
-			// Coil outlet conditions
 			DXCoil( DXCoilNum ).OutletAirTemp = OutletAirTemp;
 			DXCoil( DXCoilNum ).OutletAirHumRat = OutletAirHumRat;
 			DXCoil( DXCoilNum ).OutletAirEnthalpy = OutletAirEnthalpy;
-			
-			// Coil SH/SC
+			// Followings for VRF FluidTCtrl Only
 			DXCoil( DXCoilNum ).ActualSH = ActualSH;
 			DXCoil( DXCoilNum ).ActualSC = ActualSC;
 
@@ -14809,7 +14794,7 @@ Label50: ;
 			DXCoil( DXCoilNum ).LatCoolingEnergyRate = 0.0;
 			DXCoil( DXCoilNum ).EvapCondPumpElecPower = 0.0;
 			DXCoil( DXCoilNum ).EvapWaterConsumpRate = 0.0;
-			
+			// Followings for VRF FluidTCtrl Only
 			DXCoil( DXCoilNum ).ActualSH = 999.0;
 			DXCoil( DXCoilNum ).ActualSC = 999.0;
 
@@ -14833,7 +14818,7 @@ Label50: ;
 		DXCoilCoolInletAirWBTemp( DXCoilNum ) = PsyTwbFnTdbWPb( InletAirDryBulbTemp, InletAirHumRat, OutdoorPressure );
 
 	}
-
+		
 	void
 	CalcVRFHeatingCoil_FluidTCtrl(
 		int const CompOp, // compressor operation; 1=on, 0=off
@@ -14845,9 +14830,9 @@ Label50: ;
 	)
 	{
 		// SUBROUTINE INFORMATION:
-		//       AUTHOR         Xiufeng Pang (XP), LBNL 
+		//       AUTHOR         Xiufeng Pang (XP), LBNL
 		//       DATE WRITTEN   Mar 2013
-		//       MODIFIED       Nov 2015, RP Zhang, LBNL
+		//       MODIFIED       Jul 2015, RP Zhang, LBNL
 		//       MODIFIED       na
 		//       RE-ENGINEERED  na
 		
@@ -14864,8 +14849,6 @@ Label50: ;
 		// Using/Aliasing
 		using CurveManager::CurveValue;
 		using General::RoundSigDigits;
-		using HVACVariableRefrigerantFlow::OACompOnMassFlow;
-		using HVACVariableRefrigerantFlow::OACompOffMassFlow;    
 		using namespace DataZoneEnergyDemands;
 		using namespace HVACVariableRefrigerantFlow;
 		
@@ -14876,8 +14859,7 @@ Label50: ;
 		// na
 		
 		// INTERFACE BLOCK SPECIFICATIONS
-		
-		static std::string const RoutineNameFullLoad( "CalcVRFHeatingCoil_FluidTCtrl:fullload" );
+		// na
 		
 		// DERIVED TYPE DEFINITIONS
 		// na
@@ -14888,30 +14870,22 @@ Label50: ;
 		Real64 AirVolumeFlowRate; // Air volume flow rate across the cooling coil [m3/s]
 		Real64 VolFlowperRatedTotCap; // Air volume flow rate divided by rated total cooling capacity [m3/s-W]
 		Real64 TotCap; // gross total cooling capacity at off-rated conditions [W]
-		Real64 TotCapAdj; // adjusted total cooling capacity at off-rated conditions [W]
 		// on the type of curve
+		Real64 TotCapModFac; // Total capacity modifier 
 		Real64 InletAirDryBulbTemp; // inlet air dry bulb temperature [C]
 		Real64 InletAirWetBulbC; // wetbulb temperature of inlet air [C]
 		Real64 InletAirEnthalpy; // inlet air enthalpy [J/kg]
 		Real64 InletAirHumRat; // inlet air humidity ratio [kg/kg]
-		Real64 FullLoadOutAirEnth; // outlet full load enthalpy [J/kg]
-		Real64 FullLoadOutAirHumRat; // outlet humidity ratio at full load
-		Real64 FullLoadOutAirTemp; // outlet air temperature at full load [C]
-		Real64 FullLoadOutAirRH; // outlet air relative humidity at full load
-		Real64 EIRTempModFac( 0.0 ); // EIR modifier (function of entering drybulb, outside drybulb) depending on the
 		//  Eventually inlet air conditions will be used in DX Coil, these lines are commented out and marked with this comment line
+		Real64 EIRTempModFac( 0.0 ); // EIR modifier (function of entering drybulb, outside drybulb) depending on the
 		// type of curve
-		// Real64 DefrostEIRTempModFac; // EIR modifier for defrost (function of entering wetbulb, outside drybulb)
 		Real64 EIRFlowModFac; // EIR modifier (function of actual supply air flow vs rated flow)
 		Real64 EIR; // EIR at part load and off rated conditions
 		Real64 PLF; // Part load factor, accounts for thermal lag at compressor startup
 		Real64 PLRHeating; // PartLoadRatio in heating
-		Real64 OutdoorCoilT; // Outdoor coil temperature (C)
-		Real64 OutdoorCoildw; // Outdoor coil delta w assuming coil temp of OutdoorCoilT (kg/kg)
-		Real64 FractionalDefrostTime; // Fraction of time step system is in defrost
-		Real64 HeatingCapacityMultiplier; // Multiplier for heating capacity when system is in defrost
+		//Real64 HeatingCapacityMultiplier; // Multiplier for heating capacity when system is in defrost
 		Real64 InputPowerMultiplier; // Multiplier for power when system is in defrost
-		Real64 LoadDueToDefrost; // Additional load due to defrost
+		Real64 LoadDueToDefrost( 0.0 ); // Additional load due to defrost
 		Real64 CrankcaseHeatingPower; // power due to crankcase heater
 		Real64 OutdoorDryBulb; // Outdoor dry-bulb temperature at condenser (C)
 		Real64 OutdoorWetBulb; // Outdoor wet-bulb temperature at condenser (C)
@@ -14922,13 +14896,15 @@ Label50: ;
 		Real64 OutletAirTemp; // Supply air temperature (average value if constant fan, full output if cycling fan)
 		Real64 OutletAirHumRat; // Supply air humidity ratio (average value if constant fan, full output if cycling fan)
 		Real64 OutletAirEnthalpy; // Supply air enthalpy (average value if constant fan, full output if cycling fan)
-		
 		// Followings for VRF FluidTCtrl Only
-		Real64 QCoilReq; // Coil load (W)
-		Real64 FanSpdRatio; // Fan Speed Ratio
-		Real64 AirMassFlowMin; // Min air mass flow rate due to OA requirement [kg/s]
+		Real64 QZnHeating; // Supply air enthalpy (average value if constant fan, full output if cycling fan)
+		Real64 PartHeatRatio; // Part Heat Ratio
+		Real64 HcoilIn; // Enthalpy of the coil inlet
+		Real64 TcoilIn; // Temperature of the coil inlet
 		Real64 ActualSH; // Actual Super Heating 
 		Real64 ActualSC; // Actual Sub Cooling
+		Real64 FanSpdRatio; // Fan Speed Ratio
+		int OperatingMode; // Operation Mode
 		
 		if ( present( OnOffAirFlowRatio ) ) {
 			AirFlowRatio = OnOffAirFlowRatio;
@@ -14941,7 +14917,10 @@ Label50: ;
 		OutdoorWetBulb  = OutWetBulbTemp;
 		OutdoorHumRat   = OutHumRat;
 		OutdoorPressure = OutBaroPress;
-				
+		
+		int ZoneIndex = VRFTU( DXCoil( DXCoilNum ).VRFIUPtr ).ZoneNum; 
+		QZnHeating = ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToHeatingSP;
+		
 		AirMassFlow = DXCoil( DXCoilNum ).InletAirMassFlowRate;
 		InletAirDryBulbTemp = DXCoil( DXCoilNum ).InletAirTemp;
 		InletAirEnthalpy = DXCoil( DXCoilNum ).InletAirEnthalpy;
@@ -14962,62 +14941,36 @@ Label50: ;
 			( GetCurrentScheduleValue( DXCoil( DXCoilNum ).SchedPtr ) > 0.0 ) && 
 			( PartLoadRatio > 0.0 ) && ( OutdoorDryBulb > DXCoil( DXCoilNum ).MinOATCompressor ) ) {
 			
-			TotCap = DXCoil( DXCoilNum ).RatedTotCap( Mode );
-			QCoilReq = PartLoadRatio * TotCap;
-			if( PartLoadRatio == 0.0 ){
-				AirMassFlowMin = OACompOffMassFlow;
-			} else {
-				AirMassFlowMin = OACompOnMassFlow;
-			}
-			
-			// Call ControlVRFIUCoil to calculate: (1) FanSpdRatio, (2) coil inlet/outlet conditions, and (3) SH/SC
-			ControlVRFIUCoil( DXCoilNum, QCoilReq, DXCoil( DXCoilNum ).InletAirTemp, DXCoil( DXCoilNum ).InletAirHumRat, DXCoil( DXCoilNum ).CondensingTemp, AirMassFlowMin, FanSpdRatio, OutletAirHumRat, OutletAirTemp, OutletAirEnthalpy, ActualSH, ActualSC );
-			AirMassFlow = FanSpdRatio * DXCoil( DXCoilNum ).RatedAirMassFlowRate( Mode );
-			
-			
+			// Check for valid air volume flow per rated total cooling capacity (200 - 600 cfm/ton)			
 			AirVolumeFlowRate = AirMassFlow / PsyRhoAirFnPbTdbW( OutdoorPressure, InletAirDryBulbTemp, InletAirHumRat );
 			// Eventually inlet air conditions will be used in DX Coil, these lines are commented out and marked with this comment line
 			VolFlowperRatedTotCap = AirVolumeFlowRate / DXCoil( DXCoilNum ).RatedTotCap( Mode );
+	
 			// VolFlowperRatedTotCap was checked at the initialization step
 			// No need to check VolFlowperRatedTotCap at the simulation
 			// New VRF_FluidTCtrl model implements VAV fan which can vary air flow rate during simulation
 			
 			AirMassFlowRatio = AirMassFlow / DXCoil( DXCoilNum ).RatedAirMassFlowRate( Mode );
+			TotCapModFac = 1.0;
+			TotCap = DXCoil( DXCoilNum ).RatedTotCap( Mode ) * TotCapModFac;
 			
+			//@@
 			// Calculating adjustment factors for defrost
-			// Calculate delta w through outdoor coil by assuming a coil temp of 0.82*DBT-9.7(F) per DOE2.1E
-			OutdoorCoilT = 0.82 * OutdoorDryBulb - 8.589;
-			OutdoorCoildw = max( 1.0e-6, ( OutdoorHumRat - PsyWFnTdpPb( OutdoorCoilT, OutdoorPressure ) ) );
-
 			// Initializing defrost adjustment factors
-			LoadDueToDefrost = 0.0;
-			HeatingCapacityMultiplier = 1.0;
-			FractionalDefrostTime = 0.0;
-			InputPowerMultiplier = 1.0;
-
+			// Check outdoor temperature to determine of defrost is active
+			
 			// Modify total heating capacity based on defrost heating capacity multiplier
 			// MaxHeatCap passed from parent object VRF Condenser and is used to limit capacity of TU's to that available from condenser
-			if ( present( MaxHeatCap ) ) {
-				TotCapAdj = min( MaxHeatCap, TotCap * HeatingCapacityMultiplier );
+			if( present( MaxHeatCap ) ) {
 				TotCap = min( MaxHeatCap, TotCap );
-			} else {
-				TotCapAdj = TotCap * HeatingCapacityMultiplier;
-			}
-
-			// Calculate full load outlet conditions
-			FullLoadOutAirEnth = InletAirEnthalpy + TotCapAdj / AirMassFlow;
-			FullLoadOutAirHumRat = InletAirHumRat;
-			FullLoadOutAirTemp = PsyTdbFnHW( FullLoadOutAirEnth, FullLoadOutAirHumRat );
-			FullLoadOutAirRH = PsyRhFnTdbWPb( FullLoadOutAirTemp, FullLoadOutAirHumRat, OutdoorPressure, RoutineNameFullLoad );
-			//  Eventually inlet air conditions will be used in DX Coil, these lines are commented out and marked with this comment line
-			//  FullLoadOutAirRH = PsyRhFnTdbWPb(FullLoadOutAirTemp,FullLoadOutAirHumRat,InletAirPressure)
-			if ( FullLoadOutAirRH > 1.0 ) { // Limit to saturated conditions at FullLoadOutAirEnth
-				FullLoadOutAirTemp = PsyTsatFnHPb( FullLoadOutAirEnth, OutdoorPressure );
-				//  Eventually inlet air conditions will be used in DX Coil, these lines are commented out and marked with this comment line
-				//    FullLoadOutAirTemp = PsyTsatFnHPb(FullLoadOutAirEnth,InletAirPressure)
-				FullLoadOutAirHumRat = PsyWFnTdbH( FullLoadOutAirTemp, FullLoadOutAirEnth );
 			}
 			
+			PartHeatRatio = QZnHeating / TotCap;
+			
+			// Calculate full load outlet conditions
+			// Calculate actual outlet conditions for the input part load ratio
+			
+			// Calculate EIRTempModFac & EIRFlowModFac
 			// Calculate electricity consumed. First, get EIR modifying factors for off-rated conditions
 			// Model was extended to accept bi-quadratic curves. This allows sensitivity of the EIR
 			// to the entering dry-bulb temperature as well as the outside dry-bulb temperature. User is
@@ -15043,7 +14996,7 @@ Label50: ;
 				PLF = CurveValue( DXCoil( DXCoilNum ).PLFFPLR( Mode ), PLRHeating ); // Calculate part-load factor
 			} else {
 				PLF = 1.0;
-			}
+			}			
 			
 			if ( PLF < 0.7 ) {
 				if ( DXCoil( DXCoilNum ).PLRErrIndex == 0 ) {
@@ -15072,24 +15025,41 @@ Label50: ;
 			
 			// if cycling fan, send coil part-load fraction to on / off fan via HVACDataGlobals
 			if ( FanOpMode == CycFanCycCoil ) OnOffFanPartLoadFraction = PLF;
+			InputPowerMultiplier = 1.0;
 			DXCoil( DXCoilNum ).ElecHeatingPower = TotCap * EIR * DXCoil( DXCoilNum ).HeatingCoilRuntimeFraction * InputPowerMultiplier;
 			
 			// Calculate crankcase heater power using the runtime fraction for this DX heating coil only if there is no companion DX coil.
 			// Else use the largest runtime fraction of this DX heating coil and the companion DX cooling coil.
+			
 			if( DXCoil( DXCoilNum ).CompanionUpstreamDXCoil == 0 ) {
 				DXCoil( DXCoilNum ).CrankcaseHeaterPower = CrankcaseHeatingPower * ( 1.0 - DXCoil( DXCoilNum ).HeatingCoilRuntimeFraction );
 			} else {
 				DXCoil( DXCoilNum ).CrankcaseHeaterPower = CrankcaseHeatingPower * ( 1.0 - max( DXCoil( DXCoilNum ).HeatingCoilRuntimeFraction, DXCoil( DXCoil( DXCoilNum ).CompanionUpstreamDXCoil ).CoolingCoilRuntimeFraction ) );
 			}
 			
+			if ( QZnHeating > 0.0 ) {
+			// There is heating load
+				OperatingMode = 1;
+				// The following function calculates: (1) FanSpdRatio, (2) coil inlet/outlet conditions, and (3) SH/SC
+				CalcVRFIUAirFlow( ZoneIndex, OperatingMode, DXCoil( DXCoilNum ).CondensingTemp, DXCoilNum, DXCoilNum, true, FanSpdRatio, OutletAirHumRat, 
+								OutletAirTemp, OutletAirEnthalpy, HcoilIn, TcoilIn, ActualSH, ActualSC );
+			} else { 
+			// There is no heating load
+				OutletAirHumRat = DXCoil( DXCoilNum ).InletAirHumRat;
+				OutletAirTemp = DXCoil( DXCoilNum ).InletAirTemp;
+				OutletAirEnthalpy = DXCoil( DXCoilNum ).InletAirEnthalpy;
+				HcoilIn = DXCoil( DXCoilNum ).InletAirEnthalpy;
+				ActualSH = 998.0;
+				ActualSC = 998.0;
+			}
+			
 			DXCoil( DXCoilNum ).OutletAirTemp = OutletAirTemp;
 			DXCoil( DXCoilNum ).OutletAirHumRat = OutletAirHumRat;
 			DXCoil( DXCoilNum ).OutletAirEnthalpy = OutletAirEnthalpy;
-			DXCoil( DXCoilNum ).CompressorPartLoadRatio = PartLoadRatio;
 			DXCoil( DXCoilNum ).ActualSH = ActualSH;
 			DXCoil( DXCoilNum ).ActualSC = ActualSC;
 			
-			DXCoil( DXCoilNum ).TotalHeatingEnergyRate = AirMassFlow * ( OutletAirEnthalpy - InletAirEnthalpy );
+			DXCoil( DXCoilNum ).TotalHeatingEnergyRate = AirMassFlow * ( OutletAirEnthalpy-HcoilIn );
 			DXCoil( DXCoilNum ).DefrostPower = DXCoil( DXCoilNum ).DefrostPower * DXCoil( DXCoilNum ).HeatingCoilRuntimeFraction;
 			
 		} else {
@@ -15129,19 +15099,189 @@ Label50: ;
 			CalcSecondaryDXCoils( DXCoilNum );
 		}
 	}
-
+	
 	void
-	ControlVRFIUCoil (
-		int const CoilIndex,  // index to VRFTU coil 
-		Real64 const QCoil,   // coil load
-		Real64 const Tin, // inlet air temperature
-		Real64 const Win, // inlet air humidity ratio
+	CalcVRFIUEvapCondTemp(
+		int const VRFTUNum, // the number of the VRF TU to be simulated
+		Real64 & EvapTemp, // evaporating temperature
+		Real64 & CondTemp  // condensing temperature 
+	) {
+		// SUBROUTINE INFORMATION:
+		//       AUTHOR         Xiufeng Pang, LBNL
+		//       DATE WRITTEN   Feb 2014
+		//       MODIFIED       Jul 2015, RP Zhang, LBNL, Modify the bounds of the Te/Tc
+		//       RE-ENGINEERED  na
+		
+		// PURPOSE OF THIS SUBROUTINE:
+		//       Calculate the VRF IU Te (cooling mode) and Tc (heating mode), given zonal loads.
+		
+		// METHODOLOGY EMPLOYED:
+		//       A new physics based VRF model appliable for Fluid Temperature Control.
+		
+		// REFERENCES:
+		// na
+		
+		// USE STATEMENTS:
+		using namespace DataZoneEnergyDemands;
+		using Fans::Fan;
+		using HVACVariableRefrigerantFlow::VRF;
+		using HVACVariableRefrigerantFlow::VRFTU;
+		
+		// SUBROUTINE ARGUMENT DEFINITIONS:
+		// na
+		
+		// SUBROUTINE PARAMETER DEFINITIONS:
+		// na
+		
+		// INTERFACE BLOCK SPECIFICATIONS
+		// na
+		
+		// DERIVED TYPE DEFINITIONS
+		// na
+		
+		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
+		Real64 QZnReqSenCoolingLoad; // Zone required sensible cooling load (W) 
+		Real64 QZnReqSenHeatingLoad; // Zone required sensible heating load (W)
+		Real64 C1Tevap; // Coefficient for indoor unit coil evaporating temperature curve (-) 
+		Real64 C2Tevap; // Coefficient for indoor unit coil evaporating temperature curve (-)
+		Real64 C3Tevap; // Coefficient for indoor unit coil evaporating temperature curve (-)
+		Real64 C1Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
+		Real64 C2Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
+		Real64 C3Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
+		Real64 RatedCapCool; // Nominal cooling capacity (W)
+		Real64 RatedCapHeat; // Nominal heating capacity (W)
+		Real64 TairInlet; // Air temperature at the indoor unit inlet (C)
+		Real64 Tout; // Air temperature at the indoor unit outlet (C)
+		Real64 TcoilIn; // Temperature of the air at the coil inlet, after absorbing the heat released by fan (C)
+		Real64 Th2; // Air temperature at the coil surface (C)
+		Real64 Th2min; // Air temperature at the coil surface, correspond to the maximum cooling capacity (C)
+		Real64 Hin; // Air enthalpy at the coil inlet (kJ/kg)
+		Real64 Win; // Air humidity ratio at the coil inlet (kg/kg)
+		Real64 BFC; // Bypass factor at the cooling mode (-)
+		Real64 BFH; // Bypass factor at the heating mode (-)
+		Real64 SH; // Super heating degrees (C)
+		Real64 SC; // Subcooling degrees (C)
+		Real64 Qfan; // Heat released by fan (W)
+		Real64 Garate; // Nominal air mass flow rate
+		Real64 hADP; // Air enthalpy at the saturated condition when DBT is Th2min (kJ/kg)
+		Real64 wADP; // Air humidity ratio at the saturated condition when DBT is Th2min (kg/kg)
+		Real64 hTinwADP; // Air enthalpy when DBT is TairInlet and humidity ratio is wADP  (kJ/kg)
+		Real64 SHRini; // Initialized SHR (-)
+		Real64 DeltaT; // Difference between evaporating/condensing temperature and coil surface temperature (C)
+		Real64 RHsat; // Relative humidity of the air at saturated condition(-) 
+		Real64 EvapTempMax; // Max evaporating temperature (C)
+		Real64 EvapTempMin; // Min evaporating temperature, correspond to the maximum cooling capacity (C)
+		Real64 CondTempMin; // Min condensing temperature (C)
+		Real64 CondTempMax; // Max condensing temperature, correspond to the maximum heating capacity (C)
+		int CoolCoilNum; // index to the VRF Cooling DX coil to be simulated
+		int HeatCoilNum; // index to the VRF Heating DX coil to be simulated
+		int VRFNum; // index to VRF that the VRF Terminal Unit serves
+		int ZoneIndex; // index to zone where the VRF Terminal Unit resides
+		
+		// Get the equipment/zone index corresponding to the VRFTU
+		CoolCoilNum = VRFTU( VRFTUNum ).CoolCoilIndex;
+		HeatCoilNum = VRFTU( VRFTUNum ).HeatCoilIndex;
+		ZoneIndex = VRFTU( VRFTUNum ).ZoneNum;
+		VRFNum = VRFTU( VRFTUNum ).VRFSysNum;
+		
+		// Bounds of Te/Tc for VRF IU Control Algorithm: VariableTemp
+		EvapTempMin = VRF( VRFNum ).IUEvapTempLow;
+		EvapTempMax = VRF( VRFNum ).IUEvapTempHigh;
+		CondTempMin = VRF( VRFNum ).IUCondTempLow;
+		CondTempMax = VRF( VRFNum ).IUCondTempHigh;
+		
+		// Obtain zonal heating/cooling loads
+		QZnReqSenCoolingLoad = - 1.0 * ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToCoolingSP;
+		QZnReqSenHeatingLoad = ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToHeatingSP;
+		
+		TairInlet = DXCoil( CoolCoilNum ).InletAirTemp;
+		RatedCapCool = DXCoil( CoolCoilNum ).RatedTotCap( 1 ); // Rated total cooling capacity
+		RatedCapHeat = DXCoil( HeatCoilNum ).RatedTotCap( 1 ); // Rated heating capacity
+		Garate = DXCoil( CoolCoilNum ).RatedAirMassFlowRate( 1 ); 
+		Hin = DXCoil( CoolCoilNum ).InletAirEnthalpy;
+		Win = DXCoil( CoolCoilNum ).InletAirHumRat;
+		EvapTemp = EvapTempMin;
+		RHsat = 0.98;
+		BFC = 0.0592; 
+		BFH = 0.136;  
+		
+		// Coefficients describing coil performance
+		SH = DXCoil( CoolCoilNum ).SH;
+		SC = DXCoil( HeatCoilNum ).SC; 
+		C1Tevap = DXCoil( CoolCoilNum ).C1Te;
+		C2Tevap = DXCoil( CoolCoilNum ).C2Te;
+		C3Tevap = DXCoil( CoolCoilNum ).C3Te;
+		C1Tcond = DXCoil( HeatCoilNum ).C1Tc;
+		C2Tcond = DXCoil( HeatCoilNum ).C2Tc;
+		C3Tcond = DXCoil( HeatCoilNum ).C3Tc;
+		
+		// Get heat released by fan
+		int SupplyFanIndex = DXCoil( CoolCoilNum ).SupplyFanIndex;
+		if ( SupplyFanIndex > 0) {
+			Qfan = Fan( SupplyFanIndex ).OutletAirEnthalpy - Fan( SupplyFanIndex ).InletAirEnthalpy;
+		} else {
+			Qfan = 0;
+		}
+	
+		//1. COOLING Mode
+		if ( QZnReqSenCoolingLoad <= 0 ){
+		//1.1) There is no cooling load
+			EvapTemp = DXCoil( CoolCoilNum ).InletAirTemp;
+	
+		} else {
+		//1.2) There is cooling load
+		
+			DeltaT = C3Tevap * SH * SH + C2Tevap * SH + C1Tevap;
+			Th2min = EvapTempMin + DeltaT;  
+			hADP = PsyHFnTdbRhPb( Th2min, RHsat, OutBaroPress, "CalcVRFIUEvapCondTemp" );
+			wADP = PsyWFnTdbH( Th2min, hADP, "CalcVRFIUEvapCondTemp" );
+			hTinwADP = PsyHFnTdbW( TairInlet, wADP );
+			SHRini = min( ( hTinwADP - hADP ) / ( Hin-hADP ), 1.0 );
+	
+			if ( QZnReqSenCoolingLoad >= RatedCapCool * SHRini ) // Rated sensible cooling capacity
+			// correspond to the maximum cooling capacity
+				EvapTemp = EvapTempMin;
+			else {
+				TcoilIn = TairInlet + Qfan / Garate / 1005;
+				Tout = TcoilIn - QZnReqSenCoolingLoad / Garate / 1005;   
+				Th2 = TcoilIn - ( TcoilIn - Tout ) / ( 1 - BFC );
+				EvapTemp = max( min( (Th2 - DeltaT ), EvapTempMax ), EvapTempMin );
+			}     
+		}
+		
+		//2. HEATING Mode
+		if ( QZnReqSenHeatingLoad <= 0 ) {
+		//2.1) There is no heating load
+			CondTemp = DXCoil( HeatCoilNum ).InletAirTemp;
+		} else {
+		//2.2) There is heating load
+			if ( QZnReqSenHeatingLoad >= RatedCapHeat ) {
+				// correspond to the maximum heating capacity
+				CondTemp = CondTempMax;
+			} else {
+				TcoilIn = TairInlet + Qfan / Garate / 1005;
+				Tout = TcoilIn + QZnReqSenHeatingLoad / Garate / 1005;        
+				Th2 = TcoilIn + ( Tout - TcoilIn ) / ( 1 - BFH );
+				DeltaT = C3Tcond * SC * SC + C2Tcond * SC + C1Tcond;
+				CondTemp = max( min( ( Th2 + DeltaT ), CondTempMax ), CondTempMin);
+			}
+		}
+	}
+	
+	void
+	CalcVRFIUAirFlow (
+		int const ZoneIndex,  // index to zone where the VRF Terminal Unit resides 
+		int const Mode,       // mode 0 for cooling, 1 for heating, 2 for neither cooling nor heating
 		Real64 const TeTc,    // evaporating or condensing temperature
-		Real64 const OAMassFlow,  // mass flow rate of outdoor air 
-		Real64 & FanSpdRatio, // fan speed ratio: actual flow rate / rated flow rate
+		int const CoolCoil,   // index to VRFTU cooling coil 
+		int const HeatCoil,   // index to VRFTU heating coil
+		bool SHSCModify,      // indicate whether SH/SC would be modified
+		Real64 & FanSpdRatio, // fan speed ratio
 		Real64 & Wout,    // outlet air humidity ratio
-		Real64 & Tout, // outlet air temperature
-		Real64 & Hout, // outlet air enthalpy
+		Real64 & Toutlet, // outlet air temperature
+		Real64 & Houtlet, // outlet air enthalpy
+		Real64 & HcoilIn, // inlet air enthalpy
+		Real64 & TcIn,    // coil inlet temperature, after fan
 		Real64 & SHact,   // actual SH
 		Real64 & SCact    // actual SC
 	)
@@ -15149,16 +15289,16 @@ Label50: ;
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Xiufeng Pang, LBNL
 		//       DATE WRITTEN   Feb 2013
-		//       MODIFIED       Nov 2015, RP Zhang, LBNL
+		//       MODIFIED       Jul 2015, RP Zhang, LBNL
 		//                               
 		//       RE-ENGINEERED  na
 		//
 		// PURPOSE OF THIS SUBROUTINE:
-		//       Analyze the VRF Indoor Unit operations given coil loads.
-		//       Calculated parameters include: (1) Fan Speed Ratio (2) SH/SC, (3) Coil Outlet conditions
+		//       Analyze the VRF Indoor Unit operations given zonal loads.
+		//       Calculated parameters include: (1) Fan Speed Ratio, (2) SH/SC Degrees, and (3) Coil Inlet/Outlet conditions 
 		//
 		// METHODOLOGY EMPLOYED:
-		//       A new physics based VRF model applicable for Fluid Temperature Control.
+		//       A new physics based VRF model appliable for Fluid Temperature Control.
 		//
 		// REFERENCES:
 		//       na
@@ -15166,7 +15306,7 @@ Label50: ;
 		// USE STATEMENTS:
 		using namespace DataZoneEnergyDemands;
 		using General::SolveRegulaFalsi;
-		using Psychrometrics::PsyHFnTdbW;
+		using Fans::Fan;
 		
 		
 		// SUBROUTINE PARAMETER DEFINITIONS:
@@ -15190,232 +15330,253 @@ Label50: ;
 		Real64 C1Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
 		Real64 C2Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
 		Real64 C3Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
-		Real64 CoilOnOffRatio; // coil on/off ratio: time coil is on divided by total time
 		Real64 deltaT;  // Difference between evaporating/condensing temperature and coil surface temperature (C)
-		Real64 FanSpdRatioMin; // Min fan speed ratio, below which the cycling will be activated (-)
-		Real64 FanSpdRatioMax; // Max fan speed ratio (-)
+		Real64 FanSpdRatioMin; // Min fan speed ratio (-)
 		Real64 Garate; // Nominal air mass flow rate (m3/s)
+		Real64 Hin;    // Air enthalpy at the coil inlet (kJ/kg)
 		Real64 MaxSH;  // Max super heating degrees (C)
 		Real64 MaxSC;  // Max subcooling degrees (C)
 		Real64 QinSenMin1; //Coil capacity at minimum fan speed, corresponding to real SH (W)
 		Real64 QinSenMin2; //Coil capacity at minimum fan speed, corresponding to corresponds maximum SH (W)
 		Real64 QinSenPerFlowRate; //Coil capacity per air mass flow rate(W-s/kg)
-		Real64 QCoilSenCoolingLoad; // Coil sensible cooling load (W)
-		Real64 QCoilSenHeatingLoad; // Coil sensible heating load (W)
+		Real64 Qfan; // Heat released by fan (W)
+		Real64 QZnReqSenCoolingLoad; // Zone required sensible cooling load (W)
+		Real64 QZnReqSenHeatingLoad; // Zone required sensible heating load (W)
 		Real64 Ratio1; // Fan speed ratio (-)
 		Real64 RHsat;  // Relative humidity of the air at saturated condition(-) 
 		Real64 SH; // Super heating degrees (C)
 		Real64 SC; // Subcooling degrees (C)
-		Real64 Ts_1; // Air temperature at the coil surface, corresponding to SH (C)
-		Real64 Ts_2; // Air temperature at the coil surface, corresponding to MaxSH (C)
-		Real64 To_1; // Air temperature at the coil outlet, corresponding to SH (C)
-		Real64 To_2; // Air temperature at the coil outlet, corresponding to MaxSH (C)
-		Real64 Ts; // Air temperature at the coil surface (C)
-		Real64 Ws; // Air humidity ratio at the coil surface (kg/kg)
+		Real64 TairInlet; // Air temperature at indoor unit fan inlet (C)
+		Real64 TcoilIn; // Air temperature at indoor coil inlet (C)
+		Real64 Th21; // Air temperature at the coil surface, for temporary use (C)
+		Real64 Th22; // Air temperature at the coil surface, for temporary use (C)
+		Real64 Th2; // Air temperature at the coil surface (C)
+		Real64 Win; // Air humidity ratio at the coil inlet (kg/kg)
+		Real64 Wh2; // Air temperature at the coil surface (C)
+		
+		// Obtain zonal heating/cooling loads
+		QZnReqSenCoolingLoad = - 1.0 * ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToCoolingSP;
+		QZnReqSenHeatingLoad = ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToHeatingSP;    
 		
 		RHsat = 0.98; // Saturated RH
 		MaxSH = 15;
-		MaxSC = 20; 
-		Garate = DXCoil( CoilIndex ).RatedAirMassFlowRate( 1 );
-		FanSpdRatioMin = min( max( OAMassFlow / Garate, 0.65 ), 1.0 ); // ensure that coil flow rate is higher than OA flow rate
+		MaxSC = 20;
+		FanSpdRatioMin = 0.65; // max( min( FanSpdRatioMin, 1.0 ), 0.0);
 		
-		if( QCoil == 0 ) {
-		//No Heating or Cooling
-			FanSpdRatio = OAMassFlow / Garate;
-			CoilOnOffRatio = 0.0;
+		// Coefficients describing coil performance
+		SH = DXCoil( CoolCoil ).SH;
+		SC = DXCoil( HeatCoil ).SC;
+		C1Tevap = DXCoil( CoolCoil ).C1Te;
+		C2Tevap = DXCoil( CoolCoil ).C2Te;
+		C3Tevap = DXCoil( CoolCoil ).C3Te;
+		C1Tcond = DXCoil( HeatCoil ).C1Tc;
+		C2Tcond = DXCoil( HeatCoil ).C2Tc;
+		C3Tcond = DXCoil( HeatCoil ).C3Tc;
 		
-			SHact = 999.0;
-			SCact = 999.0;
-			Tout = Tin;
-			Hout = PsyHFnTdbW( Tin, Win );
-			Wout = Win;
-		
-		} else if( QCoil < 0 ) {
-		//Cooling Mode
-		
-			// Obtain coil cooling loads
-			QCoilSenCoolingLoad = -QCoil; 
+		if( Mode == FlagCoolMode && QZnReqSenCoolingLoad > 0.0 ) {
+		//COOLING: Mode 0
 			
-			// Coefficients describing coil performance
-			SH = DXCoil( CoilIndex ).SH;
-			C1Tevap = DXCoil( CoilIndex ).C1Te;
-			C2Tevap = DXCoil( CoilIndex ).C2Te;
-			C3Tevap = DXCoil( CoilIndex ).C3Te;
-			BF = 0.0592;
+			BF = 0.0592; 
+			Garate = DXCoil( CoolCoil ).RatedAirMassFlowRate( 1 );
+			TairInlet = DXCoil( CoolCoil ).InletAirTemp;
+			Win = DXCoil( CoolCoil ).InletAirHumRat ;
+			Hin = DXCoil( CoolCoil ).InletAirEnthalpy;
+			
+			// Get heat released by fan
+			int SupplyFanIndex = DXCoil( CoolCoil ).SupplyFanIndex;
+			if ( SupplyFanIndex > 0) {
+				Qfan = Fan( SupplyFanIndex ).OutletAirEnthalpy - Fan( SupplyFanIndex ).InletAirEnthalpy;
+			} else {
+				Qfan = 0;
+			}
+			TcoilIn = TairInlet + Qfan * pow_2( FanSpdRatioMin ) / Garate / 1005.0; //when fan runs at minimu speed.
 			
 			// Coil sensilbe heat transfer_minimum value
-			CalcVRFCoilSenCap( FlagCoolMode, CoilIndex, Tin, TeTc, SH, BF, QinSenPerFlowRate, Ts_1 );
-			To_1 = Tin - QinSenPerFlowRate / 1005;
+			CalcVRFCoilSenCap( FlagCoolMode, CoolCoil, TcoilIn, TeTc, SH, BF, QinSenPerFlowRate, Th21 );
 			QinSenMin1 = FanSpdRatioMin * Garate * QinSenPerFlowRate; // Corresponds real SH
 			
-			CalcVRFCoilSenCap( FlagCoolMode, CoilIndex, Tin, TeTc, MaxSH, BF, QinSenPerFlowRate, Ts_2 );
-			To_2 = Tin - QinSenPerFlowRate / 1005;
+			CalcVRFCoilSenCap( FlagCoolMode, CoolCoil, TcoilIn, TeTc, MaxSH, BF, QinSenPerFlowRate, Th22 );
 			QinSenMin2 = FanSpdRatioMin * Garate * QinSenPerFlowRate; // Corresponds maximum SH
 			
-			if( QCoilSenCoolingLoad > QinSenMin1 ) { 
-			// Increase fan speed to meet room sensible load; SH is not updated
-			
-				Par( 1 ) = QCoilSenCoolingLoad;
-				Par( 2 ) = Ts_1;
-				Par( 3 ) = Tin;
-				Par( 4 ) = Garate;
-				Par( 5 ) = BF;
-
-				FanSpdRatioMax = 1.0; 
-				SolveRegulaFalsi( 1.0e-3, MaxIter, SolFla, Ratio1, FanSpdResidualCool, FanSpdRatioMin, FanSpdRatioMax, Par);
-				if( SolFla < 0 ) Ratio1 = FanSpdRatioMax; // over capacity 
+			if( QZnReqSenCoolingLoad > QinSenMin1 ) { 
+			// Modulate fan speed to meet room sensible load; SH may or may not be updated
+				
+				Par( 1 ) = QZnReqSenCoolingLoad;
+				Par( 2 ) = Th21;
+				Par( 3 ) = TairInlet;
+				Par( 4 ) = Qfan;
+				Par( 5 ) = Garate;
+				Par( 6 ) = BF;
+				
+				SolveRegulaFalsi( 1.0e-3, MaxIter, SolFla, Ratio1, FanSpdResidualCool, 0.5, 1.5, Par);
 				FanSpdRatio = Ratio1;
-				CoilOnOffRatio = 1.0;
-				
-				Tout = To_1; // Since SH is not updated
-				Ws = PsyWFnTdbRhPb( Ts_1, RHsat, OutBaroPress, "CalcVRFIUAirFlow");
-				if( Ws < Win ) {
-					Wout = Win - ( Win - Ws) * ( 1 - BF );
-				} else {
-					Wout = Win;
-				}
-				Hout = PsyHFnTdbW( Tout, Wout );
-				
-				SCact = 999.0;
-				SHact = SH;
-				
-			} else {
-			// Low load modificatin algorithm
-			// Need to increase SH to further reduce coil capacity
-			// May further implement coil cycling control if SC modification is not enough
-			
-				FanSpdRatio = FanSpdRatioMin;
-				
-				CoilOnOffRatio = 1.0;
-				
-				Tout = Tin - QCoilSenCoolingLoad / 1005.0 / FanSpdRatioMin / Garate;
-				Ts = Tin - ( Tin - Tout ) / ( 1 - BF );
-				deltaT = Ts - TeTc;
-				
-				// Update SH
-				if( C3Tevap <= 0.0 ) {
-					if ( C2Tevap > 0.0)
-						SHact = ( deltaT - C1Tevap) / C2Tevap;
-					else 
-						SHact = 998.0;
-				} else {
-					SHact = ( - C2Tevap + sqrt( pow_2( C2Tevap ) - 4 * C3Tevap * ( C1Tevap-deltaT ) ) ) / 2 / C3Tevap;
-				}
-				
-				Ws = PsyWFnTdbRhPb( Ts, RHsat, OutBaroPress, "CalcVRFIUAirFlow");
-				if( Ws < Win ) {
-					Wout = Win - ( Win - Ws) * ( 1 - BF );
-				} else {
-					Wout = Win;
-				}
-				
-				if( SHact > MaxSH ) {
-				// Further implement On/Off Control
-					SHact = MaxSH;
-					CoilOnOffRatio = QCoilSenCoolingLoad / QinSenMin2; 
+				if( SHSCModify ) {
+				// No need to update SH (SHact = SH)
 					
-					Ts = Ts_2;
-					Ws = PsyWFnTdbRhPb( Ts, RHsat, OutBaroPress, "CalcVRFIUAirFlow");
-					if( Ws < Win ) {
-						Wout = Win - ( Win - Ws) * ( 1 - BF );
+					TcIn = TairInlet + Qfan *  pow_2( FanSpdRatio ) / Garate / 1005; // FanSpdRatio is updated
+					Toutlet = TcIn - ( TcIn - Th21 ) * ( 1 - BF ); // Still use Th21 = f(deltaT1) = g(SH), since SH is not updated
+					Wh2 = PsyWFnTdbRhPb( Th21, RHsat, OutBaroPress, "CalcVRFIUAirFlow");
+					
+					if( Wh2 < Win ) {
+						Wout = Win - ( Win - Wh2) * ( 1 - BF );
 					} else {
 						Wout = Win;
 					}
 					
-					//outlet air temperature and humidity ratio is time-weighted
-					Tout = CoilOnOffRatio * To_2 + ( 1 - CoilOnOffRatio ) * Tin;
-					Wout = CoilOnOffRatio * Wout + ( 1 - CoilOnOffRatio ) * Win;
+					Houtlet = PsyHFnTdbW( Toutlet, Wout );
+					HcoilIn = PsyHFnTdbW( TcIn, Win );
+					SCact = 999.0;
+					SHact = SH;
+					
+				} 
+			} else {
+			// Need to update SH to further reduce QinSenMin1
+			// That is, SHact is updated (different from SH) while using FanSpdRatio = FanSpdRatioMin.
+			
+				FanSpdRatio = FanSpdRatioMin;
+				
+				if( SHSCModify ){
+					TcIn = TcoilIn; // TcoilIn = f(FanSpdRatioMin)
+					Toutlet = TcoilIn - QZnReqSenCoolingLoad / 1005.0 / FanSpdRatio / Garate;
+					Th2 = TcoilIn - ( TcoilIn - Toutlet ) / ( 1 - BF );
+					deltaT = Th2 - TeTc;
+					
+					// Update SH
+					if( C3Tevap <= 0.0 ) {
+						if ( C2Tevap > 0.0)
+							SHact = ( deltaT - C1Tevap) / C2Tevap;
+						else 
+							SHact = 998.0;
+					} else {
+						SHact = ( - C2Tevap + sqrt( pow_2( C2Tevap ) - 4 * C3Tevap * ( C1Tevap-deltaT ) ) ) / 2 / C3Tevap;
+					}
+					
+					if( SHact > MaxSH ) {
+						SHact = MaxSH;
+						Toutlet = TcoilIn - QinSenMin2 / 1005.0 / FanSpdRatio / Garate;
+						Th2 = Th22;
+					}
+					
+					Wh2 = PsyWFnTdbRhPb( Th2, RHsat, OutBaroPress, "CalcVRFIUAirFlow");
+					
+					if( Wh2 < Win ) {
+						Wout = Win - ( Win - Wh2) * (1 - BF );
+					} else {
+						Wout = Win;
+					}
+					
+					Houtlet = PsyHFnTdbW( Toutlet, Wout );
+					HcoilIn = PsyHFnTdbW( TcoilIn, Win ); 
+					SCact = 999.0;
 				}
-				
-				Hout = PsyHFnTdbW( Tout, Wout );
-				
-				SCact = 999.0;
 			}
 			
-		} else if( QCoil > 0 ) {
-		//Heating Mode 
-			
-			// Obtain zonal heating loads
-			QCoilSenHeatingLoad = QCoil; 
-			
-			// Coefficients describing coil performance
-			SC = DXCoil( CoilIndex ).SC;
-			C1Tcond = DXCoil( CoilIndex ).C1Tc;
-			C2Tcond = DXCoil( CoilIndex ).C2Tc;
-			C3Tcond = DXCoil( CoilIndex ).C3Tc;
+		} else if( Mode == FlagHeatMode && QZnReqSenHeatingLoad > 0.0 ) {
+		//HEATING: Mode 1 
 			
 			BF = 0.136; 
+			Garate = DXCoil( HeatCoil ).RatedAirMassFlowRate( 1 );
+			TairInlet = DXCoil( HeatCoil ).InletAirTemp;
+			Win = DXCoil( HeatCoil ).InletAirHumRat;
+			Hin = DXCoil( HeatCoil ).InletAirEnthalpy;
+			
+			// Get heat released by fan
+			int SupplyFanIndex = DXCoil( HeatCoil ).SupplyFanIndex;
+			if ( SupplyFanIndex > 0) {
+				Qfan = Fan( SupplyFanIndex ).OutletAirEnthalpy - Fan( SupplyFanIndex ).InletAirEnthalpy;
+			} else {
+				Qfan = 0;
+			}
+			TcoilIn = TairInlet + Qfan *  pow_2( FanSpdRatioMin ) / Garate / 1005.0; //when fan runs at minimu speed 
 			
 			// Coil sensilbe heat transfer_minimum value
-			CalcVRFCoilSenCap( FlagHeatMode, CoilIndex, Tin, TeTc, SC, BF, QinSenPerFlowRate, Ts_1 );
-			To_1 = QinSenPerFlowRate / 1005 + Tin;
+			CalcVRFCoilSenCap( FlagHeatMode, HeatCoil, TairInlet, TeTc, SC, BF, QinSenPerFlowRate, Th21 );
 			QinSenMin1 = FanSpdRatioMin * Garate * QinSenPerFlowRate; // Corresponds real SH
 			
-			CalcVRFCoilSenCap( FlagHeatMode, CoilIndex, Tin, TeTc, MaxSC, BF, QinSenPerFlowRate, Ts_2 );
-			To_2 = QinSenPerFlowRate / 1005 + Tin;
+			CalcVRFCoilSenCap( FlagHeatMode, HeatCoil, TairInlet, TeTc, MaxSC, BF, QinSenPerFlowRate, Th22 );
 			QinSenMin2 = FanSpdRatioMin * Garate * QinSenPerFlowRate; // Corresponds maximum SH
 			
-			if( QCoilSenHeatingLoad > QinSenMin1  ) {
-			// Modulate fan speed to meet room sensible load; SC is not updated
+			if( QZnReqSenHeatingLoad > QinSenMin1  ) {
+			// Modulate fan speed to meet room sensible load; SH may or may not be updated
 				
-				Par( 1 ) = QCoilSenHeatingLoad;
-				Par( 2 ) = Ts_1;
-				Par( 3 ) = Tin;
-				Par( 4 ) = Garate;
-				Par( 5 ) = BF;
+				Par( 1 ) = QZnReqSenHeatingLoad;
+				Par( 2 ) = Th21;
+				Par( 3 ) = TairInlet;
+				Par( 4 ) = Qfan;
+				Par( 5 ) = Garate;
+				Par( 6 ) = BF;
 				
-				FanSpdRatioMax = 1.0;
-				SolveRegulaFalsi( 1.0e-3, MaxIter, SolFla, Ratio1, FanSpdResidualHeat, FanSpdRatioMin, FanSpdRatioMax, Par);
-				if( SolFla < 0 ) Ratio1 = FanSpdRatioMax; // over capacity
+				SolveRegulaFalsi( 1.0e-3, MaxIter, SolFla, Ratio1, FanSpdResidualHeat, 0.5, 1.5, Par);
 				FanSpdRatio = Ratio1;
-				CoilOnOffRatio = 1.0;
+				if( SHSCModify ) {
+				// No need to update SC (SCact = SC )
 				
-				Tout = Tin + ( Ts_1 - Tin ) * ( 1 - BF );
-				Wout = Win;
-				Hout = PsyHFnTdbW( Tout, Wout );
-			
-				SHact = 999.0;
-				SCact = SC;
+					TcIn = TairInlet + Qfan *  pow_2( FanSpdRatio ) / Garate / 1005.0;// FanSpdRatio is updated
+					Toutlet = TcIn +( Th21 - TcIn ) * ( 1 - BF );
+					Wout = Win;
+				
+					Houtlet = PsyHFnTdbW( Toutlet, Wout );
+					HcoilIn = PsyHFnTdbW( TcIn, Win );
+					SHact = 999.0;
+					SCact = SC;
+				}
 				
 			} else {
-			// Low load modificatin algorithm
-			// Need to increase SC to further reduce coil heating capacity
-			// May further implement coil cycling control if SC modification is not enough
+			// Need to update SC to further reduce QinSenMin1
+			// That is, SCact is updated (different from SC ) while using FanSpdRatio = FanSpdRatioMin.
 				
 				FanSpdRatio = FanSpdRatioMin;
-				CoilOnOffRatio = 1.0;
 				
-				Tout = Tin + QCoilSenHeatingLoad / 1005.0 / FanSpdRatio / Garate;
-				Ts = Tin + ( Tout - Tin ) / ( 1 - BF );
-				deltaT = TeTc - Ts;
-				
-				// Update SC
-				if( C3Tcond <= 0.0  ) {
-					if ( C2Tcond > 0.0)
-						SCact = ( deltaT - C1Tcond ) / C2Tcond;
-					else 
-						SCact = 998.0;
-				} else {
-					SCact = ( -C2Tcond + sqrt( pow_2( C2Tcond  ) - 4 * C3Tcond * ( C1Tcond - deltaT ) ) ) / 2 / C3Tcond;
-				}
-				
-				if( SCact > MaxSC  ) {
-				// Implement On/Off Control
-					SCact = MaxSC;
-					CoilOnOffRatio = QCoilSenHeatingLoad / QinSenMin2; 
+				if( SHSCModify ) {	
+					TcIn = TcoilIn; // TcoilIn = f(FanSpdRatioMin)
+					Toutlet = TairInlet + QZnReqSenHeatingLoad / 1005.0 / FanSpdRatio / Garate;
+					Th2 = TcoilIn + ( Toutlet - TcoilIn ) / ( 1 - BF  );
+					deltaT = TeTc - Th2;
 					
-					//outlet air temperature is time-weighted
-					Tout = CoilOnOffRatio * To_2 + ( 1 - CoilOnOffRatio ) * Tin;
+					// Update SC
+					if( C3Tcond <= 0.0  ) {
+						if ( C2Tcond > 0.0)
+							SCact = ( deltaT - C1Tcond  ) / C2Tcond;
+						else 
+							SCact = 998.0;
+					} else {
+						SCact = ( -C2Tcond + sqrt( pow_2( C2Tcond  ) -4  *  C3Tcond  *  ( C1Tcond-deltaT  ) ) ) / 2 / C3Tcond;
+					}
+					
+					if( SCact > MaxSC  ) {
+						SCact = MaxSC;
+						Toutlet = TairInlet + QinSenMin2/1005.0/FanSpdRatio/Garate;
+						Th2 = Th22;
+					}
+					
+					Wout = Win; 
+					Houtlet = PsyHFnTdbW( Toutlet, Wout  );
+					HcoilIn = PsyHFnTdbW( TcoilIn, Win  );
+					SHact = 999.0;
 				}
-				
-				Wout = Win; 
-				Hout = PsyHFnTdbW( Tout, Wout  );
-				
-				SHact = 999.0;
 			}
-		} 
+		} else {
+		//NO HEATING/COOLING: Mode 2
+			
+			TairInlet = DXCoil( CoolCoil ).InletAirTemp;
+			Win = DXCoil( CoolCoil ).InletAirHumRat;
+			Hin = DXCoil( CoolCoil ).InletAirEnthalpy;
+			
+			FanSpdRatio = 0.0;
+			
+			if( SHSCModify ) { 
+				SHact = 999.0;
+				SCact = 999.0;
+				Toutlet = TairInlet;
+				TcIn = TairInlet;
+				Houtlet = Hin;
+				HcoilIn = Hin;
+				Wout = Win;
+			}
+		}
 	
-		//FanSpdRatio = max( min( FanSpdRatio, 1.0 ), 0.0);
+		FanSpdRatio = max( min( FanSpdRatio, 1.0 ), 0.0);
+		
 	}
 	
 	void
@@ -15634,7 +15795,7 @@ Label50: ;
 		// FUNCTION INFORMATION:
 		//       AUTHOR         Xiufeng Pang (XP)
 		//       DATE WRITTEN   Mar 2013
-		//       MODIFIED       Nov 2015, RP Zhang, LBNL
+		//       MODIFIED       Jul 2015, RP Zhang, LBNL
 		//       RE-ENGINEERED
 		//
 		// PURPOSE OF THIS FUNCTION:
@@ -15651,22 +15812,25 @@ Label50: ;
 		// na
 		
 		//FUNCTION LOCAL VARIABLE DECLARATIONS:
-		Real64 BF; // Bypass factor (-)
-		Real64 FanSpdResidualCool; // Modified fan speed ratio to meet actual zone load (-)
-		Real64 Garate; // Nominal air mass flow rate (m3/s)
-		Real64 TcoilIn; // Air temperature at indoor coil inlet (C)
-		Real64 Th2; // Air temperature at the coil surface (C)
-		Real64 TotCap; // Cooling capacity of the coil (W)
-		Real64 Tout; // Air temperature at the indoor unit outlet (C)
 		Real64 ZnSenLoad;  // Zone sensible cooling load (W)
+		Real64 TairInlet; // Air temperature at indoor unit inlet (C)
+		Real64 QfanRate; // Heat released by fan (W)
+		Real64 TotCap; // Cooling capacity of the coil (W)
+		Real64 Garate; // Nominal air mass flow rate (m3/s)
+		Real64 Th2; // Air temperature at the coil surface (C)
+		Real64 Tout; // Air temperature at the indoor unit outlet (C)
+		Real64 BF; // Bypass factor (-)
+		Real64 TcoilIn; // Air temperature at indoor coil inlet (C)
+		Real64 FanSpdResidualCool; // Modified fan speed ratio to meet actual zone load (-)
 		
 		ZnSenLoad = Par( 1 );
 		Th2 = Par( 2 );
-		TcoilIn = Par( 3 ); 
-		Garate = Par( 4 );
-		BF = Par( 5 );
-		if ( std::abs( ZnSenLoad ) < 100.0 ) ZnSenLoad = sign( 100.0, ZnSenLoad );
+		TairInlet = Par( 3 ); 
+		QfanRate = Par( 4 );
+		Garate = Par( 5 );
+		BF = Par( 6 );
 		
+		TcoilIn = TairInlet + QfanRate *  pow_2( FanSpdRto ) / Garate / 1005.0;
 		Tout = TcoilIn - ( TcoilIn - Th2 ) * ( 1 - BF );
 		TotCap = FanSpdRto * Garate * 1005.0 * ( TcoilIn - Tout );
 		FanSpdResidualCool = (TotCap - ZnSenLoad ) / ZnSenLoad;
@@ -15683,7 +15847,7 @@ Label50: ;
 		// FUNCTION INFORMATION:
 		//       AUTHOR         Xiufeng Pang (XP)
 		//       DATE WRITTEN   Mar 2013
-		//       MODIFIED       Nov 2015, RP Zhang, LBNL
+		//       MODIFIED       Jul 2015, RP Zhang, LBNL
 		//       RE-ENGINEERED
 		//
 		// PURPOSE OF THIS FUNCTION:
@@ -15699,24 +15863,27 @@ Label50: ;
 		// USE STATEMENTS:
 		// na
 		
-		Real64 BF; // Bypass factor (-)
-		Real64 FanSpdResidualHeat; // Modified fan speed ratio to meet actual zone load (-)
-		Real64 Garate; // Nominal air mass flow rate (m3/s)
-		Real64 TcoilIn; // Air temperature at indoor coil inlet (C)
-		Real64 Th2; // Air temperature at the coil surface (C)
-		Real64 TotCap; // Heating capacity of the coil (W)
-		Real64 Tout; // Air temperature at the indoor unit outlet (C)
 		Real64 ZnSenLoad; // Zone sensible heating load (W)
+		Real64 TairInlet; // Air temperature at indoor unit inlet (C)
+		Real64 QfanRate; // Heat released by fan (W)
+		Real64 TotCap; // Heating capacity of the coil (W)
+		Real64 Garate; // Nominal air mass flow rate (m3/s)
+		Real64 Th2; // Air temperature at the coil surface (C)
+		Real64 Tout; // Air temperature at the indoor unit outlet (C)
+		Real64 BF; // Bypass factor (-)
+		Real64 TcoilIn; // Air temperature at indoor coil inlet (C)
+		Real64 FanSpdResidualHeat; // Modified fan speed ratio to meet actual zone load (-)
 		
 		ZnSenLoad = Par( 1 );
 		Th2 = Par( 2 );
-		TcoilIn = Par( 3 );
-		Garate = Par( 4 );
-		BF = Par( 5 );
-		if ( std::abs( ZnSenLoad ) < 100.0 ) ZnSenLoad = sign( 100.0, ZnSenLoad );
+		TairInlet = Par( 3 );
+		QfanRate = Par( 4 );
+		Garate = Par( 5 );
+		BF = Par( 6 );
 		
-		Tout = TcoilIn + ( Th2 - TcoilIn )  *  ( 1 - BF );
-		TotCap = FanSpdRto  *  Garate  *  1005.0 * ( Tout - TcoilIn );
+		TcoilIn = TairInlet + QfanRate  *  pow_2( FanSpdRto ) / Garate / 1005.0;
+		Tout = TcoilIn + ( Th2 - TcoilIn )  *  ( 1-BF );
+		TotCap = FanSpdRto  *  Garate  *  1005.0 * ( Tout - TairInlet );
 		FanSpdResidualHeat = ( TotCap - ZnSenLoad ) / ZnSenLoad;
 		
 		return FanSpdResidualHeat;

--- a/src/EnergyPlus/DXCoils.hh
+++ b/src/EnergyPlus/DXCoils.hh
@@ -1696,17 +1696,26 @@ namespace DXCoils {
 	);
 	
 	void
-	ControlVRFIUCoil (
-		int const CoilIndex,  // index to VRFTU coil 
-		Real64 const QCoil,   // coil load
-		Real64 const Tin,     // inlet air temperature
-		Real64 const Win,     // inlet air humidity ratio
-		Real64 const TeTc,    // evaporating or condensing temperature
-		Real64 const OAMassFlow,  // mass flow rate of outdoor air 
-		Real64 & FanSpdRatio, // fan speed ratio: actual flow rate / rated flow rate
+	CalcVRFIUEvapCondTemp(
+		int const VRFTUNum, // the number of the VRF TU to be simulated
+		Real64 & EvapTemp, // evaporating temperature
+		Real64 & CondTemp  // condensing temperature 
+	);
+	
+	void
+	CalcVRFIUAirFlow (
+		int const ZoneIndex,  // index to zone where the VRF Terminal Unit resides 
+		int const Mode,       // mode 0 for cooling, 1 for heating, 2 for neither cooling nor heating
+		Real64 const Temp,    // evaporating or condensing temperature
+		int const CoolCoil,   // index to VRFTU cooling coil 
+		int const HeatCoil,   // index to VRFTU heating coil
+		bool SHSCModify,      // indicate whether SH/SC would be modified
+		Real64 & FanSpdRatio, // fan speed ratio
 		Real64 & Wout,    // outlet air humidity ratio
-		Real64 & Tout, // outlet air temperature
-		Real64 & Hout, // outlet air enthalpy
+		Real64 & Toutlet, // outlet air temperature
+		Real64 & Houtlet, // outlet air enthalpy
+		Real64 & HcoilIn, // inlet air enthalpy
+		Real64 & TcoilIn, // coil inlet temperature
 		Real64 & SHact,   // actual SH
 		Real64 & SCact    // actual SC
 	);

--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
@@ -315,7 +315,7 @@ namespace HVACVariableRefrigerantFlow {
 
 		// Simulate terminal unit
 		SimVRF( VRFTUNum, FirstHVACIteration, OnOffAirFlowRatio, SysOutputProvided, LatOutputProvided, QZnReq );
-		
+
 		// mark this terminal unit as simulated
 		TerminalUnitList( TUListNum ).IsSimulated( IndexToTUInTUList ) = true;
 
@@ -2393,30 +2393,6 @@ namespace HVACVariableRefrigerantFlow {
 			
 			VRF( VRFNum ).CompMaxDeltaP  = rNumericArgs( 30 );
 			
-			//@@ The control type 
-			std::string ThermostatPriorityType = "LoadPriority"; // cAlphaArgs( 25 ) 
-			if ( SameString( ThermostatPriorityType, "LoadPriority" ) ) {
-				VRF( VRFNum ).ThermostatPriority = LoadPriority;
-			} else if ( SameString( ThermostatPriorityType, "ZonePriority" ) ) {
-				VRF( VRFNum ).ThermostatPriority = ZonePriority;
-			} else if ( SameString( ThermostatPriorityType, "ThermostatOffsetPriority" ) ) {
-				VRF( VRFNum ).ThermostatPriority = ThermostatOffsetPriority;
-			} else if ( SameString( ThermostatPriorityType, "Scheduled" ) ) {
-				VRF( VRFNum ).ThermostatPriority = ScheduledPriority;
-			} else if ( SameString( ThermostatPriorityType, "MasterThermostatPriority" ) ) {
-				VRF( VRFNum ).ThermostatPriority = MasterThermostatPriority;
-				if ( VRF( VRFNum ).MasterZonePtr == 0 ) {
-					ShowSevereError( cCurrentModuleObject + " = \"" + VRF( VRFNum ).Name + "\"" );
-					//** ShowContinueError( cAlphaFieldNames( 24 ) + " must be entered when " + cAlphaFieldNames( 25 ) + " = " + cAlphaArgs( 25 ) );
-					ErrorsFound = true;
-				}
-			} else {
-				ShowSevereError( cCurrentModuleObject + " = " + VRF( VRFNum ).Name );
-				// ShowContinueError( "Illegal " + cAlphaFieldNames( 25 ) + " = " + cAlphaArgs( 25 ) );
-				ErrorsFound = true;
-			}
-			
-			
 			// The new VRF model is Air cooled
 			VRF( VRFNum ).CondenserType = AirCooled; 
 			VRF( VRFNum ).CondenserNodeNum = 0; 
@@ -2487,7 +2463,7 @@ namespace HVACVariableRefrigerantFlow {
 				
 			}
 		}
-		
+		 
 		cCurrentModuleObject = "ZoneHVAC:TerminalUnit:VariableRefrigerantFlow";
 		for ( VRFNum = 1; VRFNum <= NumVRFTU; ++VRFNum ) {
 			VRFTUNum = VRFNum;
@@ -3347,7 +3323,6 @@ namespace HVACVariableRefrigerantFlow {
 	// Beginning Initialization Section of the Module
 	//******************************************************************************
 
-	
 	void
 	InitVRF(
 		int const VRFTUNum,
@@ -3395,6 +3370,7 @@ namespace HVACVariableRefrigerantFlow {
 		using General::RoundSigDigits;
 		using FluidProperties::GetDensityGlycol;
 		using PlantUtilities::InitComponentNodes;
+		using DXCoils::CalcVRFIUAirFlow;
 
 		// Locals
 		// SUBROUTINE ARGUMENT DEFINITIONS:
@@ -3733,14 +3709,14 @@ namespace HVACVariableRefrigerantFlow {
 			// Determine operating mode prior to simulating any terminal units connected to a VRF condenser
 			// this should happen at the beginning of a time step where all TU's are polled to see what
 			// mode the heat pump condenser will operate in
-			if ( ! any( TerminalUnitList( TUListIndex ).IsSimulated ) ) {
-				InitializeOperatingMode( FirstHVACIteration, VRFCond, TUListIndex, OnOffAirFlowRatio );
-			} 
-			//*** End of Operating Mode Initialization done at beginning of each iteration ***!
 			
-			//if ( ! any( TerminalUnitList( TUListIndex ).IsSimulated ) && VRF( VRFCond ).VRFAlgorithmTypeNum == AlgorithmTypeFluidTCtrl ) {
-			//	CalcVRFIUTeTc_FluidTCtrl( VRFCond ); // Get the VRF IU Te/Tc for the timestep
-			//}
+			//@@ XP following codes are temperarily disabled.
+			if ( VRF( VRFCond ).VRFAlgorithmTypeNum != AlgorithmTypeFluidTCtrl ) {
+				if ( ! any( TerminalUnitList( TUListIndex ).IsSimulated ) ) {
+					InitializeOperatingMode( FirstHVACIteration, VRFCond, TUListIndex, OnOffAirFlowRatio );
+				} // IF(.NOT. ANY(TerminalUnitList(TUListNum)%IsSimulated))THEN
+			}
+			//*** End of Operating Mode Initialization done at beginning of each iteration ***!
 
 			// disable VRF system when outside limits of operation based on OAT
 			EnableSystem = false; // flag used to switch operating modes when OAT is outside operating limits
@@ -4245,10 +4221,78 @@ namespace HVACVariableRefrigerantFlow {
 			OACompOffMassFlow = 0.0;
 		}
 
+		// Added to determine operation mode for the new VRF model_Jun 2015, XP
+		if ( VRF( VRFCond ).VRFAlgorithmTypeNum == AlgorithmTypeFluidTCtrl ) {
+			TUListNum = VRFTU(VRFTUNum).TUListIndex;
+			NumCoolingLoads( VRFCond ) = 0;
+			NumHeatingLoads( VRFCond ) = 0;
+				
+			Real64 QZnReqHeating;
+			
+			if ( VRF( VRFCond ).ThermostatPriority == MasterThermostatPriority ) {
+				QZnReq = ZoneSysEnergyDemand( VRF( VRFCond ).MasterZonePtr ).OutputRequiredToCoolingSP;
+				QZnReqHeating = ZoneSysEnergyDemand( VRF( VRFCond ).MasterZonePtr ).OutputRequiredToHeatingSP;
+				
+				if ( ( QZnReq < 0.0 ) && ( QZnReqHeating < 0.0 ) ) {
+					CoolingLoad( VRFCond ) = true;
+					HeatingLoad( VRFCond ) = false;
+					CompOnMassFlow = VRFTU( VRFTUNum ).MaxCoolAirMassFlow;
+				} else if ( ( QZnReq > 0.0 ) && ( QZnReqHeating > 0.0 ) ) {
+					CoolingLoad( VRFCond ) = false;
+					HeatingLoad( VRFCond ) = true;
+					CompOnMassFlow = VRFTU( VRFTUNum ).MaxHeatAirMassFlow;
+				} else {
+					CoolingLoad( VRFCond ) = false;
+					HeatingLoad( VRFCond ) = false;
+					CompOnMassFlow = VRFTU( VRFTUNum ).MaxCoolAirMassFlow;
+				}
+				
+			} else {
+
+				for ( int NumTULoop = 1; NumTULoop <= TerminalUnitList( TUListNum ).NumTUInList; NumTULoop++ ) {
+					TUIndex = TerminalUnitList( TUListNum ).ZoneTUPtr( NumTULoop );
+					int ThisZoneNum = VRFTU( TUIndex ).ZoneNum;
+					QZnReq = ZoneSysEnergyDemand( ThisZoneNum ).OutputRequiredToCoolingSP;
+					QZnReqHeating = ZoneSysEnergyDemand( ThisZoneNum ).OutputRequiredToHeatingSP;
+					
+					if( QZnReq < 0.0 ) NumCoolingLoads( VRFCond ) = NumCoolingLoads( VRFCond ) + 1;
+					if ( QZnReqHeating > 0.0 ) NumHeatingLoads( VRFCond ) = NumHeatingLoads( VRFCond ) + 1;
+				}
+				
+				if ( NumCoolingLoads( VRFCond ) > NumHeatingLoads( VRFCond ) ) {
+					CoolingLoad( VRFCond ) = true;
+					HeatingLoad( VRFCond ) = false;
+					CompOnMassFlow = VRFTU( VRFTUNum ).MaxCoolAirMassFlow;
+				} else if ( NumHeatingLoads( VRFCond ) > 0 ) {
+					CoolingLoad( VRFCond ) = false;
+					HeatingLoad( VRFCond ) = true;
+					CompOnMassFlow = VRFTU( VRFTUNum ).MaxHeatAirMassFlow;
+				} else {
+					CoolingLoad( VRFCond ) = false;
+					HeatingLoad( VRFCond ) = false;
+					CompOnMassFlow = VRFTU( VRFTUNum ).MaxCoolAirMassFlow;
+				}
+				
+			}
+		
+			if ( CoolingLoad( VRFCond ) ) {
+				int OperatingMode = 0;
+				Real64 temp = -1;
+				CalcVRFIUAirFlow( ZoneNum, OperatingMode, VRF( VRFCond ).IUEvaporatingTemp, VRFTU( VRFTUNum ).CoolCoilIndex, VRFTU( VRFTUNum ).HeatCoilIndex, false, FanSpeedRatio, temp, temp, temp, temp, temp, temp, temp );
+			} else if ( HeatingLoad( VRFCond ) ) {
+				int OperatingMode = 1;
+				Real64 temp = -1;
+				CalcVRFIUAirFlow( ZoneNum, OperatingMode, VRF( VRFCond ).IUCondensingTemp, VRFTU( VRFTUNum ).CoolCoilIndex, VRFTU( VRFTUNum ).HeatCoilIndex, false, FanSpeedRatio, temp, temp, temp, temp, temp, temp, temp );
+			} else {
+				FanSpeedRatio = VRFTU( VRFTUNum ).MaxNoCoolAirMassFlow / VRFTU( VRFTUNum ).MaxCoolAirMassFlow;
+			}
+
+			if ( FanSpeedRatio < 0.0 ) FanSpeedRatio = 0.0; 
+		}
+
 		SetAverageAirFlow( VRFTUNum, 0.0, OnOffAirFlowRatio );
 
 	}
-
 
 	void
 	SetCompFlowRate(
@@ -5259,9 +5303,7 @@ namespace HVACVariableRefrigerantFlow {
 		
 		if ( VRF( VRFTU( VRFTUNum ).VRFSysNum ).VRFAlgorithmTypeNum == AlgorithmTypeFluidTCtrl ) { 
 		// Algorithm Type: VRF model based on physics, appliable for Fluid Temperature Control
-			ControlVRF_FluidTCtrl( VRFTUNum, QZnReq, FirstHVACIteration, PartLoadRatio, OnOffAirFlowRatio );
 			CalcVRF_FluidTCtrl( VRFTUNum, FirstHVACIteration, PartLoadRatio, SysOutputProvided, OnOffAirFlowRatio, LatOutputProvided );
-			//CalcVRF( VRFTUNum, FirstHVACIteration, PartLoadRatio, SysOutputProvided, OnOffAirFlowRatio, LatOutputProvided );
 		} else {
 		// Algorithm Type: VRF model based on system curve
 			ControlVRF( VRFTUNum, QZnReq, FirstHVACIteration, PartLoadRatio, OnOffAirFlowRatio );
@@ -5272,7 +5314,7 @@ namespace HVACVariableRefrigerantFlow {
 		VRFTU( VRFTUNum ).TerminalUnitLatentRate = LatOutputProvided;
 
 	}
-		
+
 	void
 	ControlVRF(
 		int const VRFTUNum, // Index to VRF terminal unit
@@ -6063,7 +6105,7 @@ namespace HVACVariableRefrigerantFlow {
 
 		return PLRResidual;
 	}
-	
+
 	void
 	SetAverageAirFlow(
 		int const VRFTUNum, // Unit index
@@ -6115,34 +6157,52 @@ namespace HVACVariableRefrigerantFlow {
 		OutsideAirNode = VRFTU( VRFTUNum ).VRFTUOAMixerOANodeNum;
 		AirRelNode = VRFTU( VRFTUNum ).VRFTUOAMixerRelNodeNum;
 
-		if ( VRFTU( VRFTUNum ).OpMode == CycFanCycCoil ) {
-			AverageUnitMassFlow = ( PartLoadRatio * CompOnMassFlow ) + ( ( 1 - PartLoadRatio ) * CompOffMassFlow );
-			AverageOAMassFlow = ( PartLoadRatio * OACompOnMassFlow ) + ( ( 1 - PartLoadRatio ) * OACompOffMassFlow );
-		} else {
-			AverageUnitMassFlow = CompOnMassFlow;
-			AverageOAMassFlow = OACompOnMassFlow;
-		}
-		if ( CompOffFlowRatio > 0.0 ) {
-			FanSpeedRatio = ( PartLoadRatio * CompOnFlowRatio ) + ( ( 1 - PartLoadRatio ) * CompOffFlowRatio );
-		} else {
-			FanSpeedRatio = CompOnFlowRatio;
+		if ( VRF( VRFTU( VRFTUNum ).VRFSysNum  ).VRFAlgorithmTypeNum != AlgorithmTypeFluidTCtrl ) {
+			if ( VRFTU( VRFTUNum ).OpMode == CycFanCycCoil ) {
+				AverageUnitMassFlow = ( PartLoadRatio * CompOnMassFlow ) + ( ( 1 - PartLoadRatio ) * CompOffMassFlow );
+				AverageOAMassFlow = ( PartLoadRatio * OACompOnMassFlow ) + ( ( 1 - PartLoadRatio ) * OACompOffMassFlow );
+			} else {
+				AverageUnitMassFlow = CompOnMassFlow;
+				AverageOAMassFlow = OACompOnMassFlow;
+			}
+			if ( CompOffFlowRatio > 0.0 ) {
+				FanSpeedRatio = ( PartLoadRatio * CompOnFlowRatio ) + ( ( 1 - PartLoadRatio ) * CompOffFlowRatio );
+			} else {
+				FanSpeedRatio = CompOnFlowRatio;
+			}
 		}
 
 		// if the terminal unit and fan are scheduled on then set flow rate
 		if ( GetCurrentScheduleValue( VRFTU( VRFTUNum ).SchedPtr ) > 0.0 && ( GetCurrentScheduleValue( VRFTU( VRFTUNum ).FanAvailSchedPtr ) > 0.0 || ZoneCompTurnFansOn ) && ! ZoneCompTurnFansOff ) {
 
-			Node( InletNode ).MassFlowRate = AverageUnitMassFlow;
-			Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow;
-			if ( OutsideAirNode > 0 ) {
-				Node( OutsideAirNode ).MassFlowRate = AverageOAMassFlow;
-				Node( OutsideAirNode ).MassFlowRateMaxAvail = AverageOAMassFlow;
-				Node( AirRelNode ).MassFlowRate = AverageOAMassFlow;
-				Node( AirRelNode ).MassFlowRateMaxAvail = AverageOAMassFlow;
-			}
-			if ( AverageUnitMassFlow > 0.0 ) {
-				OnOffAirFlowRatio = CompOnMassFlow / AverageUnitMassFlow;
+			if ( VRF( VRFTU( VRFTUNum ).VRFSysNum  ).VRFAlgorithmTypeNum == AlgorithmTypeFluidTCtrl ) {
+				Node( InletNode ).MassFlowRate = CompOnMassFlow * FanSpeedRatio;
+				Node( InletNode ).MassFlowRateMaxAvail = CompOnMassFlow;
+				if ( OutsideAirNode > 0 ) {
+					Node( OutsideAirNode ).MassFlowRate = OACompOnMassFlow;
+					Node( OutsideAirNode ).MassFlowRateMaxAvail = OACompOnMassFlow;
+					Node( AirRelNode ).MassFlowRate = OACompOnMassFlow;
+					Node( AirRelNode ).MassFlowRateMaxAvail = OACompOnMassFlow;
+				}
+				if ( AverageUnitMassFlow > 0.0 ) {
+					OnOffAirFlowRatio = 1.0;
+				} else {
+					OnOffAirFlowRatio = 0.0;
+				}
 			} else {
-				OnOffAirFlowRatio = 0.0;
+				Node( InletNode ).MassFlowRate = AverageUnitMassFlow;
+				Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow;
+				if ( OutsideAirNode > 0 ) {
+					Node( OutsideAirNode ).MassFlowRate = AverageOAMassFlow;
+					Node( OutsideAirNode ).MassFlowRateMaxAvail = AverageOAMassFlow;
+					Node( AirRelNode ).MassFlowRate = AverageOAMassFlow;
+					Node( AirRelNode ).MassFlowRateMaxAvail = AverageOAMassFlow;
+				}
+				if ( AverageUnitMassFlow > 0.0 ) {
+					OnOffAirFlowRatio = CompOnMassFlow / AverageUnitMassFlow;
+				} else {
+					OnOffAirFlowRatio = 0.0;
+				}
 			}
 
 		} else { // terminal unit and/or fan is off
@@ -6155,6 +6215,7 @@ namespace HVACVariableRefrigerantFlow {
 			OnOffAirFlowRatio = 0.0;
 
 		}
+
 	}
 
 	void
@@ -6823,7 +6884,7 @@ namespace HVACVariableRefrigerantFlow {
 		// na
 
 		// Using/Aliasing
-		// na
+		using DXCoils::CalcVRFIUEvapCondTemp;
 		
 		// Followings for FluidTCtrl Only
 		Array1D< Real64 >  EvapTemp;
@@ -6843,7 +6904,7 @@ namespace HVACVariableRefrigerantFlow {
 			for ( int i = 1; i <= TerminalUnitList( TUListNum ).NumTUInList; i++ ) {
 				int VRFTUNumi = TerminalUnitList( TUListNum ).ZoneTUPtr( i );
 				// analyze the conditions of each IU 
-				CalcVRFIUVariableTeTc( VRFTUNumi, EvapTemp( i ), CondTemp( i ) );
+				CalcVRFIUEvapCondTemp( VRFTUNumi, EvapTemp( i ), CondTemp( i ) );
 
 				// select the Te/Tc that can satisfy all the zones
 				IUMinEvapTemp = min( IUMinEvapTemp, EvapTemp( i ), 15.0);
@@ -6861,188 +6922,6 @@ namespace HVACVariableRefrigerantFlow {
 	
 	}
 	
-	void
-	CalcVRFIUVariableTeTc(
-		int const VRFTUNum, // the number of the VRF TU to be simulated
-		Real64 & EvapTemp, // evaporating temperature
-		Real64 & CondTemp  // condensing temperature 
-	) {
-		// SUBROUTINE INFORMATION:
-		//       AUTHOR         Xiufeng Pang, LBNL
-		//       DATE WRITTEN   Feb 2014
-		//       MODIFIED       Jul 2015, RP Zhang, LBNL, Modify the bounds of the Te/Tc
-		//       MODIFIED       Nov 2015, RP Zhang, LBNL, take into account OA in Te/Tc determination
-		//       RE-ENGINEERED  na
-		
-		// PURPOSE OF THIS SUBROUTINE:
-		//       Calculate the VRF IU Te (cooling mode) and Tc (heating mode), given zonal loads.
-		
-		// METHODOLOGY EMPLOYED:
-		//       A new physics based VRF model appliable for Fluid Temperature Control.
-		
-		// REFERENCES:
-		// na
-		
-		// USE STATEMENTS:
-		using namespace DataZoneEnergyDemands;
-		using DataEnvironment::OutBaroPress;
-		using DXCoils::DXCoil;
-		using Fans::Fan;
-		using Fans::SimulateFanComponents;
-		using InputProcessor::FindItemInList;
-		using MixedAir::SimOAMixer;
-		using MixedAir::OAMixer;
-		using HVACVariableRefrigerantFlow::VRF;
-		using HVACVariableRefrigerantFlow::VRFTU;
-		using MixedAir::SimOAMixer;
-		using Psychrometrics::PsyHFnTdbW;
-		
-		// SUBROUTINE ARGUMENT DEFINITIONS:
-		// na
-		
-		// SUBROUTINE PARAMETER DEFINITIONS:
-		// na
-		
-		// INTERFACE BLOCK SPECIFICATIONS
-		// na
-		
-		// DERIVED TYPE DEFINITIONS
-		// na
-		
-		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-		int const Mode( 1 ); // Performance mode for MultiMode DX coil. Always 1 for other coil types
-		int CoolCoilNum; // index to the VRF Cooling DX coil to be simulated
-		int FanOutletNode; // index to the outlet node of the fan
-		int HeatCoilNum; // index to the VRF Heating DX coil to be simulated
-		int OAMixerNum; //OA mixer index
-		int OAMixNode; // index to the mix node of OA mixer
-		int IndexToTUInTUList; // index to TU in specific list for the VRF system
-		int TUListIndex; // index to TU list for this VRF system
-		int VRFNum; // index to VRF that the VRF Terminal Unit serves
-		int VRFInletNode; // VRF inlet node number
-		int ZoneIndex; // index to zone where the VRF Terminal Unit resides
-		Real64 BFC; // Bypass factor at the cooling mode (-)
-		Real64 BFH; // Bypass factor at the heating mode (-)
-		Real64 C1Tevap; // Coefficient for indoor unit coil evaporating temperature curve (-) 
-		Real64 C2Tevap; // Coefficient for indoor unit coil evaporating temperature curve (-)
-		Real64 C3Tevap; // Coefficient for indoor unit coil evaporating temperature curve (-)
-		Real64 C1Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
-		Real64 C2Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
-		Real64 C3Tcond; // Coefficient for indoor unit coil condensing temperature curve (-)
-		Real64 CondTempMin; // Min condensing temperature (C)
-		Real64 CondTempMax; // Max condensing temperature, correspond to the maximum heating capacity (C)
-		Real64 DeltaT; // Difference between evaporating/condensing temperature and coil surface temperature (C)
-		Real64 EvapTempMax; // Max evaporating temperature (C)
-		Real64 EvapTempMin; // Min evaporating temperature, correspond to the maximum cooling capacity (C)
-		Real64 Garate; // Nominal air mass flow rate
-		Real64 H_coil_in; // Air enthalpy at the coil inlet (kJ/kg)
-		Real64 QZnReqSenCoolingLoad; // Zone required sensible cooling load (W) 
-		Real64 QZnReqSenHeatingLoad; // Zone required sensible heating load (W)
-		Real64 RHsat; // Relative humidity of the air at saturated condition(-) 
-		Real64 SH; // Super heating degrees (C)
-		Real64 SC; // Subcooling degrees (C)
-		Real64 temp; // for temporary use
-		Real64 T_coil_in; // Temperature of the air at the coil inlet, after absorbing the heat released by fan (C)
-		Real64 T_TU_in; // Air temperature at the indoor unit inlet (C)
-		Real64 Tout; // Air temperature at the indoor unit outlet (C)
-		Real64 Th2; // Air temperature at the coil surface (C)
-		Real64 W_coil_in; // coil inlet air humidity ratio [kg/kg]
-		Real64 W_TU_in; // Air humidity ratio at the indoor unit inlet[kg/kg]
-		
-		// Get the equipment/zone index corresponding to the VRFTU
-		CoolCoilNum = VRFTU( VRFTUNum ).CoolCoilIndex;
-		HeatCoilNum = VRFTU( VRFTUNum ).HeatCoilIndex;
-		ZoneIndex = VRFTU( VRFTUNum ).ZoneNum;
-		VRFNum = VRFTU( VRFTUNum ).VRFSysNum;
-		TUListIndex = VRF( VRFNum ).ZoneTUListPtr;
-		IndexToTUInTUList = VRFTU( VRFTUNum ).IndexToTUInTUList;
-		
-		// Bounds of Te/Tc for VRF IU Control Algorithm: VariableTemp
-		EvapTempMin = VRF( VRFNum ).IUEvapTempLow;
-		EvapTempMax = VRF( VRFNum ).IUEvapTempHigh;
-		CondTempMin = VRF( VRFNum ).IUCondTempLow;
-		CondTempMax = VRF( VRFNum ).IUCondTempHigh;
-		
-		// Coefficients describing coil performance
-		SH = DXCoil( CoolCoilNum ).SH;
-		SC = DXCoil( HeatCoilNum ).SC; 
-		C1Tevap = DXCoil( CoolCoilNum ).C1Te;
-		C2Tevap = DXCoil( CoolCoilNum ).C2Te;
-		C3Tevap = DXCoil( CoolCoilNum ).C3Te;
-		C1Tcond = DXCoil( HeatCoilNum ).C1Tc;
-		C2Tcond = DXCoil( HeatCoilNum ).C2Tc;
-		C3Tcond = DXCoil( HeatCoilNum ).C3Tc;
-		
-		// Rated air flow rate for the coil
-		if ( ( ! VRF( VRFNum ).HeatRecoveryUsed && CoolingLoad( VRFNum ) ) || ( VRF( VRFNum ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRCoolRequest( IndexToTUInTUList ) ) ) {
-			// VRF terminal unit is on cooling mode
-			CompOnMassFlow = DXCoil( CoolCoilNum ).RatedAirMassFlowRate( Mode );
-		} else if ( ( ! VRF( VRFNum ).HeatRecoveryUsed && HeatingLoad( VRFNum ) ) || ( VRF( VRFNum ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRHeatRequest( IndexToTUInTUList ) ) ) {
-			// VRF terminal unit is on heating mode
-			CompOnMassFlow = DXCoil( HeatCoilNum ).RatedAirMassFlowRate( Mode );
-		} 
-		
-		// Set inlet air mass flow rate based on PLR and compressor on/off air flow rates
-		SetAverageAirFlow( VRFTUNum, 1.0, temp );
-		VRFInletNode = VRFTU( VRFTUNum ).VRFTUInletNodeNum;
-		T_TU_in = Node( VRFInletNode ).Temp;
-		W_TU_in = Node( VRFInletNode ).HumRat;
-		T_coil_in = T_TU_in;
-		W_coil_in = W_TU_in;
-		
-		// Simulation the OAMixer if there is any
-		if ( VRFTU( VRFTUNum ).OAMixerUsed ) {
-			SimOAMixer( VRFTU( VRFTUNum ).OAMixerName, false, VRFTU( VRFTUNum ).OAMixerIndex );
-			
-			OAMixerNum = FindItemInList( VRFTU( VRFTUNum ).OAMixerName, OAMixer );
-			OAMixNode = OAMixer( OAMixerNum ).MixNode;
-			T_coil_in = Node( OAMixNode ).Temp;
-			W_coil_in = Node( OAMixNode ).HumRat;
-		}
-
-		// Simulate the blow-through fan if there is any
-		if ( VRFTU( VRFTUNum ).FanPlace == BlowThru ) {
-			SimulateFanComponents( "", false, VRFTU( VRFTUNum ).FanIndex, FanSpeedRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
-			
-			FanOutletNode = Fan( VRFTU( VRFTUNum ).FanIndex ).OutletNodeNum;
-			T_coil_in = Node( FanOutletNode ).Temp;
-			W_coil_in = Node( FanOutletNode ).HumRat;
-		}
-		
-		Garate = CompOnMassFlow;
-		H_coil_in = PsyHFnTdbW( T_coil_in, W_coil_in );
-		RHsat = 0.98;
-		BFC = 0.0592; 
-		BFH = 0.136;  
-		
-		//1. COOLING Mode
-		if ( ( ! VRF( VRFNum ).HeatRecoveryUsed && CoolingLoad( VRFNum ) ) || ( VRF( VRFNum ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRCoolRequest( IndexToTUInTUList ) ) ) {
-		//1.1) Cooling coil is running
-			QZnReqSenCoolingLoad = max( 0.0, - 1.0 * ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToCoolingSP );
-			Tout = T_TU_in - QZnReqSenCoolingLoad / Garate / 1005;   
-			Th2 = T_coil_in - ( T_coil_in - Tout ) / ( 1 - BFC );
-			DeltaT = C3Tevap * SH * SH + C2Tevap * SH + C1Tevap;
-			EvapTemp = max( min( (Th2 - DeltaT ), EvapTempMax ), EvapTempMin );
-			
-		} else {
-		//1.2) Cooling coil is not running
-			EvapTemp = T_coil_in;
-		}
-		
-		//2. HEATING Mode
-		if ( ( ! VRF( VRFNum ).HeatRecoveryUsed && HeatingLoad( VRFNum ) ) || ( VRF( VRFNum ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRHeatRequest( IndexToTUInTUList ) ) ) {
-		//2.1) Heating coil is running
-			QZnReqSenHeatingLoad = max( 0.0, ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToHeatingSP );
-			Tout = T_TU_in + QZnReqSenHeatingLoad / Garate / 1005;        
-			Th2 = T_coil_in + ( Tout - T_coil_in ) / ( 1 - BFH );
-			DeltaT = C3Tcond * SC * SC + C2Tcond * SC + C1Tcond;
-			CondTemp = max( min( ( Th2 + DeltaT ), CondTempMax ), CondTempMin);
-		} else {
-		//2.2) Heating coil is not running
-			CondTemp = T_coil_in;
-		} 
-	}
-
 	void
 	CalcVRFCondenser_FluidTCtrl(
 		int const VRFCond, // index to VRF condenser
@@ -7617,7 +7496,7 @@ namespace HVACVariableRefrigerantFlow {
 							MinOutdoorUnitPe = max( Pdischarge - VRF( VRFCond ).CompMaxDeltaP, MinRefriPe );
 							MinOutdoorUnitTe = GetSatTemperatureRefrig( VRF( VRFCond ).RefrigerantName, max( min( MinOutdoorUnitPe, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 							
-							SolveRegulaFalsi( 1.0e-3, MaxIter, SolFla, SmallLoadTe, CompResidual_FluidTCtrl, MinOutdoorUnitTe, Tsuction, Par ); // SmallLoadTe is the updated Te'
+							SolveRegulaFalsi( 1.0e-3, MaxIter, SolFla, SmallLoadTe, CompResidual, MinOutdoorUnitTe, Tsuction, Par ); // SmallLoadTe is the updated Te'
 							if( SolFla < 0 ) SmallLoadTe = 6; //MinOutdoorUnitTe; //SmallLoadTe( Te'_new ) is constant during iterations
 							
 							//Initialization of Te iterations (Label11)
@@ -8021,7 +7900,7 @@ namespace HVACVariableRefrigerantFlow {
 							Par( 2 ) = OUEvapHeatExtract * C_cap_operation / VRF( VRFCond ).RatedEvapCapacity;
 							Par( 3 ) = VRF( VRFCond ).OUCoolingCAPFT( CounterCompSpdTemp );
 		
-							SolveRegulaFalsi( 1.0e-3, MaxIter, SolFla, SmallLoadTe, CompResidual_FluidTCtrl, MinOutdoorUnitTe, VRF( VRFCond ).EvaporatingTemp, Par );
+							SolveRegulaFalsi( 1.0e-3, MaxIter, SolFla, SmallLoadTe, CompResidual, MinOutdoorUnitTe, VRF( VRFCond ).EvaporatingTemp, Par );
 												 
 							if( SolFla < 0 ) SmallLoadTe = MinOutdoorUnitTe; 
 							
@@ -8121,7 +8000,7 @@ namespace HVACVariableRefrigerantFlow {
 			VRF( VRFCond ).PipingCorrectionCooling = TUHeatingLoad_temp / ( TUHeatingLoad_temp + Pipe_Q );
 			MaxHeatingCapacity( VRFCond ) = VRF( VRFCond ).HeatingCapacity; // for report
 		
-		// 3. Stop running
+		// @@@@@ 3. Stop running
 		} else { // Since: if( CoolingLoad( VRFCond ) &&( TUCoolingLoad > 0.0 ) ) 
 		
 			VRFOperationSimPath = 4; 
@@ -8490,220 +8369,6 @@ namespace HVACVariableRefrigerantFlow {
 	}
 	
 	void
-	ControlVRF_FluidTCtrl(
-		int const VRFTUNum, // Index to VRF terminal unit
-		Real64 const QZnReq, // Index to zone number
-		bool const FirstHVACIteration, // flag for 1st HVAC iteration in the time step
-		Real64 & PartLoadRatio, // unit part load ratio
-		Real64 & OnOffAirFlowRatio // ratio of compressor ON airflow to AVERAGE airflow over timestep
-	)
-	{
-
-		// SUBROUTINE INFORMATION:
-		//       AUTHOR         Rongpeng Zhang
-		//       DATE WRITTEN   Nov 2015
-		//       MODIFIED       na
-		//       RE-ENGINEERED  na
-
-		// PURPOSE OF THIS SUBROUTINE:
-		// Determine the coil load and part load ratio, given the zone load
-		// Determine the air mass flow rate corresponding to the coil load of the heat pump for this time step
-
-		// METHODOLOGY EMPLOYED:
-		// Use RegulaFalsi technique to iterate on part-load ratio until convergence is achieved.
-
-		// REFERENCES:
-		// na
-
-		// Using/Aliasing
-		using General::SolveRegulaFalsi;
-		using General::RoundSigDigits;
-		using General::TrimSigDigits;
-		using HeatingCoils::SimulateHeatingCoilComponents;
-		using DataEnvironment::OutDryBulbTemp;
-		using ScheduleManager::GetCurrentScheduleValue;
-
-		// Locals
-		// SUBROUTINE ARGUMENT DEFINITIONS:
-
-		// SUBROUTINE PARAMETER DEFINITIONS:
-		int const MaxIte( 500 ); // maximum number of iterations
-		Real64 const MinPLF( 0.0 ); // minimum part load factor allowed
-		Real64 const ErrorTol( 0.001 ); // tolerance for RegulaFalsi iterations
-		static gio::Fmt fmtLD( "*" );
-
-		// INTERFACE BLOCK SPECIFICATIONS
-		// na
-
-		// DERIVED TYPE DEFINITIONS
-		// na
-
-		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-		Real64 FullOutput; // unit full output when compressor is operating [W]
-		Real64 TempOutput; // unit output when iteration limit exceeded [W]
-		Real64 NoCompOutput; // output when no active compressor [W]
-		int SolFla; // Flag of RegulaFalsi solver
-		Array1D< Real64 > Par( 6 ); // Parameters passed to RegulaFalsi
-		std::string IterNum; // Max number of iterations for warning message
-		Real64 TempMinPLR; // min PLR used in Regula Falsi call
-		Real64 TempMaxPLR; // max PLR used in Regula Falsi call
-		bool ContinueIter; // used when convergence is an issue
-		int VRFCond; // index to VRF condenser
-		int IndexToTUInTUList; // index to TU in specific list for the VRF system
-		int TUListIndex; // index to TU list for this VRF system
-		bool VRFCoolingMode;
-		bool VRFHeatingMode;
-		bool HRCoolingMode;
-		bool HRHeatingMode;
-
-		PartLoadRatio = 0.0;
-		LoopDXCoolCoilRTF = 0.0;
-		LoopDXHeatCoilRTF = 0.0;
-		VRFCond = VRFTU( VRFTUNum ).VRFSysNum;
-		IndexToTUInTUList = VRFTU( VRFTUNum ).IndexToTUInTUList;
-		TUListIndex = VRF( VRFCond ).ZoneTUListPtr;
-		VRFCoolingMode = CoolingLoad( VRFCond );
-		VRFHeatingMode = HeatingLoad( VRFCond );
-		HRCoolingMode = TerminalUnitList( TUListIndex ).HRCoolRequest( IndexToTUInTUList );
-		HRHeatingMode = TerminalUnitList( TUListIndex ).HRHeatRequest( IndexToTUInTUList );
-
-		// The RETURNS here will jump back to SimVRF where the CalcVRF routine will simulate with lastest PLR
-
-		// do nothing else if TU is scheduled off
-		//!!LKL Discrepancy < 0
-		if ( GetCurrentScheduleValue( VRFTU( VRFTUNum ).SchedPtr ) == 0.0 ) return;
-
-		// Block the following statement: QZnReq==0 doesn't mean QCoilReq==0 due to possible OA mixer operation. zrp_201511
-		// do nothing if TU has no load (TU will be modeled using PLR=0)
-		// if ( QZnReq == 0.0 ) return;
-
-		// Set EMS value for PLR and return
-		if ( VRFTU( VRFTUNum ).EMSOverridePartLoadFrac ) {
-			PartLoadRatio = VRFTU( VRFTUNum ).EMSValueForPartLoadFrac;
-			return;
-		}
-
-		// Get result when DX coil is off
-		PartLoadRatio = 0.0;
-		
-		// Algorithm Type: VRF model based on physics, appliable for Fluid Temperature Control
-		CalcVRF_FluidTCtrl( VRFTUNum, FirstHVACIteration, 0.0, NoCompOutput, OnOffAirFlowRatio );
-
-		if ( VRFCoolingMode && HRHeatingMode ) {
-			// IF the system is in cooling mode, but the terminal unit requests heating (heat recovery)
-			if ( NoCompOutput >= QZnReq ) return;
-		} else if ( VRFHeatingMode && HRCoolingMode ) {
-			// IF the system is in heating mode, but the terminal unit requests cooling (heat recovery)
-			if ( NoCompOutput <= QZnReq ) return;
-		} else if ( VRFCoolingMode || HRCoolingMode ) {
-			// IF the system is in cooling mode and/or the terminal unit requests cooling
-			if ( NoCompOutput <= QZnReq ) return;
-		} else if ( VRFHeatingMode || HRHeatingMode ) {
-			// IF the system is in heating mode and/or the terminal unit requests heating
-			if ( NoCompOutput >= QZnReq ) return;
-		}
-
-		// Otherwise the coil needs to turn on. Get full load result
-		PartLoadRatio = 1.0;
-		CalcVRF_FluidTCtrl( VRFTUNum, FirstHVACIteration, PartLoadRatio, FullOutput, OnOffAirFlowRatio );
-
-		PartLoadRatio = 0.0;
-
-		if ( ( VRFCoolingMode && ! VRF( VRFCond ).HeatRecoveryUsed ) || ( VRF( VRFCond ).HeatRecoveryUsed && HRCoolingMode ) ) {
-			// Since we are cooling, we expect FullOutput < NoCompOutput
-			// If the QZnReq <= FullOutput the unit needs to run full out
-			if ( QZnReq <= FullOutput ) {
-				// if no coil present in terminal unit, no need to reset PLR?
-				if ( VRFTU( VRFTUNum ).CoolingCoilPresent ) PartLoadRatio = 1.0;
-				return;
-			}
-		} else if ( ( VRFHeatingMode && ! VRF( VRFCond ).HeatRecoveryUsed ) || ( VRF( VRFCond ).HeatRecoveryUsed && HRHeatingMode ) ) {
-			// Since we are heating, we expect FullOutput > NoCompOutput
-			// If the QZnReq >= FullOutput the unit needs to run full out
-			if ( QZnReq >= FullOutput ) {
-				// if no coil present in terminal unit, no need reset PLR?
-				if ( VRFTU( VRFTUNum ).HeatingCoilPresent ) PartLoadRatio = 1.0;
-				return;
-			}
-		} else {
-			// VRF terminal unit is off, PLR already set to 0 above
-			// shouldn't actually get here
-			return;
-		}
-
-		// The coil will not operate at PLR=0 or PLR=1, calculate the operating part-load ratio
-
-		if ( ( VRFHeatingMode || HRHeatingMode ) || ( VRFCoolingMode || HRCoolingMode ) ) {
-
-			Par( 1 ) = VRFTUNum;
-			Par( 2 ) = 0.0;
-			Par( 4 ) = 0.0;
-			if ( FirstHVACIteration ) {
-				Par( 3 ) = 1.0;
-			} else {
-				Par( 3 ) = 0.0;
-			}
-			//    Par(4) = OpMode
-			Par( 5 ) = QZnReq;
-			Par( 6 ) = OnOffAirFlowRatio;
-			SolveRegulaFalsi( ErrorTol, MaxIte, SolFla, PartLoadRatio, PLRResidual, 0.0, 1.0, Par );
-			if ( SolFla == -1 ) {
-				//     Very low loads may not converge quickly. Tighten PLR boundary and try again.
-				TempMaxPLR = -0.1;
-				ContinueIter = true;
-				while ( ContinueIter && TempMaxPLR < 1.0 ) {
-					TempMaxPLR += 0.1;
-					
-					CalcVRF_FluidTCtrl( VRFTUNum, FirstHVACIteration, TempMaxPLR, TempOutput, OnOffAirFlowRatio );
-					
-					if ( VRFHeatingMode && TempOutput > QZnReq ) ContinueIter = false;
-					if ( VRFCoolingMode && TempOutput < QZnReq ) ContinueIter = false;
-				}
-				TempMinPLR = TempMaxPLR;
-				ContinueIter = true;
-				while ( ContinueIter && TempMinPLR > 0.0 ) {
-					TempMaxPLR = TempMinPLR;
-					TempMinPLR -= 0.01;
-					
-					CalcVRF_FluidTCtrl( VRFTUNum, FirstHVACIteration, TempMaxPLR, TempOutput, OnOffAirFlowRatio );
-					
-					if ( VRFHeatingMode && TempOutput < QZnReq ) ContinueIter = false;
-					if ( VRFCoolingMode && TempOutput > QZnReq ) ContinueIter = false;
-				}
-				SolveRegulaFalsi( ErrorTol, MaxIte, SolFla, PartLoadRatio, PLRResidual, TempMinPLR, TempMaxPLR, Par );
-				if ( SolFla == -1 ) {
-					if ( ! FirstHVACIteration && ! WarmupFlag ) {
-						if ( VRFTU( VRFTUNum ).IterLimitExceeded == 0 ) {
-							gio::write( IterNum, fmtLD ) << MaxIte;
-							strip( IterNum );
-							ShowWarningMessage( cVRFTUTypes( VRFTU( VRFTUNum ).VRFTUType_Num ) + " \"" + VRFTU( VRFTUNum ).Name + "\"" );
-							ShowContinueError( " Iteration limit exceeded calculating terminal unit part-load ratio, maximum iterations = " + IterNum );
-							ShowContinueErrorTimeStamp( " Part-load ratio returned = " + RoundSigDigits( PartLoadRatio, 3 ) );
-							
-							CalcVRF_FluidTCtrl( VRFTUNum, FirstHVACIteration, TempMinPLR, TempOutput, OnOffAirFlowRatio );
-							
-							ShowContinueError( " Load requested = " + TrimSigDigits( QZnReq, 5 ) + ", Load delivered = " + TrimSigDigits( TempOutput, 5 ) );
-							ShowRecurringWarningErrorAtEnd( cVRFTUTypes( VRFTU( VRFTUNum ).VRFTUType_Num ) + " \"" + VRFTU( VRFTUNum ).Name + "\" -- Terminal unit Iteration limit exceeded error continues...", VRFTU( VRFTUNum ).IterLimitExceeded );
-						} else {
-							ShowRecurringWarningErrorAtEnd( cVRFTUTypes( VRFTU( VRFTUNum ).VRFTUType_Num ) + " \"" + VRFTU( VRFTUNum ).Name + "\" -- Terminal unit Iteration limit exceeded error continues...", VRFTU( VRFTUNum ).IterLimitExceeded );
-						}
-					}
-				} else if ( SolFla == -2 ) {
-					PartLoadRatio = max( MinPLF, std::abs( QZnReq - NoCompOutput ) / std::abs( FullOutput - NoCompOutput ) );
-				}
-			} else if ( SolFla == -2 ) {
-				if ( FullOutput - NoCompOutput == 0.0 ) {
-					PartLoadRatio = 0.0;
-				} else {
-					PartLoadRatio = min( 1.0, max( MinPLF, std::abs( QZnReq - NoCompOutput ) / std::abs( FullOutput - NoCompOutput ) ) );
-				}
-			}
-
-		}
-
-	}
-	
-	void
 	CalcVRF_FluidTCtrl(
 		int const VRFTUNum, // Unit index in VRF terminal unit array
 		bool const FirstHVACIteration, // flag for 1st HVAC iteration in the time step
@@ -8780,18 +8445,7 @@ namespace HVACVariableRefrigerantFlow {
 		EvapTemp = VRF(VRFCond).IUEvaporatingTemp;
 		CondTemp = VRF(VRFCond).IUCondensingTemp;
 
-		// Set inlet air mass flow rate based on PLR and compressor on/off air flow rates
-		if( PartLoadRatio == 0 ) {
-			// only provide required OA when coil is off
-			CompOnMassFlow = OACompOnMassFlow; 
-		} else {
-			// identify the air flow rate corresponding to the coil load
-			CompOnMassFlow = CalVRFTUAirFlowRate_FluidTCtrl( VRFTUNum, PartLoadRatio, FirstHVACIteration );
-		}
-		SetAverageAirFlow( VRFTUNum, PartLoadRatio, OnOffAirFlowRatio );
 		AirMassFlow = Node( VRFTUInletNodeNum ).MassFlowRate;
-		
-		// simulate OA Mixer
 		if ( VRFTU( VRFTUNum ).OAMixerUsed ) SimOAMixer( VRFTU( VRFTUNum ).OAMixerName, FirstHVACIteration, VRFTU( VRFTUNum ).OAMixerIndex );
 
 		// if blow through, simulate fan then coils
@@ -8802,9 +8456,9 @@ namespace HVACVariableRefrigerantFlow {
 		if ( VRFTU( VRFTUNum ).CoolingCoilPresent ) {
 			// above condition for heat pump mode, below condition for heat recovery mode
 			if ( ( ! VRF( VRFCond ).HeatRecoveryUsed && CoolingLoad( VRFCond ) ) || ( VRF( VRFCond ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRCoolRequest( IndexToTUInTUList ) ) ) {
-				SimDXCoil( "", On, FirstHVACIteration, VRFTU( VRFTUNum ).CoolCoilIndex, OpMode, PartLoadRatio, _, _, MaxCoolingCapacity( VRFCond ), VRF( VRFTU( VRFTUNum ).VRFSysNum ).VRFCondCyclingRatio );
+				SimDXCoil( "", On, FirstHVACIteration, VRFTU( VRFTUNum ).CoolCoilIndex, OpMode, PartLoadRatio, OnOffAirFlowRatio, _, MaxCoolingCapacity( VRFCond ), VRF( VRFTU( VRFTUNum ).VRFSysNum ).VRFCondCyclingRatio );
 			} else { // cooling coil is off
-				SimDXCoil( "", Off, FirstHVACIteration, VRFTU( VRFTUNum ).CoolCoilIndex, OpMode, 0.0, _ );
+				SimDXCoil( "", Off, FirstHVACIteration, VRFTU( VRFTUNum ).CoolCoilIndex, OpMode, 0.0, OnOffAirFlowRatio );
 			}
 			LoopDXCoolCoilRTF = LoopDXCoilRTF;
 		} else {
@@ -8814,9 +8468,9 @@ namespace HVACVariableRefrigerantFlow {
 		if ( VRFTU( VRFTUNum ).HeatingCoilPresent ) {
 			// above condition for heat pump mode, below condition for heat recovery mode
 			if ( ( ! VRF( VRFCond ).HeatRecoveryUsed && HeatingLoad( VRFCond ) ) || ( VRF( VRFCond ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRHeatRequest( IndexToTUInTUList ) ) ) {
-				SimDXCoil( "", On, FirstHVACIteration, VRFTU( VRFTUNum ).HeatCoilIndex, OpMode, PartLoadRatio, _, _, MaxHeatingCapacity( VRFCond ) );
+				SimDXCoil( "", On, FirstHVACIteration, VRFTU( VRFTUNum ).HeatCoilIndex, OpMode, PartLoadRatio, OnOffAirFlowRatio, _, MaxHeatingCapacity( VRFCond ) );
 			} else {
-				SimDXCoil( "", Off, FirstHVACIteration, VRFTU( VRFTUNum ).HeatCoilIndex, OpMode, 0.0, _ );
+				SimDXCoil( "", Off, FirstHVACIteration, VRFTU( VRFTUNum ).HeatCoilIndex, OpMode, 0.0, OnOffAirFlowRatio );
 			}
 			LoopDXHeatCoilRTF = LoopDXCoilRTF;
 		} else {
@@ -8833,7 +8487,7 @@ namespace HVACVariableRefrigerantFlow {
 
 		// calculate sensible load met using delta enthalpy at a constant (minimum) humidity ratio
 		MinHumRat = min( Node( VRFTUInletNodeNum ).HumRat, Node( VRFTUOutletNodeNum ).HumRat );
-		LoadMet = AirMassFlow * ( PsyHFnTdbW( Node( VRFTUOutletNodeNum ).Temp, MinHumRat ) - PsyHFnTdbW( Node( VRFTUInletNodeNum ).Temp, MinHumRat ) ); // sensible load met by TU
+		LoadMet = AirMassFlow * ( PsyHFnTdbW( Node( VRFTUOutletNodeNum ).Temp, MinHumRat ) - PsyHFnTdbW( Node( VRFTUInletNodeNum ).Temp, MinHumRat ) );
 
 		if ( present( LatOutputProvided ) ) {
 			//   CR9155 Remove specific humidity calculations
@@ -8844,263 +8498,8 @@ namespace HVACVariableRefrigerantFlow {
 
 	}
 
-	Real64
-	CalVRFTUAirFlowRate_FluidTCtrl(
-		int VRFTUNum, // TU index
-		Real64 PartLoadRatio, // part load ratio of the coil
-		bool FirstHVACIteration // FirstHVACIteration flag
-	)
-	{
-		// SUBROUTINE INFORMATION:
-		//       AUTHOR         Rongpeng Zhang, LBNL
-		//       DATE WRITTEN   Nov 2015
-		//       MODIFIED       na
-		//       RE-ENGINEERED  na
-
-		// PURPOSE OF THIS FUNCTION:
-		//  This function determines the TU airflow rate corresponding to the coil load.
-		//  This is used to address the coupling between OA mixer simulation and VRF-FluidTCtrl coil simulation.
-
-		// METHODOLOGY EMPLOYED:
-		//  VRF-FluidTCtrl TU airflow rate is determined by the control logic of VRF-FluidTCtrl coil to match the 
-		//  coil load. This is affected by the coil inlet conditions. However, the airflow rate will affect the 
-		//  OA mixer simulation, which leads to different coil inlet conditions. So, there is a coupling issue here.
-
-		// REFERENCES:
-		// na
-
-		// USE STATEMENTS:
-		using DXCoils::DXCoil;
-		using General::SolveRegulaFalsi;
-
-		// Return value
-		Real64 AirMassFlowRate; // air mass flow rate of the coil (kg/s)
-
-		// Argument array dimensioning
-		
-		// FUNCTION PARAMETER DEFINITIONS:
-		//  na
-
-		// INTERFACE BLOCK SPECIFICATIONS
-		//  na
-
-		// DERIVED TYPE DEFINITIONS
-		//  na
-
-		// FUNCTION LOCAL VARIABLE DECLARATIONS:
-		Array1D< Real64 > Par( 7 ); // Parameters passed to RegulaFalsi
-		int const Mode( 1 ); // Performance mode for MultiMode DX coil. Always 1 for other coil types
-		int const MaxIte( 500 ); // maximum number of iterations
-		int DXCoilNum; // index to DX Coil
-		int IndexToTUInTUList; // index to TU in specific list for the VRF system
-		int SolFla; // Flag of RegulaFalsi solver
-		int TUListIndex; // index to TU list for this VRF system
-		int VRFCond; // index to VRF condenser
-		Real64 const ErrorTol( 0.01 ); // tolerance for RegulaFalsi iterations
-		Real64 FanSpdRatio; // ratio of required and rated air flow rate
-		Real64 FanSpdRatioMin; // min fan speed ratio
-		Real64 FanSpdRatioMax; // min fan speed ratio
-		Real64 QCoilReq; // required coil load (W)
-		Real64 QCoilAct; // actural coil load (W)
-		Real64 TeTc; // evaporating temperature or condensing temperature for VRF indoor unit(C)
-
-		
-		VRFCond = VRFTU( VRFTUNum ).VRFSysNum;
-		TUListIndex = VRF( VRFCond ).ZoneTUListPtr;
-		IndexToTUInTUList = VRFTU( VRFTUNum ).IndexToTUInTUList;
-		
-		if ( ( ! VRF( VRFCond ).HeatRecoveryUsed && CoolingLoad( VRFCond ) ) || ( VRF( VRFCond ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRCoolRequest( IndexToTUInTUList ) ) ) {
-			// VRF terminal unit is on cooling mode
-			DXCoilNum = VRFTU( VRFTUNum ).CoolCoilIndex;
-			QCoilReq = - PartLoadRatio * DXCoil( DXCoilNum ).RatedTotCap( Mode ); // positive for heating; negative for cooling
-			TeTc = VRF( VRFCond ).IUEvaporatingTemp;
-			
-		} else if ( ( ! VRF( VRFCond ).HeatRecoveryUsed && HeatingLoad( VRFCond ) ) || ( VRF( VRFCond ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRHeatRequest( IndexToTUInTUList ) ) ) {
-			// VRF terminal unit is on heating mode
-			DXCoilNum = VRFTU( VRFTUNum ).HeatCoilIndex;
-			QCoilReq = PartLoadRatio * DXCoil( DXCoilNum ).RatedTotCap( Mode ); // positive for heating; negative for cooling
-			TeTc = VRF( VRFCond ).IUCondensingTemp;
-			
-		} else {
-			// VRF terminal unit is off
-			QCoilAct = 0.0;
-			AirMassFlowRate = max( OACompOnMassFlow, 0.0 );
-			return AirMassFlowRate;
-		}
-		
-		// minimum airflow rate
-		FanSpdRatioMin = min( OACompOnMassFlow / DXCoil( DXCoilNum ).RatedAirMassFlowRate( Mode ), 1.0 );
-		
-		if ( FirstHVACIteration ) {
-			Par( 1 ) = 1.0;
-		} else {
-			Par( 2 ) = 0.0;
-		}
-		Par( 2 ) = VRFTUNum;
-		Par( 3 ) = DXCoilNum;
-		Par( 4 ) = QCoilReq;
-		Par( 5 ) = TeTc;
-		Par( 6 ) = PartLoadRatio;
-		Par( 7 ) = OACompOnMassFlow;
-		
-		FanSpdRatioMax = 1.0; 
-		SolveRegulaFalsi( ErrorTol, MaxIte, SolFla, FanSpdRatio, VRFTUAirFlowResidual_FluidTCtrl, FanSpdRatioMin, FanSpdRatioMax, Par );
-		if( SolFla < 0) FanSpdRatio = FanSpdRatioMax; //over capacity
-		
-		AirMassFlowRate = FanSpdRatio * DXCoil( DXCoilNum ).RatedAirMassFlowRate( Mode );
-		
-		return AirMassFlowRate;
-		
-	}
-
-	Real64
-	VRFTUAirFlowResidual_FluidTCtrl(
-		Real64 const FanSpdRatio, // fan speed ratio of VRF VAV TU 
-		Array1< Real64 > const & Par // par(1) = VRFTUNum
-	)
-	{
-		// FUNCTION INFORMATION:
-		//       AUTHOR         Rongpeng Zhang, LBNL
-		//       DATE WRITTEN   Nov 2015
-		//       MODIFIED       na
-		//       RE-ENGINEERED  na
-
-		// PURPOSE OF THIS SUBROUTINE:
-		// 		Calculates residual function ( FanSpdRatioAct - FanSpdRatio ) / FanSpdRatio
-		// 		This is used to address the coupling between OA mixer simulation and VRF-FluidTCtrl coil simulation.
-
-		// METHODOLOGY EMPLOYED:
-		// 		VRF-FluidTCtrl TU airflow rate is determined by the control logic of VRF-FluidTCtrl coil to match the 
-		// 		coil load. This is affected by the coil inlet conditions. However, the airflow rate will affect the 
-		// 		OA mixer simulation, which leads to different coil inlet conditions. So, there is a coupling issue here.
-
-		// REFERENCES:
-		// na
-
-		// Using/Aliasing
-		using DXCoils::ControlVRFIUCoil;
-		using DXCoils::DXCoil;
-		using Fans::Fan;
-		using Fans::SimulateFanComponents;
-		using InputProcessor::FindItemInList;
-		using MixedAir::SimOAMixer;
-		using MixedAir::OAMixer;
-		using Psychrometrics::PsyHFnTdbW;
-
-		// REFERENCES:
-		// na
-
-		// USE STATEMENTS:
-		// na
-
-		// Return value
-		Real64 AirFlowRateResidual;
-
-		// Argument array dimensioning
-
-		// Locals
-		// SUBROUTINE ARGUMENT DEFINITIONS:
-		// 	Par( 1 ) = FirstHVACIteration;
-		// 	Par( 2 ) = VRFTUNum;
-		// 	Par( 3 ) = DXCoilNum;
-		// 	Par( 4 ) = QCoilReq;
-		// 	Par( 5 ) = TeTc;
-		// 	Par( 6 ) = PartLoadRatio;
-		// 	Par( 7 ) = OACompOnMassFlow;
-
-		// FUNCTION PARAMETER DEFINITIONS:
-		//  na
-
-		// INTERFACE BLOCK SPECIFICATIONS
-		//  na
-
-		// DERIVED TYPE DEFINITIONS
-		//  na
-
-		// FUNCTION LOCAL VARIABLE DECLARATIONS:
-		int const Mode( 1 ); // Performance mode for MultiMode DX coil. Always 1 for other coil types
-		int CoilIndex; // index to coil
-		int FanOutletNode; // index to the outlet node of the fan
-		int OAMixerNum; //OA mixer index
-		int OAMixNode; // index to the mix node of OA mixer
-		int VRFCond; // index to VRF condenser
-		int VRFTUNum; // Unit index in VRF terminal unit array
-		int VRFInletNode; // VRF inlet node number
-		bool FirstHVACIteration; // flag for 1st HVAC iteration in the time step
-		Real64 FanSpdRatioBase; // baseline FanSpdRatio for VRFTUAirFlowResidual
-		Real64 FanSpdRatioAct; // calculated FanSpdRatio for VRFTUAirFlowResidual
-		Real64 PartLoadRatio; //Part load ratio
-		Real64 QCoilReq; // required coil load [W]
-		Real64 QCoilAct; // actual coil load [W]
-		Real64 temp; // for temporary use
-		Real64 TeTc; //evaporating/condensing temperature [C]
-		Real64 Tin; // coil inlet air temperature [C]
-		Real64 Win; // coil inlet air humidity ratio [kg/kg]
-		Real64 Hin; // coil inlet air enthalpy
-		Real64 Wout; // coil outlet air humidity ratio
-		Real64 Tout; // coil outlet air temperature
-		Real64 Hout; // coil outlet air enthalpy
-		Real64 SHact;// coil actual SH
-		Real64 SCact;// coil actual SC
-
-		// FLOW
-
-		// FirstHVACIteration is a logical, Par is real, so make 1.0=TRUE and 0.0=FALSE
-		FirstHVACIteration = ( Par( 1 ) == 1.0 );
-		VRFTUNum = int( Par( 2 ) );
-		CoilIndex = int( Par( 3 ) );
-		QCoilReq = Par( 4 ) ;
-		TeTc = Par( 5 ) ;
-		PartLoadRatio = Par( 6 ) ;
-		OACompOnMassFlow = Par( 7 ) ;
-		
-		VRFCond = VRFTU( VRFTUNum ).VRFSysNum;
-		VRFInletNode = VRFTU( VRFTUNum ).VRFTUInletNodeNum;
-		
-		if ( std::abs( FanSpdRatio ) < 0.01 ) 
-			FanSpdRatioBase = sign( 0.01, FanSpdRatio );
-		else 
-			FanSpdRatioBase = FanSpdRatio;
-
-		// Set inlet air mass flow rate based on PLR and compressor on/off air flow rates
-		CompOnMassFlow = FanSpdRatio * DXCoil( CoilIndex ).RatedAirMassFlowRate( Mode );
-		SetAverageAirFlow( VRFTUNum, PartLoadRatio, temp );
-		Tin = Node( VRFInletNode ).Temp;
-		Win = Node( VRFInletNode ).HumRat;
-		
-		// Simulation the OAMixer if there is any
-		if ( VRFTU( VRFTUNum ).OAMixerUsed ) {
-			SimOAMixer( VRFTU( VRFTUNum ).OAMixerName, FirstHVACIteration, VRFTU( VRFTUNum ).OAMixerIndex );
-			
-			OAMixerNum = FindItemInList( VRFTU( VRFTUNum ).OAMixerName, OAMixer );
-			OAMixNode = OAMixer( OAMixerNum ).MixNode;
-			Tin = Node( OAMixNode ).Temp;
-			Win = Node( OAMixNode ).HumRat;
-		}
-
-		// Simulate the blow-through fan if there is any
-		if ( VRFTU( VRFTUNum ).FanPlace == BlowThru ) {
-			SimulateFanComponents( "", FirstHVACIteration, VRFTU( VRFTUNum ).FanIndex, FanSpeedRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
-			
-			FanOutletNode = Fan( VRFTU( VRFTUNum ).FanIndex ).OutletNodeNum;
-			Tin = Node( FanOutletNode ).Temp;
-			Win = Node( FanOutletNode ).HumRat;
-		}
-
-		// Call the coil control logic to determine the air flow rate to match the given coil load
-		ControlVRFIUCoil( CoilIndex, QCoilReq, Tin, Win, TeTc, OACompOnMassFlow, FanSpdRatioAct, Wout, Tout, Hout, SHact, SCact );
-		
-		Hin = PsyHFnTdbW( Tin, Win );
-		QCoilAct = FanSpdRatioAct * DXCoil( CoilIndex ).RatedAirMassFlowRate( Mode ) * ( Hout - Hin ); // positive for heating, negative for cooling
-		
-		AirFlowRateResidual = ( FanSpdRatioAct - FanSpdRatio ); //@@ / FanSpdRatioBase;
-
-		return AirFlowRateResidual;
-		
-	}
-
 	Real64 
-	CompResidual_FluidTCtrl( 
+	CompResidual( 
 		Real64 const Te, // Outdoor unit evaporating temperature
 		Array1< Real64 > const & Par        // parameters
 	)

--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.hh
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.hh
@@ -213,7 +213,6 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 CompressorSizeRatio; // ratio of min compressor size to total capacity
 		int NumCompressors; // number of compressors in VRF condenser
 		Real64 MaxOATCCHeater; // maximum outdoor air dry-bulb temp for crankcase heater operation (C)
-		//begin variables used for Defrost 
 		int DefrostEIRPtr; // index to defrost EIR curve
 		Real64 DefrostFraction; // defrost time period fraction (hr)
 		int DefrostStrategy; // Type of defrost (reversecycle or resistive)
@@ -222,7 +221,6 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 DefrostPower; // power used during defrost (W)
 		Real64 DefrostConsumption; // energy used during defrost (J)
 		Real64 MaxOATDefrost; // maximum outdoor air dry-bulb temp for defrost operation (C)
-		//end variables used for Defrost 
 		int CondenserType; // condenser type, evap- or air-cooled
 		int CondenserNodeNum; // condenser inlet node number
 		bool SkipCondenserNodeNumCheck; // used to check for duplicate node names
@@ -1553,22 +1551,6 @@ namespace HVACVariableRefrigerantFlow {
 	);
 	
 	void
-	CalcVRFIUVariableTeTc(
-		int const VRFTUNum, // the number of the VRF TU to be simulated
-		Real64 & EvapTemp, // evaporating temperature
-		Real64 & CondTemp  // condensing temperature 
-	);
-		
-	void
-	ControlVRF_FluidTCtrl(
-		int const VRFTUNum, // Index to VRF terminal unit
-		Real64 const QZnReq, // Index to zone number
-		bool const FirstHVACIteration, // flag for 1st HVAC iteration in the time step
-		Real64 & PartLoadRatio, // unit part load ratio
-		Real64 & OnOffAirFlowRatio // ratio of compressor ON airflow to AVERAGE airflow over timestep
-	);
-	
-	void
 	CalcVRF_FluidTCtrl(
 		int const VRFTUNum, // Unit index in VRF terminal unit array
 		bool const FirstHVACIteration, // flag for 1st HVAC iteration in the time step
@@ -1584,21 +1566,8 @@ namespace HVACVariableRefrigerantFlow {
 		bool const FirstHVACIteration // flag for first time through HVAC system simulation
 	);
 	
-	Real64
-	CalVRFTUAirFlowRate_FluidTCtrl(
-		int VRFTUNum, // TU index
-		Real64 PartLoadRatio, // part load ratio of the coil 
-		bool FirstHVACIteration // FirstHVACIteration flag
-	);
-	
-	Real64
-	VRFTUAirFlowResidual_FluidTCtrl(
-		Real64 const FanSpdRatio, // fan speed ratio of VRF VAV TU 
-		Array1< Real64 > const & Par // par(1) = VRFTUNum
-	);
-	
 	Real64 
-	CompResidual_FluidTCtrl( 
+	CompResidual( 
 		Real64 const Te, // Outdoor unit evaporating temperature
 		Array1< Real64 > const & Par // Array of parameters
 	);

--- a/testfiles/VariableRefrigerantFlow_FluidTCtrl_5Zone.idf
+++ b/testfiles/VariableRefrigerantFlow_FluidTCtrl_5Zone.idf
@@ -117,15 +117,15 @@
     R410A,                   !- Refrigerant Type
     41300,                   !- Rated Evaporative Capacity {W}
     0.344,                   !- Rated Compressor Power Per Unit of Rated Evaporative Capacity {W/W}
-    -5,                      !- Minimum Outdoor Air Temperature in Cooling Mode {C}
-    43,                      !- Maximum Outdoor Air Temperature in Cooling Mode {C}
-    -20,                     !- Minimum Outdoor Air Temperature in Heating Mode {C}
-    22,                      !- Maximum Outdoor Air Temperature in Heating Mode {C}
+    ,                        !- Minimum Outdoor Air Temperature in Cooling Mode {C}
+    ,                        !- Maximum Outdoor Air Temperature in Cooling Mode {C}
+    ,                        !- Minimum Outdoor Air Temperature in Heating Mode {C}
+    ,                        !- Maximum Outdoor Air Temperature in Heating Mode {C}
     3,                       !- Reference Outdoor Unit Superheating Degrees {C}
     3,                       !- Reference Outdoor Unit Subcooling Degrees {C}
-    ConstantTemp,            !- Refrigerant Temperature Control Algorithm for Indoor Unit
-    6,                       !- Reference Evaporating Temperature for Indoor Unit {C}
-    44,                      !- Reference Condensing Temperature for Indoor Unit {C}
+    VariableTemp,            !- Refrigerant Temperature Control Algorithm for Indoor Unit
+    ,                        !- Reference Evaporating Temperature for Indoor Unit {C}
+    ,                        !- Reference Condensing Temperature for Indoor Unit {C}
     6,                       !- Variable Evaporating Temperature Minimum for Indoor Unit {C}
     13,                      !- Variable Evaporating Temperature Maximum for Indoor Unit {C}
     42,                      !- Variable Condensing Temperature Minimum for Indoor Unit {C}
@@ -480,7 +480,7 @@
     TU1 VRF Supply Fan,      !- Name
     VRFAvailSched,           !- Availability Schedule Name
     0.7,                     !- Fan Total Efficiency
-    600,                     !- Pressure Rise {Pa}
+    200,                     !- Pressure Rise {Pa}
     autosize,                !- Maximum Flow Rate {m3/s}
     Fraction,                !- Fan Power Minimum Flow Rate Input Method
     0,                       !- Fan Power Minimum Flow Fraction
@@ -500,7 +500,7 @@
     TU2 VRF Supply Fan,      !- Name
     VRFAvailSched,           !- Availability Schedule Name
     0.7,                     !- Fan Total Efficiency
-    600,                     !- Pressure Rise {Pa}
+    200,                     !- Pressure Rise {Pa}
     autosize,                !- Maximum Flow Rate {m3/s}
     Fraction,                !- Fan Power Minimum Flow Rate Input Method
     0,                       !- Fan Power Minimum Flow Fraction
@@ -520,7 +520,7 @@
     TU3 VRF Supply Fan,      !- Name
     VRFAvailSched,           !- Availability Schedule Name
     0.7,                     !- Fan Total Efficiency
-    600,                     !- Pressure Rise {Pa}
+    200,                     !- Pressure Rise {Pa}
     autosize,                !- Maximum Flow Rate {m3/s}
     Fraction,                !- Fan Power Minimum Flow Rate Input Method
     0,                       !- Fan Power Minimum Flow Fraction
@@ -540,7 +540,7 @@
     TU4 VRF Supply Fan,      !- Name
     VRFAvailSched,           !- Availability Schedule Name
     0.7,                     !- Fan Total Efficiency
-    600,                     !- Pressure Rise {Pa}
+    200,                     !- Pressure Rise {Pa}
     autosize,                !- Maximum Flow Rate {m3/s}
     Fraction,                !- Fan Power Minimum Flow Rate Input Method
     0,                       !- Fan Power Minimum Flow Fraction
@@ -560,7 +560,7 @@
     TU5 VRF Supply Fan,      !- Name
     VRFAvailSched,           !- Availability Schedule Name
     0.7,                     !- Fan Total Efficiency
-    600,                     !- Pressure Rise {Pa}
+    200,                     !- Pressure Rise {Pa}
     autosize,                !- Maximum Flow Rate {m3/s}
     Fraction,                !- Fan Power Minimum Flow Rate Input Method
     0,                       !- Fan Power Minimum Flow Fraction

--- a/tst/EnergyPlus/unit/HVACVariableRefrigerantFlow.unit.cc
+++ b/tst/EnergyPlus/unit/HVACVariableRefrigerantFlow.unit.cc
@@ -69,6 +69,57 @@ using namespace EnergyPlus::SizingManager;
 
 namespace EnergyPlus {
 
+	TEST( HVACVariableRefrigerantFlow, VRF_FluidTCtrl_CompResidual )
+	{
+		// PURPOSE OF THIS SUBROUTINE:
+		//  Calculates residual function ((VRV terminal unit cooling output - Zone sensible cooling load)
+
+		using namespace CurveManager;
+
+		int CurveNum = 1;
+		int NumPar;
+		double Te = -2.796; // Outdoor unit evaporating temperature
+		double Tdis = 40.093;
+		double CondHeat = 1864.44;
+		Array1D< Real64 > Par;
+
+		// Allocate
+		NumCurves = 1; //CurveManager::NumCurves
+		PerfCurve.allocate( NumCurves );
+
+		NumPar = 3;
+		Par.allocate( NumPar );
+
+		// Inputs: curve parameters
+		Par( 1 ) = Tdis;
+		Par( 2 ) = CondHeat;
+		Par( 3 ) = CurveNum;
+
+		// Inputs: parameters
+		PerfCurve( CurveNum ).CurveType = CurveManager::BiQuadratic;
+		PerfCurve( CurveNum ).ObjectType = CurveType_BiQuadratic;
+		PerfCurve( CurveNum ).InterpolationType = EvaluateCurveToLimits;
+		PerfCurve( CurveNum ).Coeff1 = 724.71125; // Coefficient1 Constant
+		PerfCurve( CurveNum ).Coeff2 = -21.867868; // Coefficient2 x
+		PerfCurve( CurveNum ).Coeff3 = 0.52480042; // Coefficient3 x**2
+		PerfCurve( CurveNum ).Coeff4 = -17.043566; // Coefficient4 y
+		PerfCurve( CurveNum ).Coeff5 = -.40346383; // Coefficient5 y**2
+		PerfCurve( CurveNum ).Coeff6 = 0.29573589; // Coefficient6 x*y
+		PerfCurve( CurveNum ).Var1Min = 15; // Minimum Value of x
+		PerfCurve( CurveNum ).Var1Max = 65; // Maximum Value of x
+		PerfCurve( CurveNum ).Var2Min = -30; // Minimum Value of y
+		PerfCurve( CurveNum ).Var2Max = 15; // Maximum Value of y
+
+		// Run and Check
+		double CompResidual = HVACVariableRefrigerantFlow::CompResidual( Te, Par );
+		EXPECT_NEAR( 1.652, CompResidual, 0.005 );
+
+		// Clean up
+		PerfCurve.deallocate( );
+		Par.deallocate( );
+
+	}
+
 	TEST_F( EnergyPlusFixture, VRFFluidTCtrlGetCoilInput )
 	{
 		// PURPOSE OF THE TEST:
@@ -114,57 +165,6 @@ namespace EnergyPlus {
 		EXPECT_EQ( DXCoil( 1 ).SH, 3 );
 
 	}
-	
-	TEST( HVACVariableRefrigerantFlow, VRF_FluidTCtrl_CompResidual )
-	{
-		// PURPOSE OF THIS SUBROUTINE:
-		//  Calculates residual function ((VRV terminal unit cooling output - Zone sensible cooling load)
-
-		using namespace CurveManager;
-
-		int CurveNum = 1;
-		int NumPar;
-		double Te = -2.796; // Outdoor unit evaporating temperature
-		double Tdis = 40.093;
-		double CondHeat = 1864.44;
-		Array1D< Real64 > Par;
-
-		// Allocate
-		NumCurves = 1; //CurveManager::NumCurves
-		PerfCurve.allocate( NumCurves );
-
-		NumPar = 3;
-		Par.allocate( NumPar );
-
-		// Inputs: curve parameters
-		Par( 1 ) = Tdis;
-		Par( 2 ) = CondHeat;
-		Par( 3 ) = CurveNum;
-
-		// Inputs: parameters
-		PerfCurve( CurveNum ).CurveType = CurveManager::BiQuadratic;
-		PerfCurve( CurveNum ).ObjectType = CurveType_BiQuadratic;
-		PerfCurve( CurveNum ).InterpolationType = EvaluateCurveToLimits;
-		PerfCurve( CurveNum ).Coeff1 = 724.71125; // Coefficient1 Constant
-		PerfCurve( CurveNum ).Coeff2 = -21.867868; // Coefficient2 x
-		PerfCurve( CurveNum ).Coeff3 = 0.52480042; // Coefficient3 x**2
-		PerfCurve( CurveNum ).Coeff4 = -17.043566; // Coefficient4 y
-		PerfCurve( CurveNum ).Coeff5 = -.40346383; // Coefficient5 y**2
-		PerfCurve( CurveNum ).Coeff6 = 0.29573589; // Coefficient6 x*y
-		PerfCurve( CurveNum ).Var1Min = 15; // Minimum Value of x
-		PerfCurve( CurveNum ).Var1Max = 65; // Maximum Value of x
-		PerfCurve( CurveNum ).Var2Min = -30; // Minimum Value of y
-		PerfCurve( CurveNum ).Var2Max = 15; // Maximum Value of y
-
-		// Run and Check
-		double CompResidual = HVACVariableRefrigerantFlow::CompResidual_FluidTCtrl( Te, Par );
-		EXPECT_NEAR( 1.652, CompResidual, 0.005 );
-
-		// Clean up
-		PerfCurve.deallocate( );
-		Par.deallocate( );
-
-	}
 
 	TEST( HVACVariableRefrigerantFlow, VRF_FluidTCtrl_FanSpdResidualCool )
 	{
@@ -178,6 +178,7 @@ namespace EnergyPlus {
 		double ZnSenLoad;
 		double Th2;
 		double TairInlet;
+		double QfanRate;
 		double Garate;
 		double BF;
 		Array1D< Real64 > Par;
@@ -191,17 +192,19 @@ namespace EnergyPlus {
 		ZnSenLoad = 2716.62;
 		Th2 = 17.41212;
 		TairInlet = 25.55534;
+		QfanRate = 37.8;
 		Garate = 0.20664;
 		BF = 0.0592;
 		Par( 1 ) = ZnSenLoad;
 		Par( 2 ) = Th2;
 		Par( 3 ) = TairInlet;
-		Par( 4 ) = Garate;
-		Par( 5 ) = BF;
+		Par( 4 ) = QfanRate;
+		Par( 5 ) = Garate;
+		Par( 6 ) = BF;
 
 		// Run and Check
 		double FanSpdResidual = FanSpdResidualCool( FanSpdRto, Par );
-		EXPECT_NEAR( -0.707, FanSpdResidual, 0.0005 );
+		EXPECT_NEAR( -0.7055, FanSpdResidual, 0.0005 );
 
 		// Clean up
 		Par.deallocate( );
@@ -220,6 +223,7 @@ namespace EnergyPlus {
 		double ZnSenLoad;
 		double Th2;
 		double TairInlet;
+		double QfanRate;
 		double Garate;
 		double BF;
 		Array1D< Real64 > Par;
@@ -233,16 +237,18 @@ namespace EnergyPlus {
 		ZnSenLoad = 4241.66;
 		Th2 = 41.221;
 		TairInlet = 20.236;
+		QfanRate = 37.8;
 		Garate = 0.21136;
 		BF = 0.1360;
 		Par( 1 ) = ZnSenLoad;
 		Par( 2 ) = Th2;
 		Par( 3 ) = TairInlet;
-		Par( 4 ) = Garate;
-		Par( 5 ) = BF;
+		Par( 4 ) = QfanRate;
+		Par( 5 ) = Garate;
+		Par( 6 ) = BF;
 
 		// Run and Check
-		double FanSpdResidual = FanSpdResidualHeat( FanSpdRto, Par ); 
+		double FanSpdResidual = FanSpdResidualHeat( FanSpdRto, Par );
 		EXPECT_NEAR( -0.5459, FanSpdResidual, 0.0005 );
 
 		// Clean up
@@ -250,7 +256,7 @@ namespace EnergyPlus {
 
 	}
 
-	TEST( HVACVariableRefrigerantFlow, VRF_FluidTCtrl_ControlVRFIUCoil )
+	TEST( HVACVariableRefrigerantFlow, VRF_FluidTCtrl_CalcVRFIUAirFlow )
 	{
 		// PURPOSE OF THIS TEST:
 		//   Test the method CalcVRFIUAirFlow, which analyzes the VRF Indoor Unit operations given zonal loads.
@@ -265,11 +271,14 @@ namespace EnergyPlus {
 		int CoolCoilIndex;  // index to VRFTU cooling coil 
 		int HeatCoilIndex;  // index to VRFTU heating coil
 		int Mode;       // mode 0 for cooling, 1 for heating, 2 for neither cooling nor heating
+		bool SHSCModify = true; // indicate whether SH/SC is modified
 		Real64 Temp;    // evaporating or condensing temperature
 		Real64 FanSpdRatio; // fan speed ratio
 		Real64 Wout;    // outlet air humidity ratio
 		Real64 Toutlet; // outlet air temperature
 		Real64 Houtlet; // outlet air enthalpy
+		Real64 HcoilIn; // inlet air enthalpy
+		Real64 TcIn;    // coil inlet temperature, after fan
 		Real64 SHact;   // actual SH
 		Real64 SCact;   // actual SC
 
@@ -310,12 +319,15 @@ namespace EnergyPlus {
 		DXCoil( CoolCoilIndex ).InletAirTemp = 25.5553;
 		DXCoil( CoolCoilIndex ).InletAirHumRat = 8.4682e-3;
 		DXCoil( CoolCoilIndex ).InletAirEnthalpy = 47259.78;
-		
-		ControlVRFIUCoil( CoolCoilIndex, ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToCoolingSP, 25.5553, 8.4682e-3, Temp, 0, FanSpdRatio, Wout, Toutlet, Houtlet, SHact, SCact );
+
+		CalcVRFIUAirFlow( ZoneIndex, Mode, Temp, CoolCoilIndex, HeatCoilIndex, SHSCModify, FanSpdRatio, Wout, Toutlet, Houtlet, HcoilIn, TcIn, SHact, SCact );
+		EXPECT_NEAR( TcIn, 25.56, 0.01 );
 		EXPECT_NEAR( Toutlet, 17.89, 0.01 );
 		EXPECT_NEAR( Houtlet, 39440, 1 );
+		EXPECT_NEAR( HcoilIn, 47259, 1 );
 		EXPECT_NEAR( SHact, 3.00, 0.01 );
-		
+
+
 		// Run and Check for Heating Mode
 		Mode = 1;
 		Temp = 42;
@@ -329,9 +341,11 @@ namespace EnergyPlus {
 		DXCoil( HeatCoilIndex ).InletAirHumRat = 4.1053e-3;
 		DXCoil( HeatCoilIndex ).InletAirEnthalpy = 30755.6253;
 
-		ControlVRFIUCoil( HeatCoilIndex, ZoneSysEnergyDemand( ZoneIndex ).OutputRequiredToHeatingSP, 20.2362, 4.1053e-3, Temp, 0, FanSpdRatio, Wout, Toutlet, Houtlet, SHact, SCact );
+		CalcVRFIUAirFlow( ZoneIndex, Mode, Temp, CoolCoilIndex, HeatCoilIndex, SHSCModify, FanSpdRatio, Wout, Toutlet, Houtlet, HcoilIn, TcIn, SHact, SCact );
+		EXPECT_NEAR( TcIn, 20.24, 0.01 );
 		EXPECT_NEAR( Toutlet, 38.37, 0.01 );
 		EXPECT_NEAR( Houtlet, 49113, 1 );
+		EXPECT_NEAR( HcoilIn, 30756, 1 );
 		EXPECT_NEAR( SCact, 5.00, 0.01 );
 
 		// Clean up


### PR DESCRIPTION
Reverts NREL/EnergyPlus#5367

Develop got broken by someone, ahem @myoldmopar, by merging #5367 without noticing that tiny little debug failure.  This PR would revert out #5367 in order to produce an all-green bug-fix release of 8.4.0.  Later an updated version of #5367 could be provided that doesn't have this issue.

FYI @mjwitte @rraustad @rongpengzhang 
