### PR TITLE
Fix ChillerHeater curve references in IDD

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -61543,12 +61543,8 @@ ChillerHeater:Absorption:DirectFired,
             \note input variables being the leaving chilled water temperature and either
             \note the entering or leaving condenser water temperature.
             \type object-list
-            \object-list LinearCurves
-            \object-list QuadraticCurves
-            \object-list CubicCurves
-            \object-list QuarticCurves
-            \object-list ExponentCurves
-            \object-list UniVariateTables
+            \object-list BiquadraticCurves
+            \object-list BiVariateTables
   A9   ,  \field Fuel Input to Cooling Output Ratio Function of Temperature Curve Name
             \note The curve represents the fraction of the fuel input to the chiller at full load as
             \note it varies by temperature.  The curve is normalized so that at design conditions the
@@ -61556,23 +61552,15 @@ ChillerHeater:Absorption:DirectFired,
             \note input variables being the leaving chilled water temperature and either
             \note the entering or leaving condenser water temperature.
             \type object-list
-            \object-list LinearCurves
-            \object-list QuadraticCurves
-            \object-list CubicCurves
-            \object-list QuarticCurves
-            \object-list ExponentCurves
-            \object-list UniVariateTables
+            \object-list BiquadraticCurves
+            \object-list BiVariateTables
   A10  ,  \field Fuel Input to Cooling Output Ratio Function of Part Load Ratio Curve Name
             \note The curve represents the fraction of the fuel input to the chiller as the load on
             \note the chiller varies but the operating temperatures remain at the design values.
             \note The curve is normalized so that at full load the value of the curve should be 1.0.
             \note The curve is usually linear or quadratic.
             \type object-list
-            \object-list LinearCurves
-            \object-list QuadraticCurves
-            \object-list CubicCurves
-            \object-list QuarticCurves
-            \object-list ExponentCurves
+            \object-list UniVariateCurves
             \object-list UniVariateTables
   A11  ,  \field Electric Input to Cooling Output Ratio Function of Temperature Curve Name
             \note The curve represents the fraction of the electricity to the chiller at full load as
@@ -61581,23 +61569,15 @@ ChillerHeater:Absorption:DirectFired,
             \note input variables being the leaving chilled water temperature and either
             \note the entering or leaving condenser water temperature.
             \type object-list
-            \object-list LinearCurves
-            \object-list QuadraticCurves
-            \object-list CubicCurves
-            \object-list QuarticCurves
-            \object-list ExponentCurves
-            \object-list UniVariateTables
+            \object-list BiquadraticCurves
+            \object-list BiVariateTables
   A12  ,  \field Electric Input to Cooling Output Ratio Function of Part Load Ratio Curve Name
             \note The curve represents the fraction of the electricity to the chiller as the load on
             \note the chiller varies but the operating temperatures remain at the design values.
             \note The curve is normalized so that at full load the value of the curve should be 1.0.
             \note The curve is usually linear or quadratic.
             \type object-list
-            \object-list LinearCurves
-            \object-list QuadraticCurves
-            \object-list CubicCurves
-            \object-list QuarticCurves
-            \object-list ExponentCurves
+            \object-list UniVariateCurves
             \object-list UniVariateTables
   A13  ,  \field Heating Capacity Function of Cooling Capacity Curve Name
             \note The curve represents how the heating capacity of the chiller varies with cooling
@@ -61606,11 +61586,7 @@ ChillerHeater:Absorption:DirectFired,
             \note represents the full heating capacity (see the Heating to cooling capacity ratio input)
             \note The curve is usually linear or quadratic.
             \type object-list
-            \object-list LinearCurves
-            \object-list QuadraticCurves
-            \object-list CubicCurves
-            \object-list QuarticCurves
-            \object-list ExponentCurves
+            \object-list UniVariateCurves
             \object-list UniVariateTables
   A14  ,  \field Fuel Input to Heat Output Ratio During Heating Only Operation Curve Name
             \note When the chiller is operating as only a heater, this curve is used to represent the
@@ -61618,11 +61594,7 @@ ChillerHeater:Absorption:DirectFired,
             \note of 1.0 is the full heating capacity.  The curve is usually linear or quadratic and
             \note will probably be similar to a boiler curve for most chillers.
             \type object-list
-            \object-list LinearCurves
-            \object-list QuadraticCurves
-            \object-list CubicCurves
-            \object-list QuarticCurves
-            \object-list ExponentCurves
+            \object-list UniVariateCurves
             \object-list UniVariateTables
   A15  ,  \field Temperature Curve Input Variable
             \type choice
