### PR TITLE
Output:EnergyManagementSystem now creates .edd file

### DIFF
--- a/src/EnergyPlus/EMSManager.cc
+++ b/src/EnergyPlus/EMSManager.cc
@@ -243,15 +243,18 @@ namespace EMSManager {
 		cCurrentModuleObject = "EnergyManagementSystem:ConstructionIndexVariable";
 		NumEMSConstructionIndices = GetNumObjectsFound( cCurrentModuleObject );
 
+		cCurrentModuleObject = "Output:EnergyManagementSystem";
+		int NumOutputEMSs = GetNumObjectsFound( cCurrentModuleObject );
+
 		// added for FMU
-		if ( ( NumSensors + numActuatorsUsed + NumProgramCallManagers + NumErlPrograms 
-			+ NumErlSubroutines + NumUserGlobalVariables + NumEMSOutputVariables 
-			+ NumEMSCurveIndices + NumExternalInterfaceGlobalVariables + NumExternalInterfaceActuatorsUsed 
-			+ NumEMSConstructionIndices + NumEMSMeteredOutputVariables 
-			+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed 
-			+ NumExternalInterfaceFunctionalMockupUnitImportGlobalVariables 
-			+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed 
-			+ NumExternalInterfaceFunctionalMockupUnitExportGlobalVariables ) > 0 ) {
+		if ( ( NumSensors + numActuatorsUsed + NumProgramCallManagers + NumErlPrograms
+			+ NumErlSubroutines + NumUserGlobalVariables + NumEMSOutputVariables
+			+ NumEMSCurveIndices + NumExternalInterfaceGlobalVariables + NumExternalInterfaceActuatorsUsed
+			+ NumEMSConstructionIndices + NumEMSMeteredOutputVariables
+			+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
+			+ NumExternalInterfaceFunctionalMockupUnitImportGlobalVariables
+			+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed
+			+ NumExternalInterfaceFunctionalMockupUnitExportGlobalVariables + NumOutputEMSs) > 0 ) {
 			AnyEnergyManagementSystemInModel = true;
 		} else {
 			AnyEnergyManagementSystemInModel = false;
@@ -283,7 +286,7 @@ namespace EMSManager {
 	void
 	ManageEMS(
 		int const iCalledFrom, // indicates where subroutine was called from, parameters in DataGlobals.
-		bool & anyProgramRan, // true if any Erl programs ran for this call 
+		bool & anyProgramRan, // true if any Erl programs ran for this call
 		Optional_int_const ProgramManagerToRun // specific program manager to run
 	)
 	{
@@ -380,9 +383,9 @@ namespace EMSManager {
 		if ( ! anyProgramRan ) return;
 
 		// Set actuated variables with new values
-		for ( ActuatorUsedLoop = 1; ActuatorUsedLoop <= numActuatorsUsed 
-			+ NumExternalInterfaceActuatorsUsed 
-			+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed 
+		for ( ActuatorUsedLoop = 1; ActuatorUsedLoop <= numActuatorsUsed
+			+ NumExternalInterfaceActuatorsUsed
+			+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
 			+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed; ++ActuatorUsedLoop ) {
 			ErlVariableNum = EMSActuatorUsed( ActuatorUsedLoop ).ErlVariableNum;
 			if ( ! ( ErlVariableNum > 0 ) ) continue; // this can happen for good reason during sizing
@@ -799,39 +802,39 @@ namespace EMSManager {
 
 		cCurrentModuleObject = "EnergyManagementSystem:Actuator";
 
-		if ( numActuatorsUsed + NumExternalInterfaceActuatorsUsed + NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed 
+		if ( numActuatorsUsed + NumExternalInterfaceActuatorsUsed + NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
 			+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed > 0 ) {
-			EMSActuatorUsed.allocate( numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
+			EMSActuatorUsed.allocate( numActuatorsUsed + NumExternalInterfaceActuatorsUsed
 				+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
 				+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed );
-			for ( ActuatorNum = 1; ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
-				+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed 
+			for ( ActuatorNum = 1; ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed
+				+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
 				+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed; ++ActuatorNum ) {
 				// If we process the ExternalInterface actuators, all we need to do is to change the
 				// name of the module object, and shift the ActuatorNum in GetObjectItem
 				if ( ActuatorNum <= numActuatorsUsed ) {
-					GetObjectItem( cCurrentModuleObject, ActuatorNum, cAlphaArgs, NumAlphas, 
+					GetObjectItem( cCurrentModuleObject, ActuatorNum, cAlphaArgs, NumAlphas,
 						rNumericArgs, NumNums, IOStat, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
 				} else if ( ActuatorNum > numActuatorsUsed && ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed ) {
 					cCurrentModuleObject = "ExternalInterface:Actuator";
-					GetObjectItem( cCurrentModuleObject, ActuatorNum - numActuatorsUsed, cAlphaArgs, 
-						NumAlphas, rNumericArgs, NumNums, IOStat, lNumericFieldBlanks, 
+					GetObjectItem( cCurrentModuleObject, ActuatorNum - numActuatorsUsed, cAlphaArgs,
+						NumAlphas, rNumericArgs, NumNums, IOStat, lNumericFieldBlanks,
 						lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-				} else if ( ActuatorNum > numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
-					&& ActuatorNum <= ( numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
+				} else if ( ActuatorNum > numActuatorsUsed + NumExternalInterfaceActuatorsUsed
+					&& ActuatorNum <= ( numActuatorsUsed + NumExternalInterfaceActuatorsUsed
 					+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed ) ) {
 					cCurrentModuleObject = "ExternalInterface:FunctionalMockupUnitImport:To:Actuator";
-					GetObjectItem( cCurrentModuleObject, ActuatorNum - numActuatorsUsed 
-						- NumExternalInterfaceActuatorsUsed, cAlphaArgs, NumAlphas, rNumericArgs, 
+					GetObjectItem( cCurrentModuleObject, ActuatorNum - numActuatorsUsed
+						- NumExternalInterfaceActuatorsUsed, cAlphaArgs, NumAlphas, rNumericArgs,
 						NumNums, IOStat, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-				} else if ( ActuatorNum > numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
-					+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed && ActuatorNum <= numActuatorsUsed 
-					+ NumExternalInterfaceActuatorsUsed + NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed 
+				} else if ( ActuatorNum > numActuatorsUsed + NumExternalInterfaceActuatorsUsed
+					+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed && ActuatorNum <= numActuatorsUsed
+					+ NumExternalInterfaceActuatorsUsed + NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
 					+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed ) {
 					cCurrentModuleObject = "ExternalInterface:FunctionalMockupUnitExport:To:Actuator";
-					GetObjectItem( cCurrentModuleObject, ActuatorNum - numActuatorsUsed 
-						- NumExternalInterfaceActuatorsUsed - NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed, 
-						cAlphaArgs, NumAlphas, rNumericArgs, NumNums, IOStat, lNumericFieldBlanks, lAlphaFieldBlanks, 
+					GetObjectItem( cCurrentModuleObject, ActuatorNum - numActuatorsUsed
+						- NumExternalInterfaceActuatorsUsed - NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed,
+						cAlphaArgs, NumAlphas, rNumericArgs, NumNums, IOStat, lNumericFieldBlanks, lAlphaFieldBlanks,
 						cAlphaFieldNames, cNumericFieldNames );
 				}
 
@@ -1177,8 +1180,8 @@ namespace EMSManager {
 		} // SensorNum
 
 		// added for FMU
-		for ( ActuatorNum = 1; ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
-			+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed 
+		for ( ActuatorNum = 1; ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed
+			+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
 			+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed; ++ActuatorNum ) {
 			// If we process the ExternalInterface actuators, all we need to do is to change the
 
@@ -1186,14 +1189,14 @@ namespace EMSManager {
 				cCurrentModuleObject = "EnergyManagementSystem:Actuator";
 			} else if ( ActuatorNum > numActuatorsUsed && ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed ) {
 				cCurrentModuleObject = "ExternalInterface:Actuator";
-			} else if ( ActuatorNum > numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
-				&& ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
+			} else if ( ActuatorNum > numActuatorsUsed + NumExternalInterfaceActuatorsUsed
+				&& ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed
 				+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed ) {
 				cCurrentModuleObject = "ExternalInterface:FunctionalMockupUnitImport:To:Actuator";
-			} else if ( ActuatorNum > numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
-				+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed 
-				&& ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed 
-				+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed 
+			} else if ( ActuatorNum > numActuatorsUsed + NumExternalInterfaceActuatorsUsed
+				+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
+				&& ActuatorNum <= numActuatorsUsed + NumExternalInterfaceActuatorsUsed
+				+ NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed
 				+ NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed ) {
 				cCurrentModuleObject = "ExternalInterface:FunctionalMockupUnitExport:To:Actuator";
 			}

--- a/tst/EnergyPlus/unit/EMSManager.unit.cc
+++ b/tst/EnergyPlus/unit/EMSManager.unit.cc
@@ -124,7 +124,7 @@ TEST_F( EnergyPlusFixture, EMSManager_TestForUniqueEMSActuators )
 
 TEST_F( EnergyPlusFixture, Dual_NodeTempSetpoints ) {
 
-		std::string const idf_objects = delimited_string( { 
+		std::string const idf_objects = delimited_string( {
 		"Version,8.4;",
 
 		"OutdoorAir:Node, Test node;",
@@ -425,10 +425,10 @@ TEST_F( EnergyPlusFixture, Debug_EMSLogic ) {
 
 
 TEST_F( EnergyPlusFixture, TestAnyRanArgument ) {
-		// small test to demonstrate new boolean argument. 
+		// small test to demonstrate new boolean argument.
 		// shows a simple way to setup sensor on a node, need to call SetupNodeVarsForReporting()
 
-		std::string const idf_objects = delimited_string( { 
+		std::string const idf_objects = delimited_string( {
 		"Version,8.5;",
 
 		"OutdoorAir:Node, Test node;",
@@ -442,7 +442,7 @@ TEST_F( EnergyPlusFixture, TestAnyRanArgument ) {
 		"Test inside HVAC system iteration Loop,",
 		"InsideHVACSystemIterationLoop,",
 		"Test_InsideHVACSystemIterationLoop;",
-	
+
 		"EnergyManagementSystem:Program,",
 		"Test_InsideHVACSystemIterationLoop,",
 		"set dumm1 = Node_mdot;",
@@ -468,5 +468,27 @@ TEST_F( EnergyPlusFixture, TestAnyRanArgument ) {
 		EXPECT_TRUE( anyRan );
 
 }
+
+
+TEST_F( EnergyPlusFixture, EMSManager_CheckIfAnyEMS_OutEMS ) {
+
+	using DataGlobals::AnyEnergyManagementSystemInModel;
+
+	std::string const idf_objects = delimited_string( {
+    	"  Output:EnergyManagementSystem,                                                                ",
+		"    Verbose,                 !- Actuator Availability Dictionary Reporting                      ",
+		"    Verbose,                 !- Internal Variable Availability Dictionary Reporting             ",
+		"    Verbose;                 !- EMS Runtime Language Debug Output Level                         ",
+	} );
+
+	ASSERT_FALSE( process_idf( idf_objects ) );
+
+	CheckIfAnyEMS();
+	EXPECT_TRUE( AnyEnergyManagementSystemInModel );
+
+
+}
+
+
 
 


### PR DESCRIPTION
Addresses #5013.  Previously the presence of just an Output:EnergyManagementSystem was not sufficient to trigger obtaining and EDD file with the list of actuators and internal variables that are available.  With this change that object is included in the checks to see if there is any EMS. 
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [x] CI status: all green or justified
- [x] Performance: CI Linux results include performance check -- verify this
- [x] Unit Test(s)

No documentation changes are needed
