### PR TITLE
Tables of One and Two Independent Variables do not allow extrapolation when appropriate

### DIFF
--- a/doc/input-output-reference/src/overview/group-performance-tables.tex
+++ b/doc/input-output-reference/src/overview/group-performance-tables.tex
@@ -34,27 +34,27 @@ A unique user assigned name for an instance of a performance table. When a table
 
 \paragraph{Field: Curve Type}\label{field-curve-type}
 
-The form of the polynomial equation used to represent the tabular data. Choices are \emph{Linear}, \emph{Quadratic}, \emph{Cubic}, \emph{Quartic} and \emph{Exponent}. This field is used to determine if this table object is representative of the type of performance table (curve) allowed for a particular application (i.e., if this type of polynomial is allowed to be used as the curve type for other objects). This input infers the polynomial order (or degree). This input also specifies the number of interpolation points if the next field, Interpolation Method is set to LagrangeInterpolationLinearExtrapolation. The number of interpolation points for Linear, Quadratic, Cubic, Quartic, and Exponent are set at 2, 3, 4, 5, and 4, respectively.
+The form of the polynomial equation used to represent the tabular data. Choices are \emph{Linear}, \emph{Quadratic}, \emph{Cubic}, \emph{Quartic} and \emph{Exponent}. This field is used to determine if this table object is representative of the type of performance table (curve) allowed for a particular application (i.e., if this type of polynomial is allowed to be used as the curve type for other objects). This input infers the polynomial order (or degree). This input also specifies the number of interpolation points if the next field, Interpolation Method is set to LagrangeInterpolationLinearExtrapolation. The number of interpolation points for Linear, Quadratic, Cubic, Quartic, BiQuadratic and QuadraticLinear are set at 2, 3, 4, 5, 6 and 6, respectively.
 
 \paragraph{Field: Interpolation Method}\label{field-interpolation-method}
 
-The method used to evaluate the tabular data. Choices are \emph{LinearInterpolationOfTable, LagrangeInterpolationLinearExtrapolation} and \emph{EvaluateCurveToLimits}. When \emph{LinearInterpolationOfTable} is selected, the tabular data is interpolated within the limits of the data set and the following fields are used only within the boundary of the table limits (i.e., are only used to limit interpolation). Extrapolation of the data set is not allowed. When \emph{LagrangeInterpolationLinearExtrapolation} is selected, a polynomial interpolation routine is used within the table boundaries along with linear extrapolation. Given the valid one independent variable equations above, the polynomial order is up to 5\(^{th}\) order. When \emph{EvaluateCurveToLimits} is selected, the coefficients (i.e., C in the equations above) of the polynomial equation are calculated and used to determine the table output within the limits specified in the following fields. If these fields are not entered, the limits of the tabular data are used. The minimum number of data pairs required for this choice are 2, 3, 4, 5, and 4 data pairs for linear, quadratic, cubic, quartic, and exponent curves, respectively. If insufficient data is provided, the regression analysis is not performed and the simulation reverts to interpolating the tabular data. The performance curve is written to the eio file when the output diagnotics flag DisplayAdvancedVariables is used (ref. Output:Diagnostics, DisplayAdvancedVariables).
+The method used to evaluate the tabular data. Choices are \emph{LinearInterpolationOfTable, LagrangeInterpolationLinearExtrapolation} and \emph{EvaluateCurveToLimits}. When \emph{LinearInterpolationOfTable} is selected, the tabular data is interpolated within the limits of the data set and the following fields are used only within the boundary of the table limits (i.e., are only used to limit interpolation). Extrapolation of the data set is not allowed. When \emph{LagrangeInterpolationLinearExtrapolation} is selected, a polynomial interpolation routine is used within the table boundaries along with linear extrapolation. Given the valid one independent variable equations above, the polynomial order is up to 5\(^{th}\) order. When \emph{EvaluateCurveToLimits} is selected, the coefficients (i.e., C in the equations above) of the polynomial equation are calculated and used to determine the table output within the limits specified in the following fields. If these fields are not entered, the limits of the tabular data are used. The minimum number of data pairs required for this choice are 2, 3, 4, 5, 6 and 6 data pairs for Linear, Quadratic, Cubic, Quartic, BiQuadratic and QuadraticLinear curves, respectively. If insufficient data is provided, the regression analysis is not performed and the simulation reverts to interpolating the tabular data. The performance curve is written to the eio file when the output diagnostics flag DisplayAdvancedVariables is used (ref. Output:Diagnostics, DisplayAdvancedVariables).
 
 \paragraph{Field: Minimum Value of X}\label{field-minimum-value-of-x-000}
 
-The minimum allowable value of X. Values of X less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The minimum allowable value of X. Values of X less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Maximum Value of X}\label{field-maximum-value-of-x-000}
 
-The maximum allowable value of X. Values of X greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The maximum allowable value of X. Values of X greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Minimum Table Output}\label{field-minimum-table-output}
 
-The minimum allowable value of the table output. Values less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The minimum allowable value of the table output. Values less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the \emph{Minimum Value of X} and \emph{Maximum Value of X} determines the limit.
 
 \paragraph{Field: Maximum Table Output}\label{field-maximum-table-output}
 
-The maximum allowable value of the table output. Values greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The maximum allowable value of the table output. Values greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the \emph{Minimum Value of X} and \emph{Maximum Value of X} determines the limit.
 
 \paragraph{Field: Input Unit Type for X1}\label{field-input-unit-type-for-x1}
 
@@ -94,7 +94,7 @@ The normalization point for the data set. This field provides a method for autom
 
 \paragraph{Data Pairs}\label{data-pairs}
 
-The following inputs describe the data set. Data pairs are entered as X and Output pairs where X is the independent variable (i.e., x in the equation above) and Output is the dependent variable (i.e., Output in the equation above). Any number of data pairs may be entered, however, a minimum number of data pairs must be entered and depends on the polynomial equation. Linear (1\(^{st}\) order), Quadratic (2\(^{nd}\) order), Cubic (3\(^{rd}\) order), Quartic (4\(^{th}\) order), and Exponent (nth order) polynomials require a minimum of 2, 3, 4, 5, and 4 data pairs, respectively. This minimum requirement is for performing a regression analysis, not interpolating the tabular data. If a regression analysis is not performed (i.e., only table interpolation is used), these minimum requirements are not enforced. If a regression analysis is performed and these minimum requirements are not met, the simulation will revert to table interpolation. These fields may be repeated as many times as necessary to define the tabular data.
+The following inputs describe the data set. Data pairs are entered as X and Output pairs where X is the independent variable (i.e., x in the equation above) and Output is the dependent variable (i.e., Output in the equation above). Any number of data pairs may be entered, however, a minimum number of data pairs must be entered and depends on the polynomial equation. Linear (1\(^{st}\) order), Quadratic (2\(^{nd}\) order), Cubic (3\(^{rd}\) order), Quartic (4\(^{th}\) order), BiQuadratic and QuadraticLinear polynomials require a minimum of 2, 3, 4, 5, 6 and 6 data pairs, respectively. This minimum requirement is for performing a regression analysis, not interpolating the tabular data. If a regression analysis is not performed (i.e., only table interpolation is used), these minimum requirements are not enforced. If a regression analysis is performed and these minimum requirements are not met, the simulation will revert to table interpolation. These fields may be repeated as many times as necessary to define the tabular data.
 
 \paragraph{Field: X Value \#n}\label{field-x-value-n}
 
@@ -109,18 +109,18 @@ Following is an example input for a Table:OneIndependentVariable object:
 \begin{lstlisting}
 
 Table:OneIndependentVariable,
-  WindACCoolCapFFF,             !- Name
-  Linear,                                 !- Curve Type
-  EvaluateCurveToLimits,   !- Interpolation Type
-  0,                                           !- Minimum Value of X1,
-  1.5,                                       !- Maximum Value of X1,
-  0.8,                                       !- Minimum Table Output
-  1.1,                                       !- Maximum Table Output
-  Dimensionless,                   !- Input Unit Type for X1
-  Dimensionless,                   !- Output Unit Type
-  ,                                             !- Normalization Point
-  0,0.8,                                   !- X Value #1, Output Value #1
-  1.5,1.1;                               !- X Value #2, Output Value #2
+  WindACCoolCapFFF,            !- Name
+  Linear,                      !- Curve Type
+  EvaluateCurveToLimits,       !- Interpolation Type
+  0,                           !- Minimum Value of X1,
+  1.5,                         !- Maximum Value of X1,
+  0.8,                         !- Minimum Table Output
+  1.1,                         !- Maximum Table Output
+  Dimensionless,               !- Input Unit Type for X1
+  Dimensionless,               !- Output Unit Type
+  ,                            !- Normalization Point
+  0,0.8,                       !- X Value #1, Output Value #1
+  1.5,1.1;                     !- X Value #2, Output Value #2
 \end{lstlisting}
 
 \subsubsection{Outputs}\label{outputs-022}
@@ -157,35 +157,35 @@ A unique user assigned name for an instance of a performance table. When a table
 
 \paragraph{Field: Curve Type}\label{field-curve-type-1}
 
-The form of the polynomial equation represented by the entered data. The only valid choices are \emph{BiQuadratic} and \emph{QuadraticLinear}. This field is used to determine if this table object is representative of the type of performance table (curve) allowed for a particular equipment model (i.e., if this type of polynomial is allowed to be used as the curve type for specific input fields). A minimum of 6 data pairs are required when selecting \emph{EvaluateCurveToLimits} in the following field. This input also specifies the number of interpolation points if the next field, Interpolation Method is set to LagrangeInterpolationLinearExtrapolation. The number of interpolation points for BiQuadratic and QuadraticLinear are set at 6.
+The form of the polynomial equation represented by the entered data. The only valid choices are \emph{BiQuadratic} and \emph{QuadraticLinear}. This field is used to determine if this table object is representative of the type of performance table (curve) allowed for a particular equipment model (i.e., if this type of polynomial is allowed to be used as the curve type for specific input fields). A minimum of 6 data pairs are required when selecting \emph{EvaluateCurveToLimits} in the following field. This input also specifies the number of interpolation points if the next field, Interpolation Method, is set to LagrangeInterpolationLinearExtrapolation.
 
 \paragraph{Field: Interpolation Method}\label{field-interpolation-method-1}
 
-The method used to evaluate the tabular data. Choices are \emph{LinearInterpolationOfTable, LagrangeInterpolationLinearExtrapolation,} and \emph{EvaluateCurveToLimits}. When \emph{LinearInterpolationOfTable} is selected, the data entered is evaluated within the limits of the data set and the following fields are used only within the boundary of the table limits (i.e., are only used to limit interpolation). A complete data set is required. For each X variable, entries must include all Y variables and associated curve output (i.e., a complete table, no gaps or missing data). Extrapolation of the data set is not allowed. When Lagrange\emph{InterpolationLinearExtrapolation} is selected, a polynomial interpolation routine is used within the table boundaries along with linear extrapolation. Given the valid equations above, the polynomial order is fixed at 2 which infers that 3 data points will be used for interpolation. When \emph{EvaluateCurveToLimits} is selected, the coefficients (i.e., C in the equations above) of the polynomial equation are calculated and used to determine the table output within the limits specified in the following fields (or the tabular data, whichever provide the larger range). If the following fields are not entered, the limits of the data set are used. A complete table is not required when using this method, however, a minimum number of data is required to perform the regression analysis. The minimum number of data pairs required for this choice is 6 data pairs for both bi-quadratic and quadratic-linear curve types. If insufficient data is provided, the simulation reverts to interpolating the tabular data. The performance curve is written to the eio file when the output diagnotics flag DisplayAdvancedVariables is used (ref. Output:Diagnostics, DisplayAdvancedVariables).
+The method used to evaluate the tabular data. Choices are \emph{LinearInterpolationOfTable, LagrangeInterpolationLinearExtrapolation,} and \emph{EvaluateCurveToLimits}. When \emph{LinearInterpolationOfTable} is selected, the data entered is evaluated within the limits of the data set and the following fields are used only within the boundary of the table limits (i.e., are only used to limit interpolation). A complete data set is required. For each X variable, entries must include all Y variables and associated curve output (i.e., a complete table, no gaps or missing data). Extrapolation of the data set is not allowed. When Lagrange\emph{InterpolationLinearExtrapolation} is selected, a polynomial interpolation routine is used within the table boundaries along with linear extrapolation. Given the valid equations above, the polynomial order is fixed at 2 which infers that 3 data points will be used for interpolation. When \emph{EvaluateCurveToLimits} is selected, the coefficients (i.e., C in the equations above) of the polynomial equation are calculated and used to determine the table output within the limits specified in the following fields. If the following fields are not entered, the limits of the data set are used. A complete table is not required when using this method, however, a minimum number of data is required to perform the regression analysis. The minimum number of data pairs required for this choice is 6 data pairs for both bi-quadratic and quadratic-linear curve types. If insufficient data is provided, the simulation reverts to interpolating the tabular data. The performance curve is written to the eio file when the output diagnostics flag DisplayAdvancedVariables is used (ref. Output:Diagnostics, DisplayAdvancedVariables).
 
 \paragraph{Field: Minimum Value of X}\label{field-minimum-value-of-x-1-000}
 
-The minimum allowable value of X. Values of X less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The minimum allowable value of X. Values of X less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Maximum Value of X}\label{field-maximum-value-of-x-1-000}
 
-The maximum allowable value of X. Values of X greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The maximum allowable value of X. Values of X greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Minimum Value of Y}\label{field-minimum-value-of-y-000}
 
-The minimum allowable value of Y. Values of Y less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The minimum allowable value of Y. Values of Y less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Maximum Value of Y}\label{field-maximum-value-of-y-000}
 
-The maximum allowable value of Y. Values of Y greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The maximum allowable value of Y. Values of Y greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Minimum Table Output}\label{field-minimum-table-output-1}
 
-The minimum allowable value of the table output. Values less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The minimum allowable value of the table output. Values less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the \emph{Minimum Value of X and Y} and \emph{Maximum Value of X and Y} determines the limit.
 
 \paragraph{Field: Maximum Table Output}\label{field-maximum-table-output-1}
 
-The maximum allowable value of the table output. Values greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the data set determines the limit.
+The maximum allowable value of the table output. Values greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method}. If this field is left blank, the \emph{Minimum Value of X and Y} and \emph{Maximum Value of X and Y} determines the limit.
 
 \paragraph{Field: Input Unit Type for X}\label{field-input-unit-type-for-x-000}
 
@@ -263,37 +263,37 @@ Following is an example input for a Table:TwoIndependentVariable object:
 \begin{lstlisting}
 
 Table:TwoIndependentVariables,
-  CCOOLEIRFT,                         !- Name
+  CCOOLEIRFT,                        !- Name
   BiQuadratic,                       !- Curve Type
-  EvaluateCurveToLimits,   !- Interpolation Type
-  5.0,                                       !- Minimum Value of x,
-  60.0,                                     !- Maximum Value of x,
-  5.0,                                       !- Minimum Value of y,
-  70.0,                                     !- Maximum Value of y,
-  0.01,                                     !- Minimum Table Output
-  0.5,                                       !- Maximum Table Output
+  EvaluateCurveToLimits,             !- Interpolation Type
+  5.0,                               !- Minimum Value of x,
+  60.0,                              !- Maximum Value of x,
+  5.0,                               !- Minimum Value of y,
+  70.0,                              !- Maximum Value of y,
+  0.01,                              !- Minimum Table Output
+  0.5,                               !- Maximum Table Output
   Temperature,                       !- Input Unit Type for x
   Temperature,                       !- Input Unit Type for y
-  Dimensionless,                   !- Output Unit Type
+  Dimensionless,                     !- Output Unit Type
   0.258266502,                       !- Normalization Point
-  17.2222222,18.3333333,0.18275919, !-X Value #1,Y Value #1,Output #1
-  17.2222222,23.8888889,0.207383768,!-X Value #2,Y Value #2,Output #2
-  17.2222222,29.4444444,0.237525541,!-X Value #3,Y Value #3,Output #3
-  17.2222222,35,0.274217751,               !-X Value #4,Y Value #4,Output #4
-  17.2222222,40.5555556,0.318548624,!-X Value #5,Y Value #5,Output #5
-  17.2222222,46.1111111,0.374560389,!-X Value #6,Y Value #6,Output #6
-  19.4444444,18.3333333,0.172982816,!-X Value #7,Y Value #7,Output #7
-  19.4444444,23.8888889,0.19637691, !-X Value #8,Y Value #8,Output #8
-  19.4444444,29.4444444,0.224789822,!-X Value #9,Y Value #9,Output #9
-  19.4444444,35,0.258266502,               !-X Value #10,Y Value #10,Output #10
-  19.4444444,40.5555556,0.299896794,!-X Value #11,Y Value #11,Output #11
-  19.4444444,46.1111111,0.351242021,!-X Value #12,Y Value #12,Output #12
-  21.6666667,18.3333333,0.164081122,!-X Value #13,Y Value #13,Output #13
-  21.6666667,23.8888889,0.185603303,!-X Value #14,Y Value #14,Output #14
-  21.6666667,29.4444444,0.211709812,!-X Value #15,Y Value #15,Output #15
-  21.6666667,35,0.243492052,               !-X Value #16,Y Value #16,Output #16
-  21.6666667,40.5555556,0.281757875,!-X Value #17,Y Value #17,Output #17
-  21.6666667,46.1111111,0.331185659;!-X Value #18,Y Value #18,Output #18
+  17.2222222,18.3333333,0.18275919,  !-X Value #1,Y Value #1,Output #1
+  17.2222222,23.8888889,0.207383768, !-X Value #2,Y Value #2,Output #2
+  17.2222222,29.4444444,0.237525541, !-X Value #3,Y Value #3,Output #3
+  17.2222222,35,0.274217751,         !-X Value #4,Y Value #4,Output #4
+  17.2222222,40.5555556,0.318548624, !-X Value #5,Y Value #5,Output #5
+  17.2222222,46.1111111,0.374560389, !-X Value #6,Y Value #6,Output #6
+  19.4444444,18.3333333,0.172982816, !-X Value #7,Y Value #7,Output #7
+  19.4444444,23.8888889,0.19637691,  !-X Value #8,Y Value #8,Output #8
+  19.4444444,29.4444444,0.224789822, !-X Value #9,Y Value #9,Output #9
+  19.4444444,35,0.258266502,         !-X Value #10,Y Value #10,Output #10
+  19.4444444,40.5555556,0.299896794, !-X Value #11,Y Value #11,Output #11
+  19.4444444,46.1111111,0.351242021, !-X Value #12,Y Value #12,Output #12
+  21.6666667,18.3333333,0.164081122, !-X Value #13,Y Value #13,Output #13
+  21.6666667,23.8888889,0.185603303, !-X Value #14,Y Value #14,Output #14
+  21.6666667,29.4444444,0.211709812, !-X Value #15,Y Value #15,Output #15
+  21.6666667,35,0.243492052,         !-X Value #16,Y Value #16,Output #16
+  21.6666667,40.5555556,0.281757875, !-X Value #17,Y Value #17,Output #17
+  21.6666667,46.1111111,0.331185659; !-X Value #18,Y Value #18,Output #18
 \end{lstlisting}
 
 \subsubsection{Outputs}\label{outputs-1-017}
@@ -333,7 +333,7 @@ A unique user assigned name for an instance of a lookup table. When a table is u
 
 \paragraph{Field: Interpolation Method}\label{field-interpolation-method-2}
 
-The method used to evaluate the lookup table. The choices are \emph{LinearInterpolationOfTable, LagrangeInterpolationLinearExtrapolation, and EvaluateCurveToLimits}. . When \emph{LinearInterpolationOfTable} is selected, the data entered is evaluated within the limits of the data set and the minimum/maximum value of x and output inputs are used only within the boundary of the table limits (i.e., are only used to limit interpolation). A complete data set is required. For each X variable, entries must include all Y variables and associated curve output (i.e., a complete table, no gaps or missing data). Extrapolation of the data set is not allowed. When \emph{LagrangeInterpolationLinearExtrapolation} is selected, the lookup table is evaluated using Lagrange s form of the interpolating polynomial. The order of the polynomial is inferred to be one less than the input in the Number of Interpolation Points field below. When \emph{EvaluateCurveToLimits} is selected, the coefficients (i.e., C in the equation above) of the polynomial equation are calculated and used to determine the table output within the limits specified in the following fields (or the tabular data, whichever provide the larger range). If the minimum/maximum fields below are not entered, the limits of the data set are used. A complete table is not required when using this method, however, a minimum number of data is required to perform the regression analysis. The minimum number of data pairs required for this choice is 6 data pairs for both bi-quadratic and quadratic-linear curve types. If insufficient data is provided, the simulation reverts to interpolating the tabular data. The performance curve is written to the eio file when the output diagnotics flag DisplayAdvancedVariables is used (ref. Output:Diagnostics, DisplayAdvancedVariables). A regression analysis may only be performed on lookup tables with one or two independent variables.
+The method used to evaluate the lookup table. The choices are \emph{LinearInterpolationOfTable, LagrangeInterpolationLinearExtrapolation, and EvaluateCurveToLimits}. When \emph{LinearInterpolationOfTable} is selected, the data entered is evaluated within the limits of the data set and the minimum/maximum value of x and output inputs are used only within the boundary of the table limits (i.e., are only used to limit interpolation). A complete data set is required. For each X variable, entries must include all Y variables and associated curve output (i.e., a complete table, no gaps or missing data). Extrapolation of the data set is not allowed. When \emph{LagrangeInterpolationLinearExtrapolation} is selected, the lookup table is evaluated using Lagrange s form of the interpolating polynomial. The order of the polynomial is inferred to be one less than the input in the Number of Interpolation Points field below. When \emph{EvaluateCurveToLimits} is selected, the coefficients (i.e., C in the equation above) of the polynomial equation are calculated and used to determine the table output within the limits specified in the following fields. If the minimum/maximum fields below are not entered, the limits of the data set are used. A complete table is not required when using this method, however, a minimum number of data is required to perform the regression analysis. The minimum number of data pairs required for this choice is 6 data pairs for both bi-quadratic and quadratic-linear curve types. If insufficient data is provided, the simulation reverts to interpolating the tabular data. The performance curve is written to the eio file when the output diagnostics flag DisplayAdvancedVariables is used (ref. Output:Diagnostics, DisplayAdvancedVariables). A regression analysis may only be performed on lookup tables with one or two independent variables.
 
 \paragraph{Field: Number of Interpolation Points}\label{field-number-of-interpolation-points}
 
@@ -409,51 +409,51 @@ The normalization point for the data set. This field provides a method for autom
 
 \paragraph{Field: Minimum Value of X1}\label{field-minimum-value-of-x1}
 
-The minimum allowable value of X1. Values of X1 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit.
+The minimum allowable value of X1. Values of X1 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Maximum Value of X1}\label{field-maximum-value-of-x1}
 
-The maximum allowable value of X1. Values of X1 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit.
+The maximum allowable value of X1. Values of X1 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Minimum Value of X2}\label{field-minimum-value-of-x2}
 
-The minimum allowable value of X2. Values of X2 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 1.
+The minimum allowable value of X2. Values of X2 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 1.
 
 \paragraph{Field: Maximum Value of X2}\label{field-maximum-value-of-x2}
 
-The maximum allowable value of X2. Values of X2 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 1.
+The maximum allowable value of X2. Values of X2 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 1.
 
 \paragraph{Field: Minimum Value of X3}\label{field-minimum-value-of-x3}
 
-The minimum allowable value of X3. Values of X3 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 2.
+The minimum allowable value of X3. Values of X3 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 2.
 
 \paragraph{Field: Maximum Value of X3}\label{field-maximum-value-of-x3}
 
-The maximum allowable value of X3. Values of X3 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 2.
+The maximum allowable value of X3. Values of X3 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 2.
 
 \paragraph{Field: Minimum Value of X4}\label{field-minimum-value-of-x4}
 
-The minimum allowable value of X4. Values of X4 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 3.
+The minimum allowable value of X4. Values of X4 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 3.
 
 \paragraph{Field: Maximum Value of X4}\label{field-maximum-value-of-x4}
 
-The maximum allowable value of X4. Values of X4 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 3.
+The maximum allowable value of X4. Values of X4 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 3.
 
 \paragraph{Field: Minimum Value of X5}\label{field-minimum-value-of-x5}
 
-The minimum allowable value of X5. Values of X5 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 4.
+The minimum allowable value of X5. Values of X5 less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 4.
 
 \paragraph{Field: Maximum Value of X5}\label{field-maximum-value-of-x5}
 
-The maximum allowable value of X5. Values of X5 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 4.
+The maximum allowable value of X5. Values of X5 greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit. This field is only used when the number of independent variables is greater than 4.
 
 \paragraph{Field: Minimum Curve Output}\label{field-minimum-curve-output-000}
 
-The minimum allowable value of the evaluated curve. Values less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit.
+The minimum allowable value of the evaluated curve. Values less than the minimum will be replaced by the minimum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Maximum Curve Output}\label{field-maximum-curve-output-000}
 
-The maximum allowable value of the evaluated curve. Values greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This filed can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit.
+The maximum allowable value of the evaluated curve. Values greater than the maximum will be replaced by the maximum. This field can only limit extrapolation when the \emph{Interpolation Method} is selected as \emph{EvaluateCurveToLimits or LagrangeInterpolationLinearExtrapolation}. This field can be used to limit interpolation using any \emph{Interpolation Method.} If this field is left blank, the data set determines the limit.
 
 \paragraph{Field: Input Unit Type for X1}\label{field-input-unit-type-for-x1-1}
 
@@ -565,7 +565,7 @@ This field is used to indicate the kind of units that may be associated with the
 
 \subsection{Data Input Format}\label{data-input-format}
 
-The following inputs describe the data set. These values may also be placed in an external file starting with Field \#1. If an external file name is entered above, the following fields are not used. Data are entered in a specific order according to the number and quantity of independent variables. The data input format is described here in 3 groups as Header, Independent Variable Values, and the Tabular Data. The header is always the first line in the data set and represents the number of independent varibles followed by the number of values for each independent variable. The independent variable values are listed next and represent the values of each independent variable on a separate line. These values are only listed once at the top of the data set and are listed in ascending order. The number of independent variables, the first number in the header, specifies how many lines, or rows, make up this section of tabular data. The remaining lines are repeated as many times as necessary to completely describe the tabular data. The values of independent variables 3 n are listed on a single line followed by a matrix of data that represent the table output corresponding to independent variables 1 and 2.
+The following inputs describe the data set. These values may also be placed in an external file starting with Field \#1. If an external file name is entered above, the following fields are not used. Data are entered in a specific order according to the number and quantity of independent variables. The data input format is described here in 3 groups as Header, Independent Variable Values, and the Tabular Data. The header is always the first line in the data set and represents the number of independent variables followed by the number of values for each independent variable. The independent variable values are listed next and represent the values of each independent variable on a separate line. These values are only listed once at the top of the data set and are listed in ascending order. The number of independent variables, the first number in the header, specifies how many lines, or rows, make up this section of tabular data. The remaining lines are repeated as many times as necessary to completely describe the tabular data. The values of independent variables 3 n are listed on a single line followed by a matrix of data that represent the table output corresponding to independent variables 1 and 2.
 
 \begin{itemize}
 \tightlist
@@ -599,7 +599,7 @@ Line 5: the n values for the fifth independent variable as specified in the head
 
 Line 1: the values of the 3\(^{rd}\) through nth independent variables
 
-Line 2 m (where m-1 equals the number of variables for the second independent variable): the tabular data corresponding to the 1\(^{st}\) independent variable (the number of inputs on this line equals the number of values for 1\(^{st}\) independent variable), the mth values for the 2\(^{nd}\) independent variable and corresponding to the values for the 3\(^{rd}\) nth independent variables (see Line 1 above for Tabular Data).
+Line 2 m (where m-1 equals the number of variables for the second independent variable): the tabular data corresponding to the 1\(^{st}\) independent variable (the number of inputs on this line equals the number of values for 1\(^{st}\) independent variable), the m\(^{th})\) values for the 2\(^{nd}\) independent variable and corresponding to the values for the 3\(^{rd}\) nth independent variables (see Line 1 above for Tabular Data).
 
 Three examples are provided here as this can be difficult to describe in text. This example assumes that the table data are listed in ascending order from lowest to highest.
 
@@ -745,33 +745,33 @@ Following is an example input for a Table:MultiVariableLookup object:
 \begin{lstlisting}
 
 Table:MultiVariableLookup,
-  HPACCoolCapFT,                       !- Name
+  HPACCoolCapFT,                   !- Name
   LagrangeinterpolationLinearExtrapolation,   !- Interpolation Method
-  3,                                               !- Number of Interpolation Points
-  BiQuadratic,                           !- Interpolation Type
+  3,                               !- Number of Interpolation Points
+  BiQuadratic,                     !- Interpolation Type
   SingleLineIndependentVariableWithMatrix, !- Table Data Format
-  ,                                                 !- External File Name
-  ASCENDING,                               !- X1 Sort Order
-  ASCENDING,                               !- X2 Sort Order
-  24999.9597049817,                 !- Normalization reference
-  12.77778,                                 !- Minimum Value of X1,
-  23.88889,                                 !- Maximum Value of X1,
-  18.0,                                         !- Minimum Value of X2,
-  46.11111,                                 !- Maximum Value of X2,
-  ,                                                 !- Minimum Value of X3
-  ,                                                 !- Maximum Value of X3
-  ,                                                 !- Minimum Value of X4
-  ,                                                 !- Maximum Value of X4
-  ,                                                 !- Minimum Value of X5
-  ,                                                 !- Maximum Value of X5
-  ,                                                 !- Minimum Table Output
-  ,                                                 !- Maximum Table Output
-  Temperature,                           !- Input Unit Type for X1
-  Temperature,                           !- Input Unit Type for X2
-  ,                                                 !- Input Unit Type for X3
-  ,                                                 !- Input Unit Type for X4
-  ,                                                 !- Input Unit Type for X5
-  Dimensionless,                       !- Output Unit Type
+  ,                                !- External File Name
+  ASCENDING,                       !- X1 Sort Order
+  ASCENDING,                       !- X2 Sort Order
+  24999.9597049817,                !- Normalization reference
+  12.77778,                        !- Minimum Value of X1,
+  23.88889,                        !- Maximum Value of X1,
+  18.0,                            !- Minimum Value of X2,
+  46.11111,                        !- Maximum Value of X2,
+  ,                                !- Minimum Value of X3
+  ,                                !- Maximum Value of X3
+  ,                                !- Minimum Value of X4
+  ,                                !- Maximum Value of X4
+  ,                                !- Minimum Value of X5
+  ,                                !- Maximum Value of X5
+  ,                                !- Minimum Table Output
+  ,                                !- Maximum Table Output
+  Temperature,                     !- Input Unit Type for X1
+  Temperature,                     !- Input Unit Type for X2
+  ,                                !- Input Unit Type for X3
+  ,                                !- Input Unit Type for X4
+  ,                                !- Input Unit Type for X5
+  Dimensionless,                   !- Output Unit Type
   2, 6, 7,
   12.77778, 15, 18, 19.44448943, 21, 23.88889,
   18, 24, 30, 35, 36, 41, 46.11111,
@@ -788,7 +788,7 @@ Table:MultiVariableLookup,
 
 \subsubsection{\texorpdfstring{Performance Curve Output Value {[]}}{Performance Curve Output Value }}\label{performance-curve-output-value-2}
 
-The current value of the lookup table. Performance curves and tables use the same output variable. This value is averaged over the time step being reported. Inactive or unused performance curves will show a value of -999 (e.g., equipment is off, a specific performance curve is not required for this aspect of the equipment model at this time step, etc.). This value means that the performance curve was not called during the simulation and, therefore, not evaluated. This inactive state value is only set at the beginning of each environment. When averaging over long periods of time, this inactive state value may skew results. In this case, use a detaled reporting frequency (ref. Output:Variable object) to view results at each HVAC time step.
+The current value of the lookup table. Performance curves and tables use the same output variable. This value is averaged over the time step being reported. Inactive or unused performance curves will show a value of -999 (e.g., equipment is off, a specific performance curve is not required for this aspect of the equipment model at this time step, etc.). This value means that the performance curve was not called during the simulation and, therefore, not evaluated. This inactive state value is only set at the beginning of each environment. When averaging over long periods of time, this inactive state value may skew results. In this case, use a detailed reporting frequency (ref. Output:Variable object) to view results at each HVAC time step.
 
 \subsubsection{\texorpdfstring{Performance Curve Input Variable 1(-N) Value {[]}}{Performance Curve Input Variable 1(-N) Value }}\label{performance-curve-input-variable-1-n-value-000}
 

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -1996,7 +1996,7 @@ namespace CurveManager {
 					ShowContinueError( "The requested regression analysis is not available at this time. Curve type = " + Alphas( 2 ) );
 					PerfCurve( CurveIndex ).InterpolationType = LinearInterpolationOfTable;
 				}}
-			}
+			} 
 			// move table data to more compact array to allow interpolation using multivariable lookup table method
 			TableLookup( TableNum ).NumIndependentVars = 1;
 			TableLookup( TableNum ).NumX1Vars = size( PerfCurveTableData( TableNum ).X1 );

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -1886,22 +1886,22 @@ namespace CurveManager {
 			}}
 
 			if ( lNumericFieldBlanks( 1 ) ) {
-				PerfCurve( CurveNum ).Var1Min = 99999999999.0;
+				PerfCurve( CurveNum ).Var1Min = -99999999999.0;
 			} else {
 				PerfCurve( CurveNum ).Var1Min = Numbers( 1 );
+				PerfCurve( CurveNum ).Var1MinPresent = true;
 			}
 			if ( lNumericFieldBlanks( 2 ) ) {
-				PerfCurve( CurveNum ).Var1Max = -99999999999.0;
+				PerfCurve( CurveNum ).Var1Max = 99999999999.0;
 			} else {
 				PerfCurve( CurveNum ).Var1Max = Numbers( 2 );
+				PerfCurve( CurveNum ).Var1MaxPresent = true;
 			}
 
-			if ( ! lNumericFieldBlanks( 1 ) && ! lNumericFieldBlanks( 2 ) ) {
-				if ( Numbers( 1 ) > Numbers( 2 ) ) { // error
-					ShowSevereError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
-					ShowContinueError( cNumericFieldNames( 1 ) + " [" + RoundSigDigits( Numbers( 1 ), 2 ) + "] > " + cNumericFieldNames( 2 ) + " [" + RoundSigDigits( Numbers( 2 ), 2 ) + ']' );
-					ErrorsFound = true;
-				}
+			if ( Numbers( 1 ) > Numbers( 2 ) ) { // error
+				ShowSevereError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
+				ShowContinueError( cNumericFieldNames( 1 ) + " [" + RoundSigDigits( Numbers( 1 ), 2 ) + "] > " + cNumericFieldNames( 2 ) + " [" + RoundSigDigits( Numbers( 2 ), 2 ) + ']' );
+				ErrorsFound = true;
 			}
 			if ( NumAlphas >= 4 ) {
 				if ( ! IsCurveInputTypeValid( Alphas( 4 ) ) ) {
@@ -2066,10 +2066,30 @@ namespace CurveManager {
 				ErrorsFound = true;
 			}}
 
-			PerfCurve( CurveNum ).Var1Min = Numbers( 1 );
-			PerfCurve( CurveNum ).Var1Max = Numbers( 2 );
-			PerfCurve( CurveNum ).Var2Min = Numbers( 3 );
-			PerfCurve( CurveNum ).Var2Max = Numbers( 4 );
+			if( lNumericFieldBlanks( 1 ) ) {
+				PerfCurve( CurveNum ).Var1Min = -99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var1Min = Numbers( 1 );
+				PerfCurve( CurveNum ).Var1MinPresent = true;
+			}
+			if( lNumericFieldBlanks( 2 ) ) {
+				PerfCurve( CurveNum ).Var1Max = 99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var1Max = Numbers( 2 );
+				PerfCurve( CurveNum ).Var1MaxPresent = true;
+			}
+			if( lNumericFieldBlanks( 3 ) ) {
+				PerfCurve( CurveNum ).Var2Min = -99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var2Min = Numbers( 3 );
+				PerfCurve( CurveNum ).Var2MinPresent = true;
+			}
+			if( lNumericFieldBlanks( 4 ) ) {
+				PerfCurve( CurveNum ).Var2Max = 99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var2Max = Numbers( 4 );
+				PerfCurve( CurveNum ).Var2MaxPresent = true;
+			}
 
 			if ( Numbers( 1 ) > Numbers( 2 ) ) { // error
 				ShowSevereError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
@@ -2346,16 +2366,66 @@ namespace CurveManager {
 			} else {
 				TableData( TableNum ).NormalPoint = 1.0;
 			}
-			PerfCurve( CurveNum ).Var1Min = Numbers( 3 );
-			PerfCurve( CurveNum ).Var1Max = Numbers( 4 );
-			PerfCurve( CurveNum ).Var2Min = Numbers( 5 );
-			PerfCurve( CurveNum ).Var2Max = Numbers( 6 );
-			PerfCurve( CurveNum ).Var3Min = Numbers( 7 );
-			PerfCurve( CurveNum ).Var3Max = Numbers( 8 );
-			PerfCurve( CurveNum ).Var4Min = Numbers( 9 );
-			PerfCurve( CurveNum ).Var4Max = Numbers( 10 );
-			PerfCurve( CurveNum ).Var5Min = Numbers( 11 );
-			PerfCurve( CurveNum ).Var5Max = Numbers( 12 );
+			if( lNumericFieldBlanks( 3 ) ) {
+				PerfCurve( CurveNum ).Var1Min = -99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var1Min = Numbers( 3 );
+				PerfCurve( CurveNum ).Var1MinPresent = true;
+			}
+			if( lNumericFieldBlanks( 4 ) ) {
+				PerfCurve( CurveNum ).Var1Max = 99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var1Max = Numbers( 4 );
+				PerfCurve( CurveNum ).Var1MaxPresent = true;
+			}
+			if( lNumericFieldBlanks( 5 ) ) {
+				PerfCurve( CurveNum ).Var2Min = -99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var2Min = Numbers( 5 );
+				PerfCurve( CurveNum ).Var2MinPresent = true;
+			}
+			if( lNumericFieldBlanks( 6 ) ) {
+				PerfCurve( CurveNum ).Var2Max = 99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var2Max = Numbers( 6 );
+				PerfCurve( CurveNum ).Var2MaxPresent = true;
+			}
+			if( lNumericFieldBlanks( 7 ) ) {
+				PerfCurve( CurveNum ).Var3Min = -99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var3Min = Numbers( 7 );
+				PerfCurve( CurveNum ).Var3MinPresent = true;
+			}
+			if( lNumericFieldBlanks( 8 ) ) {
+				PerfCurve( CurveNum ).Var3Max = 99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var3Max = Numbers( 8 );
+				PerfCurve( CurveNum ).Var3MaxPresent = true;
+			}
+			if( lNumericFieldBlanks( 9 ) ) {
+				PerfCurve( CurveNum ).Var4Min = -99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var4Min = Numbers( 9 );
+				PerfCurve( CurveNum ).Var4MinPresent = true;
+			}
+			if( lNumericFieldBlanks( 10 ) ) {
+				PerfCurve( CurveNum ).Var4Max = 99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var4Max = Numbers( 10 );
+				PerfCurve( CurveNum ).Var4MaxPresent = true;
+			}
+			if( lNumericFieldBlanks( 11 ) ) {
+				PerfCurve( CurveNum ).Var5Min = -99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var5Min = Numbers( 11 );
+				PerfCurve( CurveNum ).Var5MinPresent = true;
+			}
+			if( lNumericFieldBlanks( 12 ) ) {
+				PerfCurve( CurveNum ).Var5Max = 99999999999.0;
+			} else {
+				PerfCurve( CurveNum ).Var5Max = Numbers( 12 );
+				PerfCurve( CurveNum ).Var5MaxPresent = true;
+			}
 
 			if ( Numbers( 3 ) > Numbers( 4 ) ) { // error
 				ShowSevereError( "GetTableInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
@@ -4698,12 +4768,24 @@ Label999: ;
 		{ auto const SELECT_CASE_var( PerfCurve( CurveNum ).InterpolationType );
 		if ( SELECT_CASE_var == LinearInterpolationOfTable ) {
 		} else if ( SELECT_CASE_var == EvaluateCurveToLimits ) {
-			MinX = min( MinX, PerfCurve( CurveNum ).Var1Min );
-			MaxX = max( MaxX, PerfCurve( CurveNum ).Var1Max );
-			MinX2 = min( MinX2, PerfCurve( CurveNum ).Var2Min );
-			MaxX2 = max( MaxX2, PerfCurve( CurveNum ).Var2Max );
-			MinY = min( MinY, PerfCurve( CurveNum ).CurveMin );
-			MaxY = max( MaxY, PerfCurve( CurveNum ).CurveMax );
+			if ( PerfCurve( CurveNum ).Var1MinPresent ) {
+				MinX = PerfCurve( CurveNum ).Var1Min;
+			}
+			if ( PerfCurve( CurveNum ).Var1MaxPresent ) {
+				MaxX = PerfCurve( CurveNum ).Var1Max;
+			}
+			if( PerfCurve( CurveNum ).Var2MinPresent ) {
+				MinX2 = PerfCurve( CurveNum ).Var2Min;
+			}
+			if( PerfCurve( CurveNum ).Var2MaxPresent ) {
+				MaxX2 = PerfCurve( CurveNum ).Var2Max;
+			}
+			if( PerfCurve( CurveNum ).CurveMinPresent ) {
+				MinY = PerfCurve( CurveNum ).CurveMin;
+			}
+			if( PerfCurve( CurveNum ).CurveMaxPresent ) {
+				MaxY = PerfCurve( CurveNum ).CurveMax;
+			}
 		} else {
 		}}
 

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -1997,10 +1997,10 @@ namespace CurveManager {
 					PerfCurve( CurveIndex ).InterpolationType = LinearInterpolationOfTable;
 				}}
 				if ( !PerfCurve( CurveNum ).Var1MinPresent ) {
-					PerfCurve( CurveNum ).Var1Min = minval( PerfCurveTableData( TableNum ).X1 );
+					PerfCurve( CurveNum ).Var1Min = minval( TableData( TableNum ).X1 );
 				}
 				if ( !PerfCurve( CurveNum ).Var1MaxPresent ) {
-					PerfCurve( CurveNum ).Var1Max = maxval( PerfCurveTableData( TableNum ).X1 );
+					PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
 				}
 			} 
 
@@ -2024,6 +2024,16 @@ namespace CurveManager {
 						PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
 					}
 				} else {
+					PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
+				}
+			}
+
+			// if user does not enter limits, set to min/max in table
+			if( PerfCurve( CurveNum ).InterpolationType == LagrangeInterpolationLinearExtrapolation ) {
+				if( !PerfCurve( CurveNum ).Var1MinPresent ) {
+					PerfCurve( CurveNum ).Var1Min = minval( TableData( TableNum ).X1 );
+				}
+				if( !PerfCurve( CurveNum ).Var1MaxPresent ) {
 					PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
 				}
 			}
@@ -2350,6 +2360,21 @@ namespace CurveManager {
 						PerfCurve( CurveNum ).Var2Max = maxval( TableData( TableNum ).X2 );
 					}
 				} else {
+					PerfCurve( CurveNum ).Var2Max = maxval( TableData( TableNum ).X2 );
+				}
+			}
+			// if user does not enter limits, set to min/max in table
+			if( PerfCurve( CurveNum ).InterpolationType == LagrangeInterpolationLinearExtrapolation ) {
+				if( !PerfCurve( CurveNum ).Var1MinPresent ) {
+					PerfCurve( CurveNum ).Var1Min = minval( TableData( TableNum ).X1 );
+				}
+				if( !PerfCurve( CurveNum ).Var1MaxPresent ) {
+					PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
+				}
+				if( !PerfCurve( CurveNum ).Var2MinPresent ) {
+					PerfCurve( CurveNum ).Var2Min = minval( TableData( TableNum ).X2 );
+				}
+				if( !PerfCurve( CurveNum ).Var2MaxPresent ) {
 					PerfCurve( CurveNum ).Var2Max = maxval( TableData( TableNum ).X2 );
 				}
 			}

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -1996,6 +1996,12 @@ namespace CurveManager {
 					ShowContinueError( "The requested regression analysis is not available at this time. Curve type = " + Alphas( 2 ) );
 					PerfCurve( CurveIndex ).InterpolationType = LinearInterpolationOfTable;
 				}}
+				if ( !PerfCurve( CurveNum ).Var1MinPresent ) {
+					PerfCurve( CurveNum ).Var1Min = minval( PerfCurveTableData( TableNum ).X1 );
+				}
+				if ( !PerfCurve( CurveNum ).Var1MaxPresent ) {
+					PerfCurve( CurveNum ).Var1Max = maxval( PerfCurveTableData( TableNum ).X1 );
+				}
 			} 
 
 			// if user enters limits that exceed data range, warn that limits are based on table data
@@ -2005,14 +2011,20 @@ namespace CurveManager {
 						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
 						ShowContinueError( cNumericFieldNames( 1 ) + " exceeds the data range and will not be used." );
 						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 1 ), 6 ) + ", Minimum data range = " + RoundSigDigits( minval( TableData( TableNum ).X1 ), 6 ) );
+						PerfCurve( CurveNum ).Var1Min = minval( TableData( TableNum ).X1 );
 					}
+				} else {
+					PerfCurve( CurveNum ).Var1Min = minval( TableData( TableNum ).X1 );
 				}
 				if ( PerfCurve( CurveNum ).Var1MaxPresent ) {
 					if ( PerfCurve( CurveNum ).Var1Max > maxval( TableData( TableNum ).X1 ) ) {
 						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
 						ShowContinueError( cNumericFieldNames( 2 ) + " exceeds the data range and will not be used." );
 						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 2 ), 6 ) + ", Maximum data range = " + RoundSigDigits( maxval( TableData( TableNum ).X1 ), 6 ) );
+						PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
 					}
+				} else {
+					PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
 				}
 			}
 
@@ -2284,6 +2296,18 @@ namespace CurveManager {
 					ShowContinueError( "The requested regression analysis is not available at this time. Curve type = " + Alphas( 2 ) );
 					PerfCurve( CurveIndex ).InterpolationType = LinearInterpolationOfTable;
 				}}
+				if ( !PerfCurve( CurveNum ).Var1MinPresent ) {
+					PerfCurve( CurveNum ).Var1Min = minval( TableData( TableNum ).X1 );
+				}
+				if ( !PerfCurve( CurveNum ).Var1MaxPresent ) {
+					PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
+				}
+				if ( !PerfCurve( CurveNum ).Var2MinPresent ) {
+					PerfCurve( CurveNum ).Var2Min = minval( TableData( TableNum ).X2 );
+				}
+				if ( !PerfCurve( CurveNum ).Var2MaxPresent ) {
+					PerfCurve( CurveNum ).Var2Max = maxval( TableData( TableNum ).X2 );
+				}
 			}
 
 			// if user enters limits that exceed data range, warn that limits are based on table data
@@ -2293,28 +2317,40 @@ namespace CurveManager {
 						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
 						ShowContinueError( cNumericFieldNames( 1 ) + " exceeds the data range and will not be used." );
 						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 1 ), 6 ) + ", Minimum data range = " + RoundSigDigits( minval( TableData( TableNum ).X1 ), 6 ) );
+						PerfCurve( CurveNum ).Var1Min = minval( TableData( TableNum ).X1 );
 					}
+				} else {
+					PerfCurve( CurveNum ).Var1Min = minval( TableData( TableNum ).X1 );
 				}
 				if ( PerfCurve( CurveNum ).Var1MaxPresent ) {
 					if ( PerfCurve( CurveNum ).Var1Max > maxval( TableData( TableNum ).X1 ) ) {
 						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
 						ShowContinueError( cNumericFieldNames( 2 ) + " exceeds the data range and will not be used." );
 						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 2 ), 6 ) + ", Maximum data range = " + RoundSigDigits( maxval( TableData( TableNum ).X1 ), 6 ) );
+						PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
 					}
+				} else {
+					PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
 				}
 				if ( PerfCurve( CurveNum ).Var2MinPresent ) {
 					if ( PerfCurve( CurveNum ).Var2Min < minval( TableData( TableNum ).X2 ) ) {
 						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
 						ShowContinueError( cNumericFieldNames( 3 ) + " exceeds the data range and will not be used." );
 						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 3 ), 6 ) + ", Minimum data range = " + RoundSigDigits( minval( TableData( TableNum ).X2 ), 6 ) );
+						PerfCurve( CurveNum ).Var2Min = minval( TableData( TableNum ).X2 );
 					}
+				} else {
+					PerfCurve( CurveNum ).Var2Min = minval( TableData( TableNum ).X2 );
 				}
 				if ( PerfCurve( CurveNum ).Var2MaxPresent ) {
 					if ( PerfCurve( CurveNum ).Var2Max > maxval( TableData( TableNum ).X2 ) ) {
 						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
 						ShowContinueError( cNumericFieldNames( 4 ) + " exceeds the data range and will not be used." );
 						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 4 ), 6 ) + ", Maximum data range = " + RoundSigDigits( maxval( TableData( TableNum ).X2 ), 6 ) );
+						PerfCurve( CurveNum ).Var2Max = maxval( TableData( TableNum ).X2 );
 					}
+				} else {
+					PerfCurve( CurveNum ).Var2Max = maxval( TableData( TableNum ).X2 );
 				}
 			}
 

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -4997,10 +4997,6 @@ Label999: ;
 		PerfCurve( CurveNum ).Var1Max = MaxX;
 		PerfCurve( CurveNum ).Var2Min = MinX2;
 		PerfCurve( CurveNum ).Var2Max = MaxX2;
-		PerfCurve( CurveNum ).CurveMin = MinY;
-		PerfCurve( CurveNum ).CurveMax = MaxY;
-		PerfCurve( CurveNum ).CurveMinPresent = true;
-		PerfCurve( CurveNum ).CurveMaxPresent = true;
 
 		A.deallocate();
 		Results.deallocate();

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -1997,6 +1997,25 @@ namespace CurveManager {
 					PerfCurve( CurveIndex ).InterpolationType = LinearInterpolationOfTable;
 				}}
 			}
+
+			// if user enters limits that exceed data range, warn that limits are based on table data
+			if ( PerfCurve( CurveNum ).InterpolationType == LinearInterpolationOfTable ) {
+				if ( PerfCurve( CurveNum ).Var1MinPresent ) {
+					if ( PerfCurve( CurveNum ).Var1Min < minval( TableData( TableNum ).X1 ) ) {
+						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
+						ShowContinueError( cNumericFieldNames( 1 ) + " exceeds the data range and will not be used." );
+						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 1 ), 6 ) + ", Minimum data range = " + RoundSigDigits( minval( TableData( TableNum ).X1 ), 6 ) );
+					}
+				}
+				if ( PerfCurve( CurveNum ).Var1MaxPresent ) {
+					if ( PerfCurve( CurveNum ).Var1Max > maxval( TableData( TableNum ).X1 ) ) {
+						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
+						ShowContinueError( cNumericFieldNames( 2 ) + " exceeds the data range and will not be used." );
+						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 2 ), 6 ) + ", Maximum data range = " + RoundSigDigits( maxval( TableData( TableNum ).X1 ), 6 ) );
+					}
+				}
+			}
+
 			// move table data to more compact array to allow interpolation using multivariable lookup table method
 			TableLookup( TableNum ).NumIndependentVars = 1;
 			TableLookup( TableNum ).NumX1Vars = size( PerfCurveTableData( TableNum ).X1 );
@@ -2265,6 +2284,38 @@ namespace CurveManager {
 					ShowContinueError( "The requested regression analysis is not available at this time. Curve type = " + Alphas( 2 ) );
 					PerfCurve( CurveIndex ).InterpolationType = LinearInterpolationOfTable;
 				}}
+			}
+
+			// if user enters limits that exceed data range, warn that limits are based on table data
+			if ( PerfCurve( CurveNum ).InterpolationType == LinearInterpolationOfTable ) {
+				if ( PerfCurve( CurveNum ).Var1MinPresent ) {
+					if ( PerfCurve( CurveNum ).Var1Min < minval( TableData( TableNum ).X1 ) ) {
+						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
+						ShowContinueError( cNumericFieldNames( 1 ) + " exceeds the data range and will not be used." );
+						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 1 ), 6 ) + ", Minimum data range = " + RoundSigDigits( minval( TableData( TableNum ).X1 ), 6 ) );
+					}
+				}
+				if ( PerfCurve( CurveNum ).Var1MaxPresent ) {
+					if ( PerfCurve( CurveNum ).Var1Max > maxval( TableData( TableNum ).X1 ) ) {
+						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
+						ShowContinueError( cNumericFieldNames( 2 ) + " exceeds the data range and will not be used." );
+						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 2 ), 6 ) + ", Maximum data range = " + RoundSigDigits( maxval( TableData( TableNum ).X1 ), 6 ) );
+					}
+				}
+				if ( PerfCurve( CurveNum ).Var2MinPresent ) {
+					if ( PerfCurve( CurveNum ).Var2Min < minval( TableData( TableNum ).X2 ) ) {
+						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
+						ShowContinueError( cNumericFieldNames( 3 ) + " exceeds the data range and will not be used." );
+						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 3 ), 6 ) + ", Minimum data range = " + RoundSigDigits( minval( TableData( TableNum ).X2 ), 6 ) );
+					}
+				}
+				if ( PerfCurve( CurveNum ).Var2MaxPresent ) {
+					if ( PerfCurve( CurveNum ).Var2Max > maxval( TableData( TableNum ).X2 ) ) {
+						ShowWarningError( "GetCurveInput: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
+						ShowContinueError( cNumericFieldNames( 4 ) + " exceeds the data range and will not be used." );
+						ShowContinueError( " Entered value = " + RoundSigDigits( Numbers( 4 ), 6 ) + ", Maximum data range = " + RoundSigDigits( maxval( TableData( TableNum ).X2 ), 6 ) );
+					}
+				}
 			}
 
 			// move table data to more compact array to allow interpolation using multivariable lookup table method

--- a/src/EnergyPlus/CurveManager.hh
+++ b/src/EnergyPlus/CurveManager.hh
@@ -291,6 +291,16 @@ namespace CurveManager {
 		Real64 CurveMax; // maximum value of curve output
 		bool CurveMinPresent; // If TRUE, then cap minimum curve output
 		bool CurveMaxPresent; // if TRUE, then cap maximum curve output
+		bool Var1MinPresent;  // uses data set limit to set Var1Min if false
+		bool Var1MaxPresent;  // uses data set limit to set Var1Max if false
+		bool Var2MinPresent;  // uses data set limit to set Var2Min if false
+		bool Var2MaxPresent;  // uses data set limit to set Var2Max if false
+		bool Var3MinPresent;  // uses data set limit to set Var3Min if false
+		bool Var3MaxPresent;  // uses data set limit to set Var3Max if false
+		bool Var4MinPresent;  // uses data set limit to set Var4Min if false
+		bool Var4MaxPresent;  // uses data set limit to set Var4Max if false
+		bool Var5MinPresent;  // uses data set limit to set Var5Min if false
+		bool Var5MaxPresent;  // uses data set limit to set Var5Max if false
 		Array1D< TriQuadraticCurveDataStruct > Tri2ndOrder; // structure for triquadratic curve data
 		bool EMSOverrideOn; // if TRUE, then EMS is calling to override curve value
 		Real64 EMSOverrideCurveValue; // Value of curve result EMS is directing to use
@@ -340,6 +350,16 @@ namespace CurveManager {
 			CurveMax( 0.0 ),
 			CurveMinPresent( false ),
 			CurveMaxPresent( false ),
+			Var1MinPresent( false ),
+			Var1MaxPresent( false ),
+			Var2MinPresent( false ),
+			Var2MaxPresent( false ),
+			Var3MinPresent( false ),
+			Var3MaxPresent( false ),
+			Var4MinPresent( false ),
+			Var4MaxPresent( false ),
+			Var5MinPresent( false ),
+			Var5MaxPresent( false ),
 			EMSOverrideOn( false ),
 			EMSOverrideCurveValue( 0.0 ),
 			CurveOutput( 0.0 ),

--- a/testfiles/1ZoneDataCenterCRAC_wPumpedDXCoolingCoil.idf
+++ b/testfiles/1ZoneDataCenterCRAC_wPumpedDXCoolingCoil.idf
@@ -415,7 +415,7 @@
     13.0,                    !- Minimum Value of X
     23.89,                   !- Maximum Value of X
     -10.0,                   !- Minimum Value of Y
-    46.11,                   !- Maximum Value of Y
+    46.0,                    !- Maximum Value of Y
     ,                        !- Minimum Table Output
     ,                        !- Maximum Table Output
     Temperature,             !- Input Unit Type for X

--- a/tst/EnergyPlus/unit/CurveManager.unit.cc
+++ b/tst/EnergyPlus/unit/CurveManager.unit.cc
@@ -417,8 +417,8 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_NotAnd
 		Real64 min1, max1, min2, max2;
 		CurveManager::GetCurveMinMaxValues( 1, min1, max1, min2, max2 );
 		EXPECT_EQ( 12.77778, min1 ); // Minimum Value of X
-		EXPECT_EQ( 23.88889, max1 );  // Maximum Value of X
-		EXPECT_EQ( 18.0, min2 ); // Minimum Value of Y
+		EXPECT_EQ( 19.44448943, max1 );  // Maximum Value of X
+		EXPECT_EQ( 36.0, min2 ); // Minimum Value of Y
 		EXPECT_EQ( 46.11111, max2 );  // Maximum Value of Y
 		EXPECT_EQ( ( 15000.0 / 25000.0 ), CurveManager::PerfCurve( 1 ).CurveMin );
 		EXPECT_EQ( ( 40000.0 / 25000.0 ), CurveManager::PerfCurve( 1 ).CurveMax );
@@ -448,10 +448,10 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_NotAnd
 		EXPECT_EQ( 2, index );
 
 		CurveManager::GetCurveMinMaxValues( 2, min1, max1, min2, max2 );
-		EXPECT_EQ( -99999999999.0, min1 ); // Minimum Value of X defaults to low number
-		EXPECT_EQ( 99999999999.0, max1 );  // Maximum Value of X defaults to high number
-		EXPECT_EQ( -99999999999.0, min2 ); // Minimum Value of Y defaults to low number
-		EXPECT_EQ( 99999999999.0, max2 );  // Maximum Value of Y defaults to high number
+		EXPECT_EQ( 12.77778, min1 ); // Minimum Value of X defaults to lower limit
+		EXPECT_EQ( 19.44448943, max1 );  // Maximum Value of X defaults to upper limit
+		EXPECT_EQ( 36.0, min2 ); // Minimum Value of Y defaults to lower limit
+		EXPECT_EQ( 46.11111, max2 );  // Maximum Value of Y defaults to upper limit
 		EXPECT_EQ( 0.0, CurveManager::PerfCurve( 2 ).CurveMin );
 		EXPECT_EQ( 0.0, CurveManager::PerfCurve( 2 ).CurveMax );
 		EXPECT_EQ( CurveManager::CurveType_TableTwoIV, CurveManager::GetCurveObjectTypeNum( 2 ) );
@@ -549,10 +549,10 @@ TEST_F(EnergyPlusFixture, Tables_TwoIndependentVariable_Linear_UserDidNotEnterMi
     EXPECT_EQ(1, index);
     Real64 min1, max1, min2, max2;
     CurveManager::GetCurveMinMaxValues(1, min1, max1, min2, max2);
-    EXPECT_EQ(-99999999999.0, min1); // uses large negative number as lower limit. CurveValue will test against lower boundary and use aray minimum
-    EXPECT_EQ(99999999999.0, max1);  // uses large positive number as upper limit. CurveValue will test against upper boundary and use aray maximum
-    EXPECT_EQ(-99999999999.0, min2);  // uses large negative number as lower limit. CurveValue will test against lower boundary and use aray minimum
-    EXPECT_EQ(99999999999.0, max2);  // uses large positive number as upper limit. CurveValue will test against upper boundary and use aray maximum
+    EXPECT_EQ(0.0, min1); // CurveValue will test against lower boundary and use aray minimum
+    EXPECT_EQ(5.0, max1);  // CurveValue will test against upper boundary and use aray maximum
+    EXPECT_EQ(1.0, min2);  // CurveValue will test against lower boundary and use aray minimum
+    EXPECT_EQ(2.0, max2);  // CurveValue will test against upper boundary and use aray maximum
     EXPECT_EQ(CurveManager::CurveType_TableTwoIV, CurveManager::GetCurveObjectTypeNum(1));
 
     EXPECT_DOUBLE_EQ(0.0, CurveManager::CurveValue(1, 0, 1.5)); // In-range value
@@ -691,10 +691,10 @@ TEST_F(EnergyPlusFixture, Tables_TwoIndependentVariable_Linear_UserEntersInAndOu
     EXPECT_EQ(1, index);
     Real64 min1, max1, min2, max2;
     CurveManager::GetCurveMinMaxValues(1, min1, max1, min2, max2);
-    EXPECT_EQ(-1.0, min1); // user entered value is retained, however, CurveValue will test against lower array boundary and use aray minimum
-    EXPECT_EQ(6.0, max1);  // user entered value is retained, however, CurveValue will test against upper array boundary and use aray maximum
-    EXPECT_EQ(-0.5, min2);  // user entered value is retained, however, CurveValue will test against lower array boundary and use aray minimum
-    EXPECT_EQ(4.5, max2);  // user entered value is retained, however, CurveValue will test against upper array boundary and use aray maximum
+    EXPECT_EQ(0.0, min1); // user entered value is retained, however, CurveValue will test against lower array boundary and use aray minimum
+    EXPECT_EQ(5.0, max1);  // user entered value is retained, however, CurveValue will test against upper array boundary and use aray maximum
+    EXPECT_EQ(1.0, min2);  // user entered value is retained, however, CurveValue will test against lower array boundary and use aray minimum
+    EXPECT_EQ(2, max2);  // user entered value is retained, however, CurveValue will test against upper array boundary and use aray maximum
     EXPECT_EQ(CurveManager::CurveType_TableTwoIV, CurveManager::GetCurveObjectTypeNum(1));
 
     EXPECT_DOUBLE_EQ(0.0, CurveManager::CurveValue(1, 0, 1.5)); // In-range value
@@ -724,7 +724,7 @@ TEST_F(EnergyPlusFixture, Tables_TwoIndependentVariable_Linear_UserEntersInAndOu
     EXPECT_EQ(1.0, min1); // user entered value is retained and used since it's greater than lower array boundary
     EXPECT_EQ(4.0, max1);  // user entered value is retained and used since it's less than upper array boundary
     EXPECT_EQ(1.5, min2);  // user entered value is retained and used since it's greater than lower array boundary
-    EXPECT_EQ(3.5, max2);  // user entered value is retained and used since it's less than upper array boundary
+    EXPECT_EQ(2.0, max2);  // user entered value is NOT retained since it's greater than upper array boundary
     EXPECT_EQ(CurveManager::CurveType_TableTwoIV, CurveManager::GetCurveObjectTypeNum(2));
 
     EXPECT_DOUBLE_EQ(2.0, CurveManager::CurveValue(2, 0, 1.5)); // In-range value, result is based on tighten Minimum X Value limit

--- a/tst/EnergyPlus/unit/CurveManager.unit.cc
+++ b/tst/EnergyPlus/unit/CurveManager.unit.cc
@@ -351,8 +351,8 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_UserEn
 		"  23.88889,       !- Maximum Value of X",
 		"  18.0,           !- Minimum Value of Y",
 		"  46.11111,       !- Maximum Value of Y",
-		"  25000,          !- Minimum Table Output",
-		"  25000,          !- Maximum Table Output",
+		"  15000,          !- Minimum Table Output",
+		"  40000,          !- Maximum Table Output",
 		"  Temperature,    !- Input Unit Type for X",
 		"  Temperature,    !- Input Unit Type for Y",
 		"  Dimensionless,  !- Output Unit Type",
@@ -391,10 +391,111 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_UserEn
 		EXPECT_EQ( 23.88889, max1 );  // Maximum Value of X
 		EXPECT_EQ( 18.0, min2 ); // Minimum Value of Y
 		EXPECT_EQ( 46.11111, max2 );  // Maximum Value of Y
+		EXPECT_EQ( ( 15000.0 / 25000.0 ), CurveManager::PerfCurve( 1 ).CurveMin );
+		EXPECT_EQ( ( 40000.0 / 25000.0 ), CurveManager::PerfCurve( 1 ).CurveMax );
 		EXPECT_EQ( CurveManager::CurveType_TableTwoIV, CurveManager::GetCurveObjectTypeNum( 1 ) );
 
-		EXPECT_DOUBLE_EQ( ( 25000.0 / 25000.0 ), CurveManager::CurveValue( 1, 10.0, 30.0 ) ); // Value too small, Min Table Output used
-		EXPECT_DOUBLE_EQ( ( 25000.0 / 25000.0 ), CurveManager::CurveValue( 1, 40.0, 50.0 ) ); // Value too large, Max Table Output used
-		EXPECT_DOUBLE_EQ( 1.0, CurveManager::CurveValue( 1, 15.0, 25.0 ) ); // In-range value
+		EXPECT_GT( CurveManager::CurveValue( 1, 10.0, 15.0 ), ( 15000.0 / 25000.0 ) ); // both values too small, Minimum Value of X (12.8) and Y (18) are used, Min Table Output is not used
+		EXPECT_EQ( 0.7809660128, CurveManager::CurveValue( 1, 10.0, 15.0 ) );  // result of using minimum X and Y limits
+		EXPECT_EQ( 0.7809660128, CurveManager::CurveValue( 1, 12.0, 16.0 ) );  // result shouldn't change as long as inputs are below minimum X and Y limits
+		EXPECT_LT( CurveManager::CurveValue( 1, 40.0, 50.0 ), ( 40000.0 / 25000.0 ) ); // both values too large, Maximum Value of X (23.8) and Y (46.1) are used, Max Table Output is not used
+		EXPECT_NEAR( 0.935003, CurveManager::CurveValue( 1, 40.0, 50.0 ), 0.000001 );  // result of using maximum X and Y limits
+		EXPECT_NEAR( 0.935003, CurveManager::CurveValue( 1, 25.0, 47.0 ), 0.000001 );  // result shouldn't change as long as inputs are above maximum X and Y limits
 
+		// artificially change CurveMin And CurveMax and repeat limit test
+		CurveManager::PerfCurve( 1 ).CurveMin = 0.8; // 0.8 is same as entering 20000 for Minimum Table Output
+		CurveManager::PerfCurve( 1 ).CurveMax = 0.9; // 0.9 is same as entering 22500 for Maximum Table Output
+		EXPECT_EQ( 0.8, CurveManager::CurveValue( 1, 10.0, 15.0 ) );  // result of using minimum X and Y limits when minimum output > result
+		EXPECT_EQ( 0.9, CurveManager::CurveValue( 1, 40.0, 50.0 ) );  // result of using maximum X and Y limits when maximum output < result
+}
+
+TEST_F(EnergyPlusFixture, Tables_TwoIndependentVariable_Linear_MinMaxFailure) {
+
+    std::string const idf_objects = delimited_string({
+        "Version,8.5;",
+        "Table:TwoIndependentVariables,",
+        "TestTableMinMax,         !- Name",
+        "QuadraticLinear,         !- Curve Type",
+        "LinearInterpolationOfTable, !- Interpolation Method",
+        ",                        !- Minimum Value of X",
+        ",                        !- Maximum Value of X",
+        ",                        !- Minimum Value of Y",
+        ",                        !- Maximum Value of Y",
+        ",                        !- Minimum Table Output",
+        ",                        !- Maximum Table Output",
+        "Dimensionless,           !- Input Unit Type for X",
+        "Dimensionless,           !- Input Unit Type for Y",
+        "Dimensionless,           !- Output Unit Type",
+        ",                        !- Normalization Reference",
+        "0,                       !- X Value #1",
+        "1,                       !- Y Value #1",
+        "0,                       !- Output Value #1",
+        "1,                       !- X Value #2",
+        "1,                       !- Y Value #2",
+        "2,                       !- Output Value #2",
+        "2,                       !- X Value #3",
+        "1,                       !- Y Value #3",
+        "2,                       !- Output Value #3",
+        "3,                       !- X Value #4",
+        "1,                       !- Y Value #4",
+        "3,                       !- Output Value #4",
+        "4,                       !- X Value #5",
+        "1,                       !- Y Value #5",
+        "4,                       !- Output Value #5",
+        "5,                       !- X Value #6",
+        "1,                       !- Y Value #6",
+        "2,                       !- Output Value #6",
+        "0,                       !- X Value #7",
+        "2,                       !- Y Value #7",
+        "0,                       !- Output Value #7",
+        "1,                       !- X Value #8",
+        "2,                       !- Y Value #8",
+        "2,                       !- Output Value #8",
+        "2,                       !- X Value #9",
+        "2,                       !- Y Value #9",
+        "2,                       !- Output Value #9",
+        "3,                       !- X Value #10",
+        "2,                       !- Y Value #10",
+        "3,                       !- Output Value #10",
+        "4,                       !- X Value #11",
+        "2,                       !- Y Value #11",
+        "4,                       !- Output Value #11",
+        "5,                       !- X Value #12",
+        "2,                       !- Y Value #12",
+        "2;                       !- Output Value #12" });
+
+    ASSERT_FALSE(process_idf(idf_objects));
+
+    EXPECT_EQ(0, CurveManager::NumCurves);
+    CurveManager::GetCurveInput();
+    CurveManager::GetCurvesInputFlag = false;
+    ASSERT_EQ(1, CurveManager::NumCurves);
+
+    // QuadraticLinear curve type, no min/max for IVs
+    EXPECT_EQ("QUADRATICLINEAR", CurveManager::GetCurveType(1));
+    EXPECT_EQ("TESTTABLEMINMAX", CurveManager::GetCurveName(1));
+    EXPECT_EQ(1, CurveManager::GetCurveIndex("TESTTABLEMINMAX"));
+    bool error = false;
+    int index = CurveManager::GetCurveCheck("TESTTABLEMINMAX", error, "TEST");
+    EXPECT_FALSE(error);
+    EXPECT_EQ(1, index);
+    Real64 min1, max1, min2, max2;
+    CurveManager::GetCurveMinMaxValues(1, min1, max1, min2, max2);
+    EXPECT_EQ(-99999999999.0, min1); // uses large negative number as lower limit. CurveValue will test against lower boundary and use aray minimum
+    EXPECT_EQ(99999999999.0, max1);  // uses large positive number as upper limit. CurveValue will test against upper boundary and use aray maximum
+    EXPECT_EQ(-99999999999.0, min2);  // uses large negative number as lower limit. CurveValue will test against lower boundary and use aray minimum
+    EXPECT_EQ(99999999999.0, max2);  // uses large positive number as upper limit. CurveValue will test against upper boundary and use aray maximum
+    EXPECT_EQ(CurveManager::CurveType_TableTwoIV, CurveManager::GetCurveObjectTypeNum(1));
+
+    EXPECT_DOUBLE_EQ(0.0, CurveManager::CurveValue(1, 0, 1.5)); // In-range value
+    EXPECT_DOUBLE_EQ(1.0, CurveManager::CurveValue(1, 0.5, 1.5)); // In-range value
+    EXPECT_DOUBLE_EQ(0.0, CurveManager::CurveValue(1, -10.0)); // value less than Minimum x
+    EXPECT_DOUBLE_EQ(2.0, CurveManager::CurveValue(1, 5000)); // value greater than Maximum x
+
+    CurveManager::SetCurveOutputMinMaxValues(1, error, 0.5, 1.0);
+    EXPECT_FALSE(error);
+    EXPECT_DOUBLE_EQ(0.5, CurveManager::CurveValue(1, 0, 1.5)); // In-range value
+    EXPECT_DOUBLE_EQ(1.0, CurveManager::CurveValue(1, 5, 1.5)); // In-range value
+
+    EXPECT_FALSE(has_err_output());
 }

--- a/tst/EnergyPlus/unit/CurveManager.unit.cc
+++ b/tst/EnergyPlus/unit/CurveManager.unit.cc
@@ -425,12 +425,18 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_NotAnd
 		"  12.77778,       !- X Value #1",
 		"  36,             !- Y Value #1",
 		"  19524.15032,    !- Output Value #1",
+		"  12.77778,       !- X Value #2",
+		"  42,             !- Y Value #2",
+		"  18167.25518,    !- Output Value #2",
 		"  12.77778,       !- X Value #3",
 		"  46.11111,       !- Y Value #3",
 		"  16810.36004,    !- Output Value #3",
 		"  19.44448943,    !- <none>",
 		"  41,             !- <none>",
 		"  23375.08713,    !- <none>",
+		"  19.44448943,    !- <none>",
+		"  41,             !- <none>",
+		"  22686.72090,    !- <none>",
 		"  19.44448943,    !- <none>",
 		"  46.11111,       !- <none>",
 		"  21998.35468;    !- <none>",
@@ -452,12 +458,18 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_NotAnd
 		"  12.77778,       !- X Value #1",
 		"  36,             !- Y Value #1",
 		"  19524.15032,    !- Output Value #1",
+		"  12.77778,       !- X Value #2",
+		"  42,             !- Y Value #2",
+		"  18167.25518,    !- Output Value #2",
 		"  12.77778,       !- X Value #3",
 		"  46.11111,       !- Y Value #3",
 		"  16810.36004,    !- Output Value #3",
 		"  19.44448943,    !- <none>",
 		"  41,             !- <none>",
 		"  23375.08713,    !- <none>",
+		"  19.44448943,    !- <none>",
+		"  41,             !- <none>",
+		"  22686.72090,    !- <none>",
 		"  19.44448943,    !- <none>",
 		"  46.11111,       !- <none>",
 		"  21998.35468;    !- <none>" 	} );
@@ -469,7 +481,7 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_NotAnd
 		CurveManager::GetCurvesInputFlag = false;
 		ASSERT_EQ( 2, CurveManager::NumCurves );
 
-		// Linear curve type, specified min/max
+		// BiQuadratic curve type, specified min/max
 		EXPECT_EQ( "BIQUADRATIC", CurveManager::GetCurveType( 1 ) );
 		EXPECT_EQ( "TWOVARS", CurveManager::GetCurveName( 1 ) );
 		EXPECT_EQ( 1, CurveManager::GetCurveIndex( "TWOVARS" ) );
@@ -480,28 +492,45 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_NotAnd
 		Real64 min1, max1, min2, max2;
 		CurveManager::GetCurveMinMaxValues( 1, min1, max1, min2, max2 );
 		EXPECT_EQ( 12.77778, min1 ); // Minimum Value of X
-		EXPECT_EQ( 19.44448943, max1 );  // Maximum Value of X
-		EXPECT_EQ( 36.0, min2 ); // Minimum Value of Y
+		EXPECT_EQ( 23.88889, max1 );  // Maximum Value of X
+		EXPECT_EQ( 18.0, min2 ); // Minimum Value of Y
 		EXPECT_EQ( 46.11111, max2 );  // Maximum Value of Y
 		EXPECT_EQ( ( 15000.0 / 25000.0 ), CurveManager::PerfCurve( 1 ).CurveMin );
 		EXPECT_EQ( ( 40000.0 / 25000.0 ), CurveManager::PerfCurve( 1 ).CurveMax );
 		EXPECT_EQ( CurveManager::CurveType_TableTwoIV, CurveManager::GetCurveObjectTypeNum( 1 ) );
 
 		EXPECT_GT( CurveManager::CurveValue( 1, 10.0, 15.0 ), ( 15000.0 / 25000.0 ) ); // both values too small, Minimum Value of X (12.8) and Y (18) are used, Min Table Output is not used
-		EXPECT_EQ( 0.7809660128, CurveManager::CurveValue( 1, 10.0, 15.0 ) );  // result of using minimum X and Y limits
-		EXPECT_EQ( 0.7809660128, CurveManager::CurveValue( 1, 12.0, 16.0 ) );  // result shouldn't change as long as inputs are below minimum X and Y limits
-		EXPECT_LT( CurveManager::CurveValue( 1, 40.0, 50.0 ), ( 40000.0 / 25000.0 ) ); // both values too large, Maximum Value of X (23.8) and Y (46.1) are used, Max Table Output is not used
-		EXPECT_NEAR( 0.935003, CurveManager::CurveValue( 1, 40.0, 50.0 ), 0.000001 );  // result of using maximum X and Y limits
-		EXPECT_NEAR( 0.935003, CurveManager::CurveValue( 1, 25.0, 47.0 ), 0.000001 );  // result shouldn't change as long as inputs are above maximum X and Y limits
+		Real64 Coeff1 = CurveManager::PerfCurve( 1 ).Coeff1;
+		Real64 Coeff2 = CurveManager::PerfCurve( 1 ).Coeff2;
+		Real64 Coeff3 = CurveManager::PerfCurve( 1 ).Coeff3;
+		Real64 Coeff4 = CurveManager::PerfCurve( 1 ).Coeff4;
+		Real64 Coeff5 = CurveManager::PerfCurve( 1 ).Coeff5;
+		Real64 Coeff6 = CurveManager::PerfCurve( 1 ).Coeff6;
+
+		// calculate output as if entered data was valid
+		Real64 curveOut = Coeff1 + ( Coeff2 * 10.0 ) + ( Coeff3 * 10.0 * 10.0 ) + ( Coeff4 * 15.0 ) + ( Coeff5 * 15.0 * 15.0 ) + ( Coeff6 * 10.0 * 15.0 );
+		// entered data was not valid since 10 < min X1 and 15 < min X2 so expect result to be greater than curveOut
+		EXPECT_LT( curveOut, CurveManager::CurveValue( 1, 10.0, 15.0 ) );  // result of using less than minimum X1 and X2 limits
+
+		// calculate new value using min X1 and min X2, this value should match curve output
+		Real64 curveOutActual = Coeff1 + ( Coeff2 * 12.77778 ) + ( Coeff3 * 12.77778 * 12.77778 ) + ( Coeff4 * 18.0 ) + ( Coeff5 * 18.0 * 18.0 ) + ( Coeff6 * 12.77778 * 18.0 );
+		EXPECT_NEAR( 0.7662161, curveOutActual, 0.0000001 );  // result of using less than minimum X1 and X2 limits
+		EXPECT_NEAR( curveOutActual, CurveManager::CurveValue( 1, 10.0, 15.0 ), 0.000001 );  // result of using less than minimum X1 and X2 limits
+		EXPECT_NEAR( curveOutActual, CurveManager::CurveValue( 1, 12.0, 16.0 ), 0.000001 );  // result shouldn't change as long as inputs are below minimum X1 and X2 limits
+		curveOutActual = Coeff1 + ( Coeff2 * 23.88889 ) + ( Coeff3 * 23.88889 * 23.88889 ) + ( Coeff4 * 46.11111 ) + ( Coeff5 * 46.11111 * 46.11111 ) + ( Coeff6 * 23.88889 * 46.11111 );
+		EXPECT_LT( CurveManager::CurveValue( 1, 40.0, 50.0 ), ( 40000.0 / 25000.0 ) ); // both values too large, Maximum Value of X1 (23.8) and X2 (46.1) are used, Max Table Output is too high
+		EXPECT_NEAR( curveOutActual, CurveManager::CurveValue( 1, 40.0, 50.0 ), 0.000001 );  // result of using maximum X1 and X2 limits
+		EXPECT_NEAR( curveOutActual, CurveManager::CurveValue( 1, 25.0, 47.0 ), 0.000001 );  // result shouldn't change as long as inputs are above maximum X and Y limits
+		EXPECT_NEAR( 0.91625045, curveOutActual, 0.00000001 );  // result is actually less than max ouput since a regression was performed
 
 		// artificially change CurveMin And CurveMax and repeat limit test
 		CurveManager::PerfCurve( 1 ).CurveMin = 0.8; // 0.8 is same as entering 20000 for Minimum Table Output
 		CurveManager::PerfCurve( 1 ).CurveMax = 0.9; // 0.9 is same as entering 22500 for Maximum Table Output
-		EXPECT_EQ( 0.8, CurveManager::CurveValue( 1, 10.0, 15.0 ) );  // result of using minimum X and Y limits when minimum output > result
-		EXPECT_EQ( 0.9, CurveManager::CurveValue( 1, 40.0, 50.0 ) );  // result of using maximum X and Y limits when maximum output < result
+		EXPECT_EQ( 0.8, CurveManager::CurveValue( 1, 10.0, 15.0 ) );  // result of using minimum X1 and X2 limits when minimum output > result
+		EXPECT_EQ( 0.9, CurveManager::CurveValue( 1, 40.0, 50.0 ) );  // result of using maximum X1 and X2 limits when maximum output < result
 
 		// Evaluate 2nd performance curve
-		// Linear curve type, no specified min/max
+		// BiQuadratic curve type, no specified min/max
 		EXPECT_EQ( "BIQUADRATIC", CurveManager::GetCurveType( 2 ) );
 		EXPECT_EQ( "TWOVARS2", CurveManager::GetCurveName( 2 ) );
 		EXPECT_EQ( 2, CurveManager::GetCurveIndex( "TWOVARS2" ) );
@@ -511,32 +540,79 @@ TEST_F( EnergyPlusFixture, Tables_TwoIndependentVariable_EvaluateToLimits_NotAnd
 		EXPECT_EQ( 2, index );
 
 		CurveManager::GetCurveMinMaxValues( 2, min1, max1, min2, max2 );
-		EXPECT_EQ( 12.77778, min1 ); // Minimum Value of X defaults to lower limit
-		EXPECT_EQ( 19.44448943, max1 );  // Maximum Value of X defaults to upper limit
-		EXPECT_EQ( 36.0, min2 ); // Minimum Value of Y defaults to lower limit
-		EXPECT_EQ( 46.11111, max2 );  // Maximum Value of Y defaults to upper limit
-		EXPECT_EQ( 0.0, CurveManager::PerfCurve( 2 ).CurveMin );
-		EXPECT_EQ( 0.0, CurveManager::PerfCurve( 2 ).CurveMax );
+		EXPECT_EQ( 12.77778, min1 ); // Minimum Value of X defaults to lower limit specified in table data
+		EXPECT_EQ( 19.44448943, max1 );  // Maximum Value of X defaults to upper limit specified in table data
+		EXPECT_EQ( 36.0, min2 ); // Minimum Value of Y defaults to lower limit specified in table data
+		EXPECT_EQ( 46.11111, max2 );  // Maximum Value of Y defaults to upper limit specified in table data
+
+		// curve min/max output were not entered by user. Expect min/max equal to 0 since they were not initilized 
+		EXPECT_NEAR( 0.0, CurveManager::PerfCurve( 2 ).CurveMin, 0.0000000001 );
+		EXPECT_FALSE( CurveManager::PerfCurve( 2 ).CurveMinPresent ); // min won't be used since value is NOT present
+		EXPECT_NEAR( 0.0, CurveManager::PerfCurve( 2 ).CurveMax, 0.0000000001 );
+		EXPECT_FALSE( CurveManager::PerfCurve( 2 ).CurveMaxPresent ); // max won't be used since value is NOT present
 		EXPECT_EQ( CurveManager::CurveType_TableTwoIV, CurveManager::GetCurveObjectTypeNum( 2 ) );
 
-		EXPECT_GT( CurveManager::CurveValue( 2, 10.0, 15.0 ), ( 15000.0 / 25000.0 ) ); // both values too small, Minimum Value of X (12.8) and Y (18) are used, Min Table Output is not used
-		EXPECT_EQ( 0.7809660128, CurveManager::CurveValue( 2, 10.0, 15.0 ) );  // result of using minimum X and Y limits
-		EXPECT_EQ( 0.7809660128, CurveManager::CurveValue( 2, 12.0, 16.0 ) );  // result shouldn't change as long as inputs are below minimum X and Y limits
-		EXPECT_LT( CurveManager::CurveValue( 2, 40.0, 50.0 ), ( 40000.0 / 25000.0 ) ); // both values too large, Maximum Value of X (23.8) and Y (46.1) are used, Max Table Output is not used
-		EXPECT_NEAR( 0.935003, CurveManager::CurveValue( 2, 40.0, 50.0 ), 0.000001 );  // result of using maximum X and Y limits
-		EXPECT_NEAR( 0.935003, CurveManager::CurveValue( 2, 25.0, 47.0 ), 0.000001 );  // result shouldn't change as long as inputs are above maximum X and Y limits
+		EXPECT_GT( CurveManager::CurveValue( 2, 10.0, 15.0 ), ( 15000.0 / 25000.0 ) ); // both values too small, Minimum Value of X1 (12.8) and X2 (18) are used, Min Table Output is not present
+		EXPECT_NEAR( 0.780966, CurveManager::CurveValue( 2, 10.0, 15.0 ), 0.0000001 );  // result of using minimum X1 and X2 limits
+		EXPECT_NEAR( 0.780966, CurveManager::CurveValue( 2, 12.0, 16.0 ), 0.0000001 );  // result shouldn't change as long as inputs are below minimum X1 and X2 limits
+		curveOutActual = Coeff1 + ( Coeff2 * 19.44448943 ) + ( Coeff3 * 19.44448943 * 19.44448943 ) + ( Coeff4 * 46.11111 ) + ( Coeff5 * 46.11111 * 46.11111 ) + ( Coeff6 * 19.44448943 * 46.11111 );
+		EXPECT_LT( CurveManager::CurveValue( 2, 40.0, 50.0 ), ( 23375.08713 / 25000.0 ) ); // both values too large, Maximum Value of X1 (23.8) and X2 (46.1) are used, Max Table Output is not present
+		EXPECT_NEAR( curveOutActual, CurveManager::CurveValue( 2, 40.0, 50.0 ), 0.000001 );  // result of using maximum X1 and X2 limits
+		EXPECT_NEAR( curveOutActual, CurveManager::CurveValue( 2, 25.0, 47.0 ), 0.000001 );  // result shouldn't change as long as inputs are above maximum X1 and X2 limits
 
 		// test capacity entered by user is same as calculated
 		EXPECT_NEAR( 19524.15032, ( CurveManager::CurveValue( 2, 12.77778, 36.0 ) * 25000.0 ), 0.1 ); // uses data from first entry in table
 
-		// artificially change CurveMin And CurveMax and repeat limit test
+		// artificially change CurveMin And CurveMax to be above min and below max table data and repeat limit test
 		CurveManager::PerfCurve( 2 ).CurveMin = 0.8; // 0.8 is same as entering 20000 for Minimum Table Output
-		CurveManager::PerfCurve( 2 ).CurveMinPresent = true;
-		CurveManager::PerfCurve( 2 ).CurveMax = 0.9; // 0.9 is same as entering 22500 for Maximum Table Output
-		CurveManager::PerfCurve( 2 ).CurveMaxPresent = true;
+		CurveManager::PerfCurve( 2 ).CurveMinPresent = true; // as if user did enter input data
+		CurveManager::PerfCurve( 2 ).CurveMax = 0.87; // 0.87 is same as entering 21750 for Maximum Table Output
+		CurveManager::PerfCurve( 2 ).CurveMaxPresent = true; // as if user did enter input data
 
-		EXPECT_EQ( 0.8, CurveManager::CurveValue( 2, 10.0, 15.0 ) );  // result of using minimum X and Y limits when minimum output > result
-		EXPECT_EQ( 0.9, CurveManager::CurveValue( 2, 40.0, 50.0 ) );  // result of using maximum X and Y limits when maximum output < result
+		EXPECT_EQ( 0.8, CurveManager::CurveValue( 2, 10.0, 15.0 ) );  // result of using minimum X1 and X2 table data limits, Curve Minimum Output > result
+		EXPECT_EQ( 0.87, CurveManager::CurveValue( 2, 40.0, 50.0 ) );  // result of using maximum X1 and X2 table data limits, Curve Maximum Output < result
+
+		// artificially change CurveMin And CurveMax to be below min and above max table data and repeat limit test
+		CurveManager::PerfCurve( 2 ).CurveMin = 0.5; // 0.5 is same as entering 12500 for Minimum Table Output
+		CurveManager::PerfCurve( 2 ).CurveMax = 1.2; // 1.2 is same as entering 30000 for Maximum Table Output
+		// result is lower than before when using 0.8 as Minimum Table Output
+		EXPECT_LT( 0.5, CurveManager::CurveValue( 2, 10.0, 15.0 ) );  // new result is lower than 0.8 but not lower than 0.5 since output is limited by X1 X2 min/max
+		EXPECT_GT( 0.8, CurveManager::CurveValue( 2, 10.0, 15.0 ) );
+		EXPECT_NEAR( 0.780966, CurveManager::CurveValue( 2, 10.0, 15.0 ), 0.000001 );
+		// result is higher than before when using 0.87 as Maximum Table Output
+		EXPECT_LT( 0.87, CurveManager::CurveValue( 2, 40.0, 50.0 ) );  // new result is higher than 0.87 but not higher than 1.2 since output is limited by X1 X2 min/max
+		EXPECT_GT( 1.2, CurveManager::CurveValue( 2, 40.0, 50.0 ) );
+		EXPECT_NEAR( 0.8799342, CurveManager::CurveValue( 2, 40.0, 50.0 ), 0.0000001 );
+
+		// if CurveMin And CurveMax are blank, result should be same as above
+		CurveManager::PerfCurve( 2 ).CurveMinPresent = false; // as if user did not enter input data
+		CurveManager::PerfCurve( 2 ).CurveMaxPresent = false; // as if user did not enter input data
+		EXPECT_LT( 0.5, CurveManager::CurveValue( 2, 10.0, 15.0 ) );  // curve extrapolates up to 
+		EXPECT_GT( 1.2, CurveManager::CurveValue( 2, 40.0, 50.0 ) );  // result of using maximum X and Y limits when maximum output < result
+
+		// if user actually enters min/max values to extrapolate curve, then allow extrapolation
+		CurveManager::PerfCurve( 2 ).Var1Min = 10.0;
+		CurveManager::PerfCurve( 2 ).Var1Max = 40.0;
+		CurveManager::PerfCurve( 2 ).Var2Min = 15.0;
+		CurveManager::PerfCurve( 2 ).Var2Max = 50.0;
+		Real64 extrapolatedCapacity = CurveManager::CurveValue( 2, 10.0, 15.0 ) * 25000.0;
+		EXPECT_LT( extrapolatedCapacity, 16810.36004 );  // curve extrapolates lower than minimum Y based on table data
+
+		extrapolatedCapacity = CurveManager::CurveValue( 2, 40.0, 50.0 ) * 25000.0;
+		Real64 minY = 16810.36004 / 25000.0;
+		Real64 maxY = 23375.08713 / 25000.0;
+
+		EXPECT_LT( CurveManager::CurveValue( 2, 40.0, 50.0 ), maxY );  // results show dangers of extrapolation, large X1 and X2 gives output lower than max Y table data
+		EXPECT_LT( CurveManager::CurveValue( 2, 40.0, 50.0 ), minY );  // results show dangers of extrapolation, large X1 and X2 gives output lower than min Y table data
+		Coeff1 = CurveManager::PerfCurve( 2 ).Coeff1;
+		Coeff2 = CurveManager::PerfCurve( 2 ).Coeff2;
+		Coeff3 = CurveManager::PerfCurve( 2 ).Coeff3;
+		Coeff4 = CurveManager::PerfCurve( 2 ).Coeff4;
+		Coeff5 = CurveManager::PerfCurve( 2 ).Coeff5;
+		Coeff6 = CurveManager::PerfCurve( 2 ).Coeff6;
+		curveOutActual = Coeff1 + ( Coeff2 * 40.0 ) + ( Coeff3 * 40.0 * 40.0 ) + ( Coeff4 * 50.0 ) + ( Coeff5 * 50.0 * 50.0 ) + ( Coeff6 * 40.0 * 50.0 );
+		EXPECT_NEAR( ( curveOutActual * 25000.0 ), extrapolatedCapacity, 0.001 );  // result of extrapolation is value less than minimum table data
+		EXPECT_NEAR( 9358.378, ( curveOutActual * 25000.0 ), 0.001 );  // result of extrapolation is value less than minimum table data
 
 }
 


### PR DESCRIPTION
## Pull request overview

Tables of One and Two Independent Variables did not allow extrapolation when Curve Minimum Value and Curve Maximum Value input fields were left blank. This fixes #5704. Diff's are not expected in the example files unless the input fields are blank.
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
### Review Checklist

This will not be exhaustively relevant to every PR.
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [x] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [x] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] Open windows IDF Editor with modified IDD to check for errors
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [x] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces
