### PR TITLE
Enforce full distribution of high temp radiant energy to surfaces and people

### DIFF
--- a/doc/input-output-reference/src/overview/group-radiative-convective-units.tex
+++ b/doc/input-output-reference/src/overview/group-radiative-convective-units.tex
@@ -1743,7 +1743,7 @@ This field is the name of the first surface to which radiant heat transfer from 
 
 \paragraph{Field: Fraction of Radiant Energy to Surface \textless{}x\textgreater{}}\label{field-fraction-of-radiant-energy-to-surface-x-2}
 
-This field is paired with the preceding surface name (previous field) to define the fraction of radiant heat transfer leaving the high temperature radiant system that is incident on a particular surface. Users should take into account the directionality of high temperature radiant heaters and their location when defining the value for this input field. Note that the sum of all fractions plus the fraction of radiant energy incident on people must add up to less than or equal to 1.
+This field is paired with the preceding surface name (previous field) to define the fraction of radiant heat transfer leaving the high temperature radiant system that is incident on a particular surface. Users should take into account the directionality of high temperature radiant heaters and their location when defining the value for this input field. Note that the sum of all fractions plus the fraction of radiant energy incident on people must add up to 1 so that all radiant energy is taken into account and none of it is "lost".
 
 An example IDF with a high temperature radiant system is shown below.
 

--- a/src/EnergyPlus/HighTempRadiantSystem.cc
+++ b/src/EnergyPlus/HighTempRadiantSystem.cc
@@ -219,11 +219,14 @@ namespace HighTempRadiantSystem {
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		static bool GetInputFlag( true ); // First time, input is "gotten"
+		bool ErrorsFoundInGet; // Set to true when there are severe errors during the Get routine
 		int RadSysNum; // Radiant system number/index in local derived types
 
 		// FLOW:
 		if ( GetInputFlag ) {
-			GetHighTempRadiantSystem();
+			ErrorsFoundInGet = false;
+			GetHighTempRadiantSystem( ErrorsFoundInGet );
+			if ( ErrorsFoundInGet ) ShowFatalError( "GetHighTempRadiantSystem: Errors found in input.  Preceding condition(s) cause termination." );
 			GetInputFlag = false;
 		}
 
@@ -263,7 +266,9 @@ namespace HighTempRadiantSystem {
 	}
 
 	void
-	GetHighTempRadiantSystem()
+	GetHighTempRadiantSystem(
+			bool & ErrorsFound // TRUE if errors are found on processing the input
+	)
 	{
 
 		// SUBROUTINE INFORMATION:
@@ -325,12 +330,13 @@ namespace HighTempRadiantSystem {
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		Real64 AllFracsSummed; // Sum of the fractions radiant, latent, and lost (must be <= 1)
-		static bool ErrorsFound( false ); // Set to true if errors in input, fatal at end of routine
+		Real64 FracOfRadPotentiallyLost; // Difference between unity and AllFracsSummed for error reporting
 		int IOStatus; // Used in GetObjectItem
 		int Item; // Item to be "gotten"
 		int NumAlphas; // Number of Alphas for each GetObjectItem call
 		int NumNumbers; // Number of Numbers for each GetObjectItem call
 		int SurfNum; // Surface number DO loop counter
+		Real64 TotalFracToSurfs; // Sum of fractions of radiation to surfaces
 		bool IsNotOK; // Flag to verify name
 		bool IsBlank; // Flag for blank name
 
@@ -624,9 +630,16 @@ namespace HighTempRadiantSystem {
 				ErrorsFound = true;
 			}
 			if ( AllFracsSummed < ( MaxFraction - 0.01 ) ) { // User didn't distribute all of the radiation warn that some will be lost
-				ShowWarningError( "Fraction of radiation distributed to surfaces sums up to less than 1 for " + cAlphaArgs( 1 ) );
-				ShowContinueError( "As a result, some of the radiant energy delivered by the high temp radiant heater will be lost." );
-				ShowContinueError( "Occurs for " + cCurrentModuleObject + " = " + cAlphaArgs( 1 ) );
+				TotalFracToSurfs = AllFracsSummed - HighTempRadSys( Item ).FracDistribPerson;
+				FracOfRadPotentiallyLost = 1.0 - AllFracsSummed;
+				ShowSevereError( "Fraction of radiation distributed to surfaces and people sums up to less than 1 for " + cAlphaArgs( 1 ) );
+				ShowContinueError( "This would result in some of the radiant energy delivered by the high temp radiant heater being lost." );
+				ShowContinueError( "The sum of all radiation fractions to surfaces = " + TrimSigDigits( TotalFracToSurfs, 5) );
+				ShowContinueError( "The radiant fraction to people = " + TrimSigDigits( HighTempRadSys( Item ).FracDistribPerson, 5) );
+				ShowContinueError( "So, all radiant fractions including surfaces and people = " + TrimSigDigits( AllFracsSummed, 5) );
+				ShowContinueError( "This means that the fraction of radiant energy that would be lost from the high temperature radiant heater would be = " +  TrimSigDigits( FracOfRadPotentiallyLost, 5) );
+				ShowContinueError( "Please check and correct this so that all radiant energy is accounted for in " + cCurrentModuleObject + " = " + cAlphaArgs( 1 ) );
+				ErrorsFound = true;
 			}
 
 		} // ...end of DO loop through all of the high temperature radiant heaters
@@ -644,10 +657,6 @@ namespace HighTempRadiantSystem {
 				SetupOutputVariable( "Zone Radiant HVAC Electric Energy [J]", HighTempRadSys( Item ).ElecEnergy, "System", "Sum", HighTempRadSys( Item ).Name, _, "ELECTRICITY", "Heating", _, "System" );
 			}
 
-		}
-
-		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
 		}
 
 	}