@@ -61783,12 +61755,8 @@ ChillerHeater:Absorption:DoubleEffect,
        \note input variables being the leaving chilled water temperature and either
        \note the entering or leaving condenser water temperature.
        \type object-list
-       \object-list LinearCurves
-       \object-list QuadraticCurves
-       \object-list CubicCurves
-       \object-list QuarticCurves
-       \object-list ExponentCurves
-       \object-list UniVariateTables
+       \object-list BiquadraticCurves
+       \object-list BiVariateTables
   A9 , \field Fuel Input to Cooling Output Ratio Function of Temperature Curve Name
        \note The curve represents the fraction of the fuel input to the chiller at full load as
        \note it varies by temperature.  The curve is normalized so that at design conditions the
@@ -61796,23 +61764,15 @@ ChillerHeater:Absorption:DoubleEffect,
        \note input variables being the leaving chilled water temperature and either
        \note the entering or leaving condenser water temperature.
        \type object-list
-       \object-list LinearCurves
-       \object-list QuadraticCurves
-       \object-list CubicCurves
-       \object-list QuarticCurves
-       \object-list ExponentCurves
-       \object-list UniVariateTables
+       \object-list BiquadraticCurves
+       \object-list BiVariateTables
   A10, \field Fuel Input to Cooling Output Ratio Function of Part Load Ratio Curve Name
        \note The curve represents the fraction of the fuel input to the chiller as the load on
        \note the chiller varies but the operating temperatures remain at the design values.
        \note The curve is normalized so that at full load the value of the curve should be 1.0.
        \note The curve is usually linear or quadratic.
        \type object-list
-       \object-list LinearCurves
-       \object-list QuadraticCurves
-       \object-list CubicCurves
-       \object-list QuarticCurves
-       \object-list ExponentCurves
+       \object-list UniVariateCurves
        \object-list UniVariateTables
   A11, \field Electric Input to Cooling Output Ratio Function of Temperature Curve Name
        \note The curve represents the fraction of the electricity to the chiller at full load as
@@ -61821,23 +61781,15 @@ ChillerHeater:Absorption:DoubleEffect,
        \note input variables being the leaving chilled water temperature and either
        \note the entering or leaving condenser water temperature.
        \type object-list
-       \object-list LinearCurves
-       \object-list QuadraticCurves
-       \object-list CubicCurves
-       \object-list QuarticCurves
-       \object-list ExponentCurves
-       \object-list UniVariateTables
+       \object-list BiquadraticCurves
+       \object-list BiVariateTables
   A12, \field Electric Input to Cooling Output Ratio Function of Part Load Ratio Curve Name
        \note The curve represents the fraction of the electricity to the chiller as the load on
        \note the chiller varies but the operating temperatures remain at the design values.
        \note The curve is normalized so that at full load the value of the curve should be 1.0.
        \note The curve is usually linear or quadratic.
        \type object-list
-       \object-list LinearCurves
-       \object-list QuadraticCurves
-       \object-list CubicCurves
-       \object-list QuarticCurves
-       \object-list ExponentCurves
+       \object-list UniVariateCurves
        \object-list UniVariateTables
   A13, \field Heating Capacity Function of Cooling Capacity Curve Name
        \note The curve represents how the heating capacity of the chiller varies with cooling
@@ -61846,11 +61798,7 @@ ChillerHeater:Absorption:DoubleEffect,
        \note represents the full heating capacity (see the Heating to cooling capacity ratio input)
        \note The curve is usually linear or quadratic.
        \type object-list
-       \object-list LinearCurves
-       \object-list QuadraticCurves
-       \object-list CubicCurves
-       \object-list QuarticCurves
-       \object-list ExponentCurves
+       \object-list UniVariateCurves
        \object-list UniVariateTables
   A14, \field Fuel Input to Heat Output Ratio During Heating Only Operation Curve Name
        \note When the chiller is operating as only a heater, this curve is used to represent the
@@ -61858,11 +61806,7 @@ ChillerHeater:Absorption:DoubleEffect,
        \note of 1.0 is the full heating capacity.  The curve is usually linear or quadratic and
        \note will probably be similar to a boiler curve for most chillers.
        \type object-list
-       \object-list LinearCurves
-       \object-list QuadraticCurves
-       \object-list CubicCurves
-       \object-list QuarticCurves
-       \object-list ExponentCurves
+       \object-list UniVariateCurves
        \object-list UniVariateTables
   A15, \field Temperature Curve Input Variable
        \type choice


### PR DESCRIPTION
Address #5379 .  Fix incorrect curve type references in the IDD for ChillerHeater:Absorption:DirectFired and ChillerHeater:Absorption:DoubleEffect.
