### PR TITLE
Fix array bound mismatch with transitioning 8.1 to 8.2 for ZoneHVAC:UnitHeater

### DIFF
--- a/src/Transition/CreateNewIDFUsingRulesV8_2_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV8_2_0.f90
@@ -364,7 +364,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
                   OutArgs(11)="No"
                 endif
                 ! the net effect here is the addition of 1 field
-                OutArgs(12:)=InArgs(11:)
+                OutArgs(12:15)=InArgs(11:14)
                 CurArgs = CurArgs + 1
       
               CASE('PLANTLOOP', 'CONDENSERLOOP')


### PR DESCRIPTION
Addresses #5648 
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [x] CI status: all green or justified
- [x] Performance: CI Linux results include performance check -- verify this