--- a/src/EnergyPlus/HighTempRadiantSystem.cc
+++ b/src/EnergyPlus/HighTempRadiantSystem.cc
@@ -174,7 +174,23 @@ namespace HighTempRadiantSystem {
 	Array1D< HighTempRadSysNumericFieldData > HighTempRadSysNumericFields;
 
 	// Functions
+	void
+ 	clear_state()
+ 	{
+		NumOfHighTempRadSys = 0;
+		QHTRadSource.deallocate();
+		QHTRadSrcAvg.deallocate();
+		ZeroSourceSumHATsurf.deallocate();
+		LastQHTRadSrc.deallocate();
+		LastSysTimeElapsed.deallocate();
+		LastTimeStepSys.deallocate();
+		MySizeFlag.deallocate();
+		CheckEquipName.deallocate();
+		HighTempRadSys.deallocate();
+		HighTempRadSysNumericFields.deallocate();
+	}
 
+	
 	void
 	SimHighTempRadiantSystem(
 		std::string const & CompName, // name of the low temperature radiant system

--- a/src/EnergyPlus/HighTempRadiantSystem.hh
+++ b/src/EnergyPlus/HighTempRadiantSystem.hh
@@ -203,8 +203,8 @@ namespace HighTempRadiantSystem {
 	);
 
 	void
-	GetHighTempRadiantSystem();
-
+	GetHighTempRadiantSystem( bool & ErrorsFound ); // Error flag if problems encountered on reading user input
+	
 	void
 	InitHighTempRadiantSystem(
 		bool const FirstHVACIteration, // TRUE if 1st HVAC simulation of system timestep

--- a/src/EnergyPlus/HighTempRadiantSystem.hh
+++ b/src/EnergyPlus/HighTempRadiantSystem.hh
@@ -193,7 +193,9 @@ namespace HighTempRadiantSystem {
 	extern Array1D< HighTempRadSysNumericFieldData > HighTempRadSysNumericFields;
 
 	// Functions
-
+	void
+	clear_state();
+	
 	void
 	SimHighTempRadiantSystem(
 		std::string const & CompName, // name of the low temperature radiant system

--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -64,6 +64,7 @@ set( test_src
   HeatingCoils.unit.cc
   HeatPumpWaterToWaterSimple.unit.cc
   HeatRecovery.unit.cc
+  HighTempRadiantSystem.unit.cc
   Humidifiers.unit.cc
   HVACControllers.unit.cc
   HVACFourPipeBeam.unit.cc

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
@@ -139,6 +139,7 @@
 #include <EnergyPlus/HeatPumpWaterToWaterSimple.hh>
 #include <EnergyPlus/HeatRecovery.hh>
 #include <EnergyPlus/HeatingCoils.hh>
+#include <EnergyPlus/HighTempRadiantSystem.hh>
 #include <EnergyPlus/Humidifiers.hh>
 #include <EnergyPlus/HVACControllers.hh>
 #include <EnergyPlus/HVACDXHeatPumpSystem.hh>
@@ -341,6 +342,7 @@ namespace EnergyPlus {
 		HeatPumpWaterToWaterSimple::clear_state();
 		HeatRecovery::clear_state();
 		HeatingCoils::clear_state();
+		HighTempRadiantSystem::clear_state();
 		Humidifiers::clear_state();
 		HVACControllers::clear_state();
 		HVACDXHeatPumpSystem::clear_state();

--- a/tst/EnergyPlus/unit/HighTempRadiantSystem.unit.cc
+++ b/tst/EnergyPlus/unit/HighTempRadiantSystem.unit.cc
@@ -1,0 +1,143 @@
+// EnergyPlus, Copyright (c) 1996-2016, The Board of Trustees of the University of Illinois and
+// The Regents of the University of California, through Lawrence Berkeley National Laboratory
+// (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights
+// reserved.
+//
+// If you have questions about your rights to use or distribute this software, please contact
+// Berkeley Lab's Innovation & Partnerships Office at IPO@lbl.gov.
+//
+// NOTICE: This Software was developed under funding from the U.S. Department of Energy and the
+// U.S. Government consequently retains certain rights. As such, the U.S. Government has been
+// granted for itself and others acting on its behalf a paid-up, nonexclusive, irrevocable,
+// worldwide license in the Software to reproduce, distribute copies to the public, prepare
+// derivative works, and perform publicly and display publicly, and to permit others to do so.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted
+// provided that the following conditions are met:
+//
+// (1) Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//
+// (2) Redistributions in binary form must reproduce the above copyright notice, this list of
+//     conditions and the following disclaimer in the documentation and/or other materials
+//     provided with the distribution.
+//
+// (3) Neither the name of the University of California, Lawrence Berkeley National Laboratory,
+//     the University of Illinois, U.S. Dept. of Energy nor the names of its contributors may be
+//     used to endorse or promote products derived from this software without specific prior
+//     written permission.
+//
+// (4) Use of EnergyPlus(TM) Name. If Licensee (i) distributes the software in stand-alone form
+//     without changes from the version obtained under this License, or (ii) Licensee makes a
+//     reference solely to the software portion of its product, Licensee must refer to the
+//     software as "EnergyPlus version X" software, where "X" is the version number Licensee
+//     obtained under this License and may not use a different name for the software. Except as
+//     specifically required in this Section (4), Licensee shall not use in a company name, a
+//     product name, in advertising, publicity, or other promotional activities any name, trade
+//     name, trademark, logo, or other designation of "EnergyPlus", "E+", "e+" or confusingly
+//     similar designation, without Lawrence Berkeley National Laboratory's prior written consent.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// You are under no obligation whatsoever to provide any bug fixes, patches, or upgrades to the
+// features, functionality or performance of the source code ("Enhancements") to anyone; however,
+// if you choose to make your Enhancements available either publicly, or directly to Lawrence
+// Berkeley National Laboratory, without imposing a separate written license agreement for such
+// Enhancements, then you hereby grant the following license: a non-exclusive, royalty-free
+// perpetual license to install, use, modify, prepare derivative works, incorporate into other
+// computer software, distribute, and sublicense such enhancements or derivative works thereof,
+// in binary and source code form.
+
+// EnergyPlus::Low Temperature Radiant Unit Tests
+
+// Google Test Headers
+#include <gtest/gtest.h>
+
+// EnergyPlus Headers
+#include "Fixtures/EnergyPlusFixture.hh"
+#include <EnergyPlus/HighTempRadiantSystem.hh>
+#include <EnergyPlus/DataHeatBalance.hh>
+#include <EnergyPlus/DataGlobals.hh>
+#include <EnergyPlus/DataSurfaces.hh>
+#include <EnergyPlus/UtilityRoutines.hh>
+#include <ObjexxFCL/gio.hh>
+
+
+using namespace EnergyPlus;
+using namespace EnergyPlus::HighTempRadiantSystem;
+using namespace ObjexxFCL;
+using namespace EnergyPlus::DataHeatBalance;
+using namespace DataGlobals;
+using namespace EnergyPlus::DataSurfaces;
+
+
+namespace EnergyPlus {
+	
+	TEST_F( EnergyPlusFixture, HighTempRadiantSystemTest_GetHighTempRadiantSystem )
+	{
+
+		bool ErrorsFound;
+	
+		std::string const idf_objects = delimited_string( {
+		    "  ZoneHVAC:HighTemperatureRadiant,",
+			"    ZONERADHEATER,           !- Name",
+			"    ,                        !- Availability Schedule Name",
+			"	 ZONE1,                   !- Zone Name",
+			"	 HeatingDesignCapacity,   !- Heating Design Capacity Method",
+			"	 10000,                   !- Heating Design Capacity {W}",
+			"	 ,                        !- Heating Design Capacity Per Floor Area {W/m2}",
+			"	 ,                        !- Fraction of Autosized Heating Design Capacity",
+			"	 Electricity,             !- Fuel Type",
+			"	 1.0,                     !- Combustion Efficiency",
+			"	 0.80,                    !- Fraction of Input Converted to Radiant Energy",
+			"	 0.00,                    !- Fraction of Input Converted to Latent Energy",
+			"	 0.00,                    !- Fraction of Input that Is Lost",
+			"	 MeanAirTemperature,      !- Temperature Control Type",
+			"	 2.0,                     !- Heating Throttling Range {deltaC}",
+			"	 Radiant Heating Setpoints, !- Heating Setpoint Temperature Schedule Name",
+			"	 0.04,                    !- Fraction of Radiant Energy Incident on People",
+			"	 WALL1,                   !- Surface 1 Name",
+			"	 0.80;                    !- Fraction of Radiant Energy to Surface 1",
+		} );
+		
+		clear_state();
+		
+		ASSERT_FALSE( process_idf( idf_objects ) );
+
+		Zone.allocate( 1 );
+		Zone( 1 ).Name = "ZONE1";
+		Surface.allocate( 1 );
+		Surface( 1 ).Name = "WALL1";
+		Surface( 1 ).Zone = 1;
+	
+		ErrorsFound = false;
+
+		GetHighTempRadiantSystem( ErrorsFound );
+
+		std::string const error_string01 = delimited_string( {
+			"   ** Severe  ** Heating Setpoint Temperature Schedule Name not found: RADIANT HEATING SETPOINTS",
+   			"   **   ~~~   ** Occurs for ZoneHVAC:HighTemperatureRadiant = ZONERADHEATER",
+			"   ** Severe  ** Fraction of radiation distributed to surfaces and people sums up to less than 1 for ZONERADHEATER",
+			"   **   ~~~   ** This would result in some of the radiant energy delivered by the high temp radiant heater being lost.",
+			"   **   ~~~   ** The sum of all radiation fractions to surfaces = 0.80000",
+			"   **   ~~~   ** The radiant fraction to people = 4.00000E-002",
+			"   **   ~~~   ** So, all radiant fractions including surfaces and people = 0.84000",
+			"   **   ~~~   ** This means that the fraction of radiant energy that would be lost from the high temperature radiant heater would be = 0.16000",
+			"   **   ~~~   ** Please check and correct this so that all radiant energy is accounted for in ZoneHVAC:HighTemperatureRadiant = ZONERADHEATER"
+			} );
+	
+		EXPECT_TRUE( compare_err_stream( error_string01, true ) );
+		EXPECT_TRUE( ErrorsFound );
+
+	}
+
+}
+

--- a/tst/EnergyPlus/unit/HighTempRadiantSystem.unit.cc
+++ b/tst/EnergyPlus/unit/HighTempRadiantSystem.unit.cc
@@ -108,7 +108,7 @@ namespace EnergyPlus {
 			"	 0.80;                    !- Fraction of Radiant Energy to Surface 1",
 		} );
 		
-		clear_state();
+		HighTempRadiantSystem::clear_state();
 		
 		ASSERT_FALSE( process_idf( idf_objects ) );
 

--- a/tst/EnergyPlus/unit/HighTempRadiantSystem.unit.cc
+++ b/tst/EnergyPlus/unit/HighTempRadiantSystem.unit.cc
@@ -108,8 +108,6 @@ namespace EnergyPlus {
 			"	 0.80;                    !- Fraction of Radiant Energy to Surface 1",
 		} );
 		
-		HighTempRadiantSystem::clear_state();
-		
 		ASSERT_FALSE( process_idf( idf_objects ) );
 
 		Zone.allocate( 1 );


### PR DESCRIPTION
## Pull request overview

This pull request includes the code fix, unit test, and minor documentation mod for a problem in the high temperature radiant heater code. In the code, a warning message was produced when the user did not assign all of the radiant energy emitted from the radiant heater to surfaces or people in a space. The code noted that the sum did not add up to unity and produced the warning but then simply continued to simulate things. This resulted in a loss of energy that could be up to 100% of the radiant energy. This was discovered by a user and a change was request. Now, the code will produce a severe warning and will also produce additional information telling the user what was processed and that this is not allowed. The documentation was also modified to clarify this as well. This fix applies to all high temperature radiant heater types and was logged as GitHub Issue #4324.
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [ x ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [ x ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This defect is logged as ZoneHVAC:HighTemperatureRadiant - No radiant receiving surfaces and no radiant to people or GitHub Issue #4324.
### Review Checklist

This will not be exhaustively relevant to every PR.
- [x] Code style (parentheses padding, variable names)
- [x] Functional code review (it has to work!)
- [x] If defect, results of running current develop vs this branch should exhibit the fix
- [ ] CI status: all green or justified
- [x] Performance: CI Linux results include performance check -- verify this
- [x] Unit Test(s)
- C++ checks:
  - [x] Argument types
  - [x] If any virtual classes, ensure virtual destructor included, other things
- n/a IDD changes:
- n/a If new idf included, locally check the err file and other outputs
- [x] Documentation changes in place
- [x] Changed docs build successfully
- n/a ExpandObjects changes?
- n/a If output changes, including tabular output structure, add to output rules file for interfaces
