### PR TITLE
Fixed incorrect array indices in ZoneMassConservation object report variables

### DIFF
--- a/src/EnergyPlus/HeatBalanceAirManager.cc
+++ b/src/EnergyPlus/HeatBalanceAirManager.cc
@@ -2795,18 +2795,18 @@ namespace HeatBalanceAirManager {
 			}
 			// Set up zone air mass balance output variables
 			for ( ZoneNum = 1; ZoneNum <= NumOfZones; ++ZoneNum ) {
-				SetupOutputVariable( "Zone Air Mass Balance Supply Mass Flow Rate [kg/s]", MassConservation( Mixing( Loop ).ZonePtr ).InMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
-				SetupOutputVariable( "Zone Air Mass Balance Exhaust Mass Flow Rate [kg/s]", MassConservation( Mixing( Loop ).ZonePtr ).ExhMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
-				SetupOutputVariable( "Zone Air Mass Balance Return Mass Flow Rate [kg/s]", MassConservation( Mixing( Loop ).ZonePtr ).RetMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
+				SetupOutputVariable( "Zone Air Mass Balance Supply Mass Flow Rate [kg/s]", MassConservation( ZoneNum ).InMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
+				SetupOutputVariable( "Zone Air Mass Balance Exhaust Mass Flow Rate [kg/s]", MassConservation( ZoneNum ).ExhMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
+				SetupOutputVariable( "Zone Air Mass Balance Return Mass Flow Rate [kg/s]", MassConservation( ZoneNum ).RetMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
 				if ( ZoneAirMassFlow.BalanceMixing && ( ( MassConservation( ZoneNum ).NumSourceZonesMixingObject + MassConservation( ZoneNum ).NumReceivingZonesMixingObject ) > 0 ) ) {
-					SetupOutputVariable( "Zone Air Mass Balance Mixing Receiving Mass Flow Rate [kg/s]", MassConservation( Mixing( Loop ).ZonePtr ).MixingMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
-					SetupOutputVariable( "Zone Air Mass Balance Mixing Source Mass Flow Rate [kg/s]", MassConservation( Mixing( Loop ).ZonePtr ).MixingSourceMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
+					SetupOutputVariable( "Zone Air Mass Balance Mixing Receiving Mass Flow Rate [kg/s]", MassConservation( ZoneNum ).MixingMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
+					SetupOutputVariable( "Zone Air Mass Balance Mixing Source Mass Flow Rate [kg/s]", MassConservation( ZoneNum ).MixingSourceMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
 				}
 				if ( ZoneAirMassFlow.InfiltrationTreatment != NoInfiltrationFlow ) {
 					if ( ZoneAirMassFlow.InfiltrationZoneType == AllZones || (MassConservation( ZoneNum ).NumSourceZonesMixingObject > 0 ) ) {
 						if ( MassConservation( ZoneNum ).InfiltrationPtr > 0 ) {
-							SetupOutputVariable( "Zone Air Mass Balance Infiltration Mass Flow Rate [kg/s]", MassConservation( Infiltration( Loop ).ZonePtr ).InfiltrationMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
-							SetupOutputVariable( "Zone Air Mass Balance Infiltration Status []", MassConservation( Mixing( Loop ).ZonePtr ).IncludeInfilToZoneMassBal, "System", "Average", Zone( ZoneNum ).Name );
+							SetupOutputVariable( "Zone Air Mass Balance Infiltration Mass Flow Rate [kg/s]", MassConservation( ZoneNum ).InfiltrationMassFlowRate, "System", "Average", Zone( ZoneNum ).Name );
+							SetupOutputVariable( "Zone Air Mass Balance Infiltration Status []", MassConservation( ZoneNum ).IncludeInfilToZoneMassBal, "System", "Average", Zone( ZoneNum ).Name );
 						}
 					}
 				}

--- a/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
@@ -75,6 +75,7 @@
 #include <DataAirLoop.hh>
 #include <DataAirSystems.hh>
 #include <DataHVACGlobals.hh>
+#include <EnergyPlus/OutputProcessor.hh>
 
 #include "Fixtures/EnergyPlusFixture.hh"
 
@@ -439,6 +440,77 @@ namespace EnergyPlus {
 		EXPECT_FALSE( ZoneAirMassFlow.BalanceMixing );
 		EXPECT_EQ( ZoneAirMassFlow.InfiltrationTreatment, NoInfiltrationFlow );
 		EXPECT_EQ( ZoneAirMassFlow.InfiltrationZoneType, 0 );
+
+	}
+
+	TEST_F( EnergyPlusFixture, HeatBalanceManager_ZoneAirMassFlowConservationReportVariableTest )
+	{
+		// Test get output variables for ZoneAirMassFlowConservation object #5637
+
+		std::string const idf_objects = delimited_string( {
+			"Version,8.5;",
+			"Building,",
+			"My Building, !- Name",
+			"30., !- North Axis{ deg }",
+			"City, !- Terrain",
+			"0.04, !- Loads Convergence Tolerance Value",
+			"0.4, !- Temperature Convergence Tolerance Value{ deltaC }",
+			"FullExterior, !- Solar Distribution",
+			"25, !- Maximum Number of Warmup Days",
+			"6;                       !- Minimum Number of Warmup Days",
+			"ZoneAirMassFlowConservation,",
+			"Yes, !- Adjust Zone Mixing For Zone Air Mass Flow Balance",
+			"AdjustInfiltrationFlow, !- Infiltration Balancing Method",
+			"AllZones;                !- Infiltration Balancing Zones",
+
+			"  Zone,",
+			"    WEST ZONE,               !- Name",
+			"    0,                       !- Direction of Relative North {deg}",
+			"    0,                       !- X Origin {m}",
+			"    0,                       !- Y Origin {m}",
+			"    0,                       !- Z Origin {m}",
+			"    1,                       !- Type",
+			"    1,                       !- Multiplier",
+			"    autocalculate,           !- Ceiling Height {m}",
+			"    autocalculate;           !- Volume {m3}",
+
+			"  Zone,",
+			"    EAST ZONE,               !- Name",
+			"    0,                       !- Direction of Relative North {deg}",
+			"    0,                       !- X Origin {m}",
+			"    0,                       !- Y Origin {m}",
+			"    0,                       !- Z Origin {m}",
+			"    1,                       !- Type",
+			"    1,                       !- Multiplier",
+			"    autocalculate,           !- Ceiling Height {m}",
+			"    autocalculate;           !- Volume {m3}",
+			" Output:Variable,",
+			"   *, !- Key Value",
+			"   Zone Air Mass Balance Exhaust Mass Flow Rate, !- Variable Name",
+			"   hourly;                  !- Reporting Frequency",
+		} );
+
+		ASSERT_FALSE( process_idf( idf_objects ) );
+
+		bool ErrorsFound( false ); // If errors detected in input
+
+		// call to process input
+		ErrorsFound = false;
+		GetProjectControlData( ErrorsFound ); // returns ErrorsFound false, ZoneAirMassFlowConservation never sets it
+		EXPECT_FALSE( ErrorsFound );
+		NumOfZones = 2;
+		ZoneReOrder.allocate( NumOfZones );
+		ErrorsFound = false;
+		GetZoneData( ErrorsFound );
+		EXPECT_FALSE( ErrorsFound );
+		ErrorsFound = false;
+		GetSimpleAirModelInputs( ErrorsFound );
+		EXPECT_FALSE( ErrorsFound );
+
+		EXPECT_EQ( "WEST ZONE:Zone Air Mass Balance Exhaust Mass Flow Rate", OutputProcessor::RVariableTypes( 1 ).VarName );
+		EXPECT_EQ( "EAST ZONE:Zone Air Mass Balance Exhaust Mass Flow Rate", OutputProcessor::RVariableTypes( 2 ).VarName );
+		EXPECT_EQ( 1, OutputProcessor::RVariableTypes( 1 ).ReportID );
+		EXPECT_EQ( 2, OutputProcessor::RVariableTypes( 2 ).ReportID );
 
 	}
 }


### PR DESCRIPTION
Addresses #5637
## Pull request overview

Fixed incorrect array indices in ZoneMassConservation object report variables. In addition, no crash after commenting out the ZoneMixing objects.

Differences were found in two example files as expected: 5ZoneAirCooled_ZoneAirMassFlowBalance and 5ZoneAirCooled_ZoneAirMassFlowBalance_Pressurized. 
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
### Review Checklist

This will not be exhaustively relevant to every PR.
- [ ] Code style (parentheses padding, variable names)
- [ ] If defect, results of running current develop vs this branch should exhibit the fix
- [ ] CI status: all green or justified
- [ ] Unit Test(s)
