### PR TITLE
IDD add IP units to water flow rate fields and other fields where gal is preferred over ft3

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -54475,12 +54475,10 @@ Controller:WaterCoil,
        \type real
        \units m3/s
        \autosizable
-       \ip-units gal/min
   N3 ; \field Minimum Actuated Flow
        \type real
        \default 0.0000001
        \units m3/s
-       \ip-units gal/min
 
 Controller:OutdoorAir,
        \memo Controller to set the outdoor air flow rate for an air loop. Control options include

--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -54475,10 +54475,12 @@ Controller:WaterCoil,
        \type real
        \units m3/s
        \autosizable
+       \ip-units gal/min
   N3 ; \field Minimum Actuated Flow
        \type real
        \default 0.0000001
        \units m3/s
+       \ip-units gal/min
 
 Controller:OutdoorAir,
        \memo Controller to set the outdoor air flow rate for an air loop. Control options include

--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -20735,10 +20735,12 @@ SwimmingPool:Indoor,
   N6,  \field Pool Heating System Maximum Water Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
   N7,  \field Pool Miscellaneous Equipment Power
        \note Power input per pool water flow rate
        \units W/(m3/s)
+       \ip-units W/(gal/min)
        \type real
        \minimum 0.0
   A8,  \field Setpoint Temperature Schedule
@@ -22248,6 +22250,7 @@ ZoneCoolTower:Shower,
  N1, \field Maximum Water Flow Rate
      \required-field
      \units m3/s
+     \ip-units gal/min
      \type real
  N2, \field Effective Tower Height
      \note This field is from either the spray or the wet pad to the top of the outlet.
@@ -34209,6 +34212,7 @@ ZoneHVAC:Baseboard:RadiantConvective:Water,
        \autosizable
        \type real
        \units m3/s
+       \ip-units gal/min
   N7,  \field Convergence Tolerance
        \type real
        \minimum> 0.0
@@ -45945,6 +45949,7 @@ Coil:Cooling:WaterToAirHeatPump:EquationFit,
         \type real
         \minimum> 0.0
         \units m3/s
+        \ip-units gal/min
         \autosizable
    N3,  \field Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
@@ -46084,6 +46089,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \required-field
    N5,  \field Rated Water Flow Rate At Selected Nominal Speed Level
         \units m3/s
+        \ip-units gal/min
         \type real
         \autosizable
         \default autosize
@@ -46139,6 +46145,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \required-field
    N13, \field Speed 1 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
         \required-field
@@ -46223,6 +46230,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N19, \field Speed 2 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A14, \field Speed 2 Total Cooling Capacity Function of Temperature Curve Name
@@ -46298,6 +46306,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N25, \field Speed 3 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A21, \field Speed 3 Total Cooling Capacity Function of Temperature Curve Name
@@ -46380,6 +46389,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N31, \field Speed 4 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A28, \field Speed 4 Total Cooling Capacity Function of Temperature Curve Name
@@ -46462,6 +46472,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N37, \field Speed 5 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A35, \field Speed 5 Total Cooling Capacity Function of Temperature Curve Name
@@ -46544,6 +46555,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N43, \field Speed 6 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A42, \field Speed 6 Total Cooling Capacity Function of Temperature Curve Name
@@ -46626,6 +46638,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N49, \field Speed 7 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A49, \field Speed 7 Total Cooling Capacity Function of Temperature Curve Name
@@ -46708,6 +46721,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N55, \field Speed 8 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A56, \field Speed 8 Total Cooling Capacity Function of Temperature Curve Name
@@ -46790,6 +46804,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N61, \field Speed 9 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A63, \field Speed 9 Total Cooling Capacity Function of Temperature Curve Name
@@ -46872,6 +46887,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N67, \field Speed 10 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A70, \field Speed 10 Total Cooling Capacity Function of Temperature Curve Name
@@ -46966,6 +46982,7 @@ Coil:Heating:WaterToAirHeatPump:EquationFit,
         \type real
         \minimum> 0.0
         \units m3/s
+        \ip-units gal/min
         \autosizable
    N3,  \field Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
@@ -47057,6 +47074,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \required-field
    N5,  \field Rated Water Flow Rate At Selected Nominal Speed Level
         \units m3/s
