### PR TITLE
Fix fatal error in GetInternalVariableValue when non-metered variable used on a custom meter

### DIFF
--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -7075,10 +7075,11 @@ GetInternalVariableValue(
 		resultVal = 0.0;
 	} else if ( varType == 1 ) { // Integer
 		if ( keyVarIndex > NumOfIVariable ) {
-			ShowFatalError( "GetInternalVariableValue: passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValue: Integer variable passed index beyond range of array." );
+			ShowContinueError( "Index = " + General::TrimSigDigits( keyVarIndex ) + " Number of integer variables = " + General::TrimSigDigits( NumOfIVariable ) );
 		}
 		if ( keyVarIndex < 1 ) {
-			ShowFatalError( "GetInternalVariableValue: passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValue: Integer variable passed index <1. Index = " + General::TrimSigDigits( keyVarIndex ) );
 		}
 
 		IVar >>= IVariableTypes( keyVarIndex ).VarPtr;
@@ -7086,10 +7087,11 @@ GetInternalVariableValue(
 		resultVal = double( IVar().Which );
 	} else if ( varType == 2 ) { // real
 		if ( keyVarIndex > NumOfRVariable ) {
-			ShowFatalError( "GetInternalVariableValue: passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValue: Real variable passed index beyond range of array." );
+			ShowContinueError( "Index = " + General::TrimSigDigits( keyVarIndex ) + " Number of real variables = " + General::TrimSigDigits( NumOfRVariable ) );
 		}
 		if ( keyVarIndex < 1 ) {
-			ShowFatalError( "GetInternalVariableValue: passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValue: Integer variable passed index <1. Index = " + General::TrimSigDigits( keyVarIndex ) );
 		}
 
 		RVar >>= RVariableTypes( keyVarIndex ).VarPtr;
@@ -7243,7 +7245,7 @@ GetNumMeteredVariables(
 		if ( ComponentName != RVariableTypes( Loop ).KeyNameOnlyUC ) continue;
 		RVar >>= RVariableTypes( Loop ).VarPtr;
 		if ( RVar().MeterArrayPtr == 0 ) continue;
-		++NumVariables;
+		if ( VarMeterArrays( RVar().MeterArrayPtr ).NumOnMeters > 0 ) ++NumVariables;
 	}
 
 	return NumVariables;

--- a/src/EnergyPlus/SystemReports.cc
+++ b/src/EnergyPlus/SystemReports.cc
@@ -827,13 +827,15 @@ namespace SystemReports {
 					for ( PlantLoopNum = 1; PlantLoopNum <= NumPlantLoops; ++PlantLoopNum ) {
 						for ( BranchNum = 1; BranchNum <= VentRepPlantSupplySide( PlantLoopNum ).TotalBranches; ++BranchNum ) {
 							for ( CompNum = 1; CompNum <= VentRepPlantSupplySide( PlantLoopNum ).Branch( BranchNum ).TotalComponents; ++CompNum ) {
-								CompType = VentRepPlantSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).TypeOf;
-								CompName = VentRepPlantSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).Name;
+								{ auto & thisVentRepComp( VentRepPlantSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ) );
+								CompType = thisVentRepComp.TypeOf;
+								CompName = thisVentRepComp.Name;
 								FindDemandSideMatch( CompType, CompName, MatchFound, MatchLoopType, MatchLoop, MatchBranch, MatchComp );
-								VentRepPlantSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).ConnectPlant.LoopType = MatchLoopType;
-								VentRepPlantSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).ConnectPlant.LoopNum = MatchLoop;
-								VentRepPlantSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).ConnectPlant.BranchNum = MatchBranch;
-								VentRepPlantSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).ConnectPlant.CompNum = MatchComp;
+								thisVentRepComp.ConnectPlant.LoopType = MatchLoopType;
+								thisVentRepComp.ConnectPlant.LoopNum = MatchLoop;
+								thisVentRepComp.ConnectPlant.BranchNum = MatchBranch;
+								thisVentRepComp.ConnectPlant.CompNum = MatchComp;
+								}
 							}
 						}
 					}
@@ -841,13 +843,15 @@ namespace SystemReports {
 					for ( PlantLoopNum = 1; PlantLoopNum <= NumCondLoops; ++PlantLoopNum ) {
 						for ( BranchNum = 1; BranchNum <= VentRepCondSupplySide( PlantLoopNum ).TotalBranches; ++BranchNum ) {
 							for ( CompNum = 1; CompNum <= VentRepCondSupplySide( PlantLoopNum ).Branch( BranchNum ).TotalComponents; ++CompNum ) {
-								CompType = VentRepCondSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).TypeOf;
-								CompName = VentRepCondSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).Name;
+								{ auto & thisVentRepComp( VentRepCondSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ) );
+								CompType = thisVentRepComp.TypeOf;
+								CompName = thisVentRepComp.Name;
 								FindDemandSideMatch( CompType, CompName, MatchFound, MatchLoopType, MatchLoop, MatchBranch, MatchComp );
-								VentRepCondSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).ConnectPlant.LoopType = MatchLoopType;
-								VentRepCondSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).ConnectPlant.LoopNum = MatchLoop;
-								VentRepCondSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).ConnectPlant.BranchNum = MatchBranch;
-								VentRepCondSupplySide( PlantLoopNum ).Branch( BranchNum ).Comp( CompNum ).ConnectPlant.CompNum = MatchComp;
+								thisVentRepComp.ConnectPlant.LoopType = MatchLoopType;
+								thisVentRepComp.ConnectPlant.LoopNum = MatchLoop;
+								thisVentRepComp.ConnectPlant.BranchNum = MatchBranch;
+								thisVentRepComp.ConnectPlant.CompNum = MatchComp;
+								}
 							}
 						}
 					}
@@ -1237,11 +1241,12 @@ namespace SystemReports {
 			if ( LoopType == 1 ) {
 				for ( BranchNum = 1; BranchNum <= VentRepPlantSupplySide( LoopNum ).TotalBranches; ++BranchNum ) {
 					for ( SupplySideCompNum = 1; SupplySideCompNum <= VentRepPlantSupplySide( LoopNum ).Branch( BranchNum ).TotalComponents; ++SupplySideCompNum ) {
-						DemandSideLoopType = VentRepPlantSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ).ConnectPlant.LoopType;
-						DemandSideLoopNum = VentRepPlantSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ).ConnectPlant.LoopNum;
-						DemandSideBranchNum = VentRepPlantSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ).ConnectPlant.BranchNum;
-						DemandSideCompNum = VentRepPlantSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ).ConnectPlant.CompNum;
-
+						{ auto & thisVentRepComp( VentRepPlantSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ) );
+						DemandSideLoopType = thisVentRepComp.ConnectPlant.LoopType;
+						DemandSideLoopNum = thisVentRepComp.ConnectPlant.LoopNum;
+						DemandSideBranchNum = thisVentRepComp.ConnectPlant.BranchNum;
+						DemandSideCompNum = thisVentRepComp.ConnectPlant.CompNum;
+						}
 						//If the connection is valid load the connection array
 						if ( DemandSideLoopType == 1 || DemandSideLoopType == 2 ) {
 							ConnectionFlag = true;
@@ -2261,12 +2266,14 @@ namespace SystemReports {
 						GetChildrenData( TypeOfComp, NameOfComp, NumChildren, SubCompTypes, SubCompNames, InletNodeNames, InletNodeNumbers, OutletNodeNames, OutletNodeNumbers, ErrorsFound );
 
 						for ( SubCompNum = 1; SubCompNum <= NumChildren; ++SubCompNum ) {
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf = SubCompTypes( SubCompNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name = SubCompNames( SubCompNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NodeNameIn = InletNodeNames( SubCompNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NodeNameOut = OutletNodeNames( SubCompNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NodeNumIn = InletNodeNumbers( SubCompNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NodeNumOut = OutletNodeNumbers( SubCompNum );
+							{ auto & thisSubComponent( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ) );
+							thisSubComponent.TypeOf = SubCompTypes( SubCompNum );
+							thisSubComponent.Name = SubCompNames( SubCompNum );
+							thisSubComponent.NodeNameIn = InletNodeNames( SubCompNum );
+							thisSubComponent.NodeNameOut = OutletNodeNames( SubCompNum );
+							thisSubComponent.NodeNumIn = InletNodeNumbers( SubCompNum );
+							thisSubComponent.NodeNumOut = OutletNodeNumbers( SubCompNum );
+							}
 						}
 
 						SubCompTypes.deallocate();
@@ -2299,16 +2306,17 @@ namespace SystemReports {
 							GetChildrenData( TypeOfComp, NameOfComp, NumGrandChildren, SubCompTypes, SubCompNames, InletNodeNames, InletNodeNumbers, OutletNodeNames, OutletNodeNumbers, ErrorsFound );
 
 							for ( SubSubCompNum = 1; SubSubCompNum <= NumGrandChildren; ++SubSubCompNum ) {
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).TypeOf = SubCompTypes( SubSubCompNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).Name = SubCompNames( SubSubCompNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NodeNameIn = InletNodeNames( SubSubCompNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NodeNameOut = OutletNodeNames( SubSubCompNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NodeNumIn = InletNodeNumbers( SubSubCompNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NodeNumOut = OutletNodeNumbers( SubSubCompNum );
+								{ auto & thisSubSubComponent( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ) );
+								thisSubSubComponent.TypeOf = SubCompTypes( SubSubCompNum );
+								thisSubSubComponent.Name = SubCompNames( SubSubCompNum );
+								thisSubSubComponent.NodeNameIn = InletNodeNames( SubSubCompNum );
+								thisSubSubComponent.NodeNameOut = OutletNodeNames( SubSubCompNum );
+								thisSubSubComponent.NodeNumIn = InletNodeNumbers( SubSubCompNum );
+								thisSubSubComponent.NodeNumOut = OutletNodeNumbers( SubSubCompNum );
 								NumLeft = GetNumChildren( SubCompTypes( SubSubCompNum ), SubCompNames( SubSubCompNum ) );
 								if ( NumLeft > 0 ) {
 									ShowSevereError( "Hanging Children for component=" + SubCompTypes( SubSubCompNum ) + ':' + SubCompNames( SubSubCompNum ) );
-								}
+								}}
 							}
 
 							SubCompTypes.deallocate();
@@ -2336,57 +2344,7 @@ namespace SystemReports {
 					TypeOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).TypeOf;
 					NameOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).Name;
 					NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
-					VarIndexes.allocate( NumVariables );
-					VarTypes.allocate( NumVariables );
-					IndexTypes.allocate( NumVariables );
-					UnitsStrings.allocate( NumVariables );
-					ResourceTypes.allocate( NumVariables );
-					EndUses.allocate( NumVariables );
-					Groups.allocate( NumVariables );
-					Names.allocate( NumVariables );
-					PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar.allocate( NumVariables );
-
-					PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).NumMeteredVars = NumVariables;
-					GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
-					ModeFlagOn = true;
-					for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-						if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
-							for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
-							}
-							ModeFlagOn = false;
-						} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
-							for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
-							}
-							ModeFlagOn = false;
-						} else if ( ModeFlagOn ) {
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
-						}
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
-					}
-
-					VarIndexes.deallocate();
-					VarTypes.deallocate();
-					IndexTypes.deallocate();
-					UnitsStrings.deallocate();
-					ResourceTypes.deallocate();
-					EndUses.deallocate();
-					Groups.deallocate();
-					Names.deallocate();
-
-					for ( SubCompNum = 1; SubCompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).NumSubComps; ++SubCompNum ) {
-						// Get complete list of components for complex branches
-						TypeOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
-						NameOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
-						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
+					if ( NumVariables > 0 ) {
 						VarIndexes.allocate( NumVariables );
 						VarTypes.allocate( NumVariables );
 						IndexTypes.allocate( NumVariables );
@@ -2395,33 +2353,33 @@ namespace SystemReports {
 						EndUses.allocate( NumVariables );
 						Groups.allocate( NumVariables );
 						Names.allocate( NumVariables );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar.allocate( NumVariables );
+						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar.allocate( NumVariables );
 
+						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).NumMeteredVars = NumVariables;
 						GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
-
 						ModeFlagOn = true;
 						for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-							if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
+							if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 								}
 								ModeFlagOn = false;
-							} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+							} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 								}
 								ModeFlagOn = false;
 							} else if ( ModeFlagOn ) {
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
 							}
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
 						}
 
 						VarIndexes.deallocate();
@@ -2432,14 +2390,13 @@ namespace SystemReports {
 						EndUses.deallocate();
 						Groups.deallocate();
 						Names.deallocate();
-
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumMeteredVars = NumVariables;
-
-						for ( SubSubCompNum = 1; SubSubCompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumSubSubComps; ++SubSubCompNum ) {
-							// Get complete list of components for complex branches
-							TypeOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).TypeOf;
-							NameOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).Name;
-							NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
+					}
+					for ( SubCompNum = 1; SubCompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).NumSubComps; ++SubCompNum ) {
+						// Get complete list of components for complex branches
+						TypeOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
+						NameOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
+						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
+						if ( NumVariables > 0 ) {
 							VarIndexes.allocate( NumVariables );
 							VarTypes.allocate( NumVariables );
 							IndexTypes.allocate( NumVariables );
@@ -2448,33 +2405,33 @@ namespace SystemReports {
 							EndUses.allocate( NumVariables );
 							Groups.allocate( NumVariables );
 							Names.allocate( NumVariables );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar.allocate( NumVariables );
+							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar.allocate( NumVariables );
 
 							GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 							ModeFlagOn = true;
 							for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-								if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
+								if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+										PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 									}
 									ModeFlagOn = false;
-								} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+								} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+										PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 									}
 									ModeFlagOn = false;
 								} else if ( ModeFlagOn ) {
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
 								}
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
 							}
 
 							VarIndexes.deallocate();
@@ -2485,7 +2442,62 @@ namespace SystemReports {
 							EndUses.deallocate();
 							Groups.deallocate();
 							Names.deallocate();
+						}
 
+						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumMeteredVars = NumVariables;
+
+						for ( SubSubCompNum = 1; SubSubCompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumSubSubComps; ++SubSubCompNum ) {
+							// Get complete list of components for complex branches
+							TypeOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).TypeOf;
+							NameOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).Name;
+							NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
+							if ( NumVariables > 0 ) {
+								VarIndexes.allocate( NumVariables );
+								VarTypes.allocate( NumVariables );
+								IndexTypes.allocate( NumVariables );
+								UnitsStrings.allocate( NumVariables );
+								ResourceTypes.allocate( NumVariables );
+								EndUses.allocate( NumVariables );
+								Groups.allocate( NumVariables );
+								Names.allocate( NumVariables );
+								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar.allocate( NumVariables );
+
+								GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
+
+								ModeFlagOn = true;
+								for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
+									if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+										for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
+											PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+										}
+										ModeFlagOn = false;
+									} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+										for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
+											PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+										}
+										ModeFlagOn = false;
+									} else if ( ModeFlagOn ) {
+										PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+									}
+									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+								}
+
+								VarIndexes.deallocate();
+								VarTypes.deallocate();
+								IndexTypes.deallocate();
+								UnitsStrings.deallocate();
+								ResourceTypes.deallocate();
+								EndUses.deallocate();
+								Groups.deallocate();
+								Names.deallocate();
+							}
 							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NumMeteredVars = NumVariables;
 						}
 					}
@@ -2513,58 +2525,60 @@ namespace SystemReports {
 				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).Parent = IsParent;
 				NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
 				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).NumMeteredVars = NumVariables;
-				InletNodeNames.deallocate();
-				InletNodeNumbers.deallocate();
-				InletFluidStreams.deallocate();
-				OutletNodeNames.deallocate();
-				OutletNodeNumbers.deallocate();
-				OutletFluidStreams.deallocate();
+				if ( NumVariables > 0 ) {
+					InletNodeNames.deallocate();
+					InletNodeNumbers.deallocate();
+					InletFluidStreams.deallocate();
+					OutletNodeNames.deallocate();
+					OutletNodeNumbers.deallocate();
+					OutletFluidStreams.deallocate();
 
-				VarIndexes.allocate( NumVariables );
-				VarTypes.allocate( NumVariables );
-				IndexTypes.allocate( NumVariables );
-				UnitsStrings.allocate( NumVariables );
-				ResourceTypes.allocate( NumVariables );
-				EndUses.allocate( NumVariables );
-				Groups.allocate( NumVariables );
-				Names.allocate( NumVariables );
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar.allocate( NumVariables );
+					VarIndexes.allocate( NumVariables );
+					VarTypes.allocate( NumVariables );
+					IndexTypes.allocate( NumVariables );
+					UnitsStrings.allocate( NumVariables );
+					ResourceTypes.allocate( NumVariables );
+					EndUses.allocate( NumVariables );
+					Groups.allocate( NumVariables );
+					Names.allocate( NumVariables );
+					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar.allocate( NumVariables );
 
-				GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
+					GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
-				ModeFlagOn = true;
-				for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-					if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
-						for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+					ModeFlagOn = true;
+					for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
+						if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+							for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+							}
+							ModeFlagOn = false;
+						} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+							for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+							}
+							ModeFlagOn = false;
+						} else if ( ModeFlagOn ) {
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
 						}
