### PR TITLE
Restore deleted section header for "Group Advanced Surface Concepts"

### DIFF
--- a/doc/input-output-reference/src/overview/group-advanced-surface-concepts.tex
+++ b/doc/input-output-reference/src/overview/group-advanced-surface-concepts.tex
@@ -1,3 +1,4 @@
+\section{Group -- Advanced Surface Concepts}\label{group-advanced-surface-concepts}
 
 This group of objects describe concepts applied to heat transfer surfaces that are of an advanced nature. Careful consideration must be given before using these.
 


### PR DESCRIPTION
Pull request overview
---------------------

In commit 25ce9f90474ca6145dd2b43836fd90262e450e3b on 2016-07-06, the
author was apparently trying to get the file
"group-advanced-surface-concepts.tex" to compile stand-alone. They had
deleted the section header and added a latex prelude which was
accidentally committed. In undoing that commit, the section header was
mistakenly deleted. This fix restores the section header to the file.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog
