### PR TITLE
Fix edge case for non-unique names in WindowMaterial:Gap

### DIFF
--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -4842,7 +4842,7 @@ namespace HeatBalanceManager {
 		for ( SurfNum = 1; SurfNum <= TotSurfaces; ++SurfNum ) {
 			DataSurfaces::Surface( SurfNum ).MovInsulIntPresentPrevTS = DataSurfaces::Surface( SurfNum ).MovInsulIntPresent;
 		}
-		
+
 	}
 
 	void
@@ -7199,7 +7199,7 @@ Label1000: ;
 			IsBlank = false;
 
 			// Verify unique names
-			VerifyName( cAlphaArgs( 1 ), Material, MaterNum - 1, IsNotOK, IsBlank, cCurrentModuleObject + " Name" );
+			VerifyName( cAlphaArgs( 1 ), Material, MaterNum, IsNotOK, IsBlank, cCurrentModuleObject + " Name" );
 			if ( IsNotOK ) {
 				ErrorsFound = true;
 				ShowSevereError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + ", object. Illegal value for " + cAlphaFieldNames( 1 ) + " has been found." );

--- a/testfiles/CmplxGlz_SmOff_IntExtShading.idf
+++ b/testfiles/CmplxGlz_SmOff_IntExtShading.idf
@@ -9748,11 +9748,16 @@
 !         Window Gap Layers
 !----------------------------------------------------------------------
 
-  WindowMaterial:Gap,
-    Gap_1_Layer,             !- Name
-    0.0127,                  !- Thickness {m}
-    Gas_1_W_0_0127,          !- Gas (or Gas Mixture)
-    101325.0000;             !- Pressure {Pa}
+! There were two materials called "Gap_1_Layer" and this slipped through
+! the input processing cracks.  Once this was fixed, this testfile failed,
+! so this second instance is just commented out, which is likely what
+! was occuring in the erroneous previous condition.
+!
+!  WindowMaterial:Gap,
+!    Gap_1_Layer,             !- Name
+!    0.0127,                  !- Thickness {m}
+!    Gas_1_W_0_0127,          !- Gas (or Gas Mixture)
+!    101325.0000;             !- Pressure {Pa}
 
 !----------------------------------------------------------------------
 !         Complex Shade

--- a/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
@@ -95,6 +95,78 @@ using namespace EnergyPlus::DataHVACGlobals;
 
 namespace EnergyPlus {
 
+	TEST_F( EnergyPlusFixture, HeatBalanceManager_WindowMaterial_Gap_Duplicate_Names )
+	{
+		std::string const idf_objects = delimited_string( {
+			"Version,8.6;",
+			"  WindowMaterial:Gap,",
+			"    Gap_1_Layer,             !- Name",
+			"    0.0127,                  !- Thickness {m}",
+			"    Gas_1_W_0_0127,          !- Gas (or Gas Mixture)",
+			"    101325.0000;             !- Pressure {Pa}",
+			"  WindowGap:DeflectionState,",
+			"    DeflectionState_813_Measured_Gap_1,  !- Name",
+			"    0.0120;                  !- Deflected Thickness {m}",
+			"  WindowMaterial:Gap,",
+			"    Gap_6_Layer,             !- Name",
+			"    0.0060,                  !- Thickness {m}",
+			"    Gap_6_W_0_0060,          !- Gas (or Gas Mixture)",
+			"    101300.0000,             !- Pressure {Pa}",
+			"    DeflectionState_813_Measured_Gap_1;  !- Deflection State",
+		    "  WindowMaterial:Gap,",
+			"    Gap_1_Layer,             !- Name",
+			"    0.0100,                  !- Thickness {m}",
+			"    Gas_1_W_0_0100,          !- Gas (or Gas Mixture)",
+			"    101325.0000;             !- Pressure {Pa}",
+		} );
+
+		ASSERT_FALSE( process_idf( idf_objects ) );
+
+		bool ErrorsFound( false );
+
+		GetMaterialData( ErrorsFound );
+
+		EXPECT_TRUE( ErrorsFound );
+
+	}
+
+	TEST_F( EnergyPlusFixture, HeatBalanceManager_WindowMaterial_Gap_Duplicate_Names_2 )
+	{
+		std::string const idf_objects = delimited_string(
+			{
+				"Version,8.6;",
+				"  WindowGap:DeflectionState,",
+				"    DeflectionState_813_Measured_Gap_1,  !- Name",
+				"    0.0120;                  !- Deflected Thickness {m}",
+				"  WindowMaterial:Gap,",
+				"    Gap_6_Layer,             !- Name",
+				"    0.0060,                  !- Thickness {m}",
+				"    Gap_6_W_0_0060,          !- Gas (or Gas Mixture)",
+				"    101300.0000,             !- Pressure {Pa}",
+				"    DeflectionState_813_Measured_Gap_1;  !- Deflection State",
+				"  WindowMaterial:Gap,",
+				"    Gap_1_Layer,             !- Name",
+				"    0.0127,                  !- Thickness {m}",
+				"    Gas_1_W_0_0127,          !- Gas (or Gas Mixture)",
+				"    101325.0000;             !- Pressure {Pa}",
+				"  WindowMaterial:Gap,",
+				"    Gap_1_Layer,             !- Name",
+				"    0.0100,                  !- Thickness {m}",
+				"    Gas_1_W_0_0100,          !- Gas (or Gas Mixture)",
+				"    101325.0000;             !- Pressure {Pa}",
+			}
+		);
+
+		ASSERT_FALSE( process_idf( idf_objects ) );
+
+		bool ErrorsFound( false );
+
+		GetMaterialData( ErrorsFound );
+
+		EXPECT_TRUE( ErrorsFound );
+
+	}
+
 	TEST_F( EnergyPlusFixture, HeatBalanceManager_ProcessZoneData )
 	{
 	// Test input processing of Zone object


### PR DESCRIPTION
## Pull request overview

This bug was found when refactoring InputProcessor. The lookup for unique name of WindowMaterial:Gap was off by one for the size of the Material array. This causes two back to back WindowMaterial:Gap objects with the same name to pass the unique name check. This can be seen in two complex window glazing testfiles ([CmplxGlz_SmOff_IntExtShading_1](https://github.com/NREL/EnergyPlus/blob/cd9ad17443ea4715cb30aa65357936816a417bad/testfiles/CmplxGlz_SmOff_IntExtShading.idf#L2625) / [CmplxGlz_SmOff_IntExtShading_2](https://github.com/NREL/EnergyPlus/blob/cd9ad17443ea4715cb30aa65357936816a417bad/testfiles/CmplxGlz_SmOff_IntExtShading.idf#L9752) and  CmplxGlz_MeasuredDeflectionAndShading.idf).
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
  - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
  - NewFeature: This pull request includes code to add a new feature to EnergyPlus
  - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
  - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog
### Review Checklist

This will not be exhaustively relevant to every PR.
- [ ] Code style (parentheses padding, variable names)
- [ ] Functional code review (it has to work!)
- [ ] If defect, results of running current develop vs this branch should exhibit the fix
- [ ] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [ ] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes:
  - [ ] Verify naming conventions and styles, memos and notes and defaults
  - [ ] Open windows IDF Editor with modified IDD to check for errors
  - [ ] If transition, add rules to spreadsheet
  - [ ] If transition, add transition source
  - [ ] If transition, update idfs
- [ ] If new idf included, locally check the err file and other outputs
- [ ] Documentation changes in place
- [ ] Changed docs build successfully
- [ ] ExpandObjects changes?
- [ ] If output changes, including tabular output structure, add to output rules file for interfaces