-						ModeFlagOn = false;
-					} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
-						for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
-						}
-						ModeFlagOn = false;
-					} else if ( ModeFlagOn ) {
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
 					}
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
-				}
 
-				VarIndexes.deallocate();
-				VarTypes.deallocate();
-				IndexTypes.deallocate();
-				UnitsStrings.deallocate();
-				ResourceTypes.deallocate();
-				EndUses.deallocate();
-				Groups.deallocate();
-				Names.deallocate();
+					VarIndexes.deallocate();
+					VarTypes.deallocate();
+					IndexTypes.deallocate();
+					UnitsStrings.deallocate();
+					ResourceTypes.deallocate();
+					EndUses.deallocate();
+					Groups.deallocate();
+					Names.deallocate();
+				}
 
 				if ( IsParentObject( TypeOfComp, NameOfComp ) ) {
 					NumChildren = GetNumChildren( TypeOfComp, NameOfComp );
@@ -2641,58 +2655,7 @@ namespace SystemReports {
 
 					NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
 					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).NumMeteredVars = NumVariables; //Sankar added this line
-					VarIndexes.allocate( NumVariables );
-					VarTypes.allocate( NumVariables );
-					IndexTypes.allocate( NumVariables );
-					UnitsStrings.allocate( NumVariables );
-					ResourceTypes.allocate( NumVariables );
-					EndUses.allocate( NumVariables );
-					Groups.allocate( NumVariables );
-					Names.allocate( NumVariables );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar.allocate( NumVariables );
-
-					GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
-
-					ModeFlagOn = true;
-					for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-						if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
-							for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
-							}
-							ModeFlagOn = false;
-						} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
-							for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
-							}
-							ModeFlagOn = false;
-						} else if ( ModeFlagOn ) {
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
-						}
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
-					}
-
-					VarIndexes.deallocate();
-					VarTypes.deallocate();
-					IndexTypes.deallocate();
-					UnitsStrings.deallocate();
-					ResourceTypes.deallocate();
-					EndUses.deallocate();
-					Groups.deallocate();
-					Names.deallocate();
-
-					for ( SubSubCompNum = 1; SubSubCompNum <= ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).NumSubSubEquip; ++SubSubCompNum ) {
-						TypeOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).TypeOf;
-						NameOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).Name;
-
-						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).NumMeteredVars = NumVariables; //Sankar added this line
+					if ( NumVariables > 0 ) {
 						VarIndexes.allocate( NumVariables );
 						VarTypes.allocate( NumVariables );
 						IndexTypes.allocate( NumVariables );
@@ -2701,33 +2664,33 @@ namespace SystemReports {
 						EndUses.allocate( NumVariables );
 						Groups.allocate( NumVariables );
 						Names.allocate( NumVariables );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar.allocate( NumVariables );
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar.allocate( NumVariables );
 
 						GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 						ModeFlagOn = true;
 						for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-							if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
+							if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+									ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 								}
 								ModeFlagOn = false;
-							} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+							} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+									ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 								}
 								ModeFlagOn = false;
 							} else if ( ModeFlagOn ) {
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
 							}
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
 						}
 
 						VarIndexes.deallocate();
@@ -2738,7 +2701,61 @@ namespace SystemReports {
 						EndUses.deallocate();
 						Groups.deallocate();
 						Names.deallocate();
+					}
 
+					for ( SubSubCompNum = 1; SubSubCompNum <= ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).NumSubSubEquip; ++SubSubCompNum ) {
+						TypeOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).TypeOf;
+						NameOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).Name;
+
+						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
+						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).NumMeteredVars = NumVariables; //Sankar added this line
+						if ( NumVariables > 0 ) {
+							VarIndexes.allocate( NumVariables );
+							VarTypes.allocate( NumVariables );
+							IndexTypes.allocate( NumVariables );
+							UnitsStrings.allocate( NumVariables );
+							ResourceTypes.allocate( NumVariables );
+							EndUses.allocate( NumVariables );
+							Groups.allocate( NumVariables );
+							Names.allocate( NumVariables );
+							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar.allocate( NumVariables );
+
+							GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
+
+							ModeFlagOn = true;
+							for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
+								if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
+										ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+									}
+									ModeFlagOn = false;
+								} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
+										ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+									}
+									ModeFlagOn = false;
+								} else if ( ModeFlagOn ) {
+									ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+								}
+								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+							}
+
+							VarIndexes.deallocate();
+							VarTypes.deallocate();
+							IndexTypes.deallocate();
+							UnitsStrings.deallocate();
+							ResourceTypes.deallocate();
+							EndUses.deallocate();
+							Groups.deallocate();
+							Names.deallocate();
+						}
 					}
 				}
 			}
@@ -2904,7 +2921,7 @@ namespace SystemReports {
 						TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).TypeOf;
 						NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).Name;
 						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
-						if ( NumVariables > 0 ){
+						if ( NumVariables > 0 ) {
 							VarIndexes.allocate( NumVariables );
 							VarTypes.allocate( NumVariables );
 							IndexTypes.allocate( NumVariables );
@@ -2957,7 +2974,7 @@ namespace SystemReports {
 							TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
 							NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
 							NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
-							if ( NumVariables > 0 ){
+							if ( NumVariables > 0 ) {
 								VarIndexes.allocate( NumVariables );
 								VarTypes.allocate( NumVariables );
 								IndexTypes.allocate( NumVariables );

--- a/src/EnergyPlus/SystemReports.cc
+++ b/src/EnergyPlus/SystemReports.cc
@@ -1284,11 +1284,12 @@ namespace SystemReports {
 			} else if ( LoopType == 2 ) {
 				for ( BranchNum = 1; BranchNum <= VentRepCondSupplySide( LoopNum ).TotalBranches; ++BranchNum ) {
 					for ( SupplySideCompNum = 1; SupplySideCompNum <= VentRepCondSupplySide( LoopNum ).Branch( BranchNum ).TotalComponents; ++SupplySideCompNum ) {
-						DemandSideLoopType = VentRepCondSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ).ConnectPlant.LoopType;
-						DemandSideLoopNum = VentRepCondSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ).ConnectPlant.LoopNum;
-						DemandSideBranchNum = VentRepCondSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ).ConnectPlant.BranchNum;
-						DemandSideCompNum = VentRepCondSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ).ConnectPlant.CompNum;
-
+						{ auto & thisVentRepComp( VentRepCondSupplySide( LoopNum ).Branch( BranchNum ).Comp( SupplySideCompNum ) );
+						DemandSideLoopType = thisVentRepComp.ConnectPlant.LoopType;
+						DemandSideLoopNum = thisVentRepComp.ConnectPlant.LoopNum;
+						DemandSideBranchNum = thisVentRepComp.ConnectPlant.BranchNum;
+						DemandSideCompNum = thisVentRepComp.ConnectPlant.CompNum;
+						}
 						//If the connection is valid load the connection array
 						if ( DemandSideLoopType == 1 || DemandSideLoopType == 2 ) {
 							ConnectionFlag = true;
@@ -2341,8 +2342,9 @@ namespace SystemReports {
 			for ( BranchNum = 1; BranchNum <= PrimaryAirSystem( AirLoopNum ).NumBranches; ++BranchNum ) {
 				for ( CompNum = 1; CompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).TotalComponents; ++CompNum ) {
 					// Get complete list of components for complex branches
-					TypeOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).TypeOf;
-					NameOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).Name;
+					{ auto & thisComp( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ) );
+					TypeOfComp = thisComp.TypeOf;
+					NameOfComp = thisComp.Name;
 					NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
 					if ( NumVariables > 0 ) {
 						VarIndexes.allocate( NumVariables );
@@ -2353,33 +2355,35 @@ namespace SystemReports {
 						EndUses.allocate( NumVariables );
 						Groups.allocate( NumVariables );
 						Names.allocate( NumVariables );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar.allocate( NumVariables );
+						thisComp.MeteredVar.allocate( NumVariables );
 
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).NumMeteredVars = NumVariables;
+						thisComp.NumMeteredVars = NumVariables;
 						GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 						ModeFlagOn = true;
 						for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-							if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+							{ auto & thisVar( thisComp.MeteredVar( VarNum ) );
+							thisVar.ReportVarName = Names( VarNum );
+							thisVar.ReportVarUnits = UnitsStrings( VarNum );
+							thisVar.ReportVarIndex = VarIndexes( VarNum );
+							thisVar.ReportVarIndexType = IndexTypes( VarNum );
+							thisVar.ReportVarType = VarTypes( VarNum );
+							thisVar.ResourceType = ResourceTypes( VarNum );
+							thisVar.EndUse = EndUses( VarNum );
+							if ( thisVar.EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+									thisComp.MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 								}
 								ModeFlagOn = false;
-							} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+							} else if ( thisVar.EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+									thisComp.MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 								}
 								ModeFlagOn = false;
 							} else if ( ModeFlagOn ) {
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+								thisVar.EndUse_CompMode = NoHeatNoCool;
 							}
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+							thisVar.Group = Groups( VarNum );
+							}
 						}
 
 						VarIndexes.deallocate();
@@ -2391,10 +2395,10 @@ namespace SystemReports {
 						Groups.deallocate();
 						Names.deallocate();
 					}
-					for ( SubCompNum = 1; SubCompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).NumSubComps; ++SubCompNum ) {
+					for ( SubCompNum = 1; SubCompNum <= thisComp.NumSubComps; ++SubCompNum ) {
 						// Get complete list of components for complex branches
-						TypeOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
-						NameOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
+						TypeOfComp = thisComp.SubComp( SubCompNum ).TypeOf;
+						NameOfComp = thisComp.SubComp( SubCompNum ).Name;
 						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
 						if ( NumVariables > 0 ) {
 							VarIndexes.allocate( NumVariables );
@@ -2405,33 +2409,35 @@ namespace SystemReports {
 							EndUses.allocate( NumVariables );
 							Groups.allocate( NumVariables );
 							Names.allocate( NumVariables );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar.allocate( NumVariables );
+							thisComp.SubComp( SubCompNum ).MeteredVar.allocate( NumVariables );
 
 							GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 							ModeFlagOn = true;
 							for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-								if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+								{ auto & thisVar( thisComp.SubComp( SubCompNum ).MeteredVar( VarNum ) );
+								thisVar.ReportVarName = Names( VarNum );
+								thisVar.ReportVarUnits = UnitsStrings( VarNum );
+								thisVar.ReportVarIndex = VarIndexes( VarNum );
+								thisVar.ReportVarIndexType = IndexTypes( VarNum );
+								thisVar.ReportVarType = VarTypes( VarNum );
+								thisVar.ResourceType = ResourceTypes( VarNum );
+								thisVar.EndUse = EndUses( VarNum );
+								if ( thisVar.EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+										thisComp.SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 									}
 									ModeFlagOn = false;
-								} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+								} else if ( thisVar.EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+										thisComp.SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 									}
 									ModeFlagOn = false;
 								} else if ( ModeFlagOn ) {
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+									thisVar.EndUse_CompMode = NoHeatNoCool;
 								}
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+								thisVar.Group = Groups( VarNum );
+								}
 							}
 
 							VarIndexes.deallocate();
@@ -2444,12 +2450,12 @@ namespace SystemReports {
 							Names.deallocate();
 						}
 
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumMeteredVars = NumVariables;
+						thisComp.SubComp( SubCompNum ).NumMeteredVars = NumVariables;
 
-						for ( SubSubCompNum = 1; SubSubCompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumSubSubComps; ++SubSubCompNum ) {
+						for ( SubSubCompNum = 1; SubSubCompNum <= thisComp.SubComp( SubCompNum ).NumSubSubComps; ++SubSubCompNum ) {
 							// Get complete list of components for complex branches
-							TypeOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).TypeOf;
-							NameOfComp = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).Name;
+							TypeOfComp = thisComp.SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).TypeOf;
+							NameOfComp = thisComp.SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).Name;
 							NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
 							if ( NumVariables > 0 ) {
 								VarIndexes.allocate( NumVariables );
@@ -2460,33 +2466,35 @@ namespace SystemReports {
 								EndUses.allocate( NumVariables );
 								Groups.allocate( NumVariables );
 								Names.allocate( NumVariables );
-								PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar.allocate( NumVariables );
+								thisComp.SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar.allocate( NumVariables );
 
 								GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 								ModeFlagOn = true;
 								for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-									if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+									{ auto & thisVar( thisComp.SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ) );
+									thisVar.ReportVarName = Names( VarNum );
+									thisVar.ReportVarUnits = UnitsStrings( VarNum );
+									thisVar.ReportVarIndex = VarIndexes( VarNum );
+									thisVar.ReportVarIndexType = IndexTypes( VarNum );
+									thisVar.ReportVarType = VarTypes( VarNum );
+									thisVar.ResourceType = ResourceTypes( VarNum );
+									thisVar.EndUse = EndUses( VarNum );
+									if ( thisVar.EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 										for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-											PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+											thisComp.SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 										}
 										ModeFlagOn = false;
-									} else if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+									} else if ( thisVar.EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 										for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-											PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+											thisComp.SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 										}
 										ModeFlagOn = false;
 									} else if ( ModeFlagOn ) {
-										PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+										thisVar.EndUse_CompMode = NoHeatNoCool;
 									}
-									PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+									thisVar.Group = Groups( VarNum );
+									}
 								}
 
 								VarIndexes.deallocate();
@@ -2498,9 +2506,9 @@ namespace SystemReports {
 								Groups.deallocate();
 								Names.deallocate();
 							}
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NumMeteredVars = NumVariables;
+							thisComp.SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NumMeteredVars = NumVariables;
 						}
-					}
+					}}
 
 				}
 			}
@@ -2514,17 +2522,18 @@ namespace SystemReports {
 				TypeOfComp = ZoneEquipList( CtrlZoneNum ).EquipType( CompNum );
 				NameOfComp = ZoneEquipList( CtrlZoneNum ).EquipName( CompNum );
 				GetComponentData( TypeOfComp, NameOfComp, IsParent, NumInlets, InletNodeNames, InletNodeNumbers, InletFluidStreams, NumOutlets, OutletNodeNames, OutletNodeNumbers, OutletFluidStreams, ErrorsFound );
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).TypeOf = TypeOfComp;
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).Name = NameOfComp;
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).OutletNodeNums.allocate( NumOutlets );
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).NumOutlets = NumOutlets;
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).OutletNodeNums = OutletNodeNumbers;
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).InletNodeNums.allocate( NumInlets );
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).NumInlets = NumInlets;
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).InletNodeNums = InletNodeNumbers;
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).Parent = IsParent;
+				{ auto & thisEquipData( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ) );
+				thisEquipData.TypeOf = TypeOfComp;
+				thisEquipData.Name = NameOfComp;
+				thisEquipData.OutletNodeNums.allocate( NumOutlets );
+				thisEquipData.NumOutlets = NumOutlets;
+				thisEquipData.OutletNodeNums = OutletNodeNumbers;
+				thisEquipData.InletNodeNums.allocate( NumInlets );
+				thisEquipData.NumInlets = NumInlets;
+				thisEquipData.InletNodeNums = InletNodeNumbers;
+				thisEquipData.Parent = IsParent;
 				NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
