### PR TITLE
Add warning when Meter:Custom references another Meter:Custom

### DIFF
--- a/doc/input-output-reference/src/overview/group-simulation-parameters.tex
+++ b/doc/input-output-reference/src/overview/group-simulation-parameters.tex
@@ -743,7 +743,7 @@ SimulationControl,
 
 \subsection{Meter:Custom}\label{metercustom}
 
-A custom meter allows the user to group variables or meters onto a virtual meter that can be used just like a normal meter created by EnergyPlus. For consistency, the items being grouped must all be similar.
+A custom meter allows the user to group variables or meters onto a virtual meter that can be used just like a normal meter created by EnergyPlus. For consistency, the items being grouped must all be similar. A Meter:Custom cannot reference another Meter:Custom.
 
 \subsubsection{Inputs}\label{inputs-17-008}
 
@@ -794,7 +794,7 @@ A key name field is used when the following field specifies an output variable. 
 
 \paragraph{Field: Output Variable or Meter Name \#}\label{field-output-variable-or-meter-name}
 
-This field must be a valid output variable name or a valid meter name.
+This field must be a valid output variable name or a valid meter name. If a Meter:Custom references another Meter:Custom it will generate a warning and not product any output.
 
 \subsection{Meter:CustomDecrement}\label{metercustomdecrement}
 

--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -98563,6 +98563,7 @@ Meter:Custom,
    \memo Used to allow users to combine specific variables and/or meters into
    \memo "custom" meter configurations. To access these meters by name, one must
    \memo first run a simulation to generate the RDD/MDD files and names.
+   \memo A Meter:Custom cannot reference another Meter:Custom.
    A1,  \field Name
         \required-field
    A2,  \field Fuel Type

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -1672,6 +1672,14 @@ namespace OutputProcessor {
 		cCurrentModuleObject = "Meter:Custom";
 		NumCustomMeters = GetNumObjectsFound( cCurrentModuleObject );
 
+        //make list of names for all Meter:Custom since they cannot refer to other Meter:Custom's
+		std::vector<std::string> namesOfMeterCustom;
+		for ( Loop = 1; Loop <= NumCustomMeters; ++Loop ) {
+			GetObjectItem (cCurrentModuleObject, Loop, cAlphaArgs, NumAlpha, rNumericArgs, NumNumbers, IOStat, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames);
+			namesOfMeterCustom.push_back(cAlphaArgs(1));
+		}
+
+
 		for ( Loop = 1; Loop <= NumCustomMeters; ++Loop ) {
 			GetObjectItem( cCurrentModuleObject, Loop, cAlphaArgs, NumAlpha, rNumericArgs, NumNumbers, IOStat, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
 			lbrackPos = index( cAlphaArgs( 1 ), '[' );
@@ -1689,6 +1697,22 @@ namespace OutputProcessor {
 			VarsOnCustomMeter = 0;
 			MaxVarsOnCustomMeter = 1000;
 			NumVarsOnCustomMeter = 0;
+			// check if any fields reference another Meter:Custom
+			int found = 0;
+			for ( fldIndex = 4; fldIndex <= NumAlpha; fldIndex += 2 ) {
+				for ( auto nameOfMeterCustom : namesOfMeterCustom ) {
+					if ( SameString (cAlphaArgs (fldIndex), nameOfMeterCustom)) {
+						found = fldIndex;
+						break;
+					}
+				if ( found != 0) break;
+				}
+			}
+			if ( found != 0 ) {
+				ShowWarningError (cCurrentModuleObject + "=\"" + cAlphaArgs (1) + "\", contains a reference to another " + cCurrentModuleObject + "in field: " + cAlphaFieldNames (found) + "=\"" + cAlphaArgs (found) + "\".");
+				continue;
+			}
+
 			for ( fldIndex = 3; fldIndex <= NumAlpha; fldIndex += 2 ) {
 				if ( cAlphaArgs( fldIndex ) == "*" || lAlphaFieldBlanks( fldIndex ) ) {
 					KeyIsStar = true;
@@ -1816,7 +1840,7 @@ namespace OutputProcessor {
 			}
 			if ( NumVarsOnCustomMeter == 0 ) {
 				ShowWarningError( cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", no items assigned " );
-				ShowContinueError( "...will not be shown with the Meter results" );
+				ShowContinueError( "...will not be shown with the Meter results. This may be caused by a Meter:Custom be assigned to another Meter:Custom." );
 			}
 
 		}

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -65,6 +65,7 @@
 #include <fstream>
 #include <ostream>
 #include <string>
+#include <unordered_set>
 
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array.functions.hh>
@@ -1673,12 +1674,13 @@ namespace OutputProcessor {
 		NumCustomMeters = GetNumObjectsFound( cCurrentModuleObject );
 
         //make list of names for all Meter:Custom since they cannot refer to other Meter:Custom's
-		std::vector<std::string> namesOfMeterCustom;
+		std::unordered_set<std::string> namesOfMeterCustom;
+		namesOfMeterCustom.reserve(NumCustomMeters);
+
 		for ( Loop = 1; Loop <= NumCustomMeters; ++Loop ) {
 			GetObjectItem (cCurrentModuleObject, Loop, cAlphaArgs, NumAlpha, rNumericArgs, NumNumbers, IOStat, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames);
-			namesOfMeterCustom.push_back(cAlphaArgs(1));
+			namesOfMeterCustom.emplace(MakeUPPERCase(cAlphaArgs(1)));
 		}
-
 
 		for ( Loop = 1; Loop <= NumCustomMeters; ++Loop ) {
 			GetObjectItem( cCurrentModuleObject, Loop, cAlphaArgs, NumAlpha, rNumericArgs, NumNumbers, IOStat, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
@@ -1700,12 +1702,9 @@ namespace OutputProcessor {
 			// check if any fields reference another Meter:Custom
 			int found = 0;
 			for ( fldIndex = 4; fldIndex <= NumAlpha; fldIndex += 2 ) {
-				for ( auto nameOfMeterCustom : namesOfMeterCustom ) {
-					if ( SameString (cAlphaArgs (fldIndex), nameOfMeterCustom)) {
-						found = fldIndex;
-						break;
-					}
-				if ( found != 0) break;
+				if ( namesOfMeterCustom.find(MakeUPPERCase(cAlphaArgs(fldIndex) ) ) != namesOfMeterCustom.end()) {
+					found = fldIndex;
+					break;
 				}
 			}
 			if ( found != 0 ) {

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -1708,7 +1708,7 @@ namespace OutputProcessor {
 				}
 			}
 			if ( found != 0 ) {
-				ShowWarningError (cCurrentModuleObject + "=\"" + cAlphaArgs (1) + "\", contains a reference to another " + cCurrentModuleObject + "in field: " + cAlphaFieldNames (found) + "=\"" + cAlphaArgs (found) + "\".");
+				ShowWarningError (cCurrentModuleObject + "=\"" + cAlphaArgs (1) + "\", contains a reference to another " + cCurrentModuleObject + " in field: " + cAlphaFieldNames (found) + "=\"" + cAlphaArgs (found) + "\".");
 				continue;
 			}
 
@@ -2729,10 +2729,10 @@ namespace OutputProcessor {
 
 		} else if ( endUseMeter == "BASEBOARD" || endUseMeter == "BASEBOARDS" ) {
 			EndUse = "Baseboard";
-			
+
 		} else if ( endUseMeter == "COOLINGPANEL" || endUseMeter == "COOLINGPANELS" ) {
 			EndUse = "CoolingPanel";
-			
+
 		} else if ( endUseMeter == "HEATREJECTION" || endUseMeter == "HEAT REJECTION" ) {
 			EndUse = "HeatRejection";
 

--- a/tst/EnergyPlus/unit/OutputProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/OutputProcessor.unit.cc
@@ -3355,7 +3355,7 @@ namespace EnergyPlus {
 			} ) );
 
 		}
-		TEST_F (SQLiteFixture, OutputProcessor_GenOutputVariablesAuditReport)
+		TEST_F (EnergyPlusFixture, OutputProcessor_GenOutputVariablesAuditReport)
 		{
 			std::string const idf_objects = delimited_string ({
 				"Output:Variable,*,Site Outdoor Air Drybulb Temperature,timestep;",
@@ -3401,7 +3401,6 @@ namespace EnergyPlus {
 			TimeValue (1).CurMinute = 50;
 			TimeValue (2).CurMinute = 50;
 
-			EnergyPlus::sqlite = std::move (sqlite_test);
 			GetReportVariableInput ();
 			SetupOutputVariable ("Site Outdoor Air Drybulb Temperature [C]", DataEnvironment::OutDryBulbTemp, "Zone", "Average", "Environment");
 			Real64 light_consumption = 999;


### PR DESCRIPTION
Add warning and no longer produce output in the case when a Meter:Custom references another Meter:Custom.

Addresses #5118

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
