### PR TITLE
Fix IDD ZoneAirMassFlowConservation notes to memos and transition rule for UnitarySystemPerformance:Multispeed

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -78337,7 +78337,7 @@ ElectricLoadCenter:Distribution,
        \note Modifies the target utility service demand power over time.
        \note Schedule values should be fractions from -1.0 to 1.0, inclusive.
        \note if omitted a schedule value of 1.0 is used. Negative values indicate export to grid
-       \not Schedule is used if Storage Operation Scheme is set to FacilityDemandLeveling.
+       \note Schedule is used if Storage Operation Scheme is set to FacilityDemandLeveling.
        \type object-list
        \object-list ScheduleNames
 

--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -671,8 +671,8 @@ ZoneAirMassFlowConservation,
        \memo infiltration object mass flow rates.
        \memo If either mixing or infiltration is active, then the zone air mass flow
        \memo balance calculation will attempt to enforce conservation of mass for each zone.
-       \note If mixing is "No" and infiltration is "None", then the zone air mass flow
-       \note calculation defaults to assume self-balanced simple flow mixing and infiltration objects.
+       \memo If mixing is "No" and infiltration is "None", then the zone air mass flow
+       \memo calculation defaults to assume self-balanced simple flow mixing and infiltration objects.
        \unique-object
        \min-fields 3
   A1,  \field Adjust Zone Mixing For Zone Air Mass Flow Balance

--- a/src/Transition/CreateNewIDFUsingRulesV8_5_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_5_0.f90
@@ -858,6 +858,14 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 OutArgs(8:CurArgs-2) = InArgs(10:CurArgs)  ! Move up old F10 - F16
                 CurArgs = CurArgs - 2
 
+              CASE('UNITARYSYSTEMPERFORMANCE:MULTISPEED')
+                nodiff=.false.
+                CALL GetNewObjectDefInIDD(ObjectName,NwNumArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
+                OutArgs(1:3)=InArgs(1:3)   ! No change at all
+                OutArgs(4) = 'No'
+                OutArgs(5:12)=InArgs(4:11) ! Moved down
+                CurArgs = CurArgs + 1
+
               CASE DEFAULT
                   IF (FindItemInList(ObjectName,NotInNew,SIZE(NotInNew)) /= 0) THEN
                     WRITE(Auditf,fmta) 'Object="'//TRIM(ObjectName)//'" is not in the "new" IDD.'


### PR DESCRIPTION
Addresses OpenStudio IDD parsing failure due to mistagged \memos in ZoneAirMassFlowConservation as noted by @macumber [here](https://github.com/NREL/EnergyPlus/issues/5502#issuecomment-187780770) in #5502 .

Also adds forgotten transition rule for UnitarySystemPerformance:Multispeed from #5375 
