### PR TITLE
Fix LaTeX page numbers

### DIFF
--- a/cmake/BuildDocumentation.cmake
+++ b/cmake/BuildDocumentation.cmake
@@ -9,4 +9,5 @@
 execute_process( COMMAND cmake -E copy_directory ${ORIGINAL_CMAKE_SOURCE_DIR}/doc/${INNAME} ${ORIGINAL_CMAKE_BINARY_DIR}/doc-build/${INNAME})
 execute_process( COMMAND ${XELATEX} -interaction=nonstopmode ${INNAME}.tex )
 execute_process( COMMAND ${XELATEX} -interaction=nonstopmode ${INNAME}.tex )
+execute_process( COMMAND ${XELATEX} -interaction=nonstopmode ${INNAME}.tex )
 file( RENAME "${INNAME}.pdf" "../${OUTNAME}.pdf" )

--- a/doc/header.tex
+++ b/doc/header.tex
@@ -33,8 +33,8 @@
 \newcommand{\warning}[1]{\small{\textbf{\textcolor[rgb]{0.8,0.2,0.2}{#1}}}}
 
 % Font Settings
-%\setmainfont[]{Calibri}
-%\setmonofont[Mapping=tex-ansi]{Inconsolata}
+\setmainfont[]{Calibri}
+\setmonofont[Mapping=tex-ansi]{Inconsolata}
 %\usepackage{newtxtext,newtxmath}
 
 % The depth of numbering for sections

--- a/doc/header.tex
+++ b/doc/header.tex
@@ -33,8 +33,8 @@
 \newcommand{\warning}[1]{\small{\textbf{\textcolor[rgb]{0.8,0.2,0.2}{#1}}}}
 
 % Font Settings
-\setmainfont[]{Calibri}
-\setmonofont[Mapping=tex-ansi]{Inconsolata}
+%\setmainfont[]{Calibri}
+%\setmonofont[Mapping=tex-ansi]{Inconsolata}
 %\usepackage{newtxtext,newtxmath}
 
 % The depth of numbering for sections


### PR DESCRIPTION
Add a third execution of XeLaTeX during cmake doc builds to do a final resolution of page numbers.

Fixes #5608
