### PR TITLE
SPMs with same reference and set point node name should fatal

### DIFF
--- a/doc/input-output-reference/src/overview/group-setpoint-managers.tex
+++ b/doc/input-output-reference/src/overview/group-setpoint-managers.tex
@@ -541,7 +541,7 @@ In EnergyPlus the relief and outdoor air dampers, the economizer, and any outdoo
 
 Of course any type of setpoint manager can be used to establish a temperature setpoint at the mixed air node. But the Mixed Air Setpoint Manager is likely to be the most useful.
 
-When optional inputs of Cooling Coil Inlet Node Name, Cooling coil Outlet Node Name, and Minimum Temperature at Cooling Coil Outlet Node are provided, the setpoint temperature at the mixed air node is calculated based on the maximum of both the reference setpoint temperature and minimum cooling coil outlet temperature, minus the cooling coil air temperature reduction and the supply fan air temperature rise if the supply fan placement is blow through. The setpoin temperature at the mixed air node is used to calculate the maximum outdoor air flow fraction in the corresponding Controller:OutdoorAir object. The outdoor air flow fraction is capped at the maximum outdoor air flow fraction to prevent the cooling coil from freezing, even though the fraction is below the minimum outdoor air flow fraction.
+When optional inputs of Cooling Coil Inlet Node Name, Cooling coil Outlet Node Name, and Minimum Temperature at Cooling Coil Outlet Node are provided, the setpoint temperature at the mixed air node is calculated based on the maximum of both the reference setpoint temperature and minimum cooling coil outlet temperature, minus the cooling coil air temperature reduction and the supply fan air temperature rise if the supply fan placement is blow through. The setpoint temperature at the mixed air node is used to calculate the maximum outdoor air flow fraction in the corresponding Controller:OutdoorAir object. The outdoor air flow fraction is capped at the maximum outdoor air flow fraction to prevent the cooling coil from freezing, even though the fraction is below the minimum outdoor air flow fraction.
 
 \subsubsection{Inputs}\label{inputs-8-022}
 
@@ -567,7 +567,7 @@ The name of the supply fan outlet node.
 
 \paragraph{Field: Setpoint Node or NodeList Name}\label{field-setpoint-node-or-nodelist-name-8}
 
-The name of a NodeList object containing the names of the HVAC system nodes or the HVAC System Node Name where temperature setpoints will be established by this setpoint manager.
+The name of a NodeList object containing the names of the HVAC system nodes or the HVAC System Node Name where temperature setpoints will be established by this setpoint manager. The node name(s) specified here cannot be the same as the Reference Setpoint Node Name in the previous field.
 
 \paragraph{Field: Cooling Coil Inlet Node Name}\label{field-cooling-coil-inlet-node-name}
 
@@ -674,7 +674,8 @@ The name of a node in the return air stream. This node is used to obtain the flo
 
 \paragraph{Field: Setpoint Node or NodeList Name}\label{field-setpoint-node-or-nodelist-name-9}
 
-The name of a NodeList object containing the names of the HVAC system nodes or the HVAC System Node Name for which temperature or humidity ratio setpoints will be established by this setpoint manager.
+The name of a NodeList object containing the names of the HVAC system nodes or the HVAC System Node Name for which temperature or humidity ratio setpoints will be established by this setpoint manager. The node name(s) specified here cannot be the same as the Reference Setpoint Node Name in the previous field.
+
 
 Below is an example input for an Outdoor Air Pretreat Setpoint Manager.
 