-				ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).NumMeteredVars = NumVariables;
+				thisEquipData.NumMeteredVars = NumVariables;
 				if ( NumVariables > 0 ) {
 					InletNodeNames.deallocate();
 					InletNodeNumbers.deallocate();
@@ -2541,33 +2550,35 @@ namespace SystemReports {
 					EndUses.allocate( NumVariables );
 					Groups.allocate( NumVariables );
 					Names.allocate( NumVariables );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar.allocate( NumVariables );
+					thisEquipData.MeteredVar.allocate( NumVariables );
 
 					GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 					ModeFlagOn = true;
 					for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-						if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+						{ auto & thisVar( thisEquipData.MeteredVar( VarNum ) );
+						thisVar.ReportVarName = Names( VarNum );
+						thisVar.ReportVarUnits = UnitsStrings( VarNum );
+						thisVar.ReportVarIndex = VarIndexes( VarNum );
+						thisVar.ReportVarIndexType = IndexTypes( VarNum );
+						thisVar.ReportVarType = VarTypes( VarNum );
+						thisVar.ResourceType = ResourceTypes( VarNum );
+						thisVar.EndUse = EndUses( VarNum );
+						if ( thisVar.EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 							for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+								thisEquipData.MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 							}
 							ModeFlagOn = false;
-						} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+						} else if ( thisVar.EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 							for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+								thisEquipData.MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 							}
 							ModeFlagOn = false;
 						} else if ( ModeFlagOn ) {
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+							thisVar.EndUse_CompMode = NoHeatNoCool;
 						}
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+						thisVar.Group = Groups( VarNum );
+						}
 					}
 
 					VarIndexes.deallocate();
@@ -2582,7 +2593,7 @@ namespace SystemReports {
 
 				if ( IsParentObject( TypeOfComp, NameOfComp ) ) {
 					NumChildren = GetNumChildren( TypeOfComp, NameOfComp );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).NumSubEquip = NumChildren;
+					thisEquipData.NumSubEquip = NumChildren;
 
 					SubCompTypes.allocate( NumChildren );
 					SubCompNames.allocate( NumChildren );
@@ -2590,15 +2601,15 @@ namespace SystemReports {
 					InletNodeNumbers.allocate( NumChildren );
 					OutletNodeNames.allocate( NumChildren );
 					OutletNodeNumbers.allocate( NumChildren );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData.allocate( NumChildren );
+					thisEquipData.SubEquipData.allocate( NumChildren );
 
 					GetChildrenData( TypeOfComp, NameOfComp, NumChildren, SubCompTypes, SubCompNames, InletNodeNames, InletNodeNumbers, OutletNodeNames, OutletNodeNumbers, ErrorsFound );
 
 					for ( SubCompNum = 1; SubCompNum <= NumChildren; ++SubCompNum ) {
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).TypeOf = SubCompTypes( SubCompNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).Name = SubCompNames( SubCompNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).OutletNodeNum = OutletNodeNumbers( SubCompNum );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).InletNodeNum = InletNodeNumbers( SubCompNum );
+						thisEquipData.SubEquipData( SubCompNum ).TypeOf = SubCompTypes( SubCompNum );
+						thisEquipData.SubEquipData( SubCompNum ).Name = SubCompNames( SubCompNum );
+						thisEquipData.SubEquipData( SubCompNum ).OutletNodeNum = OutletNodeNumbers( SubCompNum );
+						thisEquipData.SubEquipData( SubCompNum ).InletNodeNum = InletNodeNumbers( SubCompNum );
 					}
 
 					SubCompTypes.deallocate();
@@ -2612,26 +2623,26 @@ namespace SystemReports {
 				}
 
 				for ( SubCompNum = 1; SubCompNum <= NumChildren; ++SubCompNum ) {
-					TypeOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).TypeOf;
-					NameOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).Name;
+					TypeOfComp = thisEquipData.SubEquipData( SubCompNum ).TypeOf;
+					NameOfComp = thisEquipData.SubEquipData( SubCompNum ).Name;
 					if ( IsParentObject( TypeOfComp, NameOfComp ) ) {
 						NumGrandChildren = GetNumChildren( TypeOfComp, NameOfComp );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).NumSubSubEquip = NumGrandChildren;
+						thisEquipData.SubEquipData( SubCompNum ).NumSubSubEquip = NumGrandChildren;
 						SubCompTypes.allocate( NumGrandChildren );
 						SubCompNames.allocate( NumGrandChildren );
 						InletNodeNames.allocate( NumGrandChildren );
 						InletNodeNumbers.allocate( NumGrandChildren );
 						OutletNodeNames.allocate( NumGrandChildren );
 						OutletNodeNumbers.allocate( NumGrandChildren );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData.allocate( NumGrandChildren );
+						thisEquipData.SubEquipData( SubCompNum ).SubSubEquipData.allocate( NumGrandChildren );
 						//Sankar added the array number for EquipData
 						GetChildrenData( TypeOfComp, NameOfComp, NumGrandChildren, SubCompTypes, SubCompNames, InletNodeNames, InletNodeNumbers, OutletNodeNames, OutletNodeNumbers, ErrorsFound );
 
 						for ( SubSubCompNum = 1; SubSubCompNum <= NumGrandChildren; ++SubSubCompNum ) {
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).TypeOf = SubCompTypes( SubSubCompNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).Name = SubCompNames( SubSubCompNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).OutletNodeNum = OutletNodeNumbers( SubSubCompNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).InletNodeNum = InletNodeNumbers( SubSubCompNum );
+							thisEquipData.SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).TypeOf = SubCompTypes( SubSubCompNum );
+							thisEquipData.SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).Name = SubCompNames( SubSubCompNum );
+							thisEquipData.SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).OutletNodeNum = OutletNodeNumbers( SubSubCompNum );
+							thisEquipData.SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).InletNodeNum = InletNodeNumbers( SubSubCompNum );
 						}
 						SubCompTypes.deallocate();
 						SubCompNames.deallocate();
@@ -2642,7 +2653,7 @@ namespace SystemReports {
 					} else {
 						NumGrandChildren = 0;
 					}
-				}
+				}}
 			}
 		}
 
@@ -2650,11 +2661,12 @@ namespace SystemReports {
 			if ( ! ZoneEquipConfig( CtrlZoneNum ).IsControlled ) continue;
 			for ( CompNum = 1; CompNum <= ZoneEquipList( CtrlZoneNum ).NumOfEquipTypes; ++CompNum ) {
 				for ( SubCompNum = 1; SubCompNum <= ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).NumSubEquip; ++SubCompNum ) {
-					TypeOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).TypeOf;
-					NameOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).Name;
+					{ auto & thisSubEquipData( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ) );
+					TypeOfComp = thisSubEquipData.TypeOf;
+					NameOfComp = thisSubEquipData.Name;
 
 					NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
-					ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).NumMeteredVars = NumVariables; //Sankar added this line
+					thisSubEquipData.NumMeteredVars = NumVariables; //Sankar added this line
 					if ( NumVariables > 0 ) {
 						VarIndexes.allocate( NumVariables );
 						VarTypes.allocate( NumVariables );
@@ -2664,33 +2676,35 @@ namespace SystemReports {
 						EndUses.allocate( NumVariables );
 						Groups.allocate( NumVariables );
 						Names.allocate( NumVariables );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar.allocate( NumVariables );
+						thisSubEquipData.MeteredVar.allocate( NumVariables );
 
 						GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 						ModeFlagOn = true;
 						for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-							if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+							{ auto & thisVar( thisSubEquipData.MeteredVar( VarNum ) );
+							thisVar.ReportVarName = Names( VarNum );
+							thisVar.ReportVarUnits = UnitsStrings( VarNum );
+							thisVar.ReportVarIndex = VarIndexes( VarNum );
+							thisVar.ReportVarIndexType = IndexTypes( VarNum );
+							thisVar.ReportVarType = VarTypes( VarNum );
+							thisVar.ResourceType = ResourceTypes( VarNum );
+							thisVar.EndUse = EndUses( VarNum );
+							if ( thisVar.EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+									thisSubEquipData.MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 								}
 								ModeFlagOn = false;
-							} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+							} else if ( thisVar.EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+									thisSubEquipData.MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 								}
 								ModeFlagOn = false;
 							} else if ( ModeFlagOn ) {
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+								thisVar.EndUse_CompMode = NoHeatNoCool;
 							}
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+							thisVar.Group = Groups( VarNum );
+							}
 						}
 
 						VarIndexes.deallocate();
@@ -2703,12 +2717,12 @@ namespace SystemReports {
 						Names.deallocate();
 					}
 