+        \ip-units gal/min
         \type real
         \autosizable
         \default autosize
@@ -47087,6 +47105,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \required-field
    N9,  \field Speed 1 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
         \required-field
@@ -47166,6 +47185,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N14, \field Speed 2 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A14, \field Speed 2 Heating Capacity Function of Temperature Curve Name
@@ -47237,6 +47257,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N19, \field Speed 3 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A21, \field Speed 3 Heating Capacity Function of Temperature Curve Name
@@ -47314,6 +47335,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N24, \field Speed 4 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A28, \field Speed 4 Heating Capacity Function of Temperature Curve Name
@@ -47391,6 +47413,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N29, \field Speed 5 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A35, \field Speed 5 Heating Capacity Function of Temperature Curve Name
@@ -47468,6 +47491,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N34, \field Speed 6 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A42, \field Speed 6 Heating Capacity Function of Temperature Curve Name
@@ -47545,6 +47569,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N39, \field Speed 7 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A49, \field Speed 7 Heating Capacity Function of Temperature Curve Name
@@ -47622,6 +47647,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N44, \field Speed 8 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A56, \field Speed 8 Heating Capacity Function of Temperature Curve Name
@@ -47699,6 +47725,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N49, \field Speed 9 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A63, \field Speed 9 Heating Capacity Function of Temperature Curve Name
@@ -47776,6 +47803,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \minimum 0
    N54, \field Speed 10 Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
    A70, \field Speed 10 Heating Capacity Function of Temperature Curve Name
@@ -47907,6 +47935,7 @@ Coil:WaterHeating:AirToWaterHeatPump:Pumped,
   N8 , \field Rated Condenser Water Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum> 0
        \autocalculatable
        \note Condenser water flow rate corresponding to rated coil performance
@@ -48291,6 +48320,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
   N8 , \field Rated Condenser Water Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum> 0
        \autocalculatable
        \note Condenser water flow rate corresponding to rated coil performance
@@ -48418,6 +48448,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \required-field
   N16, \field Speed 1 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
        \required-field
@@ -48505,6 +48536,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N22, \field Speed 2 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N23, \field Speed 2 Reference Unit Water Pump Input Power At Rated Conditions
@@ -48584,6 +48616,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N28, \field Speed 3 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N29, \field Speed 3 Reference Unit Water Pump Input Power At Rated Conditions
@@ -48663,6 +48696,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N34, \field Speed 4 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N35, \field Speed 4 Reference Unit Water Pump Input Power At Rated Conditions
@@ -48742,6 +48776,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N40, \field Speed 5 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N41, \field Speed 5 Reference Unit Water Pump Input Power At Rated Conditions
@@ -48821,6 +48856,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N46, \field Speed 6 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N47, \field Speed 6 Reference Unit Water Pump Input Power At Rated Conditions
@@ -48900,6 +48936,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N52, \field Speed 7 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N53, \field Speed 7 Reference Unit Water Pump Input Power At Rated Conditions
@@ -48979,6 +49016,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N58, \field Speed 8 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N59, \field Speed 8 Reference Unit Water Pump Input Power At Rated Conditions
@@ -49058,6 +49096,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N64, \field Speed 9 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N65, \field Speed 9 Reference Unit Water Pump Input Power At Rated Conditions
@@ -49137,6 +49176,7 @@ Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed,
        \minimum 0
   N70, \field Speed 10 Reference Unit Rated Water Flow Rate
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   N71, \field Speed 10 Reference Unit Water Pump Input Power At Rated Conditions
@@ -49296,6 +49336,7 @@ Coil:WaterHeating:Desuperheater,
        \required-field
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum> 0
        \note The operating water flow rate.
   N7 , \field Water Pump Power
@@ -52101,6 +52142,7 @@ AirLoopHVAC:UnitarySystem,
   N25, \field Design Heat Recovery Water Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
        \default 0.0
        \note If non-zero, then the heat recovery inlet and outlet node names must be entered.
@@ -53274,6 +53316,7 @@ AirLoopHVAC:UnitaryHeatPump:AirToAir:MultiSpeed,
         \note If non-zero, then the heat recovery inlet and outlet node names must be entered.
         \note Used for heat recovery to an EnergyPlus plant loop.
         \units m3/s
