### PR TITLE
Added trigger to display date every two weeks when shadow calculation is occurring every timestep

### DIFF
--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -7194,6 +7194,10 @@ namespace SolarShading {
 			} else {
 				SUN3( DayOfYear, AvgSinSolarDeclin, AvgEqOfTime );
 				AvgCosSolarDeclin = std::sqrt( 1.0 - pow_2( AvgSinSolarDeclin ) );
+				// trigger display of progress in the simulation every two weeks
+				if ( !WarmupFlag && BeginDayFlag && ( DayOfSim % 14 == 0 ) ) {
+					DisplayPerfSimulationFlag = true;
+				}
 			}
 
 			CalcPerSolarBeam( AvgEqOfTime, AvgSinSolarDeclin, AvgCosSolarDeclin );


### PR DESCRIPTION
Addresses #5365 to show progress on the output window even when shadowing calculations are being done every timestep. Added a display of the date every two weeks. 
- [x] Functional code review (it has to work!)
- [x] CI status: all green or justified
- [x] Performance: CI Linux results include performance check -- verify this
- ~~Unit Test(s)~~