-					for ( SubSubCompNum = 1; SubSubCompNum <= ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).NumSubSubEquip; ++SubSubCompNum ) {
-						TypeOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).TypeOf;
-						NameOfComp = ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).Name;
+					for ( SubSubCompNum = 1; SubSubCompNum <= thisSubEquipData.NumSubSubEquip; ++SubSubCompNum ) {
+						TypeOfComp = thisSubEquipData.SubSubEquipData( SubSubCompNum ).TypeOf;
+						NameOfComp = thisSubEquipData.SubSubEquipData( SubSubCompNum ).Name;
 
 						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
-						ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).NumMeteredVars = NumVariables; //Sankar added this line
+						thisSubEquipData.SubSubEquipData( SubSubCompNum ).NumMeteredVars = NumVariables; //Sankar added this line
 						if ( NumVariables > 0 ) {
 							VarIndexes.allocate( NumVariables );
 							VarTypes.allocate( NumVariables );
@@ -2718,33 +2732,35 @@ namespace SystemReports {
 							EndUses.allocate( NumVariables );
 							Groups.allocate( NumVariables );
 							Names.allocate( NumVariables );
-							ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar.allocate( NumVariables );
+							thisSubEquipData.SubSubEquipData( SubSubCompNum ).MeteredVar.allocate( NumVariables );
 
 							GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 							ModeFlagOn = true;
 							for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-								if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+								{ auto & thisVar( thisSubEquipData.SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ) );
+								thisVar.ReportVarName = Names( VarNum );
+								thisVar.ReportVarUnits = UnitsStrings( VarNum );
+								thisVar.ReportVarIndex = VarIndexes( VarNum );
+								thisVar.ReportVarIndexType = IndexTypes( VarNum );
+								thisVar.ReportVarType = VarTypes( VarNum );
+								thisVar.ResourceType = ResourceTypes( VarNum );
+								thisVar.EndUse = EndUses( VarNum );
+								if ( thisVar.EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+										thisSubEquipData.SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 									}
 									ModeFlagOn = false;
-								} else if ( ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+								} else if ( thisVar.EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+										thisSubEquipData.SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 									}
 									ModeFlagOn = false;
 								} else if ( ModeFlagOn ) {
-									ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+									thisVar.EndUse_CompMode = NoHeatNoCool;
 								}
-								ZoneEquipList( CtrlZoneNum ).EquipData( CompNum ).SubEquipData( SubCompNum ).SubSubEquipData( SubSubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+								thisVar.Group = Groups( VarNum );
+								}
 							}
 
 							VarIndexes.deallocate();
@@ -2756,7 +2772,7 @@ namespace SystemReports {
 							Groups.deallocate();
 							Names.deallocate();
 						}
-					}
+					}}
 				}
 			}
 		}
@@ -2801,12 +2817,13 @@ namespace SystemReports {
 
 				for ( BranchNum = 1; BranchNum <= ThisReportData.TotalBranches; ++BranchNum ) {
 					for ( CompNum = 1; CompNum <= ThisReportData.Branch( BranchNum ).TotalComponents; ++CompNum ) {
-						TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).TypeOf;
-						NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).Name;
+						{ auto & thisComp( ThisReportData.Branch( BranchNum ).Comp( CompNum ) );
+						TypeOfComp = thisComp.TypeOf;
+						NameOfComp = thisComp.Name;
 						// Get complete list of components for complex branches
 						if ( IsParentObject( TypeOfComp, NameOfComp ) ) {
 
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).Parent = true;
+							thisComp.Parent = true;
 							NumChildren = GetNumChildren( TypeOfComp, NameOfComp );
 
 							SubCompTypes.allocate( NumChildren );
@@ -2815,17 +2832,17 @@ namespace SystemReports {
 							InletNodeNumbers.allocate( NumChildren );
 							OutletNodeNames.allocate( NumChildren );
 							OutletNodeNumbers.allocate( NumChildren );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp.allocate( NumChildren );
+							thisComp.SubComp.allocate( NumChildren );
 
 							GetChildrenData( TypeOfComp, NameOfComp, NumChildren, SubCompTypes, SubCompNames, InletNodeNames, InletNodeNumbers, OutletNodeNames, OutletNodeNumbers, ErrorsFound );
 
 							for ( SubCompNum = 1; SubCompNum <= NumChildren; ++SubCompNum ) {
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf = SubCompTypes( SubCompNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name = SubCompNames( SubCompNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NodeNameIn = InletNodeNames( SubCompNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NodeNameOut = OutletNodeNames( SubCompNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NodeNumIn = InletNodeNumbers( SubCompNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NodeNumOut = OutletNodeNumbers( SubCompNum );
+								thisComp.SubComp( SubCompNum ).TypeOf = SubCompTypes( SubCompNum );
+								thisComp.SubComp( SubCompNum ).Name = SubCompNames( SubCompNum );
+								thisComp.SubComp( SubCompNum ).NodeNameIn = InletNodeNames( SubCompNum );
+								thisComp.SubComp( SubCompNum ).NodeNameOut = OutletNodeNames( SubCompNum );
+								thisComp.SubComp( SubCompNum ).NodeNumIn = InletNodeNumbers( SubCompNum );
+								thisComp.SubComp( SubCompNum ).NodeNumOut = OutletNodeNumbers( SubCompNum );
 							}
 
 							SubCompTypes.deallocate();
@@ -2837,14 +2854,14 @@ namespace SystemReports {
 
 						} else {
 							NumChildren = 0;
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).Parent = false;
+							thisComp.Parent = false;
 						}
-						ThisReportData.Branch( BranchNum ).Comp( CompNum ).NumSubComps = NumChildren;
+						thisComp.NumSubComps = NumChildren;
 
 						//check for 'grandchildren'
 						for ( SubCompNum = 1; SubCompNum <= NumChildren; ++SubCompNum ) {
-							TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
-							NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
+							TypeOfComp = thisComp.SubComp( SubCompNum ).TypeOf;
+							NameOfComp = thisComp.SubComp( SubCompNum ).Name;
 							if ( IsParentObject( TypeOfComp, NameOfComp ) ) {
 								NumGrandChildren = GetNumChildren( TypeOfComp, NameOfComp );
 								SubCompTypes.allocate( NumGrandChildren );
@@ -2853,17 +2870,19 @@ namespace SystemReports {
 								InletNodeNumbers.allocate( NumGrandChildren );
 								OutletNodeNames.allocate( NumGrandChildren );
 								OutletNodeNumbers.allocate( NumGrandChildren );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp.allocate( NumGrandChildren );
+								thisComp.SubComp( SubCompNum ).SubSubComp.allocate( NumGrandChildren );
 
 								GetChildrenData( TypeOfComp, NameOfComp, NumGrandChildren, SubCompTypes, SubCompNames, InletNodeNames, InletNodeNumbers, OutletNodeNames, OutletNodeNumbers, ErrorsFound );
 
 								for ( SubSubCompNum = 1; SubSubCompNum <= NumGrandChildren; ++SubSubCompNum ) {
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).TypeOf = SubCompTypes( SubSubCompNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).Name = SubCompNames( SubSubCompNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NodeNameIn = InletNodeNames( SubSubCompNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NodeNameOut = OutletNodeNames( SubSubCompNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NodeNumIn = InletNodeNumbers( SubSubCompNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NodeNumOut = OutletNodeNumbers( SubSubCompNum );
+									{ auto & thisSubSubComp( thisComp.SubComp( SubCompNum ).SubSubComp( SubSubCompNum ) );
+									thisSubSubComp.TypeOf = SubCompTypes( SubSubCompNum );
+									thisSubSubComp.Name = SubCompNames( SubSubCompNum );
+									thisSubSubComp.NodeNameIn = InletNodeNames( SubSubCompNum );
+									thisSubSubComp.NodeNameOut = OutletNodeNames( SubSubCompNum );
+									thisSubSubComp.NodeNumIn = InletNodeNumbers( SubSubCompNum );
+									thisSubSubComp.NodeNumOut = OutletNodeNumbers( SubSubCompNum );
+									}
 								}
 
 								SubCompTypes.deallocate();
@@ -2874,12 +2893,12 @@ namespace SystemReports {
 								OutletNodeNumbers.deallocate();
 							} else {
 								NumGrandChildren = 0;
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Parent = false;
+								thisComp.SubComp( SubCompNum ).Parent = false;
 							}
 
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumSubSubComps = NumGrandChildren;
+							thisComp.SubComp( SubCompNum ).NumSubSubComps = NumGrandChildren;
 
-						}
+						}}
 					}
 				}
 			}
@@ -2918,8 +2937,9 @@ namespace SystemReports {
 				for ( BranchNum = 1; BranchNum <= ThisReportData.TotalBranches; ++BranchNum ) {
 					for ( CompNum = 1; CompNum <= ThisReportData.Branch( BranchNum ).TotalComponents; ++CompNum ) {
 						// Get complete list of components for complex branches
-						TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).TypeOf;
-						NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).Name;
+						{ auto & thisComp( ThisReportData.Branch( BranchNum ).Comp( CompNum ) );
+						TypeOfComp = thisComp.TypeOf;
+						NameOfComp = thisComp.Name;
 						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
 						if ( NumVariables > 0 ) {
 							VarIndexes.allocate( NumVariables );
@@ -2930,34 +2950,36 @@ namespace SystemReports {
 							EndUses.allocate( NumVariables );
 							Groups.allocate( NumVariables );
 							Names.allocate( NumVariables );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar.allocate( NumVariables );
+							thisComp.MeteredVar.allocate( NumVariables );
 
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).NumMeteredVars = NumVariables;
+							thisComp.NumMeteredVars = NumVariables;
 							GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 							ModeFlagOn = true;
 							for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-								if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+								{ auto & thisVar( thisComp.MeteredVar( VarNum ) );
+								thisVar.ReportVarName = Names( VarNum );
+								thisVar.ReportVarUnits = UnitsStrings( VarNum );
+								thisVar.ReportVarIndex = VarIndexes( VarNum );
+								thisVar.ReportVarIndexType = IndexTypes( VarNum );
+								thisVar.ReportVarType = VarTypes( VarNum );
+								thisVar.ResourceType = ResourceTypes( VarNum );
+								thisVar.EndUse = EndUses( VarNum );
+								if ( thisVar.EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+										thisComp.MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 									}
 									ModeFlagOn = false;
-								} else if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+								} else if ( thisVar.EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+										thisComp.MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 									}
 									ModeFlagOn = false;
 								} else if ( ModeFlagOn ) {
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+									thisVar.EndUse_CompMode = NoHeatNoCool;
 								}
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+								thisVar.Group = Groups( VarNum );
+								}
 							}
 
 							VarIndexes.deallocate();
@@ -2969,10 +2991,10 @@ namespace SystemReports {
 							Groups.deallocate();
 							Names.deallocate();
 						}
-						for ( SubCompNum = 1; SubCompNum <= ThisReportData.Branch( BranchNum ).Comp( CompNum ).NumSubComps; ++SubCompNum ) {
+						for ( SubCompNum = 1; SubCompNum <= thisComp.NumSubComps; ++SubCompNum ) {
 							// Get complete list of components for complex branches
-							TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
-							NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
+							TypeOfComp = thisComp.SubComp( SubCompNum ).TypeOf;
+							NameOfComp = thisComp.SubComp( SubCompNum ).Name;
 							NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
 							if ( NumVariables > 0 ) {
 								VarIndexes.allocate( NumVariables );
@@ -2983,33 +3005,35 @@ namespace SystemReports {
 								EndUses.allocate( NumVariables );
 								Groups.allocate( NumVariables );
 								Names.allocate( NumVariables );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar.allocate( NumVariables );
+								thisComp.SubComp( SubCompNum ).MeteredVar.allocate( NumVariables );
 
 								GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 								ModeFlagOn = true;
 								for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-									if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+									{ auto & thisVar( thisComp.SubComp( SubCompNum ).MeteredVar( VarNum ) );
+									thisVar.ReportVarName = Names( VarNum );
+									thisVar.ReportVarUnits = UnitsStrings( VarNum );
+									thisVar.ReportVarIndex = VarIndexes( VarNum );
+									thisVar.ReportVarIndexType = IndexTypes( VarNum );
+									thisVar.ReportVarType = VarTypes( VarNum );
+									thisVar.ResourceType = ResourceTypes( VarNum );
+									thisVar.EndUse = EndUses( VarNum );
+									if ( thisVar.EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 										for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-											ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+											thisComp.SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 										}
 										ModeFlagOn = false;
-									} else if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+									} else if ( thisVar.EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 										for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-											ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+											thisComp.SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 										}
 										ModeFlagOn = false;
 									} else if ( ModeFlagOn ) {
-										ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+										thisVar.EndUse_CompMode = NoHeatNoCool;
 									}
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+									thisVar.Group = Groups( VarNum );
+									}
 								}
 
 								VarIndexes.deallocate();
@@ -3021,8 +3045,8 @@ namespace SystemReports {
 								Groups.deallocate();
 								Names.deallocate();
 							}
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumMeteredVars = NumVariables;
-						}
+							thisComp.SubComp( SubCompNum ).NumMeteredVars = NumVariables;
+						}}
 					}
 				}
 			}
@@ -4413,48 +4437,51 @@ namespace SystemReports {
 		int Idx;
 
 		for ( CompNum = 1; CompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).TotalComponents; ++CompNum ) {
-			for ( VarNum = 1; VarNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).NumMeteredVars; ++VarNum ) {
-				if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ResourceType == iRT_EnergyTransfer ) {
-					PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).EnergyTransComp = EnergyTrans;
-					CompType = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).TypeOf;
-					CompName = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).Name;
+			{ auto & thisComp( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ) );
+			for ( VarNum = 1; VarNum <= thisComp.NumMeteredVars; ++VarNum ) {
+				if ( thisComp.MeteredVar( VarNum ).ResourceType == iRT_EnergyTransfer ) {
+					thisComp.EnergyTransComp = EnergyTrans;
+					CompType = thisComp.TypeOf;
+					CompName = thisComp.Name;
 					Idx = 0;
 					FindDemandSideMatch( CompType, CompName, MatchFound, MatchLoopType, MatchLoop, MatchBranch, MatchComp );
 					if ( MatchFound ) UpdateAirSysCompPtrArray( Idx, AirLoopNum, BranchNum, CompNum, MatchLoopType, MatchLoop, MatchBranch, MatchComp );
-					PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).AirSysToPlantPtr = Idx;
+					thisComp.AirSysToPlantPtr = Idx;
 					break;
 				}
 			}
-			for ( SubCompNum = 1; SubCompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).NumSubComps; ++SubCompNum ) {
+			for ( SubCompNum = 1; SubCompNum <= thisComp.NumSubComps; ++SubCompNum ) {
 				//!!!!          IF(SysVentLoad == 0.0d0)EXIT
-				for ( VarNum = 1; VarNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumMeteredVars; ++VarNum ) {
-					if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ResourceType == iRT_EnergyTransfer ) {
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).EnergyTransComp = EnergyTrans;
-						CompType = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
-						CompName = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
+				{ auto & thisSubComp( thisComp.SubComp( SubCompNum ) );
+				for ( VarNum = 1; VarNum <= thisSubComp.NumMeteredVars; ++VarNum ) {
+					if ( thisSubComp.MeteredVar( VarNum ).ResourceType == iRT_EnergyTransfer ) {
+						thisSubComp.EnergyTransComp = EnergyTrans;
+						CompType = thisSubComp.TypeOf;
+						CompName = thisSubComp.Name;
 						Idx = 0;
 						FindDemandSideMatch( CompType, CompName, MatchFound, MatchLoopType, MatchLoop, MatchBranch, MatchComp );
 						if ( MatchFound ) UpdateAirSysSubCompPtrArray( Idx, AirLoopNum, BranchNum, CompNum, SubCompNum, MatchLoopType, MatchLoop, MatchBranch, MatchComp );
-						PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).AirSysToPlantPtr = Idx;
+						thisSubComp.AirSysToPlantPtr = Idx;
 						break;
 					}
 				}
-				for ( SubSubCompNum = 1; SubSubCompNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumSubSubComps; ++SubSubCompNum ) {
+				for ( SubSubCompNum = 1; SubSubCompNum <= thisSubComp.NumSubSubComps; ++SubSubCompNum ) {
 					//!!!!            IF(SysVentLoad == 0.0d0)EXIT
-					for ( VarNum = 1; VarNum <= PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).NumMeteredVars; ++VarNum ) {
-						if ( PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).MeteredVar( VarNum ).ResourceType == iRT_EnergyTransfer ) {
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).EnergyTransComp = EnergyTrans;
-							CompType = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).TypeOf;
-							CompName = PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).Name;
+					{ auto & thisSubSubComp( thisSubComp.SubSubComp( SubSubCompNum ) );
+					for ( VarNum = 1; VarNum <= thisSubSubComp.NumMeteredVars; ++VarNum ) {
+						if ( thisSubSubComp.MeteredVar( VarNum ).ResourceType == iRT_EnergyTransfer ) {
+							thisSubSubComp.EnergyTransComp = EnergyTrans;
+							CompType = thisSubSubComp.TypeOf;
+							CompName = thisSubSubComp.Name;
 							Idx = 0;
 							FindDemandSideMatch( CompType, CompName, MatchFound, MatchLoopType, MatchLoop, MatchBranch, MatchComp );
 							if ( MatchFound ) UpdateAirSysSubSubCompPtrArray( Idx, AirLoopNum, BranchNum, CompNum, SubCompNum, SubSubCompNum, MatchLoopType, MatchLoop, MatchBranch, MatchComp );
-							PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).SubSubComp( SubSubCompNum ).AirSysToPlantPtr = Idx;
+							thisSubSubComp.AirSysToPlantPtr = Idx;
 							break;
 						}
-					}
-				}
-			}
+					}}
+				}}
+			}}
 		}
 
 	}