+        \ip-units gal/min
         \minimum 0.0
         \default 0.0
    N7,  \field Maximum Temperature for Heat Recovery
@@ -54474,8 +54517,8 @@ Controller:WaterCoil,
   N2 , \field Maximum Actuated Flow
        \type real
        \units m3/s
-       \autosizable
        \ip-units gal/min
+       \autosizable
   N3 ; \field Minimum Actuated Flow
        \type real
        \default 0.0000001
@@ -63477,6 +63520,7 @@ CoolingTower:VariableSpeed:Merkel,
   N6 , \field Design Water Flow Rate per Unit of Nominal Capacity
        \note This field is only used if the previous is set to autocalculate and performance input method is NominalCapacity
        \units m3/s-W
+       \ip-units gal/min-W
        \default 5.382E-8
        \type real
   N7 , \field Design Air Flow Rate
@@ -66496,6 +66540,7 @@ WaterHeater:HeatPump:PumpedCondenser,
   N2 , \field Condenser Water Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum> 0
        \autocalculatable
        \note Actual water flow rate through the heat pump's water coil (condenser).
@@ -75651,6 +75696,7 @@ Generator:MicroTurbine,
  N14, \field Reference Heat Recovery Water Flow Rate
       \type real
       \units m3/s
+      \ip-units gal/min
       \minimum> 0.0
  A10, \field Heat Recovery Water Flow Rate Function of Temperature and Power Curve Name
       \type object-list
@@ -75696,11 +75742,13 @@ Generator:MicroTurbine,
  N15, \field Minimum Heat Recovery Water Flow Rate
       \type real
       \units m3/s
+      \ip-units gal/min
       \minimum 0.0
       \default 0.0
  N16, \field Maximum Heat Recovery Water Flow Rate
       \type real
       \units m3/s
+      \ip-units gal/min
       \minimum 0.0
       \default 0.0
  N17, \field Maximum Heat Recovery Water Temperature

--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -24321,6 +24321,7 @@ Exterior:WaterEquipment,
   N1 , \field Design Level
        \required-field
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0
   A4 ; \field End-Use Subcategory
@@ -36786,6 +36787,7 @@ ZoneHVAC:LowTemperatureRadiant:ConstantFlow,
         \default MeanAirTemperature
    N3 , \field Rated Flow Rate
         \units m3/s
+        \ip-units gal/min
         \autosizable
    A6 , \field Pump Flow Rate Schedule Name
         \note Modifies the Rated Flow Rate of the pump on a time basis
@@ -39331,12 +39333,14 @@ AirTerminal:SingleDuct:ConstantVolume:FourPipeBeam,
   N2 , \field Design Chilled Water Volume Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
        \autosizable
        \default autosize
   N3 , \field Design Hot Water Volume Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
        \autosizable
        \default autosize
@@ -39369,6 +39373,7 @@ AirTerminal:SingleDuct:ConstantVolume:FourPipeBeam,
        \note The volume flow rate of chilled water per meter of beam length at the rating point.
        \type real
        \units m3/s-m
+       \ip-units gal/min-ft
        \minimum> 0.0
        \default 0.00005
   A11, \field Beam Cooling Capacity Temperature Difference Modification Factor Curve Name
@@ -39411,6 +39416,7 @@ AirTerminal:SingleDuct:ConstantVolume:FourPipeBeam,
        \note The volume flow rate of hoy water per meter of beam length at the rating point.
        \type real
        \units m3/s-m
+       \ip-units gal/min-ft
        \minimum> 0.0
        \default 0.00005
   A14, \field Beam Heating Capacity Temperature Difference Modification Factor Curve Name
@@ -39476,6 +39482,7 @@ AirTerminal:SingleDuct:ConstantVolume:CooledBeam,
   N2,  \field Maximum Total Chilled Water Volumetric Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
        \autosizable
        \default autosize
@@ -45634,6 +45641,7 @@ Coil:Cooling:WaterToAirHeatPump:ParameterEstimation,
         \type real
         \minimum> 0.0
         \units m3/s
+        \ip-units gal/min
    N2,  \field Nominal Cooling Coil Capacity
         \required-field
         \type real
@@ -45802,6 +45810,7 @@ Coil:Heating:WaterToAirHeatPump:ParameterEstimation,
         \type real
         \minimum> 0.0
         \units m3/s
+        \ip-units gal/min
    N2,  \field Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
         \required-field
@@ -49342,6 +49351,7 @@ Coil:WaterHeating:Desuperheater,
   N7 , \field Water Pump Power
        \type real
        \units W
+       \ip-units W
        \minimum 0.0
        \default 0.0
        \note The water circulation pump electric power.
@@ -49589,6 +49599,7 @@ Coil:Cooling:DX:SingleSpeed:ThermalStorage,
        \note This field is required when Storage Type is UserDefinedFluidType
   N1 , \field Fluid Storage Volume
        \units m3
+       \ip-units gal
        \type real
        \minimum> 0
        \note required field if Storage Type is Water or UserDefinedFluidType
@@ -50322,6 +50333,7 @@ Coil:Cooling:DX:SingleSpeed:ThermalStorage,
   N40, \field Storage Tank Plant Connection Design Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
   N41, \field Storage Tank Plant Connection Heat Transfer Effectiveness
        \type real
@@ -50561,6 +50573,7 @@ EvaporativeCooler:Indirect:ResearchSpecial,
   N4 , \field Water Pump Power Sizing Factor
        \type real
        \units W/(m3/s)
+       \ip-units W/(gal/min)
        \default 90.0
        \note This field is used when the previous field is set to autosize. The pump power is scaled with Secondary Air
        \note Design Air Flow Rate. This value was backed out from inputs in energy plus example files. Average Pump Power
@@ -50741,6 +50754,7 @@ EvaporativeCooler:Direct:ResearchSpecial,
   N4 , \field Water Pump Power Sizing Factor
        \type real
        \units W/(m3/s)
+       \ip-units W/(gal/min)
        \default 90.0
        \note This field is used when the previous field is set to autosize. The pump power is scaled with Secondary Air
        \note Design Air Flow Rate. This value was backed out from inputs in energy plus example files. Average Pump Power
@@ -53839,6 +53853,7 @@ AirConditioner:VariableRefrigerantFlow,
   N23, \field Water Condenser Volume Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \autosizable
        \note Only used when Condenser Type = WaterCooled.
   N24, \field Evaporative Condenser Effectiveness
@@ -58916,6 +58931,7 @@ PipingSystem:Underground:PipeCircuit,
         \required-field
         \type real
         \units m3/s
+        \ip-units gal/min
         \minimum> 0
    A2,  \field Circuit Inlet Node
         \required-field
@@ -59618,6 +59634,7 @@ LoadProfile:Plant,
        \required-field
        \type real
        \units m3/s
+       \ip-units gal/min
   A5 ; \field Flow Rate Fraction Schedule Name
        \required-field
        \type object-list
@@ -59650,6 +59667,7 @@ SolarCollectorPerformance:FlatPlate,
        \type real
        \minimum> 0
        \units m3/s
+       \ip-units gal/min
   A3 , \field Test Correlation Type
        \required-field
        \type choice
@@ -59704,6 +59722,7 @@ SolarCollector:FlatPlate:Water,
        \type real
        \minimum> 0
        \units m3/s
+       \ip-units gal/min
 
 SolarCollector:FlatPlate:PhotovoltaicThermal,
        \memo Models hybrid photovoltaic-thermal (PVT) solar collectors that convert incident solar
@@ -59802,6 +59821,7 @@ SolarCollector:IntegralCollectorStorage,
        \type real
        \minimum> 0
        \units m3/s
+       \ip-units gal/min
 
 SolarCollectorPerformance:IntegralCollectorStorage,
        \memo Thermal and optical performance parameters for a single glazed solar collector with
@@ -59823,6 +59843,7 @@ SolarCollectorPerformance:IntegralCollectorStorage,
        \type real
        \minimum> 0
        \units m3
+       \ip-units gal
   N3,  \field Bottom Heat Loss Conductance
        \required-field
        \type real
@@ -61013,6 +61034,7 @@ Chiller:Absorption:Indirect,
   N11, \field Design Generator Fluid Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \autosizable
        \note  For variable flow this is the max flow and for constant flow this is the flow.
   N12, \field Temperature Lower Limit Generator Inlet
@@ -61136,6 +61158,7 @@ Chiller:Absorption,
        \type real
        \autosizable
        \units m3/s
+       \ip-units gal/min
        \minimum> 0.0
   N17, \field Degree of Subcooling in Steam Generator
        \type real
@@ -62089,11 +62112,13 @@ HeatPump:WaterToWater:EquationFit:Heating,
         \type real
         \minimum> 0.0
         \units m3/s
+        \ip-units gal/min
    N2,  \field Rated Source Side Flow Rate
         \required-field
         \type real
         \minimum> 0.0
         \units m3/s
+        \ip-units gal/min
    N3,  \field Rated Heating Capacity
         \required-field
         \type real
@@ -62157,11 +62182,13 @@ HeatPump:WaterToWater:EquationFit:Cooling,
         \type real
         \minimum> 0.0
         \units m3/s
+        \ip-units gal/min
    N2,  \field Rated Source Side Flow Rate
         \required-field
         \type real
         \minimum> 0.0
         \units m3/s
+        \ip-units gal/min
    N3,  \field Rated Cooling Capacity
         \required-field
         \type real
@@ -65460,6 +65487,7 @@ GroundHeatExchanger:HorizontalTrench,
         \required-field
         \type real
         \units m3/s
+        \ip-units gal/min
         \minimum> 0
    N2 , \field Trench Length in Pipe Axial Direction
         \note This is the total pipe axial length of the heat exchanger
@@ -65587,6 +65615,7 @@ GroundHeatExchanger:Slinky,
    N1 , \field Design Flow Rate
         \type real
         \units m3/s
+        \ip-units gal/min
         \minimum> 0
         \default 0.002
    N2 , \field Soil Thermal Conductivity
@@ -65866,6 +65895,7 @@ WaterHeater:Mixed,
        \note Not yet implemented
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
        \default 0.0
   N7 , \field Heater Ignition Delay
@@ -66437,6 +66467,7 @@ WaterHeater:Sizing,
   N3 , \field Nominal Tank Volume for Autosizing Plant Connections
        \type real
        \units m3
+       \ip-units gal
        \note Only used if Design Mode = PeakDraw and the water heater also
        \note has autosized flow rates for connections on the demand side of a plant loop
   N4 , \field Number of Bedrooms
@@ -66450,21 +66481,25 @@ WaterHeater:Sizing,
   N6 , \field Storage Capacity per Person
        \type real
        \units m3/Person
+       \ip-units gal/Person
        \note Only used for Design Mode = PerPerson
        \minimum 0.0
   N7 , \field Recovery Capacity per Person
        \type real
        \units m3/hr-person
+       \ip-units gal/hr-person
        \note Only used for Design Mode = PerPerson
        \minimum 0.0
   N8 , \field Storage Capacity per Floor Area
        \type real
        \units m3/m2
+       \ip-units gal/ft2
        \note Only used for Design Mode = PerFloorArea
        \minimum 0.0
   N9 , \field Recovery Capacity per Floor Area
        \type real
        \units m3/hr-m2
+       \ip-units gal/hr-ft2
        \note Only used for Design Mode = PerFloorArea
        \minimum 0.0
   N10 , \field Number of Units
@@ -66472,16 +66507,19 @@ WaterHeater:Sizing,
        \note Only used for Design Mode = PerUnit
   N11 , \field Storage Capacity per Unit
        \units m3
+       \ip-units gal
        \type real
        \note Only used for Design Mode = PerUnit
        \minimum 0.0
   N12 , \field Recovery Capacity PerUnit
        \units m3/hr
+       \ip-units gal/hr
        \type real
        \note Only used for Design Mode = PerUnit
        \minimum 0.0
   N13 ,\field Storage Capacity per Collector Area
        \units m3/m2
+       \ip-units gal/ft2
        \type real
        \note Only used for Design Mode = PerSolarCollectorArea
        \minimum 0.0
@@ -72611,11 +72649,13 @@ Refrigeration:CompressorRack,
   N3,   \field Water-Cooled Condenser Design Flow Rate
         \type real
         \units m3/s
+        \ip-units gal/min
         \minimum> 0.0
         \note Applicable only when loop flow type is ConstantFlow.
   N4,   \field Water-Cooled Condenser Maximum Flow Rate
         \type real
         \units m3/s
+        \ip-units gal/min
         \minimum> 0.0
   N5,   \field Water-Cooled Condenser Maximum Water Outlet Temperature
         \type real
@@ -73138,12 +73178,14 @@ Refrigeration:Condenser:WaterCooled,
   N5 ,  \field Water Design Flow Rate
         \type real
         \units m3/s
+        \ip-units gal/min
         \note note required units must be converted from L/s as specified in ARI 450-2007
         \minimum> 0.0
         \note Applicable only when loop flow type is Constant Flow.
   N6 ,  \field Water Maximum Flow Rate
         \type real
         \units m3/s
+        \ip-units gal/min
         \minimum> 0.0
   N7 ,  \field Water Maximum Water Outlet Temperature
         \type real
@@ -73899,7 +73941,8 @@ Refrigeration:SecondarySystem,
   N2 ,  \field Evaporator Flow Rate for Secondary Fluid
         \type real
         \minimum 0.0
-        \units M3/s
+        \units m3/s
+        \ip-units gal/min
         \note For "FluidAlwaysLiquid", at least one of the two, Evaporator Capacity OR
         \note    Evaporator Flow Rate for Secondary Fluid, is required.
         \note For "FluidPhaseChange" loops, this input is not used. (see PhaseChange Circulating
@@ -73934,7 +73977,8 @@ Refrigeration:SecondarySystem,
   N7 ,  \field Total Pump Flow Rate
         \type real
         \minimum 0.0
-        \units M3/s
+        \units m3/s
+        \ip-units gal/min
         \note For "FluidAlwaysLiquid",if not input, Evaporator Flow Rate for Secondary Fluid
         \note       will be used.
         \note For "FluidPhaseChange", if not input, this will be calculated using the
@@ -76438,6 +76482,7 @@ Generator:FuelCell:ExhaustGasToWaterHeatExchanger,
       \type node
   N1, \field Heat Recovery Water Maximum Flow Rate
       \units m3/s
+      \ip-units gal/min
   A4, \field Exhaust Outlet Air Node Name
       \type node
   A5, \field Heat Exchanger Calculation Method
@@ -78342,10 +78387,12 @@ WaterUse:Storage,
   N1 , \field Maximum Capacity
        \type real
        \units m3
+       \ip-units gal
        \note Defaults to unlimited capacity.
   N2 , \field Initial Volume
        \type real
        \units m3
+       \ip-units gal
   N3 , \field Design In Flow Rate
        \type real
        \units m3/s
@@ -78369,14 +78416,17 @@ WaterUse:Storage,
   N5 , \field Float Valve On Capacity
        \type real
        \units m3
+       \ip-units gal
        \note Lower range of target storage level e.g. float valve kicks on
   N6 , \field Float Valve Off Capacity
        \type real
        \units m3
+       \ip-units gal
        \note Upper range of target storage level e.g. float valve kicks off
   N7 , \field Backup Mains Capacity
        \type real
        \units m3
+       \ip-units gal
        \note Lower range of secondary target storage level
        \note used to keep tanks at a minimum level using
        \note mains water if well can't keep up
@@ -78442,9 +78492,11 @@ WaterUse:Well,
   N6 , \field Well Recovery Rate
        \type real
        \units m3/s
+       \ip-units gal/min
   N7 , \field Nominal Well Storage Volume
        \type real
        \units m3
+       \ip-units gal
   A3 , \field Water Table Depth Mode
        \type choice
        \key Constant

--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -78212,6 +78212,7 @@ WaterUse:Equipment,
   N1 , \field Peak Flow Rate
        \required-field
        \units m3/s
+       \ip-units gal/min
        \type real
        \minimum 0.0
   A3 , \field Flow Rate Fraction Schedule Name
@@ -78348,10 +78349,12 @@ WaterUse:Storage,
   N3 , \field Design In Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \note Defaults to unlimited flow.
   N4 , \field Design Out Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \note Defaults to unlimited flow.
   A3 , \field Overflow Destination
        \type object-list
@@ -78427,6 +78430,7 @@ WaterUse:Well,
   N2 , \field Pump Rated Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
   N3 , \field Pump Rated Head
        \type real
        \units Pa
@@ -78479,6 +78483,7 @@ WaterUse:RainCollector,
   N2 , \field Maximum Collection Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \note Defaults to unlimited flow.
   A5 , \field Collection Surface 1 Name
        \begin-extensible

--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -50516,7 +50516,7 @@ EvaporativeCooler:Indirect:ResearchSpecial,
        \note This is the nominal design pump power of water recirculation and spray for evaporation at design air flow
        \note rates and cooler design effectiveness
        \autosizable
-       \default autosize 
+       \default autosize
   N4 , \field Water Pump Power Sizing Factor
        \type real
        \units W/(m3/s)
@@ -50525,7 +50525,7 @@ EvaporativeCooler:Indirect:ResearchSpecial,
        \note Design Air Flow Rate. This value was backed out from inputs in energy plus example files. Average Pump Power
        \note sizing factor was estimated from pump power and secondary air design flow rates inputs from energyplus example
        \note files is about 90.0 [W/(m3/s)] (=90.0 ~ Pump Power / Secondary Air Design Flow Rate). The factor ranges from
-       \note 55.0 to 150.0 [W/(m3/s)] were noted. The pump power can be sized to zero by setting this factor to zero. 
+       \note 55.0 to 150.0 [W/(m3/s)] were noted. The pump power can be sized to zero by setting this factor to zero.
   A5 , \field Water Pump Power Modifier Curve Name
        \note this curve modifies the pump power in the previous field by multiplying the design power by the result of this curve.
        \note x = ff = flow fraction on the secondary side, secondary air flow rate during operation divided by Secondary Air
@@ -50542,7 +50542,7 @@ EvaporativeCooler:Indirect:ResearchSpecial,
        \units m3/s
        \minimum> 0.0
        \autosizable
-       \default autosize   
+       \default autosize
   N6 , \field Secondary Air Flow Scaling Factor
        \type real
        \units dimensionless
@@ -50554,7 +50554,7 @@ EvaporativeCooler:Indirect:ResearchSpecial,
        \units W
        \note This is the fan design power at Secondary Design Air Flow Rate. This is the nominal design power at full speed.
        \autosizable
-       \default autosize   
+       \default autosize
   N8 , \field Secondary Air Fan Sizing Specific Power
        \type real
        \units W/(m3/s)
@@ -50584,7 +50584,7 @@ EvaporativeCooler:Indirect:ResearchSpecial,
        \units m3/s
        \minimum> 0.0
        \autosizable
-       \default autosize 
+       \default autosize
   N10, \field Dewpoint Effectiveness Factor
        \type real
        \minimum 0.0
@@ -50705,7 +50705,7 @@ EvaporativeCooler:Direct:ResearchSpecial,
        \note Design Air Flow Rate. This value was backed out from inputs in energy plus example files. Average Pump Power
        \note sizing factor was estimated from pump power and primary air design flow rates inputs from energyplus example
        \note files is about 90.0 [W/(m3/s)] (=90.0 ~ Pump Power / Primary Air Design Flow Rate). The factor ranges from
-       \note 55.0 to 150.0 [W/(m3/s)]. The pump power can be sized to zero by setting this factor to zero. 
+       \note 55.0 to 150.0 [W/(m3/s)]. The pump power can be sized to zero by setting this factor to zero.
   A4 , \field Water Pump Power Modifier Curve Name
        \note this curve modifies the pump power in the previous field by multiplying the design power by the result of this curve.
        \note x = ff = flow fraction on the primary air. The flow fraction is the secondary air flow rate during current operation divided
@@ -54475,10 +54475,12 @@ Controller:WaterCoil,
        \type real
        \units m3/s
        \autosizable
+       \ip-units gal/min
   N3 ; \field Minimum Actuated Flow
        \type real
        \default 0.0000001
        \units m3/s
+       \ip-units gal/min
 
 Controller:OutdoorAir,
        \memo Controller to set the outdoor air flow rate for an air loop. Control options include
@@ -59103,7 +59105,7 @@ Pump:VariableSpeed,
         \type choice
         \key PowerPerFlow
         \note PowerPerFlow indicates that Design Electric Power per Unit Flow Rate is used as scaling factor.
-        \note Design Power Consumption = Design Maximum Flow Rate * scaling factor 
+        \note Design Power Consumption = Design Maximum Flow Rate * scaling factor
         \key PowerPerFlowPerPressure
         \note PowerPerFlowPerPressure indicates that Design Shaft Power per Unit Flow Rate per Unit Head is used as scaling factor.
         \note Design Power Consumption = Design Maximum Flow Rate * Design Pump Head * scaling factor / Motor Efficiency
@@ -59212,7 +59214,7 @@ Pump:ConstantSpeed,
        \type choice
        \key PowerPerFlow
        \note PowerPerFlow indicates that Design Electric Power per Unit Flow Rate is used as scaling factor.
-       \note Design Power Consumption = Design Maximum Flow Rate * scaling factor 
+       \note Design Power Consumption = Design Maximum Flow Rate * scaling factor
        \key PowerPerFlowPerPressure
        \note PowerPerFlowPerPressure indicates that Design Shaft Power per Unit Flow Rate per Unit Head is used as scaling factor.
        \note Design Power Consumption = Design Maximum Flow Rate * Design Pump Head * scaling factor / Motor Efficiency
@@ -59300,7 +59302,7 @@ Pump:VariableSpeed:Condensate,
        \type choice
        \key PowerPerFlow
        \note PowerPerFlow indicates that Design Electric Power per Unit Flow Rate is used as scaling factor.
-       \note Design Power Consumption = Design Maximum Flow Rate * scaling factor 
+       \note Design Power Consumption = Design Maximum Flow Rate * scaling factor
        \key PowerPerFlowPerPressure
        \note PowerPerFlowPerPressure indicates that Design Shaft Power per Unit Flow Rate per Unit Head is used as scaling factor.
        \note Design Power Consumption = Design Maximum Flow Rate * Design Pump Head * scaling factor / Motor Efficiency
@@ -59393,7 +59395,7 @@ HeaderedPumps:ConstantSpeed,
        \type choice
        \key PowerPerFlow
        \note PowerPerFlow indicates that Design Electric Power per Unit Flow Rate is used as scaling factor.
-       \note Design Power Consumption = Design Maximum Flow Rate * scaling factor 
+       \note Design Power Consumption = Design Maximum Flow Rate * scaling factor
        \key PowerPerFlowPerPressure
        \note PowerPerFlowPerPressure indicates that Design Shaft Power per Unit Flow Rate per Unit Head is used as scaling factor.
        \note Design Power Consumption = Design Maximum Flow Rate * Design Pump Head * scaling factor / Motor Efficiency
@@ -59412,7 +59414,7 @@ HeaderedPumps:ConstantSpeed,
        \units W/((m3/s)-Pa)
        \ip-units W/((gal/min)-ftH20)
        \minimum> 0
-       
+
 HeaderedPumps:VariableSpeed,
        \memo This Headered pump object describes a pump bank with more than 1 pump in parallel
        \min-fields 14
@@ -59499,7 +59501,7 @@ HeaderedPumps:VariableSpeed,
        \type choice
        \key PowerPerFlow
        \note PowerPerFlow indicates that Design Electric Power per Unit Flow Rate is used as scaling factor.
-       \note Design Power Consumption = Design Maximum Flow Rate * scaling factor 
+       \note Design Power Consumption = Design Maximum Flow Rate * scaling factor
        \key PowerPerFlowPerPressure
        \note PowerPerFlowPerPressure indicates that Design Shaft Power per Unit Flow Rate per Unit Head is used as scaling factor.
        \note Design Power Consumption = Design Maximum Flow Rate * Design Pump Head * scaling factor / Motor Efficiency


### PR DESCRIPTION
Addresses #5452 
Added ip units of gal/min to water (liquid) flow rate fields as needed.
