### PR TITLE
Refactoring code for ZoneLoadComponent output report

### DIFF
--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -11164,7 +11164,7 @@ namespace OutputReportTabular {
 		//       AUTHOR         Jason Glazer
 		//       DATE WRITTEN   March 2012
 		//       MODIFIED       na
-		//       RE-ENGINEERED  na
+		//       RE-ENGINEERED  Amir Roth, Feb 2016 (unified with ComputeDelayedComponents to simplify code and debugging)
 
 		// PURPOSE OF THIS SUBROUTINE:
 		//   Write the tables for the ZoneLoadComponentSummary and

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -175,7 +175,8 @@ namespace OutputReportTabular {
 	using DataGlobals::OutputFileDebug;
 	using namespace DataGlobalConstants;
 	using namespace OutputReportPredefined;
-
+	using namespace DataHeatBalance;
+	
 	// Data
 	//MODULE PARAMETER DEFINITIONS:
 
@@ -403,18 +404,15 @@ namespace OutputReportTabular {
 	Array3D< Real64 > peopleInstantSeq;
 	Array3D< Real64 > peopleLatentSeq;
 	Array3D< Real64 > peopleRadSeq;
-	Array3D< Real64 > peopleDelaySeq;
 
 	Array3D< Real64 > lightInstantSeq;
 	Array3D< Real64 > lightRetAirSeq;
 	Array3D< Real64 > lightLWRadSeq; // long wave thermal radiation
 	Array3D< Real64 > lightSWRadSeq; // short wave visible radiation
-	Array3D< Real64 > lightDelaySeq;
 
 	Array3D< Real64 > equipInstantSeq;
 	Array3D< Real64 > equipLatentSeq;
 	Array3D< Real64 > equipRadSeq;
-	Array3D< Real64 > equipDelaySeq;
 
 	Array3D< Real64 > refrigInstantSeq;
 	Array3D< Real64 > refrigRetAirSeq;
@@ -425,12 +423,9 @@ namespace OutputReportTabular {
 
 	Array3D< Real64 > hvacLossInstantSeq;
 	Array3D< Real64 > hvacLossRadSeq;
-	Array3D< Real64 > hvacLossDelaySeq;
 
 	Array3D< Real64 > powerGenInstantSeq;
 	Array3D< Real64 > powerGenRadSeq;
-	Array3D< Real64 > powerGenDelaySeq;
-
 	Array3D< Real64 > infilInstantSeq;
 	Array3D< Real64 > infilLatentSeq;
 
@@ -443,10 +438,6 @@ namespace OutputReportTabular {
 	Array3D< Real64 > feneCondInstantSeq;
 	//REAL(r64), DIMENSION(:,:,:),ALLOCATABLE,PUBLIC  :: feneSolarInstantSeq
 	Array3D< Real64 > feneSolarRadSeq;
-	Array3D< Real64 > feneSolarDelaySeq;
-
-	Array3D< Real64 > surfDelaySeq;
-
 	int maxUniqueKeyCount( 0 );
 
 	// for the XML report must keep track fo the active sub-table name and report set by other routines
@@ -613,16 +604,13 @@ namespace OutputReportTabular {
 		peopleInstantSeq.deallocate();
 		peopleLatentSeq.deallocate();
 		peopleRadSeq.deallocate();
-		peopleDelaySeq.deallocate();
 		lightInstantSeq.deallocate();
 		lightRetAirSeq.deallocate();
 		lightLWRadSeq.deallocate();
 		lightSWRadSeq.deallocate();
-		lightDelaySeq.deallocate();
 		equipInstantSeq.deallocate();
 		equipLatentSeq.deallocate();
 		equipRadSeq.deallocate();
-		equipDelaySeq.deallocate();
 		refrigInstantSeq.deallocate();
 		refrigRetAirSeq.deallocate();
 		refrigLatentSeq.deallocate();
@@ -630,10 +618,8 @@ namespace OutputReportTabular {
 		waterUseLatentSeq.deallocate();
 		hvacLossInstantSeq.deallocate();
 		hvacLossRadSeq.deallocate();
-		hvacLossDelaySeq.deallocate();
 		powerGenInstantSeq.deallocate();
 		powerGenRadSeq.deallocate();
-		powerGenDelaySeq.deallocate();
 		infilInstantSeq.deallocate();
 		infilLatentSeq.deallocate();
 		zoneVentInstantSeq.deallocate();
@@ -642,8 +628,6 @@ namespace OutputReportTabular {
 		interZoneMixLatentSeq.deallocate();
 		feneCondInstantSeq.deallocate();
 		feneSolarRadSeq.deallocate();
-		feneSolarDelaySeq.deallocate();
-		surfDelaySeq.deallocate();
 		maxUniqueKeyCount = 0;
 		OutputTableBinned.deallocate();
 		BinResults.deallocate();
@@ -10824,8 +10808,6 @@ namespace OutputReportTabular {
 			peopleLatentSeq = 0.0;
 			peopleRadSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			peopleRadSeq = 0.0;
-			peopleDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-			peopleDelaySeq = 0.0;
 			lightInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			lightInstantSeq = 0.0;
 			lightRetAirSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
@@ -10834,16 +10816,12 @@ namespace OutputReportTabular {
 			lightLWRadSeq = 0.0;
 			lightSWRadSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, TotSurfaces );
 			lightSWRadSeq = 0.0;
-			lightDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-			lightLWRadSeq = 0.0;
 			equipInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			equipInstantSeq = 0.0;
 			equipLatentSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			equipLatentSeq = 0.0;
 			equipRadSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			equipRadSeq = 0.0;
-			equipDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-			equipDelaySeq = 0.0;
 			refrigInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			refrigInstantSeq = 0.0;
 			refrigRetAirSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
@@ -10858,14 +10836,10 @@ namespace OutputReportTabular {
 			hvacLossInstantSeq = 0.0;
 			hvacLossRadSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			hvacLossRadSeq = 0.0;
-			hvacLossDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-			hvacLossDelaySeq = 0.0;
 			powerGenInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			powerGenInstantSeq = 0.0;
 			powerGenRadSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			powerGenRadSeq = 0.0;
-			powerGenDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-			powerGenDelaySeq = 0.0;
 			infilInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 			infilInstantSeq = 0.0;
 			infilLatentSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
@@ -10884,10 +10858,6 @@ namespace OutputReportTabular {
 			//  feneSolarInstantSeq = 0.0d0
 			feneSolarRadSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, TotSurfaces );
 			feneSolarRadSeq = 0.0;
-			feneSolarDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-			feneSolarDelaySeq = 0.0;
-			surfDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, TotSurfaces );
-			surfDelaySeq = 0.0;
 			AllocateLoadComponentArraysDoAllocate = false;
 		}
 	}
@@ -11186,182 +11156,6 @@ namespace OutputReportTabular {
 		}
 	}
 
-	void
-	ComputeDelayedComponents()
-	{
-		// SUBROUTINE INFORMATION:
-		//       AUTHOR         Jason Glazer
-		//       DATE WRITTEN   September 2012
-		//       MODIFIED       na
-		//       RE-ENGINEERED  na
-
-		// PURPOSE OF THIS SUBROUTINE:
-		//   For load component report, convert the sequence of radiant gains
-		//   for people and equipment and other internal loads into convective
-		//   gains based on the decay curves.
-
-		// METHODOLOGY EMPLOYED:
-		//   For each step of sequence from each design day, compute the
-		//   contributations from previous timesteps multiplied by the decay
-		//   curve. Rather than store every internal load's radiant contribution
-		//   to each surface, the TMULT and ITABSF sequences were also stored
-		//   which allocates the total radiant to each surface in the zone. The
-		//   formula used is:
-		//       QRadThermInAbs(SurfNum) = QL(NZ) * TMULT(NZ) * ITABSF(SurfNum)
-
-		// REFERENCES:
-		// na
-
-		// Using/Aliasing
-		using DataSurfaces::Surface;
-		using DataSurfaces::TotSurfaces;
-		using DataSurfaces::SurfaceClass_Window;
-		using DataEnvironment::TotDesDays;
-		using DataEnvironment::TotRunDesPersDays;
-		using DataGlobals::NumOfTimeStepInHour;
-		using DataSizing::CalcFinalZoneSizing;
-		using DataZoneEquipment::ZoneEquipConfig;
-
-		// Locals
-		// SUBROUTINE ARGUMENT DEFINITIONS:
-		// na
-
-		// SUBROUTINE PARAMETER DEFINITIONS:
-		// na
-
-		// INTERFACE BLOCK SPECIFICATIONS
-		// na
-
-		// DERIVED TYPE DEFINITIONS
-		// na
-
-		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-
-		int iZone;
-		int jSurf;
-		int kTimeStep;
-		int lDesHtCl;
-		int mStepBack;
-		int desSelected;
-		bool isCooling;
-		Real64 QRadThermInAbsMult;
-		Real64 peopleConvFromSurf;
-		Real64 peopleConvIntoZone;
-		Array1D< Real64 > peopleRadIntoSurf;
-		Real64 equipConvFromSurf;
-		Real64 equipConvIntoZone;
-		Array1D< Real64 > equipRadIntoSurf;
-		Real64 hvacLossConvFromSurf;
-		Real64 hvacLossConvIntoZone;
-		Array1D< Real64 > hvacLossRadIntoSurf;
-		Real64 powerGenConvFromSurf;
-		Real64 powerGenConvIntoZone;
-		Array1D< Real64 > powerGenRadIntoSurf;
-		Real64 lightLWConvFromSurf;
-		Real64 lightLWConvIntoZone;
-		Array1D< Real64 > lightLWRadIntoSurf;
-		Real64 lightSWConvFromSurf;
-		Real64 lightSWConvIntoZone;
-		Real64 feneSolarConvFromSurf;
-		Real64 feneSolarConvIntoZone;
-		Real64 adjFeneSurfNetRadSeq;
-
-		peopleRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
-		equipRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
-		hvacLossRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
-		powerGenRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
-		lightLWRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
-		// deallocate after writing?  LKL
-		if ( allocated( CalcFinalZoneSizing ) ) {
-			for ( lDesHtCl = 1; lDesHtCl <= 2; ++lDesHtCl ) { //iterates between heating and cooling design day
-				isCooling = lDesHtCl == 2; //flag for when cooling design day otherwise heating design day
-				for ( iZone = 1; iZone <= NumOfZones; ++iZone ) {
-					if ( ! ZoneEquipConfig( iZone ).IsControlled ) continue;
-					if ( isCooling ) {
-						desSelected = CalcFinalZoneSizing( iZone ).CoolDDNum;
-					} else {
-						desSelected = CalcFinalZoneSizing( iZone ).HeatDDNum;
-					}
-					if ( desSelected == 0 ) continue;
-					for ( kTimeStep = 1; kTimeStep <= NumOfTimeStepInHour * 24; ++kTimeStep ) {
-						peopleConvIntoZone = 0.0;
-						equipConvIntoZone = 0.0;
-						hvacLossConvIntoZone = 0.0;
-						powerGenConvIntoZone = 0.0;
-						lightLWConvIntoZone = 0.0;
-						lightSWConvIntoZone = 0.0;
-						feneSolarConvIntoZone = 0.0;
-						adjFeneSurfNetRadSeq = 0.0;
-						for ( jSurf = 1; jSurf <= TotSurfaces; ++jSurf ) {
-							if ( ! Surface( jSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
-							if ( Surface( jSurf ).Zone == iZone ) {
-								//determine for each timestep the amount of radiant heat for each end use absorbed in each surface
-								QRadThermInAbsMult = TMULTseq( desSelected, kTimeStep, iZone ) * ITABSFseq( desSelected, kTimeStep, jSurf ) * Surface( jSurf ).Area;
-								peopleRadIntoSurf( kTimeStep ) = peopleRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
-								equipRadIntoSurf( kTimeStep ) = equipRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
-								hvacLossRadIntoSurf( kTimeStep ) = hvacLossRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
-								powerGenRadIntoSurf( kTimeStep ) = powerGenRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
-								lightLWRadIntoSurf( kTimeStep ) = lightLWRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
-								//for each time step, step back through time and apply decay curve
-								peopleConvFromSurf = 0.0;
-								equipConvFromSurf = 0.0;
-								hvacLossConvFromSurf = 0.0;
-								powerGenConvFromSurf = 0.0;
-								lightLWConvFromSurf = 0.0;
-								lightSWConvFromSurf = 0.0;
-								feneSolarConvFromSurf = 0.0;
-								for ( mStepBack = 1; mStepBack <= kTimeStep; ++mStepBack ) {
-									if ( isCooling ) {
-										peopleConvFromSurf += peopleRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
-										equipConvFromSurf += equipRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
-										hvacLossConvFromSurf += hvacLossRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
-										powerGenConvFromSurf += powerGenRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
-										lightLWConvFromSurf += lightLWRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
-										// short wave is already accumulated by surface
-										lightSWConvFromSurf += lightSWRadSeq( desSelected, kTimeStep - mStepBack + 1, jSurf ) * decayCurveCool( mStepBack, jSurf );
-										feneSolarConvFromSurf += feneSolarRadSeq( desSelected, kTimeStep - mStepBack + 1, jSurf ) * decayCurveCool( mStepBack, jSurf );
-									} else {
-										peopleConvFromSurf += peopleRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
-										equipConvFromSurf += equipRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
-										hvacLossConvFromSurf += hvacLossRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
-										powerGenConvFromSurf += powerGenRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
-										lightLWConvFromSurf += lightLWRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
-										// short wave is already accumulated by surface
-										lightSWConvFromSurf += lightSWRadSeq( desSelected, kTimeStep - mStepBack + 1, jSurf ) * decayCurveHeat( mStepBack, jSurf );
-										feneSolarConvFromSurf += feneSolarRadSeq( desSelected, kTimeStep - mStepBack + 1, jSurf ) * decayCurveHeat( mStepBack, jSurf );
-									}
-								}
-								peopleConvIntoZone += peopleConvFromSurf;
-								equipConvIntoZone += equipConvFromSurf;
-								hvacLossConvIntoZone += hvacLossConvFromSurf;
-								powerGenConvIntoZone += powerGenConvFromSurf;
-								lightLWConvIntoZone += lightLWConvFromSurf;
-								lightSWConvIntoZone += lightSWConvFromSurf;
-								feneSolarConvIntoZone += feneSolarConvFromSurf;
-								// determine the remaining convective heat from the surfaces that are not based
-								// on any of these other loads
-								//negative because heat from surface should be positive
-								surfDelaySeq( desSelected, kTimeStep, jSurf ) = -loadConvectedNormal( desSelected, kTimeStep, jSurf ) - netSurfRadSeq( desSelected, kTimeStep, jSurf ) - ( peopleConvFromSurf + equipConvFromSurf + hvacLossConvFromSurf + powerGenConvFromSurf + lightLWConvFromSurf + lightSWConvFromSurf + feneSolarConvFromSurf ); //remove net radiant for the surface
-								// also remove the net radiant component on the instanteous conduction for fenestration
-								if ( Surface( jSurf ).Class == SurfaceClass_Window ) {
-									adjFeneSurfNetRadSeq += netSurfRadSeq( desSelected, kTimeStep, jSurf );
-								}
-							}
-						}
-						peopleDelaySeq( desSelected, kTimeStep, iZone ) = peopleConvIntoZone;
-						equipDelaySeq( desSelected, kTimeStep, iZone ) = equipConvIntoZone;
-						hvacLossDelaySeq( desSelected, kTimeStep, iZone ) = hvacLossConvIntoZone;
-						powerGenDelaySeq( desSelected, kTimeStep, iZone ) = powerGenConvIntoZone;
-						//combine short wave (visible) and long wave (thermal) impacts
-						lightDelaySeq( desSelected, kTimeStep, iZone ) = lightLWConvIntoZone + lightSWConvIntoZone;
-						feneSolarDelaySeq( desSelected, kTimeStep, iZone ) = feneSolarConvIntoZone;
-						// also remove the net radiant component on the instanteous conduction for fenestration
-						feneCondInstantSeq( desSelected, kTimeStep, iZone ) -= adjFeneSurfNetRadSeq;
-					}
-				}
-			}
-		}
-	}
 
 	void
 	WriteZoneLoadComponentTable()
@@ -11421,6 +11215,7 @@ namespace OutputReportTabular {
 		using DataSurfaces::SurfaceClass_Floor;
 		using DataSurfaces::SurfaceClass_Roof;
 		using DataSurfaces::SurfaceClass_Door;
+		using DataSurfaces::SurfaceClass_Window;
 		using DataSurfaces::OSC;
 		using DataSizing::CalcFinalZoneSizing;
 		using DataSizing::NumTimeStepsInAvg;
@@ -11490,15 +11285,9 @@ namespace OutputReportTabular {
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 
-		static int CoolDesSelected( 0 ); // design day selected for cooling
-		static int HeatDesSelected( 0 ); // design day selected for heating
-		static int timeCoolMax( 0 ); // Time Step at Cool max
-		static int timeHeatMax( 0 ); // Time Step at Heat Max
-		static int iZone( 0 );
-		static int jTime( 0 );
-		static int k( 0 );
-		static int kSurf( 0 );
-		static int ZoneNum( 0 );
+		if ( !(displayZoneComponentLoadSummary && CompLoadReportIsReq) )
+			return;
+
 		Array1D< Real64 > seqData; // raw data sequence that has not been averaged yet
 		Array1D< Real64 > AvgData; // sequence data after averaging
 		int NumOfTimeStepInDay;
@@ -11519,1005 +11308,1216 @@ namespace OutputReportTabular {
 		Array1D_string rowHead;
 		Array2D_string tableBody;
 
-		if ( displayZoneComponentLoadSummary && CompLoadReportIsReq ) {
-			ComputeDelayedComponents();
-			NumOfTimeStepInDay = NumOfTimeStepInHour * 24;
-			seqData.allocate( NumOfTimeStepInDay );
-			AvgData.allocate( NumOfTimeStepInDay );
-			delayOpaque.allocate( rGrdTot );
-			totalColumn.allocate( rGrdTot );
-			percentColumn.allocate( rGrdTot );
-			grandTotalRow.allocate( cPerc );
-
-			//establish unit conversion factors
-			if ( unitsStyle == unitsStyleInchPound ) {
-				powerConversion = getSpecificUnitMultiplier( "W", "Btu/h" ); //or kBtuh?
-				tempConvIndx = getSpecificUnitIndex( "C", "F" );
-			} else {
-				powerConversion = 1.0;
-				tempConvIndx = 0; //when zero is used with ConvertIP the value is returned unconverted
-			}
-
-			// show the line definition for the decay curves
-			if ( ShowDecayCurvesInEIO ) {
-				gio::write( OutputFileInits, fmtA ) << "! <Radiant to Convective Decay Curves for Cooling>,Zone Name, Surface Name, Time 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36";
-				gio::write( OutputFileInits, fmtA ) << "! <Radiant to Convective Decay Curves for Heating>,Zone Name, Surface Name, Time 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36";
-			}
-
-			for ( iZone = 1; iZone <= NumOfZones; ++iZone ) {
-				if ( ! ZoneEquipConfig( iZone ).IsControlled ) continue;
-				mult = Zone( iZone ).Multiplier * Zone( iZone ).ListMultiplier;
-				if ( mult == 0.0 ) mult = 1.0;
-
-				//---- Cooling Peak Load Components Sub-Table
-				WriteReportHeaders( "Zone Component Load Summary", Zone( iZone ).Name, isAverage );
-
-				rowHead.allocate( rGrdTot );
-				columnHead.allocate( cPerc );
-				columnWidth.dimension( cPerc, 14 ); //array assignment - same for all columns
-				tableBody.allocate( cPerc, rGrdTot );
-
-				if ( unitsStyle != unitsStyleInchPound ) {
-					columnHead( cSensInst ) = "Sensible - Instant [W]";
-					columnHead( cSensDelay ) = "Sensible - Delayed [W]";
-					columnHead( cSensRA ) = "Sensible - Return Air [W]";
-					columnHead( cLatent ) = "Latent [W]";
-					columnHead( cTotal ) = "Total [W]";
-					columnHead( cPerc ) = "%Grand Total";
-				} else {
-					columnHead( cSensInst ) = "Sensible - Instant [Btu/h]";
-					columnHead( cSensDelay ) = "Sensible - Delayed [Btu/h]";
-					columnHead( cSensRA ) = "Sensible - Return Air [Btu/h]";
-					columnHead( cLatent ) = "Latent [Btu/h]";
-					columnHead( cTotal ) = "Total [Btu/h]";
-					columnHead( cPerc ) = "%Grand Total";
-				}
-
-				//internal gains
-				rowHead( rPeople ) = "People";
-				rowHead( rLights ) = "Lights";
-				rowHead( rEquip ) = "Equipment";
-				rowHead( rRefrig ) = "Refrigeration Equipment";
-				rowHead( rWaterUse ) = "Water Use Equipment";
-				rowHead( rPowerGen ) = "Power Generation Equipment";
-				rowHead( rHvacLoss ) = "HVAC Equipment Losses";
-				rowHead( rRefrig ) = "Refrigeration";
-				//misc
-				rowHead( rDOAS ) = "DOAS Direct to Zone";
-				rowHead( rInfil ) = "Infiltration";
-				rowHead( rZoneVent ) = "Zone Ventilation";
-				rowHead( rIntZonMix ) = "Interzone Mixing";
-				//opaque surfaces
-				rowHead( rRoof ) = "Roof";
-				rowHead( rIntZonCeil ) = "Interzone Ceiling";
-				rowHead( rOtherRoof ) = "Other Roof";
-				rowHead( rExtWall ) = "Exterior Wall";
-				rowHead( rIntZonWall ) = "Interzone Wall";
-				rowHead( rGrdWall ) = "Ground Contact Wall";
-				rowHead( rOtherWall ) = "Other Wall";
-				rowHead( rExtFlr ) = "Exterior Floor";
-				rowHead( rIntZonFlr ) = "Interzone Floor";
-				rowHead( rGrdFlr ) = "Ground Contact Floor";
-				rowHead( rOtherFlr ) = "Other Floor";
-				//subsurfaces
-				rowHead( rFeneCond ) = "Fenestration Conduction";
-				rowHead( rFeneSolr ) = "Fenestration Solar";
-				rowHead( rOpqDoor ) = "Opaque Door";
-				rowHead( rGrdTot ) = "Grand Total";
-
-				tableBody = "";
-				totalColumn = 0.0;
-				percentColumn = 0.0;
-				grandTotalRow = 0.0;
-
-				CoolDesSelected = CalcFinalZoneSizing( iZone ).CoolDDNum;
-				timeCoolMax = CalcFinalZoneSizing( iZone ).TimeStepNumAtCoolMax;
-				if ( CoolDesSelected != 0 && timeCoolMax != 0 ) {
-
-					//PEOPLE
-					seqData = peopleInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rPeople ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rPeople ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = peopleLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rPeople ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rPeople ) += AvgData( timeCoolMax );
-					grandTotalRow( cLatent ) += AvgData( timeCoolMax );
-
-					seqData = peopleDelaySeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rPeople ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rPeople ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
-
-					//LIGHTS
-					seqData = lightInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rLights ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rLights ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = lightRetAirSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensRA, rLights ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rLights ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensRA ) += AvgData( timeCoolMax );
-
-					seqData = lightDelaySeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rLights ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rLights ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
-
-					//EQUIPMENT
-					seqData = equipInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rEquip ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rEquip ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = equipLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rEquip ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rEquip ) += AvgData( timeCoolMax );
-					grandTotalRow( cLatent ) += AvgData( timeCoolMax );
-
-					seqData = equipDelaySeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rEquip ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rEquip ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
-
-					//REFRIGERATION EQUIPMENT
-					seqData = refrigInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rRefrig ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rRefrig ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = refrigRetAirSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensRA, rRefrig ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rRefrig ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensRA ) += AvgData( timeCoolMax );
-
-					seqData = refrigLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rRefrig ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rRefrig ) += AvgData( timeCoolMax );
-					grandTotalRow( cLatent ) += AvgData( timeCoolMax );
-
-					//WATER USE EQUIPMENT
-					seqData = waterUseInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rWaterUse ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rWaterUse ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = waterUseLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rWaterUse ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rWaterUse ) += AvgData( timeCoolMax );
-					grandTotalRow( cLatent ) += AvgData( timeCoolMax );
-
-					//HVAC EQUIPMENT LOSSES
-					seqData = hvacLossInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rHvacLoss ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rHvacLoss ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = hvacLossDelaySeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rHvacLoss ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rHvacLoss ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
-
-					//POWER GENERATION EQUIPMENT
-					seqData = powerGenInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rPowerGen ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rPowerGen ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = powerGenDelaySeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rPowerGen ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rPowerGen ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
-
-					//DOAS
-					tableBody( cSensInst, rDOAS ) = RealToStr( CalcZoneSizing( CoolDesSelected, iZone ).DOASHeatAddSeq( timeCoolMax ), 2 );
-					totalColumn( rDOAS ) += CalcZoneSizing( CoolDesSelected, iZone ).DOASHeatAddSeq( timeCoolMax );
-					grandTotalRow( cSensInst ) += CalcZoneSizing( CoolDesSelected, iZone ).DOASHeatAddSeq( timeCoolMax );
-
-					tableBody( cLatent, rDOAS ) = RealToStr( CalcZoneSizing( CoolDesSelected, iZone ).DOASLatAddSeq( timeCoolMax ), 2 );
-					totalColumn( rDOAS ) += CalcZoneSizing( CoolDesSelected, iZone ).DOASLatAddSeq( timeCoolMax );
-					grandTotalRow( cLatent ) += CalcZoneSizing( CoolDesSelected, iZone ).DOASLatAddSeq( timeCoolMax );
-
-					//INFILTRATION
-					seqData = infilInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rInfil ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rInfil ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = infilLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rInfil ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rInfil ) += AvgData( timeCoolMax );
-					grandTotalRow( cLatent ) += AvgData( timeCoolMax );
-
-					//ZONE VENTILATION
-					seqData = zoneVentInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rZoneVent ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rZoneVent ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = zoneVentLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rZoneVent ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rZoneVent ) += AvgData( timeCoolMax );
-					grandTotalRow( cLatent ) += AvgData( timeCoolMax );
-
-					//INTERZONE MIXING
-					seqData = interZoneMixInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rIntZonMix ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rIntZonMix ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					seqData = interZoneMixLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rIntZonMix ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rIntZonMix ) += AvgData( timeCoolMax );
-					grandTotalRow( cLatent ) += AvgData( timeCoolMax );
-
-					//FENESTRATION CONDUCTION
-					seqData = feneCondInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rFeneCond ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rFeneCond ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
-
-					//FENESTRATION SOLAR
-					//      seqData = feneSolarInstantSeq(iZone,:,CoolDesSelected) * powerConversion
-					//      CALL MovingAvg(seqData,NumOfTimeStepInDay,NumTimeStepsInAvg,AvgData)
-					//      tableBody(rFeneSolr,cSensInst)  = TRIM(RealToStr(AvgData(timeCoolMax),2))
-					//      totalColumn(rFeneSolr) = totalColumn(rFeneSolr) + AvgData(timeCoolMax)
-					//      grandTotalRow(cSensInst) = grandTotalRow(cSensInst) + AvgData(timeCoolMax)
-
-					seqData = feneSolarDelaySeq( CoolDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rFeneSolr ) = RealToStr( AvgData( timeCoolMax ), 2 );
-					totalColumn( rFeneSolr ) += AvgData( timeCoolMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
-
-					//opaque surfaces - must combine individual surfaces by class and other side conditions
-					delayOpaque = 0.0;
-					for ( kSurf = 1; kSurf <= TotSurfaces; ++kSurf ) {
-						if ( ! Surface( kSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
-						if ( Surface( kSurf ).Zone == iZone ) {
-							curExtBoundCond = Surface( kSurf ).ExtBoundCond;
-							//if exterior is other side coefficients using ground preprocessor terms then
-							//set it to ground instead of other side coefficients
-							if ( curExtBoundCond == OtherSideCoefNoCalcExt || curExtBoundCond == OtherSideCoefCalcExt ) {
-								if ( has_prefixi( OSC( Surface( kSurf ).OSCPtr ).Name, "surfPropOthSdCoef" ) ) {
-									curExtBoundCond = Ground;
-								}
-							}
-							seqData = surfDelaySeq( CoolDesSelected, _, kSurf );
-							MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-							singleSurfDelay = AvgData( timeCoolMax ) * powerConversion;
-							{ auto const SELECT_CASE_var( Surface( kSurf ).Class );
-							if ( SELECT_CASE_var == SurfaceClass_Wall ) {
-								{ auto const SELECT_CASE_var1( curExtBoundCond );
-								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
-									delayOpaque( rExtWall ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) ) {
-									delayOpaque( rGrdWall ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
-									delayOpaque( rOtherWall ) += singleSurfDelay;
-								} else { //interzone
-									delayOpaque( rIntZonWall ) += singleSurfDelay;
-								}}
-							} else if ( SELECT_CASE_var == SurfaceClass_Floor ) {
-								{ auto const SELECT_CASE_var1( curExtBoundCond );
-								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
-									delayOpaque( rExtFlr ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) ) {
-									delayOpaque( rGrdFlr ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
-									delayOpaque( rOtherFlr ) += singleSurfDelay;
-								} else { //interzone
-									delayOpaque( rIntZonFlr ) += singleSurfDelay;
-								}}
-							} else if ( SELECT_CASE_var == SurfaceClass_Roof ) {
-								{ auto const SELECT_CASE_var1( curExtBoundCond );
-								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
-									delayOpaque( rRoof ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) || ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
-									delayOpaque( rOtherRoof ) += singleSurfDelay;
-								} else { //interzone
-									delayOpaque( rIntZonCeil ) += singleSurfDelay;
-								}}
-							} else if ( SELECT_CASE_var == SurfaceClass_Door ) {
-								delayOpaque( rOpqDoor ) += singleSurfDelay;
-							}}
-						}
-					}
-					for ( k = rRoof; k <= rOtherFlr; ++k ) {
-						tableBody( cSensDelay, k ) = RealToStr( delayOpaque( k ), 2 );
-						totalColumn( k ) += delayOpaque( k );
-						grandTotalRow( cSensDelay ) += delayOpaque( k );
-					}
-					tableBody( cSensDelay, rOpqDoor ) = RealToStr( delayOpaque( rOpqDoor ), 2 );
-					totalColumn( rOpqDoor ) += delayOpaque( rOpqDoor );
-					grandTotalRow( cSensDelay ) += delayOpaque( rOpqDoor );
-				}
-
-				//GRAND TOTAL ROW
-				totalGrandTotal = 0.0;
-				for ( k = 1; k <= cLatent; ++k ) {
-					tableBody( k, rGrdTot ) = RealToStr( grandTotalRow( k ), 2 );
-					totalGrandTotal += grandTotalRow( k );
-				}
-				tableBody( cTotal, rGrdTot ) = RealToStr( totalGrandTotal, 2 );
-
-				//TOTAL COLUMN AND PERCENT COLUMN
-				for ( k = 1; k <= rOpqDoor; ++k ) { //to last row before total
-					tableBody( cTotal, k ) = RealToStr( totalColumn( k ), 2 );
-					if ( totalGrandTotal != 0.0 ) {
-						tableBody( cPerc, k ) = RealToStr( 100 * totalColumn( k ) / totalGrandTotal, 2 );
-					}
-				}
-
-				WriteSubtitle( "Estimated Cooling Peak Load Components" );
-				WriteTable( tableBody, rowHead, columnHead, columnWidth );
-				if ( sqlite ) {
-					sqlite->createSQLiteTabularDataRecords( tableBody, rowHead, columnHead, "ZoneComponentLoadSummary", Zone( iZone ).Name, "Estimated Cooling Peak Load Components" );
-				}
-
-				//---- Cooling Peak Conditions
-
-				rowHead.allocate( 10 );
-				columnHead.allocate( 1 );
-				columnWidth.allocate( 1 );
-				columnWidth = 14; //array assignment - same for all columns
-				tableBody.allocate( 1, 10 );
-
-				columnHead( 1 ) = "Value";
-				if ( unitsStyle != unitsStyleInchPound ) {
-					rowHead( 1 ) = "Time of Peak Load";
-					rowHead( 2 ) = "Outside  Dry Bulb Temperature [C]";
-					rowHead( 3 ) = "Outside  Wet Bulb Temperature [C]";
-					rowHead( 4 ) = "Outside Humidity Ratio at Peak [kgWater/kgAir]";
-					rowHead( 5 ) = "Zone Dry Bulb Temperature [C]";
-					rowHead( 6 ) = "Zone Relative Humdity [%]";
-					rowHead( 7 ) = "Zone Humidity Ratio at Peak [kgWater/kgAir]";
-					rowHead( 8 ) = "Peak Design Sensible Load [W]";
-					rowHead( 9 ) = "Estimated Instant + Delayed Sensible Load [W]";
-					rowHead( 10 ) = "Difference [W]";
-				} else {
-					rowHead( 1 ) = "Time of Peak Load";
-					rowHead( 2 ) = "Outside  Dry Bulb Temperature [F]";
-					rowHead( 3 ) = "Outside  Wet Bulb Temperature [F]";
-					rowHead( 4 ) = "Outside Humidity Ratio at Peak [lbWater/lbAir]";
-					rowHead( 5 ) = "Zone Dry Bulb Temperature [F]";
-					rowHead( 6 ) = "Zone Relative Humdity [%]";
-					rowHead( 7 ) = "Zone Humidity Ratio at Peak [lbWater/lbAir]";
-					rowHead( 8 ) = "Peak Design Sensible Load [Btu/h]";
-					rowHead( 9 ) = "Estimated Instant + Delayed Sensible Load [Btu/h]";
-					rowHead( 10 ) = "Difference [Btu/h]";
-				}
-
-				tableBody = "";
-
-				if ( timeCoolMax != 0 ) {
-
-					//Time of Peak Load
-					tableBody( 1, 1 ) = CoolPeakDateHrMin( iZone );
-
-					//Outside  Dry Bulb Temperature
-					tableBody( 1, 2 ) = RealToStr( ConvertIP( tempConvIndx, CalcFinalZoneSizing( iZone ).CoolOutTempSeq( timeCoolMax ) ), 2 );
-
-					//Outside  Wet Bulb Temperature
-					//use standard sea level air pressure because air pressure is not tracked with sizing data
-					if ( CalcFinalZoneSizing( iZone ).CoolOutHumRatSeq( timeCoolMax ) < 1.0 && CalcFinalZoneSizing( iZone ).CoolOutHumRatSeq( timeCoolMax ) > 0.0 ) {
-						tableBody( 1, 3 ) = RealToStr( ConvertIP( tempConvIndx, PsyTwbFnTdbWPb( CalcFinalZoneSizing( iZone ).CoolOutTempSeq( timeCoolMax ), CalcFinalZoneSizing( iZone ).CoolOutHumRatSeq( timeCoolMax ), 101325.0 ) ), 2 );
-					}
-
-					//Outside Humidity Ratio at Peak
-					tableBody( 1, 4 ) = RealToStr( CalcFinalZoneSizing( iZone ).CoolOutHumRatSeq( timeCoolMax ), 5 );
-
-					//Zone Dry Bulb Temperature
-					tableBody( 1, 5 ) = RealToStr( ConvertIP( tempConvIndx, CalcFinalZoneSizing( iZone ).CoolZoneTempSeq( timeCoolMax ) ), 2 );
-
-					//Zone Relative Humdity
-					//use standard sea level air pressure because air pressure is not tracked with sizing data
-					tableBody( 1, 6 ) = RealToStr( 100 * PsyRhFnTdbWPb( CalcFinalZoneSizing( iZone ).CoolZoneTempSeq( timeCoolMax ), CalcFinalZoneSizing( iZone ).CoolZoneHumRatSeq( timeCoolMax ), 101325.0 ), 2 );
-
-					//Zone Humidity Ratio at Peak
-					tableBody( 1, 7 ) = RealToStr( CalcFinalZoneSizing( iZone ).CoolZoneHumRatSeq( timeCoolMax ), 5 );
-
-				}
-
-				//Peak Design Sensible Load
-				tableBody( 1, 8 ) = RealToStr( ( CalcFinalZoneSizing( iZone ).DesCoolLoad / mult ) * powerConversion, 2 );
-
-				//Estimated Instant + Delayed Sensible Load
-				tableBody( 1, 9 ) = RealToStr( grandTotalRow( cSensInst ) + grandTotalRow( cSensDelay ), 2 );
-
-				//Difference
-				tableBody( 1, 10 ) = RealToStr( ( CalcFinalZoneSizing( iZone ).DesCoolLoad / mult ) * powerConversion - ( grandTotalRow( cSensInst ) + grandTotalRow( cSensDelay ) ), 2 );
-
-				WriteSubtitle( "Cooling Peak Conditions" );
-				WriteTable( tableBody, rowHead, columnHead, columnWidth );
-				if ( sqlite ) {
-					sqlite->createSQLiteTabularDataRecords( tableBody, rowHead, columnHead, "ZoneComponentLoadSummary", Zone( iZone ).Name, "Cooling Peak Conditions" );
-				}
-
-				//    !
-				//    !---- Radiant to Convective Decay Curves for Cooling
-				//    !
-				//    numObj = 0
-				//    !determine the number of surfaces to include
-				//    DO kSurf = 1, TotSurfaces
-				//      ZoneNum = Surface(kSurf)%Zone
-				//      IF (ZoneNum .NE. iZone) CYCLE
-				//      IF (ZoneNum .EQ. 0) CYCLE
-				//      IF (.not. ZoneEquipConfig(ZoneNum)%IsControlled) CYCLE
-				//      numObj = numObj + 1
-				//    END DO
-				//    ALLOCATE(rowHead(numObj))
-				//    ALLOCATE(columnHead(16))
-				//    ALLOCATE(columnWidth(16))
-				//    columnWidth = 14 !array assignment - same for all columns
-				//    ALLOCATE(tableBody(numObj,16))
-				//    columnHead(1) = 'Time 1'
-				//    columnHead(2) = 'Time 2'
-				//    columnHead(3) = 'Time 3'
-				//    columnHead(4) = 'Time 4'
-				//    columnHead(5) = 'Time 5'
-				//    columnHead(6) = 'Time 6'
-				//    columnHead(7) = 'Time 7'
-				//    columnHead(8) = 'Time 8'
-				//    columnHead(9) = 'Time 9'
-				//    columnHead(10) = 'Time 10'
-				//    columnHead(11) = 'Time 11'
-				//    columnHead(12) = 'Time 12'
-				//    columnHead(13) = 'Time 13'
-				//    columnHead(14) = 'Time 14'
-				//    columnHead(15) = 'Time 15'
-				//    columnHead(16) = 'Time 16'
-				//    tableBody = ''
-				//    objCount = 0
-				//    DO kSurf = 1, TotSurfaces
-				//      ZoneNum = Surface(kSurf)%Zone
-				//      IF (ZoneNum .NE. iZone) CYCLE
-				//      IF (ZoneNum .EQ. 0) CYCLE
-				//      IF (.not. ZoneEquipConfig(ZoneNum)%IsControlled) CYCLE
-				//      objCount = objCount + 1
-				//      rowHead(objCount) = TRIM(Surface(kSurf)%Name)
-				//      DO jTime = 1, 16
-				//        tableBody(objCount,jTime) = TRIM(RealToStr(decayCurveCool(kSurf,jTime),3))
-				//      END DO
-				//    END DO
-				//    CALL WriteSubtitle('Radiant to Convective Decay Curves for Cooling')
-				//    CALL WriteTable(tableBody,rowHead,columnHead,columnWidth)
-				//    CALL CreateSQLiteTabularDataRecords(tableBody,rowHead,columnHead,&
-				//                                        'ZoneComponentLoadDetail',&
-				//                                        TRIM(Zone(iZone)%Name),&
-				//                                        'Radiant to Convective Decay Curves for Cooling')
-				//    DEALLOCATE(columnHead)
-				//    DEALLOCATE(rowHead)
-				//    DEALLOCATE(columnWidth)
-				//    DEALLOCATE(tableBody)
-
-				// Put the decay curve into the EIO file
-				if ( ShowDecayCurvesInEIO ) {
-					for ( kSurf = 1; kSurf <= TotSurfaces; ++kSurf ) {
-						ZoneNum = Surface( kSurf ).Zone;
-						if ( ZoneNum != iZone ) continue;
-						if ( ZoneNum == 0 ) continue;
-						if ( ! ZoneEquipConfig( ZoneNum ).IsControlled ) continue;
-						{ IOFlags flags; flags.ADVANCE( "NO" ); gio::write( OutputFileInits, "(4A)", flags ) << "Radiant to Convective Decay Curves for Cooling," << Zone( iZone ).Name << ',' << Surface( kSurf ).Name; }
-						for ( jTime = 1; jTime <= min( NumOfTimeStepInHour * 24, 36 ); ++jTime ) {
-							{ IOFlags flags; flags.ADVANCE( "NO" ); gio::write( OutputFileInits, "(A,F6.3)", flags ) << ',' << decayCurveCool( jTime, kSurf ); }
-						}
-						{ IOFlags flags; flags.ADVANCE( "YES" ); gio::write( OutputFileInits, "()", flags ); } //put a line feed at the end of the line
-					}
-				}
-
-				//---- Heating Peak Load Components Sub-Table
-				rowHead.allocate( rGrdTot );
-				columnHead.allocate( cPerc );
-				columnWidth.dimension( cPerc, 14 ); //array assignment - same for all columns
-				tableBody.allocate( cPerc, rGrdTot );
-
-				if ( unitsStyle != unitsStyleInchPound ) {
-					columnHead( cSensInst ) = "Sensible - Instant [W]";
-					columnHead( cSensDelay ) = "Sensible - Delayed [W]";
-					columnHead( cSensRA ) = "Sensible - Return Air [W]";
-					columnHead( cLatent ) = "Latent [W]";
-					columnHead( cTotal ) = "Total [W]";
-					columnHead( cPerc ) = "%Grand Total";
-				} else {
-					columnHead( cSensInst ) = "Sensible - Instant [Btu/h]";
-					columnHead( cSensDelay ) = "Sensible - Delayed [Btu/h]";
-					columnHead( cSensRA ) = "Sensible - Return Air [Btu/h]";
-					columnHead( cLatent ) = "Latent [Btu/h]";
-					columnHead( cTotal ) = "Total [Btu/h]";
-					columnHead( cPerc ) = "%Grand Total";
-				}
-
-				//internal gains
-				rowHead( rPeople ) = "People";
-				rowHead( rLights ) = "Lights";
-				rowHead( rEquip ) = "Equipment";
-				rowHead( rRefrig ) = "Refrigeration Equipment";
-				rowHead( rWaterUse ) = "Water Use Equipment";
-				rowHead( rPowerGen ) = "Power Generation Equipment";
-				rowHead( rHvacLoss ) = "HVAC Equipment Losses";
-				rowHead( rRefrig ) = "Refrigeration";
-				//misc
-				rowHead( rDOAS ) = "DOAS";
-				rowHead( rInfil ) = "Infiltration";
-				rowHead( rZoneVent ) = "Zone Ventilation";
-				rowHead( rIntZonMix ) = "Interzone Mixing";
-				//opaque surfaces
-				rowHead( rRoof ) = "Roof";
-				rowHead( rIntZonCeil ) = "Interzone Ceiling";
-				rowHead( rOtherRoof ) = "Other Roof";
-				rowHead( rExtWall ) = "Exterior Wall";
-				rowHead( rIntZonWall ) = "Interzone Wall";
-				rowHead( rGrdWall ) = "Ground Contact Wall";
-				rowHead( rOtherWall ) = "Other Wall";
-				rowHead( rExtFlr ) = "Exterior Floor";
-				rowHead( rIntZonFlr ) = "Interzone Floor";
-				rowHead( rGrdFlr ) = "Ground Contact Floor";
-				rowHead( rOtherFlr ) = "Other Floor";
-				//subsurfaces
-				rowHead( rFeneCond ) = "Fenestration Conduction";
-				rowHead( rFeneSolr ) = "Fenestration Solar";
-				rowHead( rOpqDoor ) = "Opaque Door";
-				rowHead( rGrdTot ) = "Grand Total";
-
-				tableBody = "";
-				totalColumn = 0.0;
-				percentColumn = 0.0;
-				grandTotalRow = 0.0;
-
-				HeatDesSelected = CalcFinalZoneSizing( iZone ).HeatDDNum;
-				timeHeatMax = CalcFinalZoneSizing( iZone ).TimeStepNumAtHeatMax;
-				if ( HeatDesSelected != 0 && timeHeatMax != 0 ) {
-
-					//PEOPLE
-					seqData = peopleInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rPeople ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rPeople ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = peopleLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rPeople ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rPeople ) += AvgData( timeHeatMax );
-					grandTotalRow( cLatent ) += AvgData( timeHeatMax );
-
-					seqData = peopleDelaySeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rPeople ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rPeople ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
-
-					//LIGHTS
-					seqData = lightInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rLights ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rLights ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = lightRetAirSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensRA, rLights ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rLights ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensRA ) += AvgData( timeHeatMax );
-
-					seqData = lightDelaySeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rLights ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rLights ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
-
-					//EQUIPMENT
-					seqData = equipInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rEquip ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rEquip ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = equipLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rEquip ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rEquip ) += AvgData( timeHeatMax );
-					grandTotalRow( cLatent ) += AvgData( timeHeatMax );
-
-					seqData = equipDelaySeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rEquip ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rEquip ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
-
-					//REFRIGERATION EQUIPMENT
-					seqData = refrigInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rRefrig ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rRefrig ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = refrigRetAirSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensRA, rRefrig ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rRefrig ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensRA ) += AvgData( timeHeatMax );
-
-					seqData = refrigLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rRefrig ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rRefrig ) += AvgData( timeHeatMax );
-					grandTotalRow( cLatent ) += AvgData( timeHeatMax );
-
-					//WATER USE EQUIPMENT
-					seqData = waterUseInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rWaterUse ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rWaterUse ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = waterUseLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rWaterUse ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rWaterUse ) += AvgData( timeHeatMax );
-					grandTotalRow( cLatent ) += AvgData( timeHeatMax );
-
-					//HVAC EQUIPMENT LOSSES
-					seqData = hvacLossInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rHvacLoss ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rHvacLoss ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = hvacLossDelaySeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rHvacLoss ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rHvacLoss ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
-
-					//POWER GENERATION EQUIPMENT
-					seqData = powerGenInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rPowerGen ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rPowerGen ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = powerGenDelaySeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rPowerGen ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rPowerGen ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
-
-					//DOAS
-					tableBody( cSensInst, rDOAS ) = RealToStr( CalcZoneSizing( HeatDesSelected, iZone ).DOASHeatAddSeq( timeHeatMax ), 2 );
-					totalColumn( rDOAS ) += CalcZoneSizing( HeatDesSelected, iZone ).DOASHeatAddSeq( timeHeatMax );
-					grandTotalRow( cSensDelay ) += CalcZoneSizing( HeatDesSelected, iZone ).DOASHeatAddSeq( timeHeatMax );
-
-					tableBody( cLatent, rDOAS ) = RealToStr( CalcZoneSizing( HeatDesSelected, iZone ).DOASLatAddSeq( timeHeatMax ), 2 );
-					totalColumn( rDOAS ) += CalcZoneSizing( HeatDesSelected, iZone ).DOASLatAddSeq( timeHeatMax );
-					grandTotalRow( cLatent ) += CalcZoneSizing( HeatDesSelected, iZone ).DOASLatAddSeq( timeHeatMax );
-
-					//INFILTRATION
-					seqData = infilInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rInfil ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rInfil ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = infilLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rInfil ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rInfil ) += AvgData( timeHeatMax );
-					grandTotalRow( cLatent ) += AvgData( timeHeatMax );
-
-					//ZONE VENTILATION
-					seqData = zoneVentInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rZoneVent ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rZoneVent ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = zoneVentLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rZoneVent ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rZoneVent ) += AvgData( timeHeatMax );
-					grandTotalRow( cLatent ) += AvgData( timeHeatMax );
-
-					//INTERZONE MIXING
-					seqData = interZoneMixInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rIntZonMix ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rIntZonMix ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					seqData = interZoneMixLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cLatent, rIntZonMix ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rIntZonMix ) += AvgData( timeHeatMax );
-					grandTotalRow( cLatent ) += AvgData( timeHeatMax );
-
-					//FENESTRATION CONDUCTION
-					seqData = feneCondInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensInst, rFeneCond ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rFeneCond ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
-
-					//FENESTRATION SOLAR
-					//      seqData = feneSolarInstantSeq(iZone,:,HeatDesSelected) * powerConversion
-					//      CALL MovingAvg(seqData,NumOfTimeStepInDay,NumTimeStepsInAvg,AvgData)
-					//      tableBody(rFeneSolr,cSensInst)  = TRIM(RealToStr(AvgData(timeHeatMax),2))
-					//      totalColumn(rFeneSolr) = totalColumn(rFeneSolr) + AvgData(timeHeatMax)
-					//      grandTotalRow(cSensInst) = grandTotalRow(cSensInst) + AvgData(timeHeatMax)
-
-					seqData = feneSolarDelaySeq( HeatDesSelected, _, iZone ) * powerConversion;
-					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-					tableBody( cSensDelay, rFeneSolr ) = RealToStr( AvgData( timeHeatMax ), 2 );
-					totalColumn( rFeneSolr ) += AvgData( timeHeatMax );
-					grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
-
-					//opaque surfaces - must combine individual surfaces by class and other side conditions
-					delayOpaque = 0.0;
-					for ( kSurf = 1; kSurf <= TotSurfaces; ++kSurf ) {
-						if ( ! Surface( kSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
-						if ( Surface( kSurf ).Zone == iZone ) {
-							curExtBoundCond = Surface( kSurf ).ExtBoundCond;
-							//if exterior is other side coefficients using ground preprocessor terms then
-							//set it to ground instead of other side coefficients
-							if ( curExtBoundCond == OtherSideCoefNoCalcExt || curExtBoundCond == OtherSideCoefCalcExt ) {
-								if ( has_prefixi( OSC( Surface( kSurf ).OSCPtr ).Name, "surfPropOthSdCoef" ) ) {
-									curExtBoundCond = Ground;
-								}
-							}
-							seqData = surfDelaySeq( HeatDesSelected, _, kSurf );
-							MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
-							singleSurfDelay = AvgData( timeHeatMax ) * powerConversion;
-							{ auto const SELECT_CASE_var( Surface( kSurf ).Class );
-							if ( SELECT_CASE_var == SurfaceClass_Wall ) {
-								{ auto const SELECT_CASE_var1( curExtBoundCond );
-								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
-									delayOpaque( rExtWall ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) ) {
-									delayOpaque( rGrdWall ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
-									delayOpaque( rOtherWall ) += singleSurfDelay;
-								} else { //interzone
-									delayOpaque( rIntZonWall ) += singleSurfDelay;
-								}}
-							} else if ( SELECT_CASE_var == SurfaceClass_Floor ) {
-								{ auto const SELECT_CASE_var1( curExtBoundCond );
-								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
-									delayOpaque( rExtFlr ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) ) {
-									delayOpaque( rGrdFlr ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
-									delayOpaque( rOtherFlr ) += singleSurfDelay;
-								} else { //interzone
-									delayOpaque( rIntZonFlr ) += singleSurfDelay;
-								}}
-							} else if ( SELECT_CASE_var == SurfaceClass_Roof ) {
-								{ auto const SELECT_CASE_var1( curExtBoundCond );
-								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
-									delayOpaque( rRoof ) += singleSurfDelay;
-								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) || ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
-									delayOpaque( rOtherRoof ) += singleSurfDelay;
-								} else { //interzone
-									delayOpaque( rIntZonCeil ) += singleSurfDelay;
-								}}
-							} else if ( SELECT_CASE_var == SurfaceClass_Door ) {
-								delayOpaque( rOpqDoor ) += singleSurfDelay;
-							}}
-						}
-					}
-					for ( k = rRoof; k <= rOtherFlr; ++k ) {
-						tableBody( cSensDelay, k ) = RealToStr( delayOpaque( k ), 2 );
-						totalColumn( k ) += delayOpaque( k );
-						grandTotalRow( cSensDelay ) += delayOpaque( k );
-					}
-					tableBody( cSensDelay, rOpqDoor ) = RealToStr( delayOpaque( rOpqDoor ), 2 );
-					totalColumn( rOpqDoor ) += delayOpaque( rOpqDoor );
-					grandTotalRow( cSensDelay ) += delayOpaque( rOpqDoor );
-				}
-
-				//GRAND TOTAL ROW
-				totalGrandTotal = 0.0;
-				for ( k = 1; k <= cLatent; ++k ) {
-					tableBody( k, rGrdTot ) = RealToStr( grandTotalRow( k ), 2 );
-					totalGrandTotal += grandTotalRow( k );
-				}
-				tableBody( cTotal, rGrdTot ) = RealToStr( totalGrandTotal, 2 );
-
-				//TOTAL COLUMN AND PERCENT COLUMN
-				for ( k = 1; k <= rOpqDoor; ++k ) { //to last row before total
-					tableBody( cTotal, k ) = RealToStr( totalColumn( k ), 2 );
-					if ( totalGrandTotal != 0.0 ) {
-						tableBody( cPerc, k ) = RealToStr( 100 * totalColumn( k ) / totalGrandTotal, 2 );
-					}
-				}
-
-				WriteSubtitle( "Estimated Heating Peak Load Components" );
-				WriteTable( tableBody, rowHead, columnHead, columnWidth );
-				if ( sqlite ) {
-					sqlite->createSQLiteTabularDataRecords( tableBody, rowHead, columnHead, "ZoneComponentLoadSummary", Zone( iZone ).Name, "Estimated Heating Peak Load Components" );
-				}
-
-				//---- Heating Peak Conditions Sub-Table
-
-				rowHead.allocate( 10 );
-				columnHead.allocate( 1 );
-				columnWidth.allocate( 1 );
-				columnWidth = 14; //array assignment - same for all columns
-				tableBody.allocate( 1, 10 );
-
-				columnHead( 1 ) = "Value";
-				if ( unitsStyle != unitsStyleInchPound ) {
-					rowHead( 1 ) = "Time of Peak Load";
-					rowHead( 2 ) = "Outside  Dry Bulb Temperature [C]";
-					rowHead( 3 ) = "Outside  Wet Bulb Temperature [C]";
-					rowHead( 4 ) = "Outside Humidity Ratio at Peak [kgWater/kgAir]";
-					rowHead( 5 ) = "Zone Dry Bulb Temperature [C]";
-					rowHead( 6 ) = "Zone Relative Humdity [%]";
-					rowHead( 7 ) = "Zone Humidity Ratio at Peak [kgWater/kgAir]";
-					rowHead( 8 ) = "Peak Design Sensible Load [W]";
-					rowHead( 9 ) = "Estimated Instant + Delayed Sensible Load [W]";
-					rowHead( 10 ) = "Difference [W]";
-				} else {
-					rowHead( 1 ) = "Time of Peak Load";
-					rowHead( 2 ) = "Outside  Dry Bulb Temperature [F]";
-					rowHead( 3 ) = "Outside  Wet Bulb Temperature [F]";
-					rowHead( 4 ) = "Outside Humidity Ratio at Peak [lbWater/lbAir]";
-					rowHead( 5 ) = "Zone Dry Bulb Temperature [F]";
-					rowHead( 6 ) = "Zone Relative Humdity [%]";
-					rowHead( 7 ) = "Zone Humidity Ratio at Peak [lbWater/lbAir]";
-					rowHead( 8 ) = "Peak Design Sensible Load [Btu/h]";
-					rowHead( 9 ) = "Estimated Instant + Delayed Sensible Load [Btu/h]";
-					rowHead( 10 ) = "Difference [Btu/h]";
-				}
-
-				tableBody = "";
-
-				if ( timeHeatMax != 0 ) {
-					//Time of Peak Load
-					tableBody( 1, 1 ) = HeatPeakDateHrMin( iZone );
-
-					//Outside  Dry Bulb Temperature
-					tableBody( 1, 2 ) = RealToStr( ConvertIP( tempConvIndx, CalcFinalZoneSizing( iZone ).HeatOutTempSeq( timeHeatMax ) ), 2 );
-
-					//Outside  Wet Bulb Temperature
-					//use standard sea level air pressure because air pressure is not tracked with sizing data
-					if ( CalcFinalZoneSizing( iZone ).HeatOutHumRatSeq( timeHeatMax ) < 1.0 && CalcFinalZoneSizing( iZone ).HeatOutHumRatSeq( timeHeatMax ) > 0.0 ) {
-						tableBody( 1, 3 ) = RealToStr( ConvertIP( tempConvIndx, PsyTwbFnTdbWPb( CalcFinalZoneSizing( iZone ).HeatOutTempSeq( timeHeatMax ), CalcFinalZoneSizing( iZone ).HeatOutHumRatSeq( timeHeatMax ), 101325.0 ) ), 2 );
-					}
-
-					//Humidity Ratio at Peak
-					tableBody( 1, 4 ) = RealToStr( CalcFinalZoneSizing( iZone ).HeatOutHumRatSeq( timeHeatMax ), 5 );
-
-					//Zone Dry Bulb Temperature
-					tableBody( 1, 5 ) = RealToStr( ConvertIP( tempConvIndx, CalcFinalZoneSizing( iZone ).HeatZoneTempSeq( timeHeatMax ) ), 2 );
-
-					//Zone Relative Temperature
-					//use standard sea level air pressure because air pressure is not tracked with sizing data
-					tableBody( 1, 6 ) = RealToStr( 100 * PsyRhFnTdbWPb( CalcFinalZoneSizing( iZone ).HeatZoneTempSeq( timeHeatMax ), CalcFinalZoneSizing( iZone ).HeatZoneHumRatSeq( timeHeatMax ), 101325.0 ), 2 );
-
-					//Zone Relative Humdity
-					tableBody( 1, 7 ) = RealToStr( CalcFinalZoneSizing( iZone ).HeatZoneHumRatSeq( timeHeatMax ), 5 );
-
-				}
-
-				//Peak Design Sensible Load
-				tableBody( 1, 8 ) = RealToStr( ( -CalcFinalZoneSizing( iZone ).DesHeatLoad / mult ) * powerConversion, 2 ); //change sign
-
-				//Estimated Instant + Delayed Sensible Load
-				tableBody( 1, 9 ) = RealToStr( grandTotalRow( cSensInst ) + grandTotalRow( cSensDelay ), 2 );
-
-				//Difference
-				tableBody( 1, 10 ) = RealToStr( ( -CalcFinalZoneSizing( iZone ).DesHeatLoad / mult ) * powerConversion - ( grandTotalRow( cSensInst ) + grandTotalRow( cSensDelay ) ), 2 );
-
-				WriteSubtitle( "Heating Peak Conditions" );
-				WriteTable( tableBody, rowHead, columnHead, columnWidth );
-				if ( sqlite ) {
-					sqlite->createSQLiteTabularDataRecords( tableBody, rowHead, columnHead, "ZoneComponentLoadSummary", Zone( iZone ).Name, "Heating Peak Conditions" );
-				}
-
-				//    !
-				//    !---- Radiant to Convective Decay Curves for Heating
-				//    !
-				//    numObj = 0
-				//    !determine the number of surfaces to include
-				//    DO kSurf = 1, TotSurfaces
-				//      ZoneNum = Surface(kSurf)%Zone
-				//      IF (ZoneNum .NE. iZone) CYCLE
-				//      IF (ZoneNum .EQ. 0) CYCLE
-				//      IF (.not. ZoneEquipConfig(ZoneNum)%IsControlled) CYCLE
-				//      numObj = numObj + 1
-				//    END DO
-				//    ALLOCATE(rowHead(numObj))
-				//    ALLOCATE(columnHead(16))
-				//    ALLOCATE(columnWidth(16))
-				//    columnWidth = 14 !array assignment - same for all columns
-				//    ALLOCATE(tableBody(numObj,16))
-				//    columnHead(1) = 'Time 1'
-				//    columnHead(2) = 'Time 2'
-				//    columnHead(3) = 'Time 3'
-				//    columnHead(4) = 'Time 4'
-				//    columnHead(5) = 'Time 5'
-				//    columnHead(6) = 'Time 6'
-				//    columnHead(7) = 'Time 7'
-				//    columnHead(8) = 'Time 8'
-				//    columnHead(9) = 'Time 9'
-				//    columnHead(10) = 'Time 10'
-				//    columnHead(11) = 'Time 11'
-				//    columnHead(12) = 'Time 12'
-				//    columnHead(13) = 'Time 13'
-				//    columnHead(14) = 'Time 14'
-				//    columnHead(15) = 'Time 15'
-				//    columnHead(16) = 'Time 16'
-				//    tableBody = ''
-				//    objCount = 0
-				//    DO kSurf = 1, TotSurfaces
-				//      ZoneNum = Surface(kSurf)%Zone
-				//      IF (ZoneNum .NE. iZone) CYCLE
-				//      IF (ZoneNum .EQ. 0) CYCLE
-				//      IF (.not. ZoneEquipConfig(ZoneNum)%IsControlled) CYCLE
-				//      objCount = objCount + 1
-				//      rowHead(objCount) = TRIM(Surface(kSurf)%Name)
-				//      DO jTime = 1, 16
-				//        tableBody(objCount,jTime) = TRIM(RealToStr(decayCurveHeat(kSurf,jTime),3))
-				//      END DO
-				//    END DO
-				//    CALL WriteSubtitle('Radiant to Convective Decay Curves for Heating')
-				//    CALL WriteTable(tableBody,rowHead,columnHead,columnWidth)
-				//    CALL CreateSQLiteTabularDataRecords(tableBody,rowHead,columnHead,&
-				//                                        'ZoneComponentLoadDetail',&
-				//                                        TRIM(Zone(iZone)%Name),&
-				//                                        'Radiant to Convective Decay Curves for Heating')
-				//    DEALLOCATE(columnHead)
-				//    DEALLOCATE(rowHead)
-				//    DEALLOCATE(columnWidth)
-				//    DEALLOCATE(tableBody)
-
-				// Put the decay curve into the EIO file
-				if ( ShowDecayCurvesInEIO ) {
-					for ( kSurf = 1; kSurf <= TotSurfaces; ++kSurf ) {
-						ZoneNum = Surface( kSurf ).Zone;
-						if ( ZoneNum != iZone ) continue;
-						if ( ZoneNum == 0 ) continue;
-						if ( ! ZoneEquipConfig( ZoneNum ).IsControlled ) continue;
-						{ IOFlags flags; flags.ADVANCE( "NO" ); gio::write( OutputFileInits, "(4A)", flags ) << "Radiant to Convective Decay Curves for Heating," << Zone( iZone ).Name << ',' << Surface( kSurf ).Name; }
-						for ( jTime = 1; jTime <= min( NumOfTimeStepInHour * 24, 36 ); ++jTime ) {
-							{ IOFlags flags; flags.ADVANCE( "NO" ); gio::write( OutputFileInits, "(A,F6.3)", flags ) << ',' << decayCurveHeat( jTime, kSurf ); }
-						}
-						{ IOFlags flags; flags.ADVANCE( "YES" ); gio::write( OutputFileInits, "()", flags ); } //put a line feed at the end of the line
-					}
-				}
-
-			}
+		// Delayed components are moved into this function so that we can calculate them one zone at a time
+		// with Array1D 
+		Array1D< Real64 > peopleDelaySeqHeat;
+		Array1D< Real64 > peopleDelaySeqCool;
+		Array1D< Real64 > lightDelaySeqHeat;
+		Array1D< Real64 > lightDelaySeqCool;
+		Array1D< Real64 > equipDelaySeqHeat;
+		Array1D< Real64 > equipDelaySeqCool;
+		Array1D< Real64 > hvacLossDelaySeqHeat;
+		Array1D< Real64 > hvacLossDelaySeqCool;
+		Array1D< Real64 > powerGenDelaySeqHeat;
+		Array1D< Real64 > powerGenDelaySeqCool;
+		Array1D< Real64 > feneSolarDelaySeqHeat;
+		Array1D< Real64 > feneSolarDelaySeqCool;
+		Array2D< Real64 > surfDelaySeqHeat;
+		Array2D< Real64 > surfDelaySeqCool;
+		
+		peopleDelaySeqHeat.dimension( NumOfTimeStepInHour * 24, 0.0 );
+		peopleDelaySeqHeat = 0.0;
+		peopleDelaySeqCool.allocate( NumOfTimeStepInHour * 24 );
+		peopleDelaySeqCool = 0.0;
+		lightDelaySeqHeat.allocate( NumOfTimeStepInHour * 24 );
+		lightDelaySeqHeat = 0.0;
+		lightDelaySeqCool.allocate( NumOfTimeStepInHour * 24 );
+		lightDelaySeqCool = 0.0;
+		equipDelaySeqHeat.allocate( NumOfTimeStepInHour * 24 );
+		equipDelaySeqHeat = 0.0;
+		equipDelaySeqCool.allocate( NumOfTimeStepInHour * 24 );
+		equipDelaySeqCool = 0.0;
+		hvacLossDelaySeqHeat.allocate( NumOfTimeStepInHour * 24 );
+		hvacLossDelaySeqHeat = 0.0;
+		hvacLossDelaySeqCool.allocate( NumOfTimeStepInHour * 24 );
+		hvacLossDelaySeqCool = 0.0;
+		powerGenDelaySeqHeat.allocate( NumOfTimeStepInHour * 24 );
+		powerGenDelaySeqHeat = 0.0;
+		powerGenDelaySeqCool.allocate( NumOfTimeStepInHour * 24 );
+		powerGenDelaySeqCool = 0.0;
+		feneSolarDelaySeqHeat.allocate( NumOfTimeStepInHour * 24 );
+		feneSolarDelaySeqHeat = 0.0;
+		feneSolarDelaySeqCool.allocate( NumOfTimeStepInHour * 24 );
+		feneSolarDelaySeqCool = 0.0;
+		surfDelaySeqHeat.allocate( NumOfTimeStepInHour * 24, TotSurfaces );
+		surfDelaySeqHeat = 0.0;
+		surfDelaySeqCool.allocate( NumOfTimeStepInHour * 24, TotSurfaces );
+		surfDelaySeqCool = 0.0;
+		
+		Array1D< Real64 > peopleRadIntoSurf;
+		Array1D< Real64 > equipRadIntoSurf;
+		Array1D< Real64 > hvacLossRadIntoSurf;
+		Array1D< Real64 > powerGenRadIntoSurf;
+		Array1D< Real64 > lightLWRadIntoSurf;
+		
+		peopleRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
+		equipRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
+		hvacLossRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
+		powerGenRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
+		lightLWRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
+
+		NumOfTimeStepInDay = NumOfTimeStepInHour * 24;
+		seqData.allocate( NumOfTimeStepInDay );
+		AvgData.allocate( NumOfTimeStepInDay );
+		delayOpaque.allocate( rGrdTot );
+		totalColumn.allocate( rGrdTot );
+		percentColumn.allocate( rGrdTot );
+		grandTotalRow.allocate( cPerc );
+
+		//establish unit conversion factors
+		if ( unitsStyle == unitsStyleInchPound ) {
+			powerConversion = getSpecificUnitMultiplier( "W", "Btu/h" ); //or kBtuh?
+			tempConvIndx = getSpecificUnitIndex( "C", "F" );
+		} else {
+			powerConversion = 1.0;
+			tempConvIndx = 0; //when zero is used with ConvertIP the value is returned unconverted
 		}
 
-	}
+		// show the line definition for the decay curves
+		if ( ShowDecayCurvesInEIO ) {
+			gio::write( OutputFileInits, fmtA ) << "! <Radiant to Convective Decay Curves for Cooling>,Zone Name, Surface Name, Time 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36";
+			gio::write( OutputFileInits, fmtA ) << "! <Radiant to Convective Decay Curves for Heating>,Zone Name, Surface Name, Time 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36";
+		}
+
+		for ( int iZone = 1; iZone <= NumOfZones; ++iZone ) {
+			if ( ! ZoneEquipConfig( iZone ).IsControlled ) continue;
+			mult = Zone( iZone ).Multiplier * Zone( iZone ).ListMultiplier;
+			if ( mult == 0.0 ) mult = 1.0;
+
+			ZoneData &zd( Zone( iZone ) );
+			if ( allocated( CalcFinalZoneSizing ) ) {
+
+				// Heating design days
+				int desSelected = CalcFinalZoneSizing( iZone ).HeatDDNum;
+				if ( desSelected != 0 ) {
+					
+					for ( int kTimeStep = 1; kTimeStep <= NumOfTimeStepInHour * 24; ++kTimeStep ) {
+						Real64 peopleConvIntoZone = 0.0;
+						Real64 equipConvIntoZone = 0.0;
+						Real64 hvacLossConvIntoZone = 0.0;
+						Real64 powerGenConvIntoZone = 0.0;
+						Real64 lightLWConvIntoZone = 0.0;
+						Real64 lightSWConvIntoZone = 0.0;
+						Real64 feneSolarConvIntoZone = 0.0;
+						Real64 adjFeneSurfNetRadSeq = 0.0;
+						
+						for ( int jSurf = zd.SurfaceFirst; jSurf <= zd.SurfaceLast; ++jSurf ) {
+							if ( ! Surface( jSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
+							
+							//determine for each timestep the amount of radiant heat for each end use absorbed in each surface
+							Real64 QRadThermInAbsMult = TMULTseq( desSelected, kTimeStep, iZone ) * ITABSFseq( desSelected, kTimeStep, jSurf ) * Surface( jSurf ).Area;
+							peopleRadIntoSurf( kTimeStep ) = peopleRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							equipRadIntoSurf( kTimeStep ) = equipRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							hvacLossRadIntoSurf( kTimeStep ) = hvacLossRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							powerGenRadIntoSurf( kTimeStep ) = powerGenRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							lightLWRadIntoSurf( kTimeStep ) = lightLWRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							//for each time step, step back through time and apply decay curve
+							Real64 peopleConvFromSurf = 0.0;
+							Real64 equipConvFromSurf = 0.0;
+							Real64 hvacLossConvFromSurf = 0.0;
+							Real64 powerGenConvFromSurf = 0.0;
+							Real64 lightLWConvFromSurf = 0.0;
+							Real64 lightSWConvFromSurf = 0.0;
+							Real64 feneSolarConvFromSurf = 0.0;
+							for ( int mStepBack = 1; mStepBack <= kTimeStep; ++mStepBack ) {
+								peopleConvFromSurf += peopleRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
+								equipConvFromSurf += equipRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
+								hvacLossConvFromSurf += hvacLossRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
+								powerGenConvFromSurf += powerGenRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
+								lightLWConvFromSurf += lightLWRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveHeat( mStepBack, jSurf );
+								// short wave is already accumulated by surface
+								lightSWConvFromSurf += lightSWRadSeq( desSelected, kTimeStep - mStepBack + 1, jSurf ) * decayCurveHeat( mStepBack, jSurf );
+								feneSolarConvFromSurf += feneSolarRadSeq( desSelected, kTimeStep - mStepBack + 1, jSurf ) * decayCurveHeat( mStepBack, jSurf );
+							} // for mStepBack
+							peopleConvIntoZone += peopleConvFromSurf;
+							equipConvIntoZone += equipConvFromSurf;
+							hvacLossConvIntoZone += hvacLossConvFromSurf;
+							powerGenConvIntoZone += powerGenConvFromSurf;
+							lightLWConvIntoZone += lightLWConvFromSurf;
+							lightSWConvIntoZone += lightSWConvFromSurf;
+							feneSolarConvIntoZone += feneSolarConvFromSurf;
+							// determine the remaining convective heat from the surfaces that are not based
+							// on any of these other loads
+							//negative because heat from surface should be positive
+							surfDelaySeqHeat( kTimeStep, jSurf ) = -loadConvectedNormal( desSelected, kTimeStep, jSurf ) - netSurfRadSeq( desSelected, kTimeStep, jSurf ) - ( peopleConvFromSurf + equipConvFromSurf + hvacLossConvFromSurf + powerGenConvFromSurf + lightLWConvFromSurf + lightSWConvFromSurf + feneSolarConvFromSurf ); //remove net radiant for the surface
+							// also remove the net radiant component on the instanteous conduction for fenestration
+							if ( Surface( jSurf ).Class == SurfaceClass_Window ) {
+								adjFeneSurfNetRadSeq += netSurfRadSeq( desSelected, kTimeStep, jSurf );
+							}
+						} // for jSurf
+						peopleDelaySeqHeat( kTimeStep ) = peopleConvIntoZone;
+						equipDelaySeqHeat( kTimeStep ) = equipConvIntoZone;
+						hvacLossDelaySeqHeat( kTimeStep ) = hvacLossConvIntoZone;
+						powerGenDelaySeqHeat( kTimeStep ) = powerGenConvIntoZone;
+						//combine short wave (visible) and long wave (thermal) impacts
+						lightDelaySeqHeat( kTimeStep ) = lightLWConvIntoZone + lightSWConvIntoZone;
+						feneSolarDelaySeqHeat( kTimeStep ) = feneSolarConvIntoZone;
+						// also remove the net radiant component on the instanteous conduction for fenestration
+						feneCondInstantSeq( desSelected, kTimeStep, iZone ) -= adjFeneSurfNetRadSeq;
+					} // for kTimeStep
+				} // if desSelected != 0
+				
+				// Cooling design days
+				desSelected = CalcFinalZoneSizing( iZone ).CoolDDNum;
+				if ( desSelected != 0 ) {
+					
+					for ( int kTimeStep = 1; kTimeStep <= NumOfTimeStepInHour * 24; ++kTimeStep ) {
+						Real64 peopleConvIntoZone = 0.0;
+						Real64 equipConvIntoZone = 0.0;
+						Real64 hvacLossConvIntoZone = 0.0;
+						Real64 powerGenConvIntoZone = 0.0;
+						Real64 lightLWConvIntoZone = 0.0;
+						Real64 lightSWConvIntoZone = 0.0;
+						Real64 feneSolarConvIntoZone = 0.0;
+						Real64 adjFeneSurfNetRadSeq = 0.0;
+						
+						for ( int jSurf = zd.SurfaceFirst; jSurf <= zd.SurfaceLast; ++jSurf ) {
+							if ( ! Surface( jSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
+								
+							//determine for each timestep the amount of radiant heat for each end use absorbed in each surface
+							Real64 QRadThermInAbsMult = TMULTseq( desSelected, kTimeStep, iZone ) * ITABSFseq( desSelected, kTimeStep, jSurf ) * Surface( jSurf ).Area;
+							peopleRadIntoSurf( kTimeStep ) = peopleRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							equipRadIntoSurf( kTimeStep ) = equipRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							hvacLossRadIntoSurf( kTimeStep ) = hvacLossRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							powerGenRadIntoSurf( kTimeStep ) = powerGenRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							lightLWRadIntoSurf( kTimeStep ) = lightLWRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
+							//for each time step, step back through time and apply decay curve
+							Real64 peopleConvFromSurf = 0.0;
+							Real64 equipConvFromSurf = 0.0;
+							Real64 hvacLossConvFromSurf = 0.0;
+							Real64 powerGenConvFromSurf = 0.0;
+							Real64 lightLWConvFromSurf = 0.0;
+							Real64 lightSWConvFromSurf = 0.0;
+							Real64 feneSolarConvFromSurf = 0.0;
+							for ( int mStepBack = 1; mStepBack <= kTimeStep; ++mStepBack ) {
+								peopleConvFromSurf += peopleRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
+								equipConvFromSurf += equipRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
+								hvacLossConvFromSurf += hvacLossRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
+								powerGenConvFromSurf += powerGenRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
+								lightLWConvFromSurf += lightLWRadIntoSurf( kTimeStep - mStepBack + 1 ) * decayCurveCool( mStepBack, jSurf );
+								// short wave is already accumulated by surface
+								lightSWConvFromSurf += lightSWRadSeq( desSelected, kTimeStep - mStepBack + 1, jSurf ) * decayCurveCool( mStepBack, jSurf );
+								feneSolarConvFromSurf += feneSolarRadSeq( desSelected, kTimeStep - mStepBack + 1, jSurf ) * decayCurveCool( mStepBack, jSurf );
+							} // for mStepBack
+							peopleConvIntoZone += peopleConvFromSurf;
+							equipConvIntoZone += equipConvFromSurf;
+							hvacLossConvIntoZone += hvacLossConvFromSurf;
+							powerGenConvIntoZone += powerGenConvFromSurf;
+							lightLWConvIntoZone += lightLWConvFromSurf;
+							lightSWConvIntoZone += lightSWConvFromSurf;
+							feneSolarConvIntoZone += feneSolarConvFromSurf;
+							// determine the remaining convective heat from the surfaces that are not based
+							// on any of these other loads
+							//negative because heat from surface should be positive
+							surfDelaySeqCool( kTimeStep, jSurf ) = -loadConvectedNormal( desSelected, kTimeStep, jSurf ) - netSurfRadSeq( desSelected, kTimeStep, jSurf ) - ( peopleConvFromSurf + equipConvFromSurf + hvacLossConvFromSurf + powerGenConvFromSurf + lightLWConvFromSurf + lightSWConvFromSurf + feneSolarConvFromSurf ); //remove net radiant for the surface
+							// also remove the net radiant component on the instanteous conduction for fenestration
+							if ( Surface( jSurf ).Class == SurfaceClass_Window ) {
+								adjFeneSurfNetRadSeq += netSurfRadSeq( desSelected, kTimeStep, jSurf );
+							}
+						} // for jSurf
+						peopleDelaySeqCool( kTimeStep ) = peopleConvIntoZone;
+						equipDelaySeqCool( kTimeStep ) = equipConvIntoZone;
+						hvacLossDelaySeqCool( kTimeStep ) = hvacLossConvIntoZone;
+						powerGenDelaySeqCool( kTimeStep ) = powerGenConvIntoZone;
+						//combine short wave (visible) and long wave (thermal) impacts
+						lightDelaySeqCool( kTimeStep ) = lightLWConvIntoZone + lightSWConvIntoZone;
+						feneSolarDelaySeqCool( kTimeStep ) = feneSolarConvIntoZone;
+						// also remove the net radiant component on the instanteous conduction for fenestration
+						feneCondInstantSeq( desSelected, kTimeStep, iZone ) -= adjFeneSurfNetRadSeq;
+					} // for kTimeStep
+				} // if desSelected != 0
+				
+			} // if allocated( CalcFinalZoneSizing )
+
+			//---- Cooling Peak Load Components Sub-Table
+			WriteReportHeaders( "Zone Component Load Summary", Zone( iZone ).Name, isAverage );
+
+			rowHead.allocate( rGrdTot );
+			columnHead.allocate( cPerc );
+			columnWidth.dimension( cPerc, 14 ); //array assignment - same for all columns
+			tableBody.allocate( cPerc, rGrdTot );
+
+			if ( unitsStyle != unitsStyleInchPound ) {
+				columnHead( cSensInst ) = "Sensible - Instant [W]";
+				columnHead( cSensDelay ) = "Sensible - Delayed [W]";
+				columnHead( cSensRA ) = "Sensible - Return Air [W]";
+				columnHead( cLatent ) = "Latent [W]";
+				columnHead( cTotal ) = "Total [W]";
+				columnHead( cPerc ) = "%Grand Total";
+			} else {
+				columnHead( cSensInst ) = "Sensible - Instant [Btu/h]";
+				columnHead( cSensDelay ) = "Sensible - Delayed [Btu/h]";
+				columnHead( cSensRA ) = "Sensible - Return Air [Btu/h]";
+				columnHead( cLatent ) = "Latent [Btu/h]";
+				columnHead( cTotal ) = "Total [Btu/h]";
+				columnHead( cPerc ) = "%Grand Total";
+			}
+
+			//internal gains
+			rowHead( rPeople ) = "People";
+			rowHead( rLights ) = "Lights";
+			rowHead( rEquip ) = "Equipment";
+			rowHead( rRefrig ) = "Refrigeration Equipment";
+			rowHead( rWaterUse ) = "Water Use Equipment";
+			rowHead( rPowerGen ) = "Power Generation Equipment";
+			rowHead( rHvacLoss ) = "HVAC Equipment Losses";
+			rowHead( rRefrig ) = "Refrigeration";
+			//misc
+			rowHead( rDOAS ) = "DOAS Direct to Zone";
+			rowHead( rInfil ) = "Infiltration";
+			rowHead( rZoneVent ) = "Zone Ventilation";
+			rowHead( rIntZonMix ) = "Interzone Mixing";
+			//opaque surfaces
+			rowHead( rRoof ) = "Roof";
+			rowHead( rIntZonCeil ) = "Interzone Ceiling";
+			rowHead( rOtherRoof ) = "Other Roof";
+			rowHead( rExtWall ) = "Exterior Wall";
+			rowHead( rIntZonWall ) = "Interzone Wall";
+			rowHead( rGrdWall ) = "Ground Contact Wall";
+			rowHead( rOtherWall ) = "Other Wall";
+			rowHead( rExtFlr ) = "Exterior Floor";
+			rowHead( rIntZonFlr ) = "Interzone Floor";
+			rowHead( rGrdFlr ) = "Ground Contact Floor";
+			rowHead( rOtherFlr ) = "Other Floor";
+			//subsurfaces
+			rowHead( rFeneCond ) = "Fenestration Conduction";
+			rowHead( rFeneSolr ) = "Fenestration Solar";
+			rowHead( rOpqDoor ) = "Opaque Door";
+			rowHead( rGrdTot ) = "Grand Total";
+
+			tableBody = "";
+			totalColumn = 0.0;
+			percentColumn = 0.0;
+			grandTotalRow = 0.0;
+
+			int CoolDesSelected = CalcFinalZoneSizing( iZone ).CoolDDNum;
+			int timeCoolMax = CalcFinalZoneSizing( iZone ).TimeStepNumAtCoolMax;
+			if ( CoolDesSelected != 0 && timeCoolMax != 0 ) {
+
+				//PEOPLE
+				seqData = peopleInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rPeople ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rPeople ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = peopleLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rPeople ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rPeople ) += AvgData( timeCoolMax );
+				grandTotalRow( cLatent ) += AvgData( timeCoolMax );
+
+				seqData = peopleDelaySeqCool( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rPeople ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rPeople ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
+
+				//LIGHTS
+				seqData = lightInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rLights ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rLights ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = lightRetAirSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensRA, rLights ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rLights ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensRA ) += AvgData( timeCoolMax );
+
+				seqData = lightDelaySeqCool( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rLights ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rLights ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
+
+				//EQUIPMENT
+				seqData = equipInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rEquip ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rEquip ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = equipLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rEquip ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rEquip ) += AvgData( timeCoolMax );
+				grandTotalRow( cLatent ) += AvgData( timeCoolMax );
+
+				seqData = equipDelaySeqCool( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rEquip ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rEquip ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
+
+				//REFRIGERATION EQUIPMENT
+				seqData = refrigInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rRefrig ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rRefrig ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = refrigRetAirSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensRA, rRefrig ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rRefrig ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensRA ) += AvgData( timeCoolMax );
+
+				seqData = refrigLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rRefrig ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rRefrig ) += AvgData( timeCoolMax );
+				grandTotalRow( cLatent ) += AvgData( timeCoolMax );
+
+				//WATER USE EQUIPMENT
+				seqData = waterUseInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rWaterUse ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rWaterUse ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = waterUseLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rWaterUse ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rWaterUse ) += AvgData( timeCoolMax );
+				grandTotalRow( cLatent ) += AvgData( timeCoolMax );
+
+				//HVAC EQUIPMENT LOSSES
+				seqData = hvacLossInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rHvacLoss ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rHvacLoss ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = hvacLossDelaySeqCool( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rHvacLoss ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rHvacLoss ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
+
+				//POWER GENERATION EQUIPMENT
+				seqData = powerGenInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rPowerGen ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rPowerGen ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = powerGenDelaySeqCool( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rPowerGen ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rPowerGen ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
+
+				//DOAS
+				tableBody( cSensInst, rDOAS ) = RealToStr( CalcZoneSizing( CoolDesSelected, iZone ).DOASHeatAddSeq( timeCoolMax ), 2 );
+				totalColumn( rDOAS ) += CalcZoneSizing( CoolDesSelected, iZone ).DOASHeatAddSeq( timeCoolMax );
+				grandTotalRow( cSensInst ) += CalcZoneSizing( CoolDesSelected, iZone ).DOASHeatAddSeq( timeCoolMax );
+
+				tableBody( cLatent, rDOAS ) = RealToStr( CalcZoneSizing( CoolDesSelected, iZone ).DOASLatAddSeq( timeCoolMax ), 2 );
+				totalColumn( rDOAS ) += CalcZoneSizing( CoolDesSelected, iZone ).DOASLatAddSeq( timeCoolMax );
+				grandTotalRow( cLatent ) += CalcZoneSizing( CoolDesSelected, iZone ).DOASLatAddSeq( timeCoolMax );
+
+				//INFILTRATION
+				seqData = infilInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rInfil ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rInfil ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = infilLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rInfil ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rInfil ) += AvgData( timeCoolMax );
+				grandTotalRow( cLatent ) += AvgData( timeCoolMax );
+
+				//ZONE VENTILATION
+				seqData = zoneVentInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rZoneVent ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rZoneVent ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = zoneVentLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rZoneVent ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rZoneVent ) += AvgData( timeCoolMax );
+				grandTotalRow( cLatent ) += AvgData( timeCoolMax );
+
+				//INTERZONE MIXING
+				seqData = interZoneMixInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rIntZonMix ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rIntZonMix ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				seqData = interZoneMixLatentSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rIntZonMix ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rIntZonMix ) += AvgData( timeCoolMax );
+				grandTotalRow( cLatent ) += AvgData( timeCoolMax );
+
+				//FENESTRATION CONDUCTION
+				seqData = feneCondInstantSeq( CoolDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rFeneCond ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rFeneCond ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensInst ) += AvgData( timeCoolMax );
+
+				//FENESTRATION SOLAR
+				//      seqData = feneSolarInstantSeq(iZone,:,CoolDesSelected) * powerConversion
+				//      CALL MovingAvg(seqData,NumOfTimeStepInDay,NumTimeStepsInAvg,AvgData)
+				//      tableBody(rFeneSolr,cSensInst)  = TRIM(RealToStr(AvgData(timeCoolMax),2))
+				//      totalColumn(rFeneSolr) = totalColumn(rFeneSolr) + AvgData(timeCoolMax)
+				//      grandTotalRow(cSensInst) = grandTotalRow(cSensInst) + AvgData(timeCoolMax)
+
+				seqData = feneSolarDelaySeqCool( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rFeneSolr ) = RealToStr( AvgData( timeCoolMax ), 2 );
+				totalColumn( rFeneSolr ) += AvgData( timeCoolMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeCoolMax );
+
+				//opaque surfaces - must combine individual surfaces by class and other side conditions
+				delayOpaque = 0.0;
+				for ( int kSurf = zd.SurfaceFirst; kSurf <= zd.SurfaceLast; ++kSurf ) {
+					if ( ! Surface( kSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
+
+					curExtBoundCond = Surface( kSurf ).ExtBoundCond;
+					//if exterior is other side coefficients using ground preprocessor terms then
+					//set it to ground instead of other side coefficients
+					if ( curExtBoundCond == OtherSideCoefNoCalcExt || curExtBoundCond == OtherSideCoefCalcExt ) {
+						if ( has_prefixi( OSC( Surface( kSurf ).OSCPtr ).Name, "surfPropOthSdCoef" ) ) {
+							curExtBoundCond = Ground;
+						}
+					}
+					seqData = surfDelaySeqCool( _, kSurf );
+					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+					singleSurfDelay = AvgData( timeCoolMax ) * powerConversion;
+					{ auto const SELECT_CASE_var( Surface( kSurf ).Class );
+						if ( SELECT_CASE_var == SurfaceClass_Wall ) {
+							{ auto const SELECT_CASE_var1( curExtBoundCond );
+								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
+									delayOpaque( rExtWall ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) ) {
+									delayOpaque( rGrdWall ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
+									delayOpaque( rOtherWall ) += singleSurfDelay;
+								} else { //interzone
+									delayOpaque( rIntZonWall ) += singleSurfDelay;
+								}}
+						} else if ( SELECT_CASE_var == SurfaceClass_Floor ) {
+							{ auto const SELECT_CASE_var1( curExtBoundCond );
+								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
+									delayOpaque( rExtFlr ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) ) {
+									delayOpaque( rGrdFlr ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
+									delayOpaque( rOtherFlr ) += singleSurfDelay;
+								} else { //interzone
+									delayOpaque( rIntZonFlr ) += singleSurfDelay;
+								}}
+						} else if ( SELECT_CASE_var == SurfaceClass_Roof ) {
+							{ auto const SELECT_CASE_var1( curExtBoundCond );
+								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
+									delayOpaque( rRoof ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) || ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
+									delayOpaque( rOtherRoof ) += singleSurfDelay;
+								} else { //interzone
+									delayOpaque( rIntZonCeil ) += singleSurfDelay;
+								}}
+						} else if ( SELECT_CASE_var == SurfaceClass_Door ) {
+							delayOpaque( rOpqDoor ) += singleSurfDelay;
+						}}
+				}
+			}
+			for ( int k = rRoof; k <= rOtherFlr; ++k ) {
+				tableBody( cSensDelay, k ) = RealToStr( delayOpaque( k ), 2 );
+				totalColumn( k ) += delayOpaque( k );
+				grandTotalRow( cSensDelay ) += delayOpaque( k );
+			}
+			tableBody( cSensDelay, rOpqDoor ) = RealToStr( delayOpaque( rOpqDoor ), 2 );
+			totalColumn( rOpqDoor ) += delayOpaque( rOpqDoor );
+			grandTotalRow( cSensDelay ) += delayOpaque( rOpqDoor );
+
+			//GRAND TOTAL ROW
+			totalGrandTotal = 0.0;
+			for ( int k = 1; k <= cLatent; ++k ) {
+				tableBody( k, rGrdTot ) = RealToStr( grandTotalRow( k ), 2 );
+				totalGrandTotal += grandTotalRow( k );
+			}
+			tableBody( cTotal, rGrdTot ) = RealToStr( totalGrandTotal, 2 );
+
+			//TOTAL COLUMN AND PERCENT COLUMN
+			for ( int k = 1; k <= rOpqDoor; ++k ) { //to last row before total
+				tableBody( cTotal, k ) = RealToStr( totalColumn( k ), 2 );
+				if ( totalGrandTotal != 0.0 ) {
+					tableBody( cPerc, k ) = RealToStr( 100 * totalColumn( k ) / totalGrandTotal, 2 );
+				}
+			}
+
+			WriteSubtitle( "Estimated Cooling Peak Load Components" );
+			WriteTable( tableBody, rowHead, columnHead, columnWidth );
+			if ( sqlite ) {
+				sqlite->createSQLiteTabularDataRecords( tableBody, rowHead, columnHead, "ZoneComponentLoadSummary", Zone( iZone ).Name, "Estimated Cooling Peak Load Components" );
+			}
+
+			//---- Cooling Peak Conditions
+
+			rowHead.allocate( 10 );
+			columnHead.allocate( 1 );
+			columnWidth.allocate( 1 );
+			columnWidth = 14; //array assignment - same for all columns
+			tableBody.allocate( 1, 10 );
+
+			columnHead( 1 ) = "Value";
+			if ( unitsStyle != unitsStyleInchPound ) {
+				rowHead( 1 ) = "Time of Peak Load";
+				rowHead( 2 ) = "Outside  Dry Bulb Temperature [C]";
+				rowHead( 3 ) = "Outside  Wet Bulb Temperature [C]";
+				rowHead( 4 ) = "Outside Humidity Ratio at Peak [kgWater/kgAir]";
+				rowHead( 5 ) = "Zone Dry Bulb Temperature [C]";
+				rowHead( 6 ) = "Zone Relative Humdity [%]";
+				rowHead( 7 ) = "Zone Humidity Ratio at Peak [kgWater/kgAir]";
+				rowHead( 8 ) = "Peak Design Sensible Load [W]";
+				rowHead( 9 ) = "Estimated Instant + Delayed Sensible Load [W]";
+				rowHead( 10 ) = "Difference [W]";
+			} else {
+				rowHead( 1 ) = "Time of Peak Load";
+				rowHead( 2 ) = "Outside  Dry Bulb Temperature [F]";
+				rowHead( 3 ) = "Outside  Wet Bulb Temperature [F]";
+				rowHead( 4 ) = "Outside Humidity Ratio at Peak [lbWater/lbAir]";
+				rowHead( 5 ) = "Zone Dry Bulb Temperature [F]";
+				rowHead( 6 ) = "Zone Relative Humdity [%]";
+				rowHead( 7 ) = "Zone Humidity Ratio at Peak [lbWater/lbAir]";
+				rowHead( 8 ) = "Peak Design Sensible Load [Btu/h]";
+				rowHead( 9 ) = "Estimated Instant + Delayed Sensible Load [Btu/h]";
+				rowHead( 10 ) = "Difference [Btu/h]";
+			}
+
+			tableBody = "";
+
+			if ( timeCoolMax != 0 ) {
+
+				//Time of Peak Load
+				tableBody( 1, 1 ) = CoolPeakDateHrMin( iZone );
+
+				//Outside  Dry Bulb Temperature
+				tableBody( 1, 2 ) = RealToStr( ConvertIP( tempConvIndx, CalcFinalZoneSizing( iZone ).CoolOutTempSeq( timeCoolMax ) ), 2 );
+
+				//Outside  Wet Bulb Temperature
+				//use standard sea level air pressure because air pressure is not tracked with sizing data
+				if ( CalcFinalZoneSizing( iZone ).CoolOutHumRatSeq( timeCoolMax ) < 1.0 && CalcFinalZoneSizing( iZone ).CoolOutHumRatSeq( timeCoolMax ) > 0.0 ) {
+					tableBody( 1, 3 ) = RealToStr( ConvertIP( tempConvIndx, PsyTwbFnTdbWPb( CalcFinalZoneSizing( iZone ).CoolOutTempSeq( timeCoolMax ), CalcFinalZoneSizing( iZone ).CoolOutHumRatSeq( timeCoolMax ), 101325.0 ) ), 2 );
+				}
+
+				//Outside Humidity Ratio at Peak
+				tableBody( 1, 4 ) = RealToStr( CalcFinalZoneSizing( iZone ).CoolOutHumRatSeq( timeCoolMax ), 5 );
+
+				//Zone Dry Bulb Temperature
+				tableBody( 1, 5 ) = RealToStr( ConvertIP( tempConvIndx, CalcFinalZoneSizing( iZone ).CoolZoneTempSeq( timeCoolMax ) ), 2 );
+
+				//Zone Relative Humdity
+				//use standard sea level air pressure because air pressure is not tracked with sizing data
+				tableBody( 1, 6 ) = RealToStr( 100 * PsyRhFnTdbWPb( CalcFinalZoneSizing( iZone ).CoolZoneTempSeq( timeCoolMax ), CalcFinalZoneSizing( iZone ).CoolZoneHumRatSeq( timeCoolMax ), 101325.0 ), 2 );
+
+				//Zone Humidity Ratio at Peak
+				tableBody( 1, 7 ) = RealToStr( CalcFinalZoneSizing( iZone ).CoolZoneHumRatSeq( timeCoolMax ), 5 );
+
+			}
+
+			//Peak Design Sensible Load
+			tableBody( 1, 8 ) = RealToStr( ( CalcFinalZoneSizing( iZone ).DesCoolLoad / mult ) * powerConversion, 2 );
+
+			//Estimated Instant + Delayed Sensible Load
+			tableBody( 1, 9 ) = RealToStr( grandTotalRow( cSensInst ) + grandTotalRow( cSensDelay ), 2 );
+
+			//Difference
+			tableBody( 1, 10 ) = RealToStr( ( CalcFinalZoneSizing( iZone ).DesCoolLoad / mult ) * powerConversion - ( grandTotalRow( cSensInst ) + grandTotalRow( cSensDelay ) ), 2 );
+
+			WriteSubtitle( "Cooling Peak Conditions" );
+			WriteTable( tableBody, rowHead, columnHead, columnWidth );
+			if ( sqlite ) {
+				sqlite->createSQLiteTabularDataRecords( tableBody, rowHead, columnHead, "ZoneComponentLoadSummary", Zone( iZone ).Name, "Cooling Peak Conditions" );
+			}
+
+			//    !
+			//    !---- Radiant to Convective Decay Curves for Cooling
+			//    !
+			//    numObj = 0
+			//    !determine the number of surfaces to include
+			//    DO kSurf = 1, TotSurfaces
+			//      ZoneNum = Surface(kSurf)%Zone
+			//      IF (ZoneNum .NE. iZone) CYCLE
+			//      IF (ZoneNum .EQ. 0) CYCLE
+			//      IF (.not. ZoneEquipConfig(ZoneNum)%IsControlled) CYCLE
+			//      numObj = numObj + 1
+			//    END DO
+			//    ALLOCATE(rowHead(numObj))
+			//    ALLOCATE(columnHead(16))
+			//    ALLOCATE(columnWidth(16))
+			//    columnWidth = 14 !array assignment - same for all columns
+			//    ALLOCATE(tableBody(numObj,16))
+			//    columnHead(1) = 'Time 1'
+			//    columnHead(2) = 'Time 2'
+			//    columnHead(3) = 'Time 3'
+			//    columnHead(4) = 'Time 4'
+			//    columnHead(5) = 'Time 5'
+			//    columnHead(6) = 'Time 6'
+			//    columnHead(7) = 'Time 7'
+			//    columnHead(8) = 'Time 8'
+			//    columnHead(9) = 'Time 9'
+			//    columnHead(10) = 'Time 10'
+			//    columnHead(11) = 'Time 11'
+			//    columnHead(12) = 'Time 12'
+			//    columnHead(13) = 'Time 13'
+			//    columnHead(14) = 'Time 14'
+			//    columnHead(15) = 'Time 15'
+			//    columnHead(16) = 'Time 16'
+			//    tableBody = ''
+			//    objCount = 0
+			//    DO kSurf = 1, TotSurfaces
+			//      ZoneNum = Surface(kSurf)%Zone
+			//      IF (ZoneNum .NE. iZone) CYCLE
+			//      IF (ZoneNum .EQ. 0) CYCLE
+			//      IF (.not. ZoneEquipConfig(ZoneNum)%IsControlled) CYCLE
+			//      objCount = objCount + 1
+			//      rowHead(objCount) = TRIM(Surface(kSurf)%Name)
+			//      DO jTime = 1, 16
+			//        tableBody(objCount,jTime) = TRIM(RealToStr(decayCurveCool(kSurf,jTime),3))
+			//      END DO
+			//    END DO
+			//    CALL WriteSubtitle('Radiant to Convective Decay Curves for Cooling')
+			//    CALL WriteTable(tableBody,rowHead,columnHead,columnWidth)
+			//    CALL CreateSQLiteTabularDataRecords(tableBody,rowHead,columnHead,&
+			//                                        'ZoneComponentLoadDetail',&
+			//                                        TRIM(Zone(iZone)%Name),&
+			//                                        'Radiant to Convective Decay Curves for Cooling')
+			//    DEALLOCATE(columnHead)
+			//    DEALLOCATE(rowHead)
+			//    DEALLOCATE(columnWidth)
+			//    DEALLOCATE(tableBody)
+
+			// Put the decay curve into the EIO file
+			if ( ShowDecayCurvesInEIO ) {
+				for ( int kSurf = zd.SurfaceFirst; kSurf <= zd.SurfaceLast; ++kSurf ) {
+					{ IOFlags flags; flags.ADVANCE( "NO" ); gio::write( OutputFileInits, "(4A)", flags ) << "Radiant to Convective Decay Curves for Cooling," << Zone( iZone ).Name << ',' << Surface( kSurf ).Name; }
+					for ( int jTime = 1; jTime <= min( NumOfTimeStepInHour * 24, 36 ); ++jTime ) {
+						{ IOFlags flags; flags.ADVANCE( "NO" ); gio::write( OutputFileInits, "(A,F6.3)", flags ) << ',' << decayCurveCool( jTime, kSurf ); }
+					}
+					{ IOFlags flags; flags.ADVANCE( "YES" ); gio::write( OutputFileInits, "()", flags ); } //put a line feed at the end of the line
+				}
+			}
+		
+			//---- Heating Peak Load Components Sub-Table
+			rowHead.allocate( rGrdTot );
+			columnHead.allocate( cPerc );
+			columnWidth.dimension( cPerc, 14 ); //array assignment - same for all columns
+			tableBody.allocate( cPerc, rGrdTot );
+
+			if ( unitsStyle != unitsStyleInchPound ) {
+				columnHead( cSensInst ) = "Sensible - Instant [W]";
+				columnHead( cSensDelay ) = "Sensible - Delayed [W]";
+				columnHead( cSensRA ) = "Sensible - Return Air [W]";
+				columnHead( cLatent ) = "Latent [W]";
+				columnHead( cTotal ) = "Total [W]";
+				columnHead( cPerc ) = "%Grand Total";
+			} else {
+				columnHead( cSensInst ) = "Sensible - Instant [Btu/h]";
+				columnHead( cSensDelay ) = "Sensible - Delayed [Btu/h]";
+				columnHead( cSensRA ) = "Sensible - Return Air [Btu/h]";
+				columnHead( cLatent ) = "Latent [Btu/h]";
+				columnHead( cTotal ) = "Total [Btu/h]";
+				columnHead( cPerc ) = "%Grand Total";
+			}
+
+			//internal gains
+			rowHead( rPeople ) = "People";
+			rowHead( rLights ) = "Lights";
+			rowHead( rEquip ) = "Equipment";
+			rowHead( rRefrig ) = "Refrigeration Equipment";
+			rowHead( rWaterUse ) = "Water Use Equipment";
+			rowHead( rPowerGen ) = "Power Generation Equipment";
+			rowHead( rHvacLoss ) = "HVAC Equipment Losses";
+			rowHead( rRefrig ) = "Refrigeration";
+			//misc
+			rowHead( rDOAS ) = "DOAS";
+			rowHead( rInfil ) = "Infiltration";
+			rowHead( rZoneVent ) = "Zone Ventilation";
+			rowHead( rIntZonMix ) = "Interzone Mixing";
+			//opaque surfaces
+			rowHead( rRoof ) = "Roof";
+			rowHead( rIntZonCeil ) = "Interzone Ceiling";
+			rowHead( rOtherRoof ) = "Other Roof";
+			rowHead( rExtWall ) = "Exterior Wall";
+			rowHead( rIntZonWall ) = "Interzone Wall";
+			rowHead( rGrdWall ) = "Ground Contact Wall";
+			rowHead( rOtherWall ) = "Other Wall";
+			rowHead( rExtFlr ) = "Exterior Floor";
+			rowHead( rIntZonFlr ) = "Interzone Floor";
+			rowHead( rGrdFlr ) = "Ground Contact Floor";
+			rowHead( rOtherFlr ) = "Other Floor";
+			//subsurfaces
+			rowHead( rFeneCond ) = "Fenestration Conduction";
+			rowHead( rFeneSolr ) = "Fenestration Solar";
+			rowHead( rOpqDoor ) = "Opaque Door";
+			rowHead( rGrdTot ) = "Grand Total";
+
+			tableBody = "";
+			totalColumn = 0.0;
+			percentColumn = 0.0;
+			grandTotalRow = 0.0;
+
+			int HeatDesSelected = CalcFinalZoneSizing( iZone ).HeatDDNum;
+			int timeHeatMax = CalcFinalZoneSizing( iZone ).TimeStepNumAtHeatMax;
+			if ( HeatDesSelected != 0 && timeHeatMax != 0 ) {
+
+				//PEOPLE
+				seqData = peopleInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rPeople ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rPeople ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = peopleLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rPeople ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rPeople ) += AvgData( timeHeatMax );
+				grandTotalRow( cLatent ) += AvgData( timeHeatMax );
+
+				seqData = peopleDelaySeqHeat( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rPeople ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rPeople ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
+
+				//LIGHTS
+				seqData = lightInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rLights ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rLights ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = lightRetAirSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensRA, rLights ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rLights ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensRA ) += AvgData( timeHeatMax );
+
+				seqData = lightDelaySeqHeat( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rLights ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rLights ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
+
+				//EQUIPMENT
+				seqData = equipInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rEquip ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rEquip ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = equipLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rEquip ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rEquip ) += AvgData( timeHeatMax );
+				grandTotalRow( cLatent ) += AvgData( timeHeatMax );
+
+				seqData = equipDelaySeqHeat( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rEquip ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rEquip ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
+
+				//REFRIGERATION EQUIPMENT
+				seqData = refrigInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rRefrig ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rRefrig ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = refrigRetAirSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensRA, rRefrig ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rRefrig ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensRA ) += AvgData( timeHeatMax );
+
+				seqData = refrigLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rRefrig ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rRefrig ) += AvgData( timeHeatMax );
+				grandTotalRow( cLatent ) += AvgData( timeHeatMax );
+
+				//WATER USE EQUIPMENT
+				seqData = waterUseInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rWaterUse ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rWaterUse ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = waterUseLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rWaterUse ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rWaterUse ) += AvgData( timeHeatMax );
+				grandTotalRow( cLatent ) += AvgData( timeHeatMax );
+
+				//HVAC EQUIPMENT LOSSES
+				seqData = hvacLossInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rHvacLoss ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rHvacLoss ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = hvacLossDelaySeqHeat( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rHvacLoss ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rHvacLoss ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
+
+				//POWER GENERATION EQUIPMENT
+				seqData = powerGenInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rPowerGen ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rPowerGen ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = powerGenDelaySeqHeat( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rPowerGen ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rPowerGen ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
+
+				//DOAS
+				tableBody( cSensInst, rDOAS ) = RealToStr( CalcZoneSizing( HeatDesSelected, iZone ).DOASHeatAddSeq( timeHeatMax ), 2 );
+				totalColumn( rDOAS ) += CalcZoneSizing( HeatDesSelected, iZone ).DOASHeatAddSeq( timeHeatMax );
+				grandTotalRow( cSensDelay ) += CalcZoneSizing( HeatDesSelected, iZone ).DOASHeatAddSeq( timeHeatMax );
+
+				tableBody( cLatent, rDOAS ) = RealToStr( CalcZoneSizing( HeatDesSelected, iZone ).DOASLatAddSeq( timeHeatMax ), 2 );
+				totalColumn( rDOAS ) += CalcZoneSizing( HeatDesSelected, iZone ).DOASLatAddSeq( timeHeatMax );
+				grandTotalRow( cLatent ) += CalcZoneSizing( HeatDesSelected, iZone ).DOASLatAddSeq( timeHeatMax );
+
+				//INFILTRATION
+				seqData = infilInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rInfil ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rInfil ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = infilLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rInfil ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rInfil ) += AvgData( timeHeatMax );
+				grandTotalRow( cLatent ) += AvgData( timeHeatMax );
+
+				//ZONE VENTILATION
+				seqData = zoneVentInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rZoneVent ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rZoneVent ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = zoneVentLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rZoneVent ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rZoneVent ) += AvgData( timeHeatMax );
+				grandTotalRow( cLatent ) += AvgData( timeHeatMax );
+
+				//INTERZONE MIXING
+				seqData = interZoneMixInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rIntZonMix ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rIntZonMix ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				seqData = interZoneMixLatentSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cLatent, rIntZonMix ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rIntZonMix ) += AvgData( timeHeatMax );
+				grandTotalRow( cLatent ) += AvgData( timeHeatMax );
+
+				//FENESTRATION CONDUCTION
+				seqData = feneCondInstantSeq( HeatDesSelected, _, iZone ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensInst, rFeneCond ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rFeneCond ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensInst ) += AvgData( timeHeatMax );
+
+				//FENESTRATION SOLAR
+				//      seqData = feneSolarInstantSeq(iZone,:,HeatDesSelected) * powerConversion
+				//      CALL MovingAvg(seqData,NumOfTimeStepInDay,NumTimeStepsInAvg,AvgData)
+				//      tableBody(rFeneSolr,cSensInst)  = TRIM(RealToStr(AvgData(timeHeatMax),2))
+				//      totalColumn(rFeneSolr) = totalColumn(rFeneSolr) + AvgData(timeHeatMax)
+				//      grandTotalRow(cSensInst) = grandTotalRow(cSensInst) + AvgData(timeHeatMax)
+
+				seqData = feneSolarDelaySeqHeat( _ ) * powerConversion;
+				MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+				tableBody( cSensDelay, rFeneSolr ) = RealToStr( AvgData( timeHeatMax ), 2 );
+				totalColumn( rFeneSolr ) += AvgData( timeHeatMax );
+				grandTotalRow( cSensDelay ) += AvgData( timeHeatMax );
+
+				//opaque surfaces - must combine individual surfaces by class and other side conditions
+				delayOpaque = 0.0;
+				for ( int kSurf = zd.SurfaceFirst; kSurf <= zd.SurfaceLast; ++kSurf ) {
+					if ( ! Surface( kSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
+
+					curExtBoundCond = Surface( kSurf ).ExtBoundCond;
+					//if exterior is other side coefficients using ground preprocessor terms then
+					//set it to ground instead of other side coefficients
+					if ( curExtBoundCond == OtherSideCoefNoCalcExt || curExtBoundCond == OtherSideCoefCalcExt ) {
+						if ( has_prefixi( OSC( Surface( kSurf ).OSCPtr ).Name, "surfPropOthSdCoef" ) ) {
+							curExtBoundCond = Ground;
+						}
+					}
+					seqData = surfDelaySeqHeat( _, kSurf );
+					MovingAvg( seqData, NumOfTimeStepInDay, NumTimeStepsInAvg, AvgData );
+					singleSurfDelay = AvgData( timeHeatMax ) * powerConversion;
+					{ auto const SELECT_CASE_var( Surface( kSurf ).Class );
+						if ( SELECT_CASE_var == SurfaceClass_Wall ) {
+							{ auto const SELECT_CASE_var1( curExtBoundCond );
+								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
+									delayOpaque( rExtWall ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) ) {
+									delayOpaque( rGrdWall ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
+									delayOpaque( rOtherWall ) += singleSurfDelay;
+								} else { //interzone
+									delayOpaque( rIntZonWall ) += singleSurfDelay;
+								}}
+						} else if ( SELECT_CASE_var == SurfaceClass_Floor ) {
+							{ auto const SELECT_CASE_var1( curExtBoundCond );
+								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
+									delayOpaque( rExtFlr ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) ) {
+									delayOpaque( rGrdFlr ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
+									delayOpaque( rOtherFlr ) += singleSurfDelay;
+								} else { //interzone
+									delayOpaque( rIntZonFlr ) += singleSurfDelay;
+								}}
+						} else if ( SELECT_CASE_var == SurfaceClass_Roof ) {
+							{ auto const SELECT_CASE_var1( curExtBoundCond );
+								if ( SELECT_CASE_var1 == ExternalEnvironment ) {
+									delayOpaque( rRoof ) += singleSurfDelay;
+								} else if ( ( SELECT_CASE_var1 == Ground ) || ( SELECT_CASE_var1 == GroundFCfactorMethod ) || ( SELECT_CASE_var1 == OtherSideCoefNoCalcExt ) || ( SELECT_CASE_var1 == OtherSideCoefCalcExt ) || ( SELECT_CASE_var1 == OtherSideCondModeledExt ) ) {
+									delayOpaque( rOtherRoof ) += singleSurfDelay;
+								} else { //interzone
+									delayOpaque( rIntZonCeil ) += singleSurfDelay;
+								}}
+						} else if ( SELECT_CASE_var == SurfaceClass_Door ) {
+							delayOpaque( rOpqDoor ) += singleSurfDelay;
+						}}
+				}
+			}
+			for ( int k = rRoof; k <= rOtherFlr; ++k ) {
+				tableBody( cSensDelay, k ) = RealToStr( delayOpaque( k ), 2 );
+				totalColumn( k ) += delayOpaque( k );
+				grandTotalRow( cSensDelay ) += delayOpaque( k );
+			}
+			tableBody( cSensDelay, rOpqDoor ) = RealToStr( delayOpaque( rOpqDoor ), 2 );
+			totalColumn( rOpqDoor ) += delayOpaque( rOpqDoor );
+			grandTotalRow( cSensDelay ) += delayOpaque( rOpqDoor );
+
+			//GRAND TOTAL ROW
+			totalGrandTotal = 0.0;
+			for ( int k = 1; k <= cLatent; ++k ) {
+				tableBody( k, rGrdTot ) = RealToStr( grandTotalRow( k ), 2 );
+				totalGrandTotal += grandTotalRow( k );
+			}
+			tableBody( cTotal, rGrdTot ) = RealToStr( totalGrandTotal, 2 );
+
+			//TOTAL COLUMN AND PERCENT COLUMN
+			for ( int k = 1; k <= rOpqDoor; ++k ) { //to last row before total
+				tableBody( cTotal, k ) = RealToStr( totalColumn( k ), 2 );
+				if ( totalGrandTotal != 0.0 ) {
+					tableBody( cPerc, k ) = RealToStr( 100 * totalColumn( k ) / totalGrandTotal, 2 );
+				}
+			}
+
+			WriteSubtitle( "Estimated Heating Peak Load Components" );
+			WriteTable( tableBody, rowHead, columnHead, columnWidth );
+			if ( sqlite ) {
+				sqlite->createSQLiteTabularDataRecords( tableBody, rowHead, columnHead, "ZoneComponentLoadSummary", Zone( iZone ).Name, "Estimated Heating Peak Load Components" );
+			}
+
+			//---- Heating Peak Conditions Sub-Table
+
+			rowHead.allocate( 10 );
+			columnHead.allocate( 1 );
+			columnWidth.allocate( 1 );
+			columnWidth = 14; //array assignment - same for all columns
+			tableBody.allocate( 1, 10 );
+
+			columnHead( 1 ) = "Value";
+			if ( unitsStyle != unitsStyleInchPound ) {
+				rowHead( 1 ) = "Time of Peak Load";
+				rowHead( 2 ) = "Outside  Dry Bulb Temperature [C]";
+				rowHead( 3 ) = "Outside  Wet Bulb Temperature [C]";
+				rowHead( 4 ) = "Outside Humidity Ratio at Peak [kgWater/kgAir]";
+				rowHead( 5 ) = "Zone Dry Bulb Temperature [C]";
+				rowHead( 6 ) = "Zone Relative Humdity [%]";
+				rowHead( 7 ) = "Zone Humidity Ratio at Peak [kgWater/kgAir]";
+				rowHead( 8 ) = "Peak Design Sensible Load [W]";
+				rowHead( 9 ) = "Estimated Instant + Delayed Sensible Load [W]";
+				rowHead( 10 ) = "Difference [W]";
+			} else {
+				rowHead( 1 ) = "Time of Peak Load";
+				rowHead( 2 ) = "Outside  Dry Bulb Temperature [F]";
+				rowHead( 3 ) = "Outside  Wet Bulb Temperature [F]";
+				rowHead( 4 ) = "Outside Humidity Ratio at Peak [lbWater/lbAir]";
+				rowHead( 5 ) = "Zone Dry Bulb Temperature [F]";
+				rowHead( 6 ) = "Zone Relative Humdity [%]";
+				rowHead( 7 ) = "Zone Humidity Ratio at Peak [lbWater/lbAir]";
+				rowHead( 8 ) = "Peak Design Sensible Load [Btu/h]";
+				rowHead( 9 ) = "Estimated Instant + Delayed Sensible Load [Btu/h]";
+				rowHead( 10 ) = "Difference [Btu/h]";
+			}
+
+			tableBody = "";
+
+			if ( timeHeatMax != 0 ) {
+				//Time of Peak Load
+				tableBody( 1, 1 ) = HeatPeakDateHrMin( iZone );
+
+				//Outside  Dry Bulb Temperature
+				tableBody( 1, 2 ) = RealToStr( ConvertIP( tempConvIndx, CalcFinalZoneSizing( iZone ).HeatOutTempSeq( timeHeatMax ) ), 2 );
+
+				//Outside  Wet Bulb Temperature
+				//use standard sea level air pressure because air pressure is not tracked with sizing data
+				if ( CalcFinalZoneSizing( iZone ).HeatOutHumRatSeq( timeHeatMax ) < 1.0 && CalcFinalZoneSizing( iZone ).HeatOutHumRatSeq( timeHeatMax ) > 0.0 ) {
+					tableBody( 1, 3 ) = RealToStr( ConvertIP( tempConvIndx, PsyTwbFnTdbWPb( CalcFinalZoneSizing( iZone ).HeatOutTempSeq( timeHeatMax ), CalcFinalZoneSizing( iZone ).HeatOutHumRatSeq( timeHeatMax ), 101325.0 ) ), 2 );
+				}
+
+				//Humidity Ratio at Peak
+				tableBody( 1, 4 ) = RealToStr( CalcFinalZoneSizing( iZone ).HeatOutHumRatSeq( timeHeatMax ), 5 );
+
+				//Zone Dry Bulb Temperature
+				tableBody( 1, 5 ) = RealToStr( ConvertIP( tempConvIndx, CalcFinalZoneSizing( iZone ).HeatZoneTempSeq( timeHeatMax ) ), 2 );
+
+				//Zone Relative Temperature
+				//use standard sea level air pressure because air pressure is not tracked with sizing data
+				tableBody( 1, 6 ) = RealToStr( 100 * PsyRhFnTdbWPb( CalcFinalZoneSizing( iZone ).HeatZoneTempSeq( timeHeatMax ), CalcFinalZoneSizing( iZone ).HeatZoneHumRatSeq( timeHeatMax ), 101325.0 ), 2 );
+
+				//Zone Relative Humdity
+				tableBody( 1, 7 ) = RealToStr( CalcFinalZoneSizing( iZone ).HeatZoneHumRatSeq( timeHeatMax ), 5 );
+
+			}
+
+			//Peak Design Sensible Load
+			tableBody( 1, 8 ) = RealToStr( ( -CalcFinalZoneSizing( iZone ).DesHeatLoad / mult ) * powerConversion, 2 ); //change sign
+
+			//Estimated Instant + Delayed Sensible Load
+			tableBody( 1, 9 ) = RealToStr( grandTotalRow( cSensInst ) + grandTotalRow( cSensDelay ), 2 );
+
+			//Difference
+			tableBody( 1, 10 ) = RealToStr( ( -CalcFinalZoneSizing( iZone ).DesHeatLoad / mult ) * powerConversion - ( grandTotalRow( cSensInst ) + grandTotalRow( cSensDelay ) ), 2 );
+
+			WriteSubtitle( "Heating Peak Conditions" );
+			WriteTable( tableBody, rowHead, columnHead, columnWidth );
+			if ( sqlite ) {
+				sqlite->createSQLiteTabularDataRecords( tableBody, rowHead, columnHead, "ZoneComponentLoadSummary", Zone( iZone ).Name, "Heating Peak Conditions" );
+			}
+
+			//    !
+			//    !---- Radiant to Convective Decay Curves for Heating
+			//    !
+			//    numObj = 0
+			//    !determine the number of surfaces to include
+			//    DO kSurf = 1, TotSurfaces
+			//      ZoneNum = Surface(kSurf)%Zone
+			//      IF (ZoneNum .NE. iZone) CYCLE
+			//      IF (ZoneNum .EQ. 0) CYCLE
+			//      IF (.not. ZoneEquipConfig(ZoneNum)%IsControlled) CYCLE
+			//      numObj = numObj + 1
+			//    END DO
+			//    ALLOCATE(rowHead(numObj))
+			//    ALLOCATE(columnHead(16))
+			//    ALLOCATE(columnWidth(16))
+			//    columnWidth = 14 !array assignment - same for all columns
+			//    ALLOCATE(tableBody(numObj,16))
+			//    columnHead(1) = 'Time 1'
+			//    columnHead(2) = 'Time 2'
+			//    columnHead(3) = 'Time 3'
+			//    columnHead(4) = 'Time 4'
+			//    columnHead(5) = 'Time 5'
+			//    columnHead(6) = 'Time 6'
+			//    columnHead(7) = 'Time 7'
+			//    columnHead(8) = 'Time 8'
+			//    columnHead(9) = 'Time 9'
+			//    columnHead(10) = 'Time 10'
+			//    columnHead(11) = 'Time 11'
+			//    columnHead(12) = 'Time 12'
+			//    columnHead(13) = 'Time 13'
+			//    columnHead(14) = 'Time 14'
+			//    columnHead(15) = 'Time 15'
+			//    columnHead(16) = 'Time 16'
+			//    tableBody = ''
+			//    objCount = 0
+			//    DO kSurf = 1, TotSurfaces
+			//      ZoneNum = Surface(kSurf)%Zone
+			//      IF (ZoneNum .NE. iZone) CYCLE
+			//      IF (ZoneNum .EQ. 0) CYCLE
+			//      IF (.not. ZoneEquipConfig(ZoneNum)%IsControlled) CYCLE
+			//      objCount = objCount + 1
+			//      rowHead(objCount) = TRIM(Surface(kSurf)%Name)
+			//      DO jTime = 1, 16
+			//        tableBody(objCount,jTime) = TRIM(RealToStr(decayCurveHeat(kSurf,jTime),3))
+			//      END DO
+			//    END DO
+			//    CALL WriteSubtitle('Radiant to Convective Decay Curves for Heating')
+			//    CALL WriteTable(tableBody,rowHead,columnHead,columnWidth)
+			//    CALL CreateSQLiteTabularDataRecords(tableBody,rowHead,columnHead,&
+			//                                        'ZoneComponentLoadDetail',&
+			//                                        TRIM(Zone(iZone)%Name),&
+			//                                        'Radiant to Convective Decay Curves for Heating')
+			//    DEALLOCATE(columnHead)
+			//    DEALLOCATE(rowHead)
+			//    DEALLOCATE(columnWidth)
+			//    DEALLOCATE(tableBody)
+
+			// Put the decay curve into the EIO file
+			if ( ShowDecayCurvesInEIO ) {
+				for ( int kSurf = zd.SurfaceFirst; kSurf <= zd.SurfaceLast; ++kSurf ) {
+					{ IOFlags flags; flags.ADVANCE( "NO" ); gio::write( OutputFileInits, "(4A)", flags ) << "Radiant to Convective Decay Curves for Heating," << Zone( iZone ).Name << ',' << Surface( kSurf ).Name; }
+					for ( int jTime = 1; jTime <= min( NumOfTimeStepInHour * 24, 36 ); ++jTime ) {
+						{ IOFlags flags; flags.ADVANCE( "NO" ); gio::write( OutputFileInits, "(A,F6.3)", flags ) << ',' << decayCurveHeat( jTime, kSurf ); }
+					}
+					{ IOFlags flags; flags.ADVANCE( "YES" ); gio::write( OutputFileInits, "()", flags ); } //put a line feed at the end of the line
+				}
+			} // if ShowDecayCurvesInEIO
+
+		} // for iZone
+
+		peopleRadIntoSurf.deallocate();
+		equipRadIntoSurf.deallocate();
+		hvacLossRadIntoSurf.deallocate();
+		powerGenRadIntoSurf.deallocate();
+		lightLWRadIntoSurf.deallocate();
+		
+		peopleDelaySeqHeat.deallocate();
+		peopleDelaySeqCool.deallocate();
+		lightDelaySeqHeat.deallocate();
+		lightDelaySeqCool.deallocate();
+		equipDelaySeqHeat.deallocate();
+		equipDelaySeqCool.deallocate();
+		hvacLossDelaySeqHeat.deallocate();
+		hvacLossDelaySeqCool.deallocate();
+		powerGenDelaySeqHeat.deallocate();
+		powerGenDelaySeqCool.deallocate();
+		feneSolarDelaySeqHeat.deallocate();
+		feneSolarDelaySeqCool.deallocate();
+		surfDelaySeqHeat.deallocate();
+		surfDelaySeqCool.deallocate();
+
+	} // WriteZoneLoadComponentTable()
 
 	void
 	WriteReportHeaders(

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -176,7 +176,7 @@ namespace OutputReportTabular {
 	using namespace DataGlobalConstants;
 	using namespace OutputReportPredefined;
 	using namespace DataHeatBalance;
-	
+
 	// Data
 	//MODULE PARAMETER DEFINITIONS:
 
@@ -11309,7 +11309,7 @@ namespace OutputReportTabular {
 		Array2D_string tableBody;
 
 		// Delayed components are moved into this function so that we can calculate them one zone at a time
-		// with Array1D 
+		// with Array1D
 		Array1D< Real64 > peopleDelaySeqHeat;
 		Array1D< Real64 > peopleDelaySeqCool;
 		Array1D< Real64 > lightDelaySeqHeat;
@@ -11324,7 +11324,7 @@ namespace OutputReportTabular {
 		Array1D< Real64 > feneSolarDelaySeqCool;
 		Array2D< Real64 > surfDelaySeqHeat;
 		Array2D< Real64 > surfDelaySeqCool;
-		
+
 		peopleDelaySeqHeat.dimension( NumOfTimeStepInHour * 24, 0.0 );
 		peopleDelaySeqHeat = 0.0;
 		peopleDelaySeqCool.allocate( NumOfTimeStepInHour * 24 );
@@ -11353,13 +11353,13 @@ namespace OutputReportTabular {
 		surfDelaySeqHeat = 0.0;
 		surfDelaySeqCool.allocate( NumOfTimeStepInHour * 24, TotSurfaces );
 		surfDelaySeqCool = 0.0;
-		
+
 		Array1D< Real64 > peopleRadIntoSurf;
 		Array1D< Real64 > equipRadIntoSurf;
 		Array1D< Real64 > hvacLossRadIntoSurf;
 		Array1D< Real64 > powerGenRadIntoSurf;
 		Array1D< Real64 > lightLWRadIntoSurf;
-		
+
 		peopleRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
 		equipRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
 		hvacLossRadIntoSurf.allocate( NumOfTimeStepInHour * 24 );
@@ -11400,7 +11400,7 @@ namespace OutputReportTabular {
 				// Heating design days
 				int desSelected = CalcFinalZoneSizing( iZone ).HeatDDNum;
 				if ( desSelected != 0 ) {
-					
+
 					for ( int kTimeStep = 1; kTimeStep <= NumOfTimeStepInHour * 24; ++kTimeStep ) {
 						Real64 peopleConvIntoZone = 0.0;
 						Real64 equipConvIntoZone = 0.0;
@@ -11410,10 +11410,10 @@ namespace OutputReportTabular {
 						Real64 lightSWConvIntoZone = 0.0;
 						Real64 feneSolarConvIntoZone = 0.0;
 						Real64 adjFeneSurfNetRadSeq = 0.0;
-						
+
 						for ( int jSurf = zd.SurfaceFirst; jSurf <= zd.SurfaceLast; ++jSurf ) {
 							if ( ! Surface( jSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
-							
+
 							//determine for each timestep the amount of radiant heat for each end use absorbed in each surface
 							Real64 QRadThermInAbsMult = TMULTseq( desSelected, kTimeStep, iZone ) * ITABSFseq( desSelected, kTimeStep, jSurf ) * Surface( jSurf ).Area;
 							peopleRadIntoSurf( kTimeStep ) = peopleRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
@@ -11466,11 +11466,11 @@ namespace OutputReportTabular {
 						feneCondInstantSeq( desSelected, kTimeStep, iZone ) -= adjFeneSurfNetRadSeq;
 					} // for kTimeStep
 				} // if desSelected != 0
-				
+
 				// Cooling design days
 				desSelected = CalcFinalZoneSizing( iZone ).CoolDDNum;
 				if ( desSelected != 0 ) {
-					
+
 					for ( int kTimeStep = 1; kTimeStep <= NumOfTimeStepInHour * 24; ++kTimeStep ) {
 						Real64 peopleConvIntoZone = 0.0;
 						Real64 equipConvIntoZone = 0.0;
@@ -11480,10 +11480,10 @@ namespace OutputReportTabular {
 						Real64 lightSWConvIntoZone = 0.0;
 						Real64 feneSolarConvIntoZone = 0.0;
 						Real64 adjFeneSurfNetRadSeq = 0.0;
-						
+
 						for ( int jSurf = zd.SurfaceFirst; jSurf <= zd.SurfaceLast; ++jSurf ) {
 							if ( ! Surface( jSurf ).HeatTransSurf ) continue; // Skip non-heat transfer surfaces
-								
+
 							//determine for each timestep the amount of radiant heat for each end use absorbed in each surface
 							Real64 QRadThermInAbsMult = TMULTseq( desSelected, kTimeStep, iZone ) * ITABSFseq( desSelected, kTimeStep, jSurf ) * Surface( jSurf ).Area;
 							peopleRadIntoSurf( kTimeStep ) = peopleRadSeq( desSelected, kTimeStep, iZone ) * QRadThermInAbsMult;
@@ -11536,7 +11536,7 @@ namespace OutputReportTabular {
 						feneCondInstantSeq( desSelected, kTimeStep, iZone ) -= adjFeneSurfNetRadSeq;
 					} // for kTimeStep
 				} // if desSelected != 0
-				
+
 			} // if allocated( CalcFinalZoneSizing )
 
 			//---- Cooling Peak Load Components Sub-Table
@@ -12017,7 +12017,7 @@ namespace OutputReportTabular {
 					{ IOFlags flags; flags.ADVANCE( "YES" ); gio::write( OutputFileInits, "()", flags ); } //put a line feed at the end of the line
 				}
 			}
-		
+
 			//---- Heating Peak Load Components Sub-Table
 			rowHead.allocate( rGrdTot );
 			columnHead.allocate( cPerc );
@@ -12501,7 +12501,7 @@ namespace OutputReportTabular {
 		hvacLossRadIntoSurf.deallocate();
 		powerGenRadIntoSurf.deallocate();
 		lightLWRadIntoSurf.deallocate();
-		
+
 		peopleDelaySeqHeat.deallocate();
 		peopleDelaySeqCool.deallocate();
 		lightDelaySeqHeat.deallocate();

--- a/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
+++ b/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
@@ -366,7 +366,7 @@ TEST_F( EnergyPlusFixture, OutputReportTabularTest_AllocateLoadComponentArraysTe
 	EXPECT_EQ( peopleRadSeq.size(), 1920u );
 
 	// peopleDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-	EXPECT_EQ( peopleDelaySeq.size(), 1920u );
+	// EXPECT_EQ( peopleDelaySeq.size(), 1920u );
 
 	// lightInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 	EXPECT_EQ( lightInstantSeq.size(), 1920u );
@@ -381,7 +381,7 @@ TEST_F( EnergyPlusFixture, OutputReportTabularTest_AllocateLoadComponentArraysTe
 	EXPECT_EQ( lightSWRadSeq.size(), 3360u );
 
 	// lightDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-	EXPECT_EQ( lightDelaySeq.size(), 1920u );
+	// EXPECT_EQ( lightDelaySeq.size(), 1920u );
 
 	// equipInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 	EXPECT_EQ( equipInstantSeq.size(), 1920u );
@@ -393,7 +393,7 @@ TEST_F( EnergyPlusFixture, OutputReportTabularTest_AllocateLoadComponentArraysTe
 	EXPECT_EQ( equipRadSeq.size(), 1920u );
 
 	// equipDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-	EXPECT_EQ( equipDelaySeq.size(), 1920u );
+	// EXPECT_EQ( equipDelaySeq.size(), 1920u );
 
 	// refrigInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 	EXPECT_EQ( refrigInstantSeq.size(), 1920u );
@@ -417,7 +417,7 @@ TEST_F( EnergyPlusFixture, OutputReportTabularTest_AllocateLoadComponentArraysTe
 	EXPECT_EQ( hvacLossRadSeq.size(), 1920u );
 
 	// hvacLossDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-	EXPECT_EQ( hvacLossDelaySeq.size(), 1920u );
+	// EXPECT_EQ( hvacLossDelaySeq.size(), 1920u );
 
 	// powerGenInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 	EXPECT_EQ( powerGenInstantSeq.size(), 1920u );
@@ -426,7 +426,7 @@ TEST_F( EnergyPlusFixture, OutputReportTabularTest_AllocateLoadComponentArraysTe
 	EXPECT_EQ( powerGenRadSeq.size(), 1920u );
 
 	// powerGenDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-	EXPECT_EQ( powerGenDelaySeq.size(), 1920u );
+	// EXPECT_EQ( powerGenDelaySeq.size(), 1920u );
 
 	// infilInstantSeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
 	EXPECT_EQ( infilInstantSeq.size(), 1920u );
@@ -453,10 +453,10 @@ TEST_F( EnergyPlusFixture, OutputReportTabularTest_AllocateLoadComponentArraysTe
 	EXPECT_EQ( feneSolarRadSeq.size(), 3360u );
 
 	// feneSolarDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, NumOfZones );
-	EXPECT_EQ( feneSolarDelaySeq.size(), 1920u );
+	// EXPECT_EQ( feneSolarDelaySeq.size(), 1920u );
 
 	// surfDelaySeq.allocate( TotDesDays + TotRunDesPersDays, NumOfTimeStepInHour * 24, TotSurfaces );
-	EXPECT_EQ( surfDelaySeq.size(), 3360u );
+	// EXPECT_EQ( surfDelaySeq.size(), 3360u );
 
 }
 


### PR DESCRIPTION
I refactored/simplified the ZoneLoadComponent report to compute delayed components one zone at a time during the table generation process. This allows the delayed components to use Array1D's rather than Array3D's which should simplify debugging, which in turn should allow me to make progress on the ResortedSurfaces branch.
