### PR TITLE
#5629 chiller electric eir air/evap cooled condenser outlet node conditions not correct and evap condenser water use = 0

### DIFF
--- a/doc/engineering-reference/src/simulation-models-encyclopedic-reference-003/chillerheaterperformance-electric-eir.tex
+++ b/doc/engineering-reference/src/simulation-models-encyclopedic-reference-003/chillerheaterperformance-electric-eir.tex
@@ -152,6 +152,27 @@ QEva{p_{c\lg }} = \dot QEva{p_{c\lg }} \cdot TimeStepSys \cdot 3600
 
 \(QCon{d_{c\lg }} = \dot QCon{d_{c\lg }} \cdot TimeStepSys \cdot 3600\) ~.
 
+Water consumption for the evaporative-cooled condenser is calculated using the difference in air humidity level across the evaporative media and the condenser air mass flow rate:
+
+\begin{equation}
+{V_{water}} = \frac{{{{\mathop m\limits^ \bullet  }_{_{air}}}\left( {{\omega_{evapcond,out}} - {\omega_{evapcond,in}}} \right)}}{{{\rho_{water}}}}\left( {PLR} \right)\left( {TimeStepSys} \right)\left( {3600.} \right)\,
+\end{equation}
+
+where
+
+\({V_{water}}\) ~~~~~~~~ = DX cooling coil evap condenser water consumption, m\(^{3}\)
+
+\({\mathop m\limits^ \bullet_{_{air}}}\) ~~~~~~~~~ = evaporative condenser air mass flow rate, kg/s
+
+\({\omega_{evapcond,in}}\) ~ = humidity ratio of outdoor air entering the evap condenser, kg/kg
+
+\({\omega_{evapcond,out}}\) = humidity ratio of air leaving the evap condenser, kg/kg
+
+\({\rho_{water}}\) ~~~~~~~~ = density of water at the outdoor dry-bulb temperature, kg/m\(^{3}\)
+
+\emph{TimeStepSys} = HVAC system simulation time step, hr
+
+
 \subsubsection{Heating-only mode and Simultaneous cooling-heating mode}\label{heating-only-mode-and-simultaneous-cooling-heating-mode}
 
 The following nomenclature is used in the heating equations:

--- a/doc/input-output-reference/src/overview/group-plant-equipment.tex
+++ b/doc/input-output-reference/src/overview/group-plant-equipment.tex
@@ -1780,7 +1780,7 @@ These outputs are the heat transfer rate and total heat transfer due to false lo
 
 \paragraph{Chiller Evaporative Condenser Mains Supply Water Volume {[}m3{]}}\label{chiller-evaporative-condenser-mains-supply-water-volume-m3}
 
-These outputs are the water use for evaporatively-cooled condensers. When the chiller operates, the water consumed by the evaporatively-cooled condenser is proportional to the chiller condenser heat transfer. The evaporative condenser is assumed to be 100% effective where the condenser inlet air dry-bulb temperature is equal to the outdoor wet-bulb temperature. 
+These outputs are the water use for evaporatively-cooled condensers. When the chiller operates, the water consumed by the evaporatively-cooled condenser is proportional to the chiller condenser heat transfer. The evaporative condenser is assumed to be 100\% effective where the condenser inlet air dry-bulb temperature is equal to the outdoor wet-bulb temperature. 
 
 \subsection{Chiller:Electric:ReformulatedEIR}\label{chillerelectricreformulatedeir}
 

--- a/doc/input-output-reference/src/overview/group-plant-equipment.tex
+++ b/doc/input-output-reference/src/overview/group-plant-equipment.tex
@@ -1437,7 +1437,7 @@ For a variable flow chiller this is the maximum water flow rate and for a consta
 
 \paragraph{Field: Reference Condenser Fluid Flow Rate}\label{field-reference-condenser-fluid-flow-rate}
 
-This numeric field contains the chiller's operating condenser water flow rate in cubic meters per second. This field can be autosized. This field is also used to enter the air flow rate if Condenser Type = AirCooled or EvaporativelyCooled and Heat Recovery is specified..
+This numeric field contains the chiller's operating condenser water flow rate in cubic meters per second. This field can be autosized. This field is also used to enter the air flow rate if Condenser Type = AirCooled or EvaporativelyCooled and Heat Recovery is specified. If AirCooled or EvaporativelyCooled and this field is autosized, the air flow rate is set to 0.000114 m3/s/W (850 cfm/ton) multiplied by the chiller Reference Capacity.
 
 \paragraph{Field: Cooling Capacity Function of Temperature Curve Name}\label{field-cooling-capacity-function-of-temperature-curve-name}
 
@@ -1706,6 +1706,10 @@ Evap-cooled:
   HVAC,Average,Chiller Basin Heater Electric Power {[}W{]}
 \item
   HVAC,Average,Chiller Basin Heater Electric Energy {[}J{]}
+\item
+  HVAC,Sum,Chiller Evaporative Condenser Water Volume {[}m3{]}
+\item
+  HVAC,Sum,Chiller Evaporative Condenser Mains Supply Water Volume {[}m3{]}
 \end{itemize}
 
 Water-cooled:
@@ -1771,6 +1775,12 @@ The cycling ratio is the amount of time the chiller operates during each simulat
 \paragraph{Chiller False Load Heat Transfer Energy {[}J{]}}\label{chiller-false-load-heat-transfer-energy-j}
 
 These outputs are the heat transfer rate and total heat transfer due to false loading of the chiller. When the chiller part-load ratio is below the minimum unloading ratio, the chiller false loads (e.g.~hot-gas bypass) to further reduce capacity. The false load heat transfer output variable is not metered.
+
+\paragraph{Chiller Evaporative Condenser Water Volume {[}m3{]}}\label{chiller-evaporative-condenser-water-volume-m3}
+
+\paragraph{Chiller Evaporative Condenser Mains Supply Water Volume {[}m3{]}}\label{chiller-evaporative-condenser-mains-supply-water-volume-m3}
+
+These outputs are the water use for evaporatively-cooled condensers. When the chiller operates, the water consumed by the evaporatively-cooled condenser is proportional to the chiller condenser heat transfer. The evaporative condenser is assumed to be 100% effective where the condenser inlet air dry-bulb temperature is equal to the outdoor wet-bulb temperature. 
 
 \subsection{Chiller:Electric:ReformulatedEIR}\label{chillerelectricreformulatedeir}
 

--- a/doc/input-output-reference/src/overview/group-plant-equipment.tex
+++ b/doc/input-output-reference/src/overview/group-plant-equipment.tex
@@ -1437,7 +1437,7 @@ For a variable flow chiller this is the maximum water flow rate and for a consta
 
 \paragraph{Field: Reference Condenser Fluid Flow Rate}\label{field-reference-condenser-fluid-flow-rate}
 
-This numeric field contains the chiller's operating condenser water flow rate in cubic meters per second. This field can be autosized. This field is also used to enter the air flow rate if Condenser Type = AirCooled or EvaporativelyCooled and Heat Recovery is specified. If AirCooled or EvaporativelyCooled and this field is autosized, the air flow rate is set to 0.000114 m3/s/W (850 cfm/ton) multiplied by the chiller Reference Capacity.
+This numeric field contains the chiller's operating condenser fluid flow rate in cubic meters per second. This field can be autosized. This field is also used to enter the air flow rate if Condenser Type = AirCooled or EvaporativelyCooled and Heat Recovery is specified. If AirCooled or EvaporativelyCooled and this field is autosized, the air flow rate is set to 0.000114 m3/s/W (850 cfm/ton) multiplied by the chiller Reference Capacity. For air- and evaporatively-cooled condensers, this flow rate is used to set condenser outlet air node conditions and used for evaporatively-cooled condensers to calculate water use rate.
 
 \paragraph{Field: Cooling Capacity Function of Temperature Curve Name}\label{field-cooling-capacity-function-of-temperature-curve-name}
 

--- a/src/EnergyPlus/ChillerElectricEIR.cc
+++ b/src/EnergyPlus/ChillerElectricEIR.cc
@@ -1139,7 +1139,6 @@ namespace ChillerElectricEIR {
 		bool bPRINT = true; // TRUE if sizing is reported to output (eio)
 		Real64 TempSize; // autosized value of coil input field
 		int SizingMethod; // Integer representation of sizing method (e.g., CoolingAirflowSizing, HeatingCapacitySizing, etc.)
-		bool PrintFlag; // TRUE when sizing information is reported in the eio file
 
 		if ( MyOneTimeFlag ) {
 			MyFlag.dimension( NumElectricEIRChillers, true );
@@ -1290,24 +1289,24 @@ namespace ChillerElectricEIR {
 					ElectricEIRChiller( EIRChillNum ).CondVolFlowRate = tmpCondVolFlowRate;
 					if ( PlantFinalSizesOkayToReport ) {
 						ReportSizingOutput( "Chiller:Electric:EIR", ElectricEIRChiller( EIRChillNum ).Name,
-							"Design Size Reference Condenser Water Flow Rate [m3/s]", tmpCondVolFlowRate );
+							"Design Size Reference Condenser Fluid Flow Rate [m3/s]", tmpCondVolFlowRate );
 					}
 					if ( PlantFirstSizesOkayToReport ) {
 						ReportSizingOutput( "Chiller:Electric:EIR", ElectricEIRChiller( EIRChillNum ).Name,
-							"Initial Design Size Reference Condenser Water Flow Rate [m3/s]", tmpCondVolFlowRate );
+							"Initial Design Size Reference Condenser Fluid Flow Rate [m3/s]", tmpCondVolFlowRate );
 					}
 				} else {
 					if ( ElectricEIRChiller( EIRChillNum ).CondVolFlowRate > 0.0 && tmpCondVolFlowRate > 0.0 ) {
 						CondVolFlowRateUser = ElectricEIRChiller( EIRChillNum ).CondVolFlowRate;
 						if ( PlantFinalSizesOkayToReport ) {
 							ReportSizingOutput( "Chiller:Electric:EIR", ElectricEIRChiller( EIRChillNum ).Name,
-								"Design Size Reference Condenser Water Flow Rate [m3/s]", tmpCondVolFlowRate,
-								"User-Specified Reference Condenser Water Flow Rate [m3/s]", CondVolFlowRateUser );
+								"Design Size Reference Condenser Fluid Flow Rate [m3/s]", tmpCondVolFlowRate,
+								"User-Specified Reference Condenser Fluid Flow Rate [m3/s]", CondVolFlowRateUser );
 							if ( DisplayExtraWarnings ) {
 								if ( ( std::abs( tmpCondVolFlowRate - CondVolFlowRateUser ) / CondVolFlowRateUser ) > AutoVsHardSizingThreshold ) {
 									ShowMessage( "SizeChillerElectricEIR: Potential issue with equipment sizing for " + ElectricEIRChiller( EIRChillNum ).Name );
-									ShowContinueError( "User-Specified Reference Condenser Water Flow Rate of " + RoundSigDigits( CondVolFlowRateUser, 5 ) + " [m3/s]" );
-									ShowContinueError( "differs from Design Size Reference Condenser Water Flow Rate of " + RoundSigDigits( tmpCondVolFlowRate, 5 ) + " [m3/s]" );
+									ShowContinueError( "User-Specified Reference Condenser Fluid Flow Rate of " + RoundSigDigits( CondVolFlowRateUser, 5 ) + " [m3/s]" );
+									ShowContinueError( "differs from Design Size Reference Condenser Fluid Flow Rate of " + RoundSigDigits( tmpCondVolFlowRate, 5 ) + " [m3/s]" );
 									ShowContinueError( "This may, or may not, indicate mismatched component sizes." );
 									ShowContinueError( "Verify that the value entered is intended and is consistent with other components." );
 								}
@@ -1321,7 +1320,7 @@ namespace ChillerElectricEIR {
 			if ( ElectricEIRChiller( EIRChillNum ).CondenserType == WaterCooled ) {
 
 				if ( ElectricEIRChiller( EIRChillNum ).CondVolFlowRateWasAutoSized && PlantFirstSizesOkayToFinalize ) {
-					ShowSevereError( "Autosizing of Electric EIR Chiller condenser flow rate requires a condenser" );
+					ShowSevereError( "Autosizing of Electric EIR Chiller condenser fluid flow rate requires a condenser" );
 					ShowContinueError( "loop Sizing:Plant object" );
 					ShowContinueError( "Occurs in Electric EIR Chiller object=" + ElectricEIRChiller( EIRChillNum ).Name );
 					ErrorsFound = true;
@@ -1329,7 +1328,7 @@ namespace ChillerElectricEIR {
 				if ( ! ElectricEIRChiller( EIRChillNum ).CondVolFlowRateWasAutoSized && PlantFinalSizesOkayToReport
 						&& ( ElectricEIRChiller( EIRChillNum ).CondVolFlowRate > 0.0 )) {
 						ReportSizingOutput( "Chiller:Electric:EIR", ElectricEIRChiller( EIRChillNum ).Name,
-							"User-Specified Reference Condenser Water Flow Rate [m3/s]", ElectricEIRChiller( EIRChillNum ).CondVolFlowRate );
+							"User-Specified Reference Condenser Fluid Flow Rate [m3/s]", ElectricEIRChiller( EIRChillNum ).CondVolFlowRate );
 				}
 
 			} else {
@@ -1924,7 +1923,8 @@ namespace ChillerElectricEIR {
 
 			if ( ElectricEIRChiller( EIRChillNum ).CondenserType == EvapCooled ) {
 				RhoAir = Psychrometrics::PsyRhoAirFnPbTdbW( DataEnvironment::StdBaroPress, CondInletTemp, Node( CondInletNode ).HumRat, RoutineName );
-				EvapWaterConsumpRate = ( CondOutletHumRat - Node( CondInletNode ).HumRat ) * CondMassFlowRate / RhoAir * PartLoadRat;
+				// CondMassFlowRate is already multiplied by PLR, convert to water use rate
+				EvapWaterConsumpRate = ( ( CondOutletHumRat - Node( CondInletNode ).HumRat ) * CondMassFlowRate ) / RhoAir;
 			}
 		}
 

--- a/src/EnergyPlus/ChillerElectricEIR.cc
+++ b/src/EnergyPlus/ChillerElectricEIR.cc
@@ -1336,7 +1336,7 @@ namespace ChillerElectricEIR {
 				// Auto size condenser air flow to Total Capacity * 0.000114 m3/s/w (850 cfm/ton)
 				if ( PlantFinalSizesOkayToReport ) {
 					SizingMethod = DataHVACGlobals::AutoCalculateSizing;
-					CompType = DataPlant::ValidLoopEquipTypes( DataPlant::TypeOf_Chiller_ElectricEIR );
+					CompType = DataPlant::ccSimPlantEquipTypes( DataPlant::TypeOf_Chiller_ElectricEIR );
 					CompName = ElectricEIRChiller( EIRChillNum ).Name;
 					SizingString = "Reference Condenser Fluid Flow Rate  [m3/s]";
 					DataConstantUsedForSizing = ElectricEIRChiller( EIRChillNum ).RefCap;

--- a/src/EnergyPlus/ChillerElectricEIR.hh
+++ b/src/EnergyPlus/ChillerElectricEIR.hh
@@ -317,6 +317,7 @@ namespace ChillerElectricEIR {
 		Real64 CondenserFanEnergyConsumption; // reporting: Air-cooled condenser fan energy [J]
 		Real64 BasinHeaterPower; // Basin heater power (W)
 		Real64 BasinHeaterConsumption; // Basin heater energy consumption (J)
+		Real64 EvapWaterConsump; // Evap cooler water consumption (m3)
 
 		// Default Constructor
 		ReportEIRVars() :
@@ -349,7 +350,8 @@ namespace ChillerElectricEIR {
 			CondenserFanPowerUse( 0.0 ),
 			CondenserFanEnergyConsumption( 0.0 ),
 			BasinHeaterPower( 0.0 ),
-			BasinHeaterConsumption( 0.0 )
+			BasinHeaterConsumption( 0.0 ),
+			EvapWaterConsump( 0.0 )
 		{}
 
 	};

--- a/tst/EnergyPlus/unit/ChillerElectricEIR.unit.cc
+++ b/tst/EnergyPlus/unit/ChillerElectricEIR.unit.cc
@@ -64,6 +64,10 @@
 // EnergyPlus Headers
 #include <EnergyPlus/ChillerElectricEIR.hh>
 #include <EnergyPlus/DataLoopNode.hh>
+#include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataPlant.hh>
+#include <EnergyPlus/DataSizing.hh>
+#include <EnergyPlus/Psychrometrics.hh>
 
 #include "Fixtures/EnergyPlusFixture.hh"
 
@@ -101,4 +105,118 @@ TEST_F( EnergyPlusFixture, ChillerElectricEIR_TestOutletNodeConditions )
 	Node.deallocate();
 	ElectricEIRChiller.deallocate();
 	ElectricEIRChillerReport.deallocate();
+}
+
+TEST_F( EnergyPlusFixture, ChillerElectricEIR_AirCooledChiller )
+{
+
+		bool FirstHVACIteration( false );
+		bool ErrorsFound( false );
+		Real64 QZnReq( -1000.0 );
+		DataPlant::TotNumLoops = 2;
+		DataEnvironment::OutBaroPress = 101325.0;
+		DataEnvironment::StdRhoAir = 1.20;
+		DataGlobals::NumOfTimeStepInHour = 1;
+		DataGlobals::TimeStep = 1;
+		DataGlobals::MinutesPerTimeStep = 60;
+
+		Psychrometrics::InitializePsychRoutines();
+
+		std::string const idf_objects = delimited_string({
+		"Chiller:Electric:EIR,",
+		"  AirCooledChiller,                   !- Name",
+		"  autosize,                           !- Reference Capacity {W}",
+		"  5.50,                               !- Reference COP {W/W}",
+		"  6.67,                               !- Reference Leaving Chilled Water Temperature {C}",
+		"  29.40,                              !- Reference Entering Condenser Fluid Temperature {C}",
+		"  autosize,                           !- Reference Chilled Water Flow Rate {m3/s}",
+		"  autosize,                           !- Reference Condenser Fluid Flow Rate {m3/s}",
+		"  Air cooled CentCapFT,               !- Cooling Capacity Function of Temperature Curve Name",
+		"  Air cooled CentEIRFT,               !- Electric Input to Cooling Output Ratio Function of Temperature Curve Name",
+		"  Air cooled CentEIRFPLR,             !- Electric Input to Cooling Output Ratio Function of Part Load Ratio Curve Name",
+		"  0.10,                               !- Minimum Part Load Ratio",
+		"  1.00,                               !- Maximum Part Load Ratio",
+		"  1.00,                               !- Optimum Part Load Ratio",
+		"  0.25,                               !- Minimum Unloading Ratio",
+		"  CHW Inlet Node,                     !- Chilled Water Inlet Node Name",
+		"  CHW Outlet Node,                    !- Chilled Water Outlet Node Name",
+		"  Outdoor Air Condenser Inlet Node,   !- Condenser Inlet Node Name",
+		"  Outdoor Air Condenser Outlet Node,  !- Condenser Outlet Node Name",
+		"  AirCooled,                          !- Condenser Type",
+		"  0.04,                               !- Condenser Fan Power Ratio {W/W}",
+		"  1.00,                               !- Fraction of Compressor Electric Consumption Rejected by Condenser",
+		"  5.00,                               !- Leaving Chilled Water Lower Temperature Limit {C}",
+		"  NotModulated,                       !- Chiller Flow Mode",
+		"  0.0,                                !- Design Heat Recovery Water Flow Rate {m3/s}",
+		"  ,                                   !- Heat Recovery Inlet Node Name",
+		"  ,                                   !- Heat Recovery Outlet Node Name",
+		"  1.00,                               !- Sizing Factor",
+		"  0.00,                               !- Basin Heater Capacity {W/K}",
+		"  2.00,                               !- Basin Heater Setpoint Temperature {C}",
+		"  ,                                   !- Basin Heater Operating Schedule Name",
+		"  1.00,                               !- Condenser Heat Recovery Relative Capacity Fraction",
+		"  ,                                   !- Heat Recovery Inlet High Temperature Limit Schedule Name",
+		"  ;                                   !- Heat Recovery Leaving Temperature Setpoint Node Name",
+
+		"Curve:Biquadratic, Air cooled CentCapFT, 0.257896, 0.0389016, -0.00021708, 0.0468684, -0.00094284, -0.00034344, 5, 10, 24, 35, , , , , ;",
+		"Curve:Biquadratic, Air cooled CentEIRFT, 0.933884, -0.058212,  0.00450036, 0.00243,    0.000486,   -0.001215,   5, 10, 24, 35, , , , , ;",
+		"Curve:Quadratic, Air cooled CentEIRFPLR, 0.222903,  0.313387,  0.46371,    0, 1, , , , ;",
+
+	});
+
+	EXPECT_FALSE( process_idf( idf_objects, false ) );
+
+	DataPlant::PlantLoop.allocate( DataPlant::TotNumLoops );
+	DataPlant::PlantLoop.allocate( DataPlant::TotNumLoops );
+	for( int l = 1; l <= DataPlant::TotNumLoops; ++l ) {
+		auto & loop( DataPlant::PlantLoop( l ) );
+		loop.LoopSide.allocate( 2 );
+		auto & loopside( DataPlant::PlantLoop( l ).LoopSide( 1 ) );
+		loopside.TotalBranches = 1;
+		loopside.Branch.allocate( 1 );
+		auto & loopsidebranch( DataPlant::PlantLoop( l ).LoopSide( 1 ).Branch( 1 ) );
+		loopsidebranch.TotalComponents = 1;
+		loopsidebranch.Comp.allocate( 1 );
+	}
+
+		GetElectricEIRChillerInput();
+
+		DataPlant::PlantLoop( 1 ).Name = "ChilledWaterLoop";
+		DataPlant::PlantLoop( 1 ).FluidName = "ChilledWater";
+		DataPlant::PlantLoop( 1 ).FluidIndex = 1;
+		DataPlant::PlantLoop( 1 ).PlantSizNum = 1;
+		DataPlant::PlantLoop( 1 ).FluidName = "WATER";
+		DataPlant::PlantLoop( 1 ).LoopSide( 1 ).Branch( 1 ).Comp( 1 ).Name = ElectricEIRChiller( 1 ).Name;
+		DataPlant::PlantLoop( 1 ).LoopSide( 1 ).Branch( 1 ).Comp( 1 ).TypeOf_Num = DataPlant::TypeOf_Chiller_ElectricEIR;
+		DataPlant::PlantLoop( 1 ).LoopSide( 1 ).Branch( 1 ).Comp( 1 ).NodeNumIn = ElectricEIRChiller( 1 ).EvapInletNodeNum;
+		DataPlant::PlantLoop( 1 ).LoopSide( 1 ).Branch( 1 ).Comp( 1 ).NodeNumOut = ElectricEIRChiller( 1 ).EvapOutletNodeNum;
+
+		DataSizing::PlantSizData.allocate( 1 );
+		DataSizing::PlantSizData( 1 ).DesVolFlowRate = 0.001;
+		DataSizing::PlantSizData( 1 ).DeltaT = 5.0;
+
+		bool RunFlag( true );
+		Real64 MyLoad( -10000.0 );
+
+		DataPlant::PlantFirstSizesOkayToFinalize = true;
+		DataPlant::PlantFirstSizesOkayToReport = true;
+		DataPlant::PlantFinalSizesOkayToReport = true;
+
+		InitElectricEIRChiller( 1, RunFlag, MyLoad );
+		SizeElectricEIRChiller( 1 );
+
+		// run through init again after sizing is complete to set mass flow rate
+		DataGlobals::BeginEnvrnFlag = true;
+		InitElectricEIRChiller( 1, RunFlag, MyLoad );
+
+		// check chiller water side evap flow rate is non-zero
+		EXPECT_NEAR( ElectricEIRChiller( 1 ).EvapMassFlowRateMax, 0.999898, 0.0000001 );
+
+		// check autocalculate for air-cooled or evap-cooled chiller condenser side fluid flow rate
+		Real64 CalcCondVolFlow = ElectricEIRChiller( 1 ).RefCap * 0.000114;
+		EXPECT_EQ( CalcCondVolFlow, ElectricEIRChiller( 1 ).CondVolFlowRate );
+		EXPECT_NEAR( ElectricEIRChiller( 1 ).CondVolFlowRate, 2.3925760323498, 0.0000001 );
+		EXPECT_NEAR( ElectricEIRChiller( 1 ).CondMassFlowRateMax, 2.7918772761695, 0.0000001 );
+
+
 }

--- a/tst/EnergyPlus/unit/ChillerElectricEIR.unit.cc
+++ b/tst/EnergyPlus/unit/ChillerElectricEIR.unit.cc
@@ -110,9 +110,9 @@ TEST_F( EnergyPlusFixture, ChillerElectricEIR_TestOutletNodeConditions )
 TEST_F( EnergyPlusFixture, ChillerElectricEIR_AirCooledChiller )
 {
 
-		bool FirstHVACIteration( false );
-		bool ErrorsFound( false );
-		Real64 QZnReq( -1000.0 );
+		bool RunFlag( true );
+		Real64 MyLoad( -10000.0 );
+
 		DataPlant::TotNumLoops = 2;
 		DataEnvironment::OutBaroPress = 101325.0;
 		DataEnvironment::StdRhoAir = 1.20;
@@ -194,9 +194,6 @@ TEST_F( EnergyPlusFixture, ChillerElectricEIR_AirCooledChiller )
 		DataSizing::PlantSizData.allocate( 1 );
 		DataSizing::PlantSizData( 1 ).DesVolFlowRate = 0.001;
 		DataSizing::PlantSizData( 1 ).DeltaT = 5.0;
-
-		bool RunFlag( true );
-		Real64 MyLoad( -10000.0 );
 
 		DataPlant::PlantFirstSizesOkayToFinalize = true;
 		DataPlant::PlantFirstSizesOkayToReport = true;


### PR DESCRIPTION
## Pull request overview

Air-cooled and evaporatively-cooled EIR chillers reports very high condenser air outlet node temperatures. Evap-cooled chiller condenser also shows no water use. Fixes issue #5629.
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
### Review Checklist

This will not be exhaustively relevant to every PR.
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [ ] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [x] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] Open windows IDF Editor with modified IDD to check for errors
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [x] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces
