### PR TITLE
Correct UnitarySystem and Multispeed Heat Pump heat recovery calculation to honor maximum outlet temperature

### DIFF
--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
@@ -3263,7 +3263,6 @@ namespace HVACMultiSpeedHeatPump {
 		Real64 HeatRecOutletTemp; // Heat reclaim outlet temp [C]
 		Real64 HeatRecMassFlowRate; // Heat reclaim mass flow rate [m3/s]
 		Real64 CpHeatRec; // Heat reclaim water inlet specific heat [J/kg-K]
-		Real64 HeatRecInletEnth; // Heat reclaim water inlet enthalpy [J/kg]
 
 		// Begin routine
 		HeatRecInNode = MSHeatPump( MSHeatPumpNum ).HeatRecInletNodeNum;
@@ -3271,7 +3270,6 @@ namespace HVACMultiSpeedHeatPump {
 
 		// Inlet node to the heat recovery heat exchanger
 		HeatRecInletTemp = Node( HeatRecInNode ).Temp;
-		HeatRecInletEnth = Node( HeatRecInNode ).Enthalpy;
 
 		// Set heat recovery mass flow rates
 		HeatRecMassFlowRate = Node( HeatRecInNode ).MassFlowRate;
@@ -3283,9 +3281,13 @@ namespace HVACMultiSpeedHeatPump {
 			CpHeatRec = GetSpecificHeatGlycol( PlantLoop( MSHeatPump( MSHeatPumpNum ).HRLoopNum ).FluidName, HeatRecInletTemp, PlantLoop( MSHeatPump( MSHeatPumpNum ).HRLoopNum ).FluidIndex, RoutineName );
 
 			HeatRecOutletTemp = QHeatRec / ( HeatRecMassFlowRate * CpHeatRec ) + HeatRecInletTemp;
-			if ( HeatRecOutletTemp > MSHeatPump( MSHeatPumpNum ).MaxHeatRecOutletTemp ) HeatRecOutletTemp = MSHeatPump( MSHeatPumpNum ).MaxHeatRecOutletTemp;
+			if ( HeatRecOutletTemp > MSHeatPump( MSHeatPumpNum ).MaxHeatRecOutletTemp ) {
+				HeatRecOutletTemp = max( HeatRecInletTemp, MSHeatPump( MSHeatPumpNum ).MaxHeatRecOutletTemp );
+				QHeatRec = HeatRecMassFlowRate * CpHeatRec * ( HeatRecOutletTemp - HeatRecInletTemp );
+			}
 		} else {
 			HeatRecOutletTemp = HeatRecInletTemp;
+			QHeatRec = 0.0;
 		}
 
 		SafeCopyPlantNode( HeatRecInNode, HeatRecOutNode );


### PR DESCRIPTION
## Pull request overview

Fixes 5516 defect for Multispeed coil heat recovery calculation where heat transfer still occurs when outlet water temperature is above the maximum limit. No diff's are expected in example files.
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
### Review Checklist

This will not be exhaustively relevant to every PR.
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [x] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [x] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] Open windows IDF Editor with modified IDD to check for errors
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [ ] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces
