### PR TITLE
Fixes 8.2-8.3 transition for GroundHeatExchanger:Vertical

### DIFF
--- a/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
@@ -378,7 +378,9 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 ! Remove Max flow rate field
                 nodiff=.false.
                 CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
-                OutArgs(1:10) = InArgs(1:10)
+                OutArgs(1:3) = InArgs(1:3)
+                OutArgs(4)='Design Flow Rate'
+                OutArgs(5:10) = InArgs(5:10)
                 OutArgs(11:CurArgs-1) = InArgs(12:CurArgs)
                 CurArgs = CurArgs - 1
 

--- a/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_3_0.f90
@@ -379,7 +379,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                 nodiff=.false.
                 CALL GetNewObjectDefInIDD(ObjectName,NwNUmArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
                 OutArgs(1:3) = InArgs(1:3)
-                OutArgs(4)='Design Flow Rate'
+                OutArgs(4) = InArgs(11) 
                 OutArgs(5:10) = InArgs(5:10)
                 OutArgs(11:CurArgs-1) = InArgs(12:CurArgs)
                 CurArgs = CurArgs - 1


### PR DESCRIPTION
Addresses #5113. `Max Flow Rate` field was removed; `Design Flow Rate` field was moved.
