### PR TITLE
ExpandObject - Missing Setpoint

### DIFF
--- a/src/ExpandObjects/epfilter.f90
+++ b/src/ExpandObjects/epfilter.f90
@@ -31450,7 +31450,7 @@ DO iSys = 1, numCompactDedOutAir
   END IF
 
   ! Cooling coil setpoint manager (If there is no cooling coil and no heating coil but there is heat recovery, then need this)
-  IF ((coolCoilKind .NE. ccNone) .OR. ((heatRecovery .NE. htrecNone) .AND. heatCoilType .EQ. ctNone)) THEN
+  IF ((coolCoilKind .NE. ccNone) .OR. (heatRecovery .NE. htrecNone)) THEN
     CALL CreateNewObj('NodeList')
     CALL AddToObjFld('Name', base + doasNameOff,' Cooling Setpoint Nodes')
     IF (dehumidCtrlKind .EQ. dehumidCoolRhtDesuper) THEN


### PR DESCRIPTION
When the HVACTemplate:System:DedicatedOutdoorAir object is used with no
cooling coil, a heating coil and is setup with heat recovery, a severe
error occurs. A setpoint manager is missing at the reference setpoint
node for the economizer setpoint manager (SetpointManager:MixedAir).

The change to epfilter.f90 seems to fix the issue. I've recompiled
ExpandObjects locally and tried it with EnergyPlus v8.5.0 and my model
runs fine now.

It hope this description is clear enough!
