### PR TITLE
Correct crash with only single node reference in input check CheckNod…

### DIFF
--- a/src/EnergyPlus/BranchNodeConnections.cc
+++ b/src/EnergyPlus/BranchNodeConnections.cc
@@ -650,6 +650,7 @@ namespace BranchNodeConnections {
 				FluidStreamOutletCount = 0;
 				FluidStreamCounts = false;
 				Loop1 = NodeObjects( Object );
+				if ( NumOfNodeConnections < 2 ) continue;
 				if ( NodeConnections( Loop1 ).ObjectIsParent ) continue;
 				if ( NodeConnections( Loop1 ).ConnectionType == ValidConnectionTypes( NodeConnectionType_Inlet ) ) ++FluidStreamInletCount( NodeConnections( Loop1 ).FluidStream );
 				if ( NodeConnections( Loop1 ).ConnectionType == ValidConnectionTypes( NodeConnectionType_Outlet ) ) ++FluidStreamOutletCount( NodeConnections( Loop1 ).FluidStream );

--- a/tst/EnergyPlus/unit/BranchNodeConnections.unit.cc
+++ b/tst/EnergyPlus/unit/BranchNodeConnections.unit.cc
@@ -101,6 +101,17 @@ using namespace ObjexxFCL;
 
 namespace EnergyPlus {
 
+	TEST_F( EnergyPlusFixture, BranchNodeErrorCheck_SingleNode ) {
+		bool errFlag = false;
+		RegisterNodeConnection( 1, "BadNode", "Type1", "Object1", "ZoneNode", 1, false, errFlag );
+		bool ErrorsFound = false;
+
+		CheckNodeConnections( ErrorsFound );
+
+		EXPECT_FALSE( errFlag ); //Node should register without error
+		EXPECT_FALSE( ErrorsFound ); //Node check should not fail on Check 10 -- zone node name must be unique
+	}
+
 	TEST_F( EnergyPlusFixture, BranchNodeErrorCheck11Test ) {
 		bool errFlag = false; 
 		RegisterNodeConnection(1, "BadNode", "Type1", "Object1", "ZoneNode", 1, false, errFlag);
@@ -119,6 +130,7 @@ namespace EnergyPlus {
 		EXPECT_TRUE( compare_err_stream( error_string, true ) );
 		EXPECT_TRUE( ErrorsFound ); //Node check will fail on Check 11 -- zone node name must be unique
 	}
+
 	TEST_F( EnergyPlusFixture, BranchNodeConnections_ReturnPlenumNodeCheckFailure )
 	{
 		// AUTHOR: R. Raustad, FSEC


### PR DESCRIPTION
## Pull request overview

Simulation crashes when only 1 node or reference to node exists in input. Workaround is to ensure at least 2 node references exist in input. Addresses #5534.
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
  - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
  - NewFeature: This pull request includes code to add a new feature to EnergyPlus
  - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
  - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog
### Review Checklist

This will not be exhaustively relevant to every PR.
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [x] CI status: all green or justified
- [x] Performance: CI Linux results include performance check -- verify this
- [x] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [ ] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces

…eConnections #10
