### PR TITLE
#5524 ZoneHVAC:OutdoorAirUnit reported fan power and energy corrected with exhaust fan

### DIFF
--- a/src/EnergyPlus/OutdoorAirUnit.cc
+++ b/src/EnergyPlus/OutdoorAirUnit.cc
@@ -1461,11 +1461,13 @@ namespace OutdoorAirUnit {
 				SimulateFanComponents( OutAirUnit( OAUnitNum ).SFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).SFan_Index, _, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
 				OutAirUnit( OAUnitNum ).ElecFanRate += FanElecPower;
 				SimZoneOutAirUnitComps( OAUnitNum, FirstHVACIteration );
-				if ( OutAirUnit( OAUnitNum ).ExtFan ) SimulateFanComponents( OutAirUnit( OAUnitNum ).ExtFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).ExtFan_Index );
 			} else if ( OutAirUnit( OAUnitNum ).FanPlace == DrawThru ) {
 				SimZoneOutAirUnitComps( OAUnitNum, FirstHVACIteration );
 				SimulateFanComponents( OutAirUnit( OAUnitNum ).SFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).SFan_Index, _, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
-				if ( OutAirUnit( OAUnitNum ).ExtFan ) SimulateFanComponents( OutAirUnit( OAUnitNum ).ExtFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).ExtFan_Index );
+			}
+			if ( OutAirUnit( OAUnitNum ).ExtFan ) {
+				SimulateFanComponents( OutAirUnit( OAUnitNum ).ExtFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).ExtFan_Index );
+				OutAirUnit( OAUnitNum ).ElecFanRate += FanElecPower;
 			}
 
 		} else { // System On
@@ -1502,6 +1504,7 @@ namespace OutdoorAirUnit {
 
 			if ( OutAirUnit( OAUnitNum ).FanPlace == BlowThru ) {
 				SimulateFanComponents( OutAirUnit( OAUnitNum ).SFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).SFan_Index );
+				OutAirUnit( OAUnitNum ).ElecFanRate += FanElecPower;
 				DesOATemp = Node( SFanOutletNode ).Temp;
 			} else if ( OutAirUnit( OAUnitNum ).FanPlace == DrawThru ) {
 				DesOATemp = Node( OutsideAirNode ).Temp;
@@ -1562,10 +1565,14 @@ namespace OutdoorAirUnit {
 				OutAirUnit( OAUnitNum ).FanCorTemp = ( Node( OutletNode ).Temp - OutAirUnit( OAUnitNum ).CompOutSetTemp );
 				SimZoneOutAirUnitComps( OAUnitNum, FirstHVACIteration );
 				SimulateFanComponents( OutAirUnit( OAUnitNum ).SFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).SFan_Index );
+				OutAirUnit( OAUnitNum ).ElecFanRate += FanElecPower;
 
 				OutAirUnit( OAUnitNum ).FanEffect = false;
 			}
-			if ( OutAirUnit( OAUnitNum ).ExtFan ) SimulateFanComponents( OutAirUnit( OAUnitNum ).ExtFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).ExtFan_Index );
+			if ( OutAirUnit( OAUnitNum ).ExtFan ) {
+				SimulateFanComponents( OutAirUnit( OAUnitNum ).ExtFanName, FirstHVACIteration, OutAirUnit( OAUnitNum ).ExtFan_Index );
+				OutAirUnit( OAUnitNum ).ElecFanRate += FanElecPower;
+			}
 		} // ...end of system ON/OFF IF-THEN block
 
 		AirMassFlow = Node( OutletNode ).MassFlowRate;
@@ -1611,8 +1618,6 @@ namespace OutdoorAirUnit {
 			OutAirUnit( OAUnitNum ).LatCoolingRate = 0.0;
 			OutAirUnit( OAUnitNum ).LatHeatingRate = LatLoadMet;
 		}
-
-		OutAirUnit( OAUnitNum ).ElecFanRate = FanElecPower;
 
 		PowerMet = QUnitOut;
 		LatOutputProvided = LatentOutput;


### PR DESCRIPTION
## Pull request overview

ZoneHVAC:OutdoorAirUnit report for fan electric power only include one fan. This corrects #5524. Diff's in example files are expected for those files that report fan power.
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
### Review Checklist

This will not be exhaustively relevant to every PR.
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [x] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [x] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] Open windows IDF Editor with modified IDD to check for errors
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [ ] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces

…only one fan