--- a/src/EnergyPlus/SystemReports.cc
+++ b/src/EnergyPlus/SystemReports.cc
@@ -2904,58 +2904,7 @@ namespace SystemReports {
 						TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).TypeOf;
 						NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).Name;
 						NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
-						VarIndexes.allocate( NumVariables );
-						VarTypes.allocate( NumVariables );
-						IndexTypes.allocate( NumVariables );
-						UnitsStrings.allocate( NumVariables );
-						ResourceTypes.allocate( NumVariables );
-						EndUses.allocate( NumVariables );
-						Groups.allocate( NumVariables );
-						Names.allocate( NumVariables );
-						ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar.allocate( NumVariables );
-
-						ThisReportData.Branch( BranchNum ).Comp( CompNum ).NumMeteredVars = NumVariables;
-						GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
-
-						ModeFlagOn = true;
-						for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-							if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
-								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
-								}
-								ModeFlagOn = false;
-							} else if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
-								for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
-								}
-								ModeFlagOn = false;
-							} else if ( ModeFlagOn ) {
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
-							}
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
-						}
-
-						VarIndexes.deallocate();
-						VarTypes.deallocate();
-						IndexTypes.deallocate();
-						UnitsStrings.deallocate();
-						ResourceTypes.deallocate();
-						EndUses.deallocate();
-						Groups.deallocate();
-						Names.deallocate();
-
-						for ( SubCompNum = 1; SubCompNum <= ThisReportData.Branch( BranchNum ).Comp( CompNum ).NumSubComps; ++SubCompNum ) {
-							// Get complete list of components for complex branches
-							TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
-							NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
-							NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
+						if ( NumVariables > 0 ){
 							VarIndexes.allocate( NumVariables );
 							VarTypes.allocate( NumVariables );
 							IndexTypes.allocate( NumVariables );
@@ -2964,33 +2913,34 @@ namespace SystemReports {
 							EndUses.allocate( NumVariables );
 							Groups.allocate( NumVariables );
 							Names.allocate( NumVariables );
-							ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar.allocate( NumVariables );
+							ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar.allocate( NumVariables );
 
+							ThisReportData.Branch( BranchNum ).Comp( CompNum ).NumMeteredVars = NumVariables;
 							GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
 
 							ModeFlagOn = true;
 							for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
-								if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
+								if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+										ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
 									}
 									ModeFlagOn = false;
-								} else if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+								} else if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
 									for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
-										ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+										ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
 									}
 									ModeFlagOn = false;
 								} else if ( ModeFlagOn ) {
-									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
 								}
-								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
 							}
 
 							VarIndexes.deallocate();
@@ -3001,7 +2951,59 @@ namespace SystemReports {
 							EndUses.deallocate();
 							Groups.deallocate();
 							Names.deallocate();
+						}
+						for ( SubCompNum = 1; SubCompNum <= ThisReportData.Branch( BranchNum ).Comp( CompNum ).NumSubComps; ++SubCompNum ) {
+							// Get complete list of components for complex branches
+							TypeOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).TypeOf;
+							NameOfComp = ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).Name;
+							NumVariables = GetNumMeteredVariables( TypeOfComp, NameOfComp );
+							if ( NumVariables > 0 ){
+								VarIndexes.allocate( NumVariables );
+								VarTypes.allocate( NumVariables );
+								IndexTypes.allocate( NumVariables );
+								UnitsStrings.allocate( NumVariables );
+								ResourceTypes.allocate( NumVariables );
+								EndUses.allocate( NumVariables );
+								Groups.allocate( NumVariables );
+								Names.allocate( NumVariables );
+								ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar.allocate( NumVariables );
 
+								GetMeteredVariables( TypeOfComp, NameOfComp, VarIndexes, VarTypes, IndexTypes, UnitsStrings, ResourceTypes, EndUses, Groups, Names, NumFound );
+
+								ModeFlagOn = true;
+								for ( VarNum = 1; VarNum <= NumVariables; ++VarNum ) {
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarName = Names( VarNum );
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarUnits = UnitsStrings( VarNum );
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndex = VarIndexes( VarNum );
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarIndexType = IndexTypes( VarNum );
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ReportVarType = VarTypes( VarNum );
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).ResourceType = ResourceTypes( VarNum );
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse = EndUses( VarNum );
+									if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "HEATINGCOILS" && ModeFlagOn ) {
+										for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
+											ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = HeatingOnly;
+										}
+										ModeFlagOn = false;
+									} else if ( ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse == "COOLINGCOILS" && ModeFlagOn ) {
+										for ( VarNum1 = 1; VarNum1 <= NumVariables; ++VarNum1 ) {
+											ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum1 ).EndUse_CompMode = CoolingOnly;
+										}
+										ModeFlagOn = false;
+									} else if ( ModeFlagOn ) {
+										ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).EndUse_CompMode = NoHeatNoCool;
+									}
+									ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).MeteredVar( VarNum ).Group = Groups( VarNum );
+								}
+
+								VarIndexes.deallocate();
+								VarTypes.deallocate();
+								IndexTypes.deallocate();
+								UnitsStrings.deallocate();
+								ResourceTypes.deallocate();
+								EndUses.deallocate();
+								Groups.deallocate();
+								Names.deallocate();
+							}
 							ThisReportData.Branch( BranchNum ).Comp( CompNum ).SubComp( SubCompNum ).NumMeteredVars = NumVariables;
 						}
 					}


### PR DESCRIPTION
## Pull request overview

Addresses issue #5753.  If an output variable which is not normally metered is used in a custom meter (`Meter:Custom`) then it would cause warnings and in some cases a fatal error.

Three types of changes:
1. In `OutputProcessor::GetNumMeteredVariables` return number of variables that are connected only to a standard meter.  Previously connections to custom meters were also counted here, but those a not applicable for this function.
2. In `SystemReports::*` anywhere that `NumVariables = GetNumMeteredVariables` is used, check if `NumVariables` is zero and skip entire blocks.  This eliminates the "wrong context" meter warnings and prevents the fatal bad index error later on.
3. In `SystemReports:*` throughout, add references to get rid of lonnnnnng variable constructs like `PrimaryAirSystem( AirLoopNum ).Branch( BranchNum ).Comp( CompNum ).MeteredVar( VarNum )`.
### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
- [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
- [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
  - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
  - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
  - NewFeature: This pull request includes code to add a new feature to EnergyPlus
  - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
  - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog
### Review Checklist

This will not be exhaustively relevant to every PR.
- [ ] Code style (parentheses padding, variable names)
- [ ] Functional code review (it has to work!)
- [ ] If defect, results of running current develop vs this branch should exhibit the fix
- [ ] CI status: all green or justified
- [ ] Performance: CI Linux results include performance check -- verify this
- [ ] Unit Test(s)
- C++ checks:
  - [ ] Argument types
  - [ ] If any virtual classes, ensure virtual destructor included, other things
- IDD changes n/a
