### PR TITLE
Correct max iteration warnings in AirloopHVAC:UnitarySystem

### DIFF
--- a/src/EnergyPlus/Furnaces.cc
+++ b/src/EnergyPlus/Furnaces.cc
@@ -5055,19 +5055,16 @@ namespace Furnaces {
 			Furnace( FurnaceNum ).iterationMode = 0;
 		}
 		Furnace( FurnaceNum ).iterationCounter += 1;
-		if ( Furnace( FurnaceNum ).iterationCounter > size( Furnace( FurnaceNum ).iterationMode ) ) {
-			Furnace( FurnaceNum ).iterationMode.allocate( size( Furnace( FurnaceNum ).iterationMode ) + 20 );
-		}
 
-		if( CoolingLoad ) {
+		if ( CoolingLoad && Furnace( FurnaceNum ).iterationCounter  <= 20 ) {
 			Furnace( FurnaceNum ).iterationMode( Furnace( FurnaceNum ).iterationCounter ) = CoolingMode;
-		} else if( HeatingLoad ) {
+		} else if ( HeatingLoad && Furnace( FurnaceNum ).iterationCounter <= 20 ) {
 			Furnace( FurnaceNum ).iterationMode( Furnace( FurnaceNum ).iterationCounter ) = HeatingMode;
-		} else {
+		} else if ( Furnace( FurnaceNum ).iterationCounter <= 20 ) {
 			Furnace( FurnaceNum ).iterationMode( Furnace( FurnaceNum ).iterationCounter ) = NoCoolHeat;
 		}
 		// IF small loads to meet or not converging, just shut down unit
-		if( std::abs( ZoneLoad ) < Small5WLoad ) {
+		if ( std::abs( ZoneLoad ) < Small5WLoad ) {
 			ZoneLoad = 0.0;
 			CoolingLoad = false;
 			HeatingLoad = false;
@@ -5076,13 +5073,13 @@ namespace Furnaces {
 			OperatingModeMinusOne = Furnace( FurnaceNum ).iterationMode( 4 );
 			OperatingModeMinusTwo = Furnace( FurnaceNum ).iterationMode( 3 );
 			Oscillate = true;
-			if( OperatingMode == OperatingModeMinusOne && OperatingMode == OperatingModeMinusTwo ) Oscillate = false;
-			if( Oscillate ) {
-				if( QToCoolSetPt < 0.0 ) {
+			if ( OperatingMode == OperatingModeMinusOne && OperatingMode == OperatingModeMinusTwo ) Oscillate = false;
+			if ( Oscillate ) {
+				if ( QToCoolSetPt < 0.0 ) {
 					HeatingLoad = false;
 					CoolingLoad = true;
 					ZoneLoad = QToCoolSetPt;
-				} else if( QToHeatSetPt > 0.0 ) {
+				} else if ( QToHeatSetPt > 0.0 ) {
 					HeatingLoad = true;
 					CoolingLoad = false;
 					ZoneLoad = QToHeatSetPt;
@@ -8176,7 +8173,7 @@ namespace Furnaces {
 
 		{ auto const SELECT_CASE_var( CoilTypeNum );
 		if ( ( SELECT_CASE_var == Coil_HeatingGas ) || ( SELECT_CASE_var == Coil_HeatingElectric ) || ( SELECT_CASE_var == Coil_HeatingDesuperheater ) ) {
-			SimulateHeatingCoilComponents( HeatingCoilName, FirstHVACIteration, QCoilLoad, HeatingCoilIndex, _, SuppHeatingCoilFlag, FanMode );
+			SimulateHeatingCoilComponents( HeatingCoilName, FirstHVACIteration, QCoilLoad, HeatingCoilIndex, QActual, SuppHeatingCoilFlag, FanMode );
 		} else if ( SELECT_CASE_var == Coil_HeatingWater ) {
 			if ( QCoilLoad > SmallLoad ) {
 				SetComponentFlowRate( MaxHotWaterFlow, CoilControlNode, CoilOutletNode, LoopNum, LoopSideNum, BranchNum, CompNum );

--- a/src/EnergyPlus/Furnaces.hh
+++ b/src/EnergyPlus/Furnaces.hh
@@ -290,6 +290,8 @@ namespace Furnaces {
 		// end of the additional variables for variable speed water source heat pump
 		int WaterCyclingMode; // Heat Pump Coil water flow mode; See definitions in DataHVACGlobals,
 		// 1=water cycling, 2=water constant, 3=water constant on demand (old mode)
+		int iterationCounter; // track time step iterations
+		Array1D< int > iterationMode; // keep track of previous iteration mode (i.e., cooling or heating)
 
 		// Default Constructor
 		FurnaceEquipConditions() :
@@ -427,7 +429,9 @@ namespace Furnaces {
 			CompSpeedRatio( 0.0 ),
 			ErrIndexCyc( 0 ),
 			ErrIndexVar( 0 ),
-			WaterCyclingMode( 0 )
+			WaterCyclingMode( 0 ),
+			iterationCounter( 0 ),
+			iterationMode( 0 )
 		{}
 
 	};

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -1794,7 +1794,7 @@ namespace HVACManager {
 							FlowRatio = Node( SupplyNode ).MassFlowRate / Node( SupplyNode ).MassFlowRateSetPoint;
 							for ( ZonesCooledIndex = 1; ZonesCooledIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesCooled; ++ZonesCooledIndex ) {
 								TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitCoolInletNodes( ZonesCooledIndex );
-								Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+								Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
 							}
 						}
 						if ( ( Node( SupplyNode ).MassFlowRateSetPoint - Node( SupplyNode ).MassFlowRate ) < -HVACFlowRateToler * 0.01 ) {
@@ -1811,7 +1811,7 @@ namespace HVACManager {
 								FlowRatio = Node( SupplyNode ).MassFlowRate / Node( SupplyNode ).MassFlowRateSetPoint;
 								for ( ZonesCooledIndex = 1; ZonesCooledIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesCooled; ++ZonesCooledIndex ) {
 									TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitCoolInletNodes( ZonesCooledIndex );
-									Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+									Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
 								}
 							}
 						}
@@ -1828,7 +1828,7 @@ namespace HVACManager {
 							FlowRatio = Node( SupplyNode ).MassFlowRate / Node( SupplyNode ).MassFlowRateSetPoint;
 							for ( ZonesHeatedIndex = 1; ZonesHeatedIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesHeated; ++ZonesHeatedIndex ) {
 								TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitHeatInletNodes( ZonesHeatedIndex );
-								Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+								Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
 							}
 						}
 						if ( ( Node( SupplyNode ).MassFlowRateSetPoint - Node( SupplyNode ).MassFlowRate ) < -HVACFlowRateToler * 0.01 ) {
@@ -1845,7 +1845,7 @@ namespace HVACManager {
 								FlowRatio = Node( SupplyNode ).MassFlowRate / Node( SupplyNode ).MassFlowRateSetPoint;
 								for ( ZonesHeatedIndex = 1; ZonesHeatedIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesHeated; ++ZonesHeatedIndex ) {
 									TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitHeatInletNodes( ZonesHeatedIndex );
-									Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+									Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
 								}
 							}
 						}

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -1619,7 +1619,7 @@ namespace HVACManager {
 				}
 				if ( SimZoneEquipment ) {
 					if ( ( IterAir == 1 ) && ( ! FlowMaxAvailAlreadyReset ) ) { // don't do reset if already done in FirstHVACIteration
-						ResetTerminalUnitFlowLimits();
+//						ResetTerminalUnitFlowLimits();
 						FlowResolutionNeeded = true;
 					} else {
 						ResolveAirLoopFlowLimits();
@@ -1794,7 +1794,7 @@ namespace HVACManager {
 							FlowRatio = Node( SupplyNode ).MassFlowRate / Node( SupplyNode ).MassFlowRateSetPoint;
 							for ( ZonesCooledIndex = 1; ZonesCooledIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesCooled; ++ZonesCooledIndex ) {
 								TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitCoolInletNodes( ZonesCooledIndex );
-								Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+								Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
 							}
 						}
 						if ( ( Node( SupplyNode ).MassFlowRateSetPoint - Node( SupplyNode ).MassFlowRate ) < -HVACFlowRateToler * 0.01 ) {
@@ -1811,7 +1811,7 @@ namespace HVACManager {
 								FlowRatio = Node( SupplyNode ).MassFlowRate / Node( SupplyNode ).MassFlowRateSetPoint;
 								for ( ZonesCooledIndex = 1; ZonesCooledIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesCooled; ++ZonesCooledIndex ) {
 									TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitCoolInletNodes( ZonesCooledIndex );
-									Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+									Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
 								}
 							}
 						}
@@ -1828,7 +1828,7 @@ namespace HVACManager {
 							FlowRatio = Node( SupplyNode ).MassFlowRate / Node( SupplyNode ).MassFlowRateSetPoint;
 							for ( ZonesHeatedIndex = 1; ZonesHeatedIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesHeated; ++ZonesHeatedIndex ) {
 								TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitHeatInletNodes( ZonesHeatedIndex );
-								Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+								Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
 							}
 						}
 						if ( ( Node( SupplyNode ).MassFlowRateSetPoint - Node( SupplyNode ).MassFlowRate ) < -HVACFlowRateToler * 0.01 ) {
@@ -1845,7 +1845,7 @@ namespace HVACManager {
 								FlowRatio = Node( SupplyNode ).MassFlowRate / Node( SupplyNode ).MassFlowRateSetPoint;
 								for ( ZonesHeatedIndex = 1; ZonesHeatedIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesHeated; ++ZonesHeatedIndex ) {
 									TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitHeatInletNodes( ZonesHeatedIndex );
-									Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+									Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
 								}
 							}
 						}

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -1795,6 +1795,7 @@ namespace HVACManager {
 							for ( ZonesCooledIndex = 1; ZonesCooledIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesCooled; ++ZonesCooledIndex ) {
 								TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitCoolInletNodes( ZonesCooledIndex );
 								Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+								Node( TermInletNode ).MassFlowRateMinAvail = min( Node( TermInletNode ).MassFlowRateMaxAvail, Node( TermInletNode ).MassFlowRateMinAvail );
 							}
 						}
 						if ( ( Node( SupplyNode ).MassFlowRateSetPoint - Node( SupplyNode ).MassFlowRate ) < -HVACFlowRateToler * 0.01 ) {
@@ -1830,6 +1831,7 @@ namespace HVACManager {
 							for ( ZonesHeatedIndex = 1; ZonesHeatedIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesHeated; ++ZonesHeatedIndex ) {
 								TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitHeatInletNodes( ZonesHeatedIndex );
 								Node( TermInletNode ).MassFlowRateMaxAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+								Node( TermInletNode ).MassFlowRateMinAvail = min( Node( TermInletNode ).MassFlowRateMaxAvail, Node( TermInletNode ).MassFlowRateMinAvail );
 							}
 						}
 						if ( ( Node( SupplyNode ).MassFlowRateSetPoint - Node( SupplyNode ).MassFlowRate ) < -HVACFlowRateToler * 0.01 ) {
@@ -1847,6 +1849,7 @@ namespace HVACManager {
 								for ( ZonesHeatedIndex = 1; ZonesHeatedIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesHeated; ++ZonesHeatedIndex ) {
 									TermInletNode = AirToZoneNodeInfo( AirLoopIndex ).TermUnitHeatInletNodes( ZonesHeatedIndex );
 									Node( TermInletNode ).MassFlowRateMinAvail = Node( TermInletNode ).MassFlowRate * FlowRatio;
+									Node( TermInletNode ).MassFlowRateMaxAvail = max( Node( TermInletNode ).MassFlowRateMaxAvail, Node( TermInletNode ).MassFlowRateMinAvail );
 								}
 							}
 						}

--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -426,17 +426,17 @@ namespace HVACUnitarySystem {
 		if ( present( HeatActive ) ) HeatActive = false;
 		if ( present( CoolActive ) ) CoolActive = false;
 
-		// MassFlowRateMaxAvail issues are impeding non-VAV air loop equipment by limiting air flow
-		// temporarily open up flow limits while simulating, and then set this same value at the INLET after this parent has simulated
-		TempMassFlowRateMaxAvail = Node( UnitarySystem( UnitarySysNum ).UnitarySystemInletNodeNum ).MassFlowRateMaxAvail;
-		Node( UnitarySystem( UnitarySysNum ).UnitarySystemInletNodeNum ).MassFlowRateMaxAvail = UnitarySystem( UnitarySysNum ).DesignMassFlowRate;
-
 		FanSpeedRatio = 1.0;
 		if ( present( ZoneEquipment ) ) {
 			InitUnitarySystems( UnitarySysNum, 0, FirstHVACIteration, OAUnitNum, OAUCoilOutTemp );
 		} else {
 			InitUnitarySystems( UnitarySysNum, AirLoopNum, FirstHVACIteration, OAUnitNum, OAUCoilOutTemp );
 		}
+
+		// MassFlowRateMaxAvail issues are impeding non-VAV air loop equipment by limiting air flow
+		// temporarily open up flow limits while simulating, and then set this same value at the INLET after this parent has simulated
+		TempMassFlowRateMaxAvail = Node( UnitarySystem( UnitarySysNum ).UnitarySystemInletNodeNum ).MassFlowRateMaxAvail;
+		Node( UnitarySystem( UnitarySysNum ).UnitarySystemInletNodeNum ).MassFlowRateMaxAvail = UnitarySystem( UnitarySysNum ).DesignMassFlowRate;
 
 		HXUnitOn = false;
 		{ auto const SELECT_CASE_var( UnitarySystem( UnitarySysNum ).ControlType );

--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -10752,7 +10752,7 @@ namespace HVACUnitarySystem {
 				// zone equipment needs to set flow since no other device regulates flow (ZoneHVAC /= AirLoopEquipment)
 				if ( !UnitarySystem( UnitarySysNum ).AirLoopEquipment ) {
 					Node( InletNode ).MassFlowRate = AverageUnitMassFlow;
-					Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow;
+//					Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow;
 				}
 				if ( AverageUnitMassFlow > 0.0 ) {
 					OnOffAirFlowRatio = 1.0;
@@ -10761,7 +10761,7 @@ namespace HVACUnitarySystem {
 				}
 			} else {
 				Node( InletNode ).MassFlowRate = AverageUnitMassFlow;
-				Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow;
+//				Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow;
 				if ( AverageUnitMassFlow > 0.0 ) {
 					OnOffAirFlowRatio = CompOnMassFlow / AverageUnitMassFlow;
 				} else {

--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -1711,14 +1711,11 @@ namespace HVACUnitarySystem {
 			} else {
 			}}
 
-			if( UnitarySystem( UnitarySysNum ).iterationCounter > size( UnitarySystem( UnitarySysNum ).iterationMode ) ) {
-				UnitarySystem( UnitarySysNum ).iterationMode.allocate( size( UnitarySystem( UnitarySysNum ).iterationMode ) + 20 );
-			}
-			if( CoolingLoad ) {
+			if ( CoolingLoad && UnitarySystem( UnitarySysNum ).iterationCounter <= 20 ) {
 				UnitarySystem( UnitarySysNum ).iterationMode( UnitarySystem( UnitarySysNum ).iterationCounter ) = CoolingMode;
-			} else if( HeatingLoad ) {
+			} else if ( HeatingLoad && UnitarySystem( UnitarySysNum ).iterationCounter <= 20 ) {
 				UnitarySystem( UnitarySysNum ).iterationMode( UnitarySystem( UnitarySysNum ).iterationCounter ) = HeatingMode;
-			} else {
+			} else if( UnitarySystem( UnitarySysNum ).iterationCounter <= 20 ) {
 				UnitarySystem( UnitarySysNum ).iterationMode( UnitarySystem( UnitarySysNum ).iterationCounter ) = NoCoolHeat;
 			}
 			// IF small loads to meet or not converging, just shut down unit
@@ -1731,13 +1728,13 @@ namespace HVACUnitarySystem {
 				OperatingModeMinusOne = UnitarySystem( UnitarySysNum ).iterationMode( 4 );
 				OperatingModeMinusTwo = UnitarySystem( UnitarySysNum ).iterationMode( 3 );
 				Oscillate = true;
-				if( OperatingMode == OperatingModeMinusOne && OperatingMode == OperatingModeMinusTwo ) Oscillate = false;
-				if( Oscillate ) {
-					if( QToCoolSetPt < 0.0 ) {
+				if ( OperatingMode == OperatingModeMinusOne && OperatingMode == OperatingModeMinusTwo ) Oscillate = false;
+				if ( Oscillate ) {
+					if ( QToCoolSetPt < 0.0 ) {
 						HeatingLoad = false;
 						CoolingLoad = true;
 						ZoneLoad = QToCoolSetPt;
-					} else if( QToHeatSetPt > 0.0 ) {
+					} else if ( QToHeatSetPt > 0.0 ) {
 						HeatingLoad = true;
 						CoolingLoad = false;
 						ZoneLoad = QToHeatSetPt;

--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -10752,7 +10752,7 @@ namespace HVACUnitarySystem {
 				// zone equipment needs to set flow since no other device regulates flow (ZoneHVAC /= AirLoopEquipment)
 				if ( !UnitarySystem( UnitarySysNum ).AirLoopEquipment ) {
 					Node( InletNode ).MassFlowRate = AverageUnitMassFlow;
-//					Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow;
+//					Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow; #5531 max iterations
 				}
 				if ( AverageUnitMassFlow > 0.0 ) {
 					OnOffAirFlowRatio = 1.0;
@@ -10761,7 +10761,7 @@ namespace HVACUnitarySystem {
 				}
 			} else {
 				Node( InletNode ).MassFlowRate = AverageUnitMassFlow;
-//				Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow;
+//				Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow; #5531 max iterations
 				if ( AverageUnitMassFlow > 0.0 ) {
 					OnOffAirFlowRatio = CompOnMassFlow / AverageUnitMassFlow;
 				} else {

--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -472,8 +472,12 @@ namespace HVACUnitarySystem {
 				AirLoopControlInfo( AirLoopNum ).ReqstEconoLockoutWithCompressor = false;
 			}
 
-			if ( ( HeatActive ) && ( AirLoopControlInfo( AirLoopNum ).CanLockoutEconoWithCompressor || AirLoopControlInfo( AirLoopNum ).CanLockoutEconoWithHeating ) ) {
-				AirLoopControlInfo( AirLoopNum ).ReqstEconoLockoutWithHeating = true;
+			if ( present (HeatActive) ) {
+				if ( ( HeatActive ) && ( AirLoopControlInfo( AirLoopNum ).CanLockoutEconoWithCompressor || AirLoopControlInfo( AirLoopNum ).CanLockoutEconoWithHeating ) ) {
+					AirLoopControlInfo( AirLoopNum ).ReqstEconoLockoutWithHeating = true;
+				} else {
+					AirLoopControlInfo( AirLoopNum ).ReqstEconoLockoutWithHeating = false;
+				}
 			} else {
 				AirLoopControlInfo( AirLoopNum ).ReqstEconoLockoutWithHeating = false;
 			}
@@ -10777,7 +10781,7 @@ namespace HVACUnitarySystem {
 				// zone equipment needs to set flow since no other device regulates flow (ZoneHVAC /= AirLoopEquipment)
 				if ( !UnitarySystem( UnitarySysNum ).AirLoopEquipment ) {
 					Node( InletNode ).MassFlowRate = AverageUnitMassFlow;
-//					Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow; #5531 max iterations
+					Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow; // #5531 zone equipment needs MaxAvail set or fan will not turn ON
 				}
 				if ( AverageUnitMassFlow > 0.0 ) {
 					OnOffAirFlowRatio = 1.0;
@@ -10786,7 +10790,9 @@ namespace HVACUnitarySystem {
 				}
 			} else {
 				Node( InletNode ).MassFlowRate = AverageUnitMassFlow;
-//				Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow; #5531 max iterations
+				if ( !UnitarySystem( UnitarySysNum ).AirLoopEquipment ) {
+					Node( InletNode ).MassFlowRateMaxAvail = AverageUnitMassFlow; // #5531 zone equipment needs MaxAvail set or fan will not turn ON
+				}
 				if ( AverageUnitMassFlow > 0.0 ) {
 					OnOffAirFlowRatio = CompOnMassFlow / AverageUnitMassFlow;
 				} else {

--- a/src/EnergyPlus/HVACUnitarySystem.hh
+++ b/src/EnergyPlus/HVACUnitarySystem.hh
@@ -467,6 +467,8 @@ namespace HVACUnitarySystem {
 		int HeatIndexAvail; // Index used to minimize the occurrence of output warnings
 		bool FirstPass; // used to determine when first call is made
 		int SingleMode; // Single mode operation Yes/No; 1=Yes, 0=No
+		int iterationCounter; // track time step iterations
+		Array1D< int > iterationMode; // keep track of previous iteration mode (i.e., cooling or heating)
 
 		// Default Constructor
 		UnitarySystemData() :
@@ -715,8 +717,10 @@ namespace HVACUnitarySystem {
 			HeatCountAvail( 0 ),
 			HeatIndexAvail( 0 ),
 			FirstPass( true ),
-			SingleMode( 0 )
-		{}
+			SingleMode( 0 ),
+			iterationCounter( 0 ),
+			iterationMode( 0 )
+			{}
 
 	};
 

--- a/tst/EnergyPlus/unit/HVACUnitarySystem.unit.cc
+++ b/tst/EnergyPlus/unit/HVACUnitarySystem.unit.cc
@@ -1036,6 +1036,7 @@ TEST_F( EnergyPlusFixture, UnitarySystem_GetInput ) {
 	Schedule( 1 ).CurrentValue = 1.0;
 	DataGlobals::BeginEnvrnFlag = true;
 	DataEnvironment::StdRhoAir = PsyRhoAirFnPbTdbW( 101325.0, 20.0, 0.0 ); // initialize RhoAir
+	Node( InletNode ).MassFlowRateMaxAvail = UnitarySystem( 1 ).MaxCoolAirVolFlow * StdRhoAir;
 
 	SimUnitarySystem( UnitarySystem( 1 ).Name, FirstHVACIteration, UnitarySystem( 1 ).ControlZoneNum, ZoneEquipList( 1 ).EquipIndex( 1 ), _, _, _, _, true );
 
@@ -1829,6 +1830,7 @@ TEST_F( EnergyPlusFixture, UnitarySystem_VarSpeedCoils ) {
 	Schedule( 1 ).CurrentValue = 1.0;
 	DataGlobals::BeginEnvrnFlag = true;
 	DataEnvironment::StdRhoAir = PsyRhoAirFnPbTdbW( 101325.0, 20.0, 0.0 ); // initialize RhoAir
+	Node( InletNode ).MassFlowRateMaxAvail = UnitarySystem( 1 ).MaxCoolAirVolFlow * StdRhoAir;
 
 	SetPredefinedTables();
 	SimUnitarySystem( UnitarySystem( 1 ).Name, FirstHVACIteration, UnitarySystem( 1 ).ControlZoneNum, ZoneEquipList( 1 ).EquipIndex( 1 ), _, _, _, _, true );
@@ -4001,6 +4003,7 @@ TEST_F( EnergyPlusFixture, UnitarySystem_MultiSpeedCoils_SingleMode ) {
 
 	int Iter;
 	Real64 StdRhoAir = 1.2;
+	Node( InletNode ).MassFlowRateMaxAvail = UnitarySystem( UnitarySysNum ).MaxCoolAirVolFlow * StdRhoAir;
 	Iter = 4;
 	UnitarySystem( UnitarySysNum ).CoolVolumeFlowRate( Iter ) = UnitarySystem( UnitarySysNum ).MaxCoolAirVolFlow * DesignSpecMSHP( 1 ).CoolingVolFlowRatio( Iter );
 	UnitarySystem( UnitarySysNum ).CoolMassFlowRate( Iter ) = UnitarySystem( UnitarySysNum ).CoolVolumeFlowRate( Iter ) * StdRhoAir;


### PR DESCRIPTION
## Pull request overview

Example file HVACTemplate:UnitarySystem showed max iteration warnings on design day simulations (#5531). Corrected by removing the "set" of available flow rate in the parent object (AirloopHVAC:UnitarySystem) and allowing the air loop to control convergence. Also added a test to see if the system is oscillating on operating mode (e.g., cooling then heating then cooling) in the same iteration, and if so, control to the zone load instead of the system output. 
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
### Review Checklist

This will not be exhaustively relevant to every PR.
- [ ] Code style (parentheses padding, variable names)
- [ ] Functional code review (it has to work!)
- [ ] If defect, results of running current develop vs this branch should exhibit the fix
- [ ] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [ ] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [ ] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces

…llow a wider range of flow rates for cycling fan systems.
