### PR TITLE
Fix memory allocation bug in FMI libraries.

### DIFF
--- a/third_party/FMI/main.c
+++ b/third_party/FMI/main.c
@@ -183,7 +183,7 @@ static void addfmuInstances(FMU* s){
 	if(fmuLocCoun == arrsize){
 		temp = (FMU**)malloc(sizeof(FMU*) * (DELTA + arrsize));
 		arrsize += DELTA;
-		memcpy(temp, fmuInstances, fmuLocCoun);
+		memcpy(temp, fmuInstances, sizeof(FMU*) * fmuLocCoun);
 		free(fmuInstances);
 		fmuInstances = temp;
 	}


### PR DESCRIPTION
This addresses issue #5712.