--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -529,6 +529,22 @@ namespace SetPointManager {
 	void
 	GetSetPointManagerInputs()
 	{
+		// wrapper for GetInput to allow unit testing when fatal inputs are detected
+		static bool ErrorsFound( false );
+		static std::string const RoutineName( "GetSetPointManagerInputs: " ); // include trailing blank space
+
+		GetSetPointManagerInputData( ErrorsFound );
+
+		if ( ErrorsFound ) {
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+		}
+
+	}
+
+	void
+	GetSetPointManagerInputData( 
+		bool & ErrorsFound )
+	{
 
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Fred Buhl
@@ -617,7 +633,6 @@ namespace SetPointManager {
 		int ZoneNum; // loop index for zone nodes
 		int NumNodes;
 		Array1D_int NodeNums;
-		static bool ErrorsFound( false );
 		bool IsNotOK; // Flag to verify name
 		bool IsBlank; // Flag for blank name
 		static bool NodeListError( false );
@@ -1585,14 +1600,14 @@ namespace SetPointManager {
 
 			Found = FindNumberInList( MixedAirSetPtMgr( SetPtMgrNum ).RefNode, MixedAirSetPtMgr( SetPtMgrNum ).CtrlNodes, MixedAirSetPtMgr( SetPtMgrNum ).NumCtrlNodes );
 			if ( Found > 0 ) {
+				ShowSevereError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", reference node." );
 				if ( MixedAirSetPtMgr( SetPtMgrNum ).NumCtrlNodes > 1 ) {
-					ShowWarningError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", reference node." );
 					ShowContinueError( "..Reference Node is the same as one of the nodes in SetPoint NodeList" );
 				} else {
-					ShowWarningError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", reference node." );
 					ShowContinueError( "..Reference Node is the same as the SetPoint Node" );
 				}
 				ShowContinueError( "Reference Node Name=\"" + NodeID( MixedAirSetPtMgr( SetPtMgrNum ).RefNode ) + "\"." );
+				ErrorsFound = true;
 			}
 
 			AllSetPtMgrNum = SetPtMgrNum + NumSchSetPtMgrs + NumDualSchSetPtMgrs + NumOutAirSetPtMgrs + NumSZRhSetPtMgrs + NumSZHtSetPtMgrs + NumSZClSetPtMgrs + NumSZMinHumSetPtMgrs + NumSZMaxHumSetPtMgrs;
@@ -1704,14 +1719,14 @@ namespace SetPointManager {
 
 			Found = FindNumberInList( OAPretreatSetPtMgr( SetPtMgrNum ).RefNode, OAPretreatSetPtMgr( SetPtMgrNum ).CtrlNodes, OAPretreatSetPtMgr( SetPtMgrNum ).NumCtrlNodes );
 			if ( Found > 0 ) {
+				ShowSevereError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", reference node." );
 				if ( OAPretreatSetPtMgr( SetPtMgrNum ).NumCtrlNodes > 1 ) {
-					ShowWarningError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", reference node." );
 					ShowContinueError( "..Reference Node is the same as one of the nodes in SetPoint NodeList" );
 				} else {
-					ShowWarningError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", reference node." );
 					ShowContinueError( "..Reference Node is the same as the SetPoint Node" );
 				}
 				ShowContinueError( "Reference Node Name=\"" + NodeID( OAPretreatSetPtMgr( SetPtMgrNum ).RefNode ) + "\"." );
+				ErrorsFound = true;
 			}
 
 			AllSetPtMgrNum = SetPtMgrNum + NumSchSetPtMgrs + NumDualSchSetPtMgrs + NumOutAirSetPtMgrs + NumSZRhSetPtMgrs + NumSZHtSetPtMgrs + NumSZClSetPtMgrs + NumSZMinHumSetPtMgrs + NumSZMaxHumSetPtMgrs + NumMixedAirSetPtMgrs;
@@ -2658,10 +2673,6 @@ namespace SetPointManager {
 
 		}
 
-		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
-		}
-
 		for ( SetPtMgrNum = 1; SetPtMgrNum <= NumWarmestSetPtMgrsTempFlow; ++SetPtMgrNum ) {
 			SetupOutputVariable( "Setpoint Manager Warmest Temperature Critical Zone Number []", WarmestSetPtMgrTempFlow( SetPtMgrNum ).CritZoneNum, "System", "Average", WarmestSetPtMgrTempFlow( SetPtMgrNum ).Name );
 			SetupOutputVariable( "Setpoint Manager Warmest Temperature Turndown Flow Fraction []", WarmestSetPtMgrTempFlow( SetPtMgrNum ).Turndown, "System", "Average", WarmestSetPtMgrTempFlow( SetPtMgrNum ).Name );
@@ -3060,10 +3071,6 @@ namespace SetPointManager {
 		cNumericFieldNames.deallocate();
 		rNumericArgs.deallocate();
 		lNumericFieldBlanks.deallocate();
-
-		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
-		}
 
 	}
 

--- a/src/EnergyPlus/SetPointManager.hh
+++ b/src/EnergyPlus/SetPointManager.hh
@@ -1289,7 +1289,10 @@ namespace SetPointManager {
 	ManageSetPoints();
 
 	void
-	GetSetPointManagerInputs();
+	GetSetPointManagerInputs(); // wrapper for GetInput to accomodate unit testing
+
+	void
+	GetSetPointManagerInputData( bool & ErrorsFound );
 
 	void
 	VerifySetPointManagers( bool & ErrorsFound ); // flag to denote node conflicts in input. !unused1208


### PR DESCRIPTION
## Pull request overview

This defect includes SetpointMangers MixedAir and OutdoorAirPretreat. Each of these set point managers have an input for "Reference Setpoint Node Name". The name of this node should not be the same as any "Setpoint Node" or set point node name in the "NodeList". This causes a circular reference where the set point continues to adjust without limit. Diff's are not expected since there should be no examples where these node names are the same. Addresses #5631 
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
  - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
  - NewFeature: This pull request includes code to add a new feature to EnergyPlus
  - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
  - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog
### Review Checklist

This will not be exhaustively relevant to every PR.
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [x] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [ ] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [x] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces
