### PR TITLE
Provide warning for DX heating coil when DefrostEIR performance curve name is blank and defrost method is reverse cycle

### DIFF
--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -2209,12 +2209,12 @@ namespace DXCoils {
 
 			// Only required for reverse cycle heat pumps
 			DXCoil( DXCoilNum ).DefrostEIRFT = GetCurveIndex( Alphas( 10 ) ); // convert curve name to number
-			if ( SameString( Alphas( 11 ), "ReverseCycle" ) && SameString( Alphas( 12 ), "OnDemand" ) ) {
+			if ( SameString( Alphas( 11 ), "ReverseCycle" ) ) {
 				if ( DXCoil( DXCoilNum ).DefrostEIRFT == 0 ) {
 					if ( lAlphaBlanks( 10 ) ) {
 						ShowSevereError( RoutineName + CurrentModuleObject + "=\"" + DXCoil( DXCoilNum ).Name + "\", missing" );
 						ShowContinueError( "...required " + cAlphaFields( 10 ) + " is blank." );
-						ShowContinueError( "...field is required because " + cAlphaFields( 11 ) + " is \"ReverseCycle\" and " + cAlphaFields( 12 ) + " is \"OnDemand\"." );
+						ShowContinueError( "...field is required because " + cAlphaFields( 11 ) + " is \"ReverseCycle\"." );
 					} else {
 						ShowSevereError( RoutineName + CurrentModuleObject + "=\"" + DXCoil( DXCoilNum ).Name + "\", invalid" );
 						ShowContinueError( "...not found " + cAlphaFields( 10 ) + "=\"" + Alphas( 10 ) + "\"." );


### PR DESCRIPTION
## Pull request overview

Correct test for DX heating coil to require defrost EIR performance curve if defrost strategy is Reverse Cycle. Corrects issue #5700. No diff's expected in example files.
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
    ### Review Checklist
    This will not be exhaustively relevant to every PR.
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [ ] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [x] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [ ] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces
