### PR TITLE
Fix EMS actuator initialization to Null at get input

### DIFF
--- a/src/EnergyPlus/EMSManager.cc
+++ b/src/EnergyPlus/EMSManager.cc
@@ -861,6 +861,8 @@ namespace EMSManager {
 					} else {
 						VariableNum = NewEMSVariable( cAlphaArgs( 1 ), 0 );
 						EMSActuatorUsed( ActuatorNum ).ErlVariableNum = VariableNum;
+						//initialize Erl variable for actuator to null
+						ErlVariable( VariableNum ).Value = Null;
 						if ( ActuatorNum > numActuatorsUsed ) {
 							// Initialize variables for the ExternalInterface variables
 							ExternalInterfaceInitializeErlVariable( VariableNum, SetErlValueNumber( rNumericArgs( 1 ) ), lNumericFieldBlanks( 1 ) );

--- a/tst/EnergyPlus/unit/EMSManager.unit.cc
+++ b/tst/EnergyPlus/unit/EMSManager.unit.cc
@@ -75,6 +75,7 @@
 #include <EnergyPlus/SimulationManager.hh>
 #include <EnergyPlus/PlantCondLoopOperation.hh>
 #include <EnergyPlus/PlantUtilities.hh>
+#include <DataRuntimeLanguage.hh>
 
 using namespace EnergyPlus;
 using namespace EnergyPlus::EMSManager;
@@ -175,9 +176,42 @@ TEST_F( EnergyPlusFixture, Dual_NodeTempSetpoints ) {
 		EMSManager::ManageEMS( DataGlobals::emsCallFromBeginNewEvironment, anyRan );
 
 
-		EXPECT_NEAR(DataLoopNode::Node(1).TempSetPointHi, 20.0, 0.000001 );
+		EXPECT_NEAR( DataLoopNode::Node(1).TempSetPointHi, 20.0, 0.000001 );
 
-		EXPECT_NEAR(DataLoopNode::Node(1).TempSetPointLo, 16.0, 0.000001 );
+		EXPECT_NEAR( DataLoopNode::Node(1).TempSetPointLo, 16.0, 0.000001 );
+
+}
+
+TEST_F( EnergyPlusFixture, CheckActuatorInit ) {
+		// this test checks that new actuators have the Erl variable associated with them set to Null right away, issue #5710
+		std::string const idf_objects = delimited_string( {
+		"Version,8.6;",
+
+		"OutdoorAir:Node, Test node;",
+
+		"EnergyManagementSystem:Actuator,",
+		"TempSetpointLo,          !- Name",
+		"Test node,  !- Actuated Component Unique Name",
+		"System Node Setpoint,    !- Actuated Component Type",
+		"Temperature Minimum Setpoint;    !- Actuated Component Control Type",
+
+		"EnergyManagementSystem:ProgramCallingManager,",
+		"Dual Setpoint Test Manager,  !- Name",
+		"EndSystemTimestepBeforeHVACReporting,  !- EnergyPlus Model Calling Point",
+		"DualSetpointTestControl;  !- Program Name 1",
+
+		"EnergyManagementSystem:Program,",
+		"DualSetpointTestControl,",
+		"Set TempSetpointLo = 16.0;",
+
+		} );
+
+		ASSERT_FALSE( process_idf( idf_objects ) );
+		OutAirNodeManager::SetOutAirNodes();
+		EMSManager::GetEMSInput();
+
+		// now check that Erl variable is Null
+		EXPECT_EQ( DataRuntimeLanguage::ErlVariable( 1 ).Value.Type, DataRuntimeLanguage::ValueNull );
 
 }
 


### PR DESCRIPTION
## Pull request overview

This PR is for fixing issue #5710.  Erl variables are created with value type number for general use, but those used for Actuators should be set to Null right away to be sure they never get used before other initializations take place. 
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
  - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
  - NewFeature: This pull request includes code to add a new feature to EnergyPlus
  - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
  - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog
### Review Checklist

This will not be exhaustively relevant to every PR.
- [ ] Code style (parentheses padding, variable names)
- [ ] Functional code review (it has to work!)
- [ ] If defect, results of running current develop vs this branch should exhibit the fix
- [ ] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [ ] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] Open windows IDF Editor with modified IDD to check for errors
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [ ] Documentation changes in place
- [ ] ExpandObjects changes??
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces
