### PR TITLE
ObjexxFCL minor update to correct public visibility of protected methods and data

### DIFF
--- a/src/EnergyPlus/ExternalInterface.cc
+++ b/src/EnergyPlus/ExternalInterface.cc
@@ -571,9 +571,9 @@ namespace ExternalInterface {
 
 				// now make the library call
 				if ( haveExternalInterfaceBCVTB ) {
-					retVal = getepvariables(simCfgFilNam.c_str(), &xmlStrOutTypArr[0], &xmlStrOutArr[0], &nOutVal, xmlStrInKey.c_str(), &nInKeys, &xmlStrInArr[0], &nInpVar, inpVarTypes.data_, &lenXmlStr);
+					retVal = getepvariables(simCfgFilNam.c_str(), &xmlStrOutTypArr[0], &xmlStrOutArr[0], &nOutVal, xmlStrInKey.c_str(), &nInKeys, &xmlStrInArr[0], &nInpVar, inpVarTypes.data(), &lenXmlStr);
 				} else if ( haveExternalInterfaceFMUExport ) {
-					retVal = getepvariablesFMU(simCfgFilNam.c_str(), &xmlStrOutTypArr[0], &xmlStrOutArr[0], &nOutVal, xmlStrInKey.c_str(), &nInKeys, &xmlStrInArr[0], &nInpVar, inpVarTypes.data_, &lenXmlStr);
+					retVal = getepvariablesFMU(simCfgFilNam.c_str(), &xmlStrOutTypArr[0], &xmlStrOutArr[0], &nOutVal, xmlStrInKey.c_str(), &nInKeys, &xmlStrInArr[0], &nInpVar, inpVarTypes.data(), &lenXmlStr);
 				} else {
 					//there should be no else condition at this point, however we'll still assign the error value for completeness
 					retVal = -1;
@@ -913,8 +913,8 @@ namespace ExternalInterface {
 		// Instantiate FMUs
 		for ( i = 1; i <= NumFMUObjects; ++i ) {
 			for ( j = 1; j <= FMU( i ).NumInstances; ++j ) {
-				FMU(i).Instance(j).fmicomponent = fmiEPlusInstantiateSlave( 
-					(char*)FMU(i).Instance(j).WorkingFolder.c_str(), &FMU(i).Instance(j).LenWorkingFolder, 
+				FMU(i).Instance(j).fmicomponent = fmiEPlusInstantiateSlave(
+					(char*)FMU(i).Instance(j).WorkingFolder.c_str(), &FMU(i).Instance(j).LenWorkingFolder,
 					&FMU(i).TimeOut, &FMU(i).Visible, &FMU(i).Interactive, &FMU(i).LoggingOn, &FMU(i).Instance(j).Index);
 				// TODO: This is doing a null pointer check; OK?
 				if ( ! FMU( i ).Instance( j ).fmicomponent ) {
@@ -930,7 +930,7 @@ namespace ExternalInterface {
 		int localfmiTrue( fmiTrue );
 		for ( i = 1; i <= NumFMUObjects; ++i ) {
 			for ( j = 1; j <= FMU( i ).NumInstances; ++j ) {
-				FMU( i ).Instance( j ).fmistatus = fmiEPlusInitializeSlave( &FMU( i ).Instance( j ).fmicomponent, 
+				FMU( i ).Instance( j ).fmistatus = fmiEPlusInitializeSlave( &FMU( i ).Instance( j ).fmicomponent,
 					&tStart, &localfmiTrue, &tStop, &FMU( i ).Instance( j ).Index );
 				if ( FMU( i ).Instance( j ).fmistatus != fmiOK ) {
 					ShowSevereError( "ExternalInterface/CalcExternalInterfaceFMUImport: Error when trying to initialize" );
@@ -965,7 +965,7 @@ namespace ExternalInterface {
 		// Initialize FMUs
 		for ( i = 1; i <= NumFMUObjects; ++i ) {
 			for ( j = 1; j <= FMU( i ).NumInstances; ++j ) {
-				FMU( i ).Instance( j ).fmistatus = fmiEPlusInitializeSlave( &FMU( i ).Instance( j ).fmicomponent, 
+				FMU( i ).Instance( j ).fmistatus = fmiEPlusInitializeSlave( &FMU( i ).Instance( j ).fmicomponent,
 					&tStart, &localfmiTrue, &tStop, &FMU( i ).Instance( j ).Index );
 				if ( FMU( i ).Instance( j ).fmistatus != fmiOK ) {
 					ShowSevereError( "ExternalInterface/CalcExternalInterfaceFMUImport: Error when trying to initialize" );
@@ -2099,9 +2099,9 @@ namespace ExternalInterface {
 			retVal = 0;
 			flaRea = 0;
 			if ( haveExternalInterfaceBCVTB ) {
-				retVal = exchangedoubleswithsocket( &socketFD, &flaWri, &flaRea, &nDblWri, &nDblRea, &preSimTim, dblValWri.data_, &curSimTim, dblValRea.data_ );
+				retVal = exchangedoubleswithsocket( &socketFD, &flaWri, &flaRea, &nDblWri, &nDblRea, &preSimTim, dblValWri.data(), &curSimTim, dblValRea.data() );
 			} else if ( haveExternalInterfaceFMUExport ) {
-				retVal = exchangedoubleswithsocketFMU( &socketFD, &flaWri, &flaRea, &nDblWri, &nDblRea, &preSimTim, dblValWri.data_, &curSimTim, dblValRea.data_, &FMUExportActivate );
+				retVal = exchangedoubleswithsocketFMU( &socketFD, &flaWri, &flaRea, &nDblWri, &nDblRea, &preSimTim, dblValWri.data(), &curSimTim, dblValRea.data(), &FMUExportActivate );
 			}
 			continueSimulation = true;
 

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Array.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Array.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Array</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Array.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Array.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Array</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -670,7 +670,7 @@ C = A + 3; // Adds 3 to each element</pre>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.CArray.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.CArray.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: CArray</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.CArray.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.CArray.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: CArray</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -188,7 +188,7 @@ v += 4.2; // Now all elements are 127</pre></td>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.CArrayA.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.CArrayA.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: CArrayA</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.CArrayA.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.CArrayA.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: CArrayA</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -189,7 +189,7 @@ v += 4.2; // Now all elements are 127</pre></td>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.CArrayP.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.CArrayP.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: CArrayP</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -204,7 +204,7 @@ v += 4.2; // Now all elements are 127</pre></td>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.CArrayP.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.CArrayP.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: CArrayP</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.ChunkVector.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.ChunkVector.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: ChunkVector</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.ChunkVector.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.ChunkVector.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: ChunkVector</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -203,7 +203,7 @@ v.assign( s, p );</pre></td>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Cstring.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Cstring.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Cstring</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -103,7 +103,7 @@ Cstring initial( 'E' ); // char<br />Cstring street( the_street ); // std::strin
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Cstring.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Cstring.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Cstring</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Developers.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Developers.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Developers Guide</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -388,7 +388,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Developers.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Developers.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Developers Guide</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Formatted_IO.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Formatted_IO.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Formatted I/O</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Formatted_IO.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Formatted_IO.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Formatted I/O</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -174,7 +174,7 @@ stream &lt;&lt; A(address,30) &lt;&lt; '\n';</pre>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Functions.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Functions.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Functions</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -81,7 +81,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Functions.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Functions.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Functions</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Global_IO.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Global_IO.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Global I/O</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Global_IO.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Global_IO.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Global I/O</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -195,7 +195,7 @@ gio::close( 88, flags );
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.IndexRange.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.IndexRange.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Index Ranges</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -121,7 +121,7 @@ std::cout &lt;&lt; I.size() &lt;&lt; std::endl; // Prints 11</pre></td>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.IndexRange.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.IndexRange.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Index Ranges</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.MArray.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.MArray.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: MArray</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.MArray.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.MArray.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: MArray</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -97,7 +97,7 @@ auto am( a.ma( &decltype( a )::Value::m ) ); // Array ma method alternative</pre
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Optional.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Optional.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Optional &amp; Required</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Optional.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Optional.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Optional &amp; Required</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -99,7 +99,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Organization.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Organization.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Organization</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Organization.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Organization.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Organization</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -251,7 +251,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Platforms.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Platforms.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Platforms</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Platforms.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Platforms.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Platforms</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -97,7 +97,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Reference.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Reference.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Reference</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Reference.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Reference.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Reference</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -119,7 +119,7 @@ r.deallocate(); // r is unattached again</pre>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Release.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Release.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Release Notes</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Release.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Release.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Release Notes</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -327,7 +327,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Support.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Support.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Support</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -106,7 +106,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Support.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Support.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Support</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Users.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Users.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Users.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Users.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -140,7 +140,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Vector.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Vector.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Vectors</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -199,7 +199,7 @@ std::cin &gt;&gt; v // Input vector from cin</pre></td>
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.Vector.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.Vector.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: Vectors</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.byte.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.byte.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: byte</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.byte.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.byte.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Users Guide: byte</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -75,7 +75,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Fortran Compatibility Library</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2016 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">
@@ -152,7 +152,7 @@
 		<td height="21"></td>
 		<td></td>
 		<td></td>
-		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2016 Objexx Engineering, Inc. All Rights Reserved.</td>
+		<td colspan="3" valign="bottom" class="footer_text">Copyright &copy; 2000-2017 Objexx Engineering, Inc. All Rights Reserved.</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/third_party/ObjexxFCL/doc/ObjexxFCL.html
+++ b/third_party/ObjexxFCL/doc/ObjexxFCL.html
@@ -5,7 +5,7 @@
 	<title>ObjexxFCL Fortran Compatibility Library</title>
 	<meta name="description" content="Objexx Fortran Compatibility Library">
 	<meta name="keywords" content="ObjexxFCL, Fortran-to-C++, F2C++, F2Cpp, F2Cxx, F2C, Fortran, C++, array library">
-	<meta name="copyright" content="Copyright 2000-2017 Objexx Engineering, Inc. All rights reserved.">
+	<meta name="copyright" content="Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="styles/Objexx.css" type="text/css">

--- a/third_party/ObjexxFCL/src/ObjexxFCL/AlignedAllocator.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/AlignedAllocator.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.functions.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1.hh
@@ -82,22 +82,25 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
+	typedef  void  iterator_category; // Prevent compile failure when std::distance is in scope
+
 	using Super::isize;
 	using Super::npos;
 	using Super::overlap;
-	using Super::shift_set;
 	using Super::size;
+
+protected: // Types
+
+	using Super::shift_set;
 	using Super::size_of;
 	using Super::slice_k;
 	using Super::swapB;
+
 	using Super::capacity_;
 	using Super::data_;
 	using Super::sdata_;
 	using Super::shift_;
 	using Super::size_;
-
-	// Types to prevent compile failure when std::distance is in scope
-	typedef  void  iterator_category;
 
 protected: // Creation
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1A.hh
@@ -64,8 +64,12 @@ public: // Types
 	using Super::conformable;
 	using Super::npos;
 	using Super::operator ();
+
+protected: // Types
+
 	using Super::shift_set;
 	using Super::size_set;
+
 	using Super::data_;
 	using Super::I_;
 	using Super::sdata_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1D.hh
@@ -73,26 +73,30 @@ public: // Types
 
 	typedef  std::function< void( Array1D< T > & ) >  InitializerFunction;
 
-	using Super::assign;
-	using Super::clear_move;
 	using Super::conformable;
 	using Super::contains;
 	using Super::index;
-	using Super::initialize;
 	using Super::isize1;
 	using Super::l;
+	using Super::operator ();
+	using Super::operator [];
+	using Super::size1;
+	using Super::u;
+
+protected: // Types
+
+	using Super::assign;
+	using Super::clear_move;
+	using Super::initialize;
 	using Super::move_if;
 	using Super::move_or_copy;
 	using Super::move_or_copy_backward;
-	using Super::operator ();
-	using Super::operator [];
 	using Super::resize;
 	using Super::shift_set;
 	using Super::shift_only_set;
-	using Super::size1;
 	using Super::size_of;
 	using Super::swap1;
-	using Super::u;
+
 	using Super::capacity_;
 	using Super::data_;
 	using Super::I_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1S.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1S.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1S.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array1S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array1S.hh
@@ -66,12 +66,15 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::slice_k;
+
 	using Super::contiguous_;
 	using Super::data_;
 	using Super::data_beg_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2.hh
@@ -84,9 +84,13 @@ public: // Types
 	using Super::npos;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
 	using Super::size_of;
 	using Super::slice_k;
 	using Super::swapB;
+
 	using Super::data_;
 	using Super::sdata_;
 	using Super::shift_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2A.hh
@@ -64,9 +64,13 @@ public: // Types
 	using Super::conformable;
 	using Super::npos;
 	using Super::operator ();
+
+protected: // Types
+
 	using Super::shift_set;
 	using Super::size_of;
 	using Super::size_set;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2D.hh
@@ -73,28 +73,32 @@ public: // Types
 
 	typedef  std::function< void( Array2D< T > & ) >  InitializerFunction;
 
-	using Super::assign;
-	using Super::clear_move;
 	using Super::conformable;
 	using Super::contains;
 	using Super::index;
-	using Super::initialize;
 	using Super::isize1;
 	using Super::isize2;
 	using Super::l1;
 	using Super::l2;
-	using Super::move_if;
 	using Super::operator ();
 	using Super::operator [];
+	using Super::size1;
+	using Super::size2;
+	using Super::u1;
+	using Super::u2;
+
+protected: // Types
+
+	using Super::assign;
+	using Super::clear_move;
+	using Super::initialize;
+	using Super::move_if;
 	using Super::resize;
 	using Super::shift_set;
 	using Super::shift_only_set;
-	using Super::size1;
-	using Super::size2;
 	using Super::size_of;
 	using Super::swap2;
-	using Super::u1;
-	using Super::u2;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2S.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2S.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2S.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array2S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array2S.hh
@@ -60,12 +60,15 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::slice_k;
+
 	using Super::contiguous_;
 	using Super::data_;
 	using Super::data_beg_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3.hh
@@ -83,9 +83,13 @@ public: // Types
 	using Super::npos;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
 	using Super::size_of;
 	using Super::slice_k;
 	using Super::swapB;
+
 	using Super::data_;
 	using Super::sdata_;
 	using Super::shift_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3A.hh
@@ -64,9 +64,13 @@ public: // Types
 	using Super::conformable;
 	using Super::npos;
 	using Super::operator ();
+
+protected: // Types
+
 	using Super::shift_set;
 	using Super::size_of;
 	using Super::size_set;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3D.hh
@@ -73,32 +73,36 @@ public: // Types
 
 	typedef  std::function< void( Array3D< T > & ) >  InitializerFunction;
 
-	using Super::assign;
-	using Super::clear_move;
 	using Super::conformable;
 	using Super::contains;
 	using Super::index;
-	using Super::initialize;
 	using Super::isize1;
 	using Super::isize2;
 	using Super::isize3;
 	using Super::l1;
 	using Super::l2;
 	using Super::l3;
-	using Super::move_if;
 	using Super::operator ();
 	using Super::operator [];
-	using Super::resize;
-	using Super::shift_set;
-	using Super::shift_only_set;
 	using Super::size1;
 	using Super::size2;
 	using Super::size3;
-	using Super::size_of;
-	using Super::swap3;
 	using Super::u1;
 	using Super::u2;
 	using Super::u3;
+
+protected: // Types
+
+	using Super::assign;
+	using Super::clear_move;
+	using Super::initialize;
+	using Super::move_if;
+	using Super::resize;
+	using Super::shift_set;
+	using Super::shift_only_set;
+	using Super::size_of;
+	using Super::swap3;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3S.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3S.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3S.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array3S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array3S.hh
@@ -60,12 +60,15 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::slice_k;
+
 	using Super::contiguous_;
 	using Super::data_;
 	using Super::data_beg_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4.hh
@@ -83,9 +83,13 @@ public: // Types
 	using Super::npos;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
 	using Super::size_of;
 	using Super::slice_k;
 	using Super::swapB;
+
 	using Super::data_;
 	using Super::sdata_;
 	using Super::shift_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4A.hh
@@ -64,9 +64,13 @@ public: // Types
 	using Super::conformable;
 	using Super::npos;
 	using Super::operator ();
+
+protected: // Types
+
 	using Super::shift_set;
 	using Super::size_of;
 	using Super::size_set;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4D.hh
@@ -73,12 +73,9 @@ public: // Types
 
 	typedef  std::function< void( Array4D< T > & ) >  InitializerFunction;
 
-	using Super::assign;
-	using Super::clear_move;
 	using Super::conformable;
 	using Super::contains;
 	using Super::index;
-	using Super::initialize;
 	using Super::isize1;
 	using Super::isize2;
 	using Super::isize3;
@@ -87,22 +84,29 @@ public: // Types
 	using Super::l2;
 	using Super::l3;
 	using Super::l4;
-	using Super::move_if;
 	using Super::operator ();
 	using Super::operator [];
-	using Super::resize;
-	using Super::shift_set;
-	using Super::shift_only_set;
 	using Super::size1;
 	using Super::size2;
 	using Super::size3;
 	using Super::size4;
-	using Super::size_of;
-	using Super::swap4;
 	using Super::u1;
 	using Super::u2;
 	using Super::u3;
 	using Super::u4;
+
+protected: // Types
+
+	using Super::assign;
+	using Super::clear_move;
+	using Super::initialize;
+	using Super::move_if;
+	using Super::resize;
+	using Super::shift_set;
+	using Super::shift_only_set;
+	using Super::size_of;
+	using Super::swap4;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4S.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4S.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4S.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array4S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array4S.hh
@@ -60,12 +60,15 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::slice_k;
+
 	using Super::contiguous_;
 	using Super::data_;
 	using Super::data_beg_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5.hh
@@ -83,9 +83,13 @@ public: // Types
 	using Super::npos;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
 	using Super::size_of;
 	using Super::slice_k;
 	using Super::swapB;
+
 	using Super::data_;
 	using Super::sdata_;
 	using Super::shift_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5A.hh
@@ -64,9 +64,13 @@ public: // Types
 	using Super::conformable;
 	using Super::npos;
 	using Super::operator ();
+
+protected: // Types
+
 	using Super::shift_set;
 	using Super::size_of;
 	using Super::size_set;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5D.hh
@@ -73,12 +73,9 @@ public: // Types
 
 	typedef  std::function< void( Array5D< T > & ) >  InitializerFunction;
 
-	using Super::assign;
-	using Super::clear_move;
 	using Super::conformable;
 	using Super::contains;
 	using Super::index;
-	using Super::initialize;
 	using Super::isize1;
 	using Super::isize2;
 	using Super::isize3;
@@ -89,24 +86,31 @@ public: // Types
 	using Super::l3;
 	using Super::l4;
 	using Super::l5;
-	using Super::move_if;
 	using Super::operator ();
 	using Super::operator [];
-	using Super::resize;
-	using Super::shift_set;
-	using Super::shift_only_set;
 	using Super::size1;
 	using Super::size2;
 	using Super::size3;
 	using Super::size4;
 	using Super::size5;
-	using Super::size_of;
-	using Super::swap5;
 	using Super::u1;
 	using Super::u2;
 	using Super::u3;
 	using Super::u4;
 	using Super::u5;
+
+protected: // Types
+
+	using Super::assign;
+	using Super::clear_move;
+	using Super::initialize;
+	using Super::move_if;
+	using Super::resize;
+	using Super::shift_set;
+	using Super::shift_only_set;
+	using Super::size_of;
+	using Super::swap5;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5S.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5S.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5S.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array5S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array5S.hh
@@ -60,12 +60,15 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::slice_k;
+
 	using Super::contiguous_;
 	using Super::data_;
 	using Super::data_beg_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6.hh
@@ -83,9 +83,13 @@ public: // Types
 	using Super::npos;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
 	using Super::size_of;
 	using Super::slice_k;
 	using Super::swapB;
+
 	using Super::data_;
 	using Super::sdata_;
 	using Super::shift_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6A.hh
@@ -64,9 +64,13 @@ public: // Types
 	using Super::conformable;
 	using Super::npos;
 	using Super::operator ();
+
+protected: // Types
+
 	using Super::shift_set;
 	using Super::size_of;
 	using Super::size_set;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6D.hh
@@ -73,12 +73,9 @@ public: // Types
 
 	typedef  std::function< void( Array6D< T > & ) >  InitializerFunction;
 
-	using Super::assign;
-	using Super::clear_move;
 	using Super::conformable;
 	using Super::contains;
 	using Super::index;
-	using Super::initialize;
 	using Super::isize1;
 	using Super::isize2;
 	using Super::isize3;
@@ -91,26 +88,33 @@ public: // Types
 	using Super::l4;
 	using Super::l5;
 	using Super::l6;
-	using Super::move_if;
 	using Super::operator ();
 	using Super::operator [];
-	using Super::resize;
-	using Super::shift_set;
-	using Super::shift_only_set;
 	using Super::size1;
 	using Super::size2;
 	using Super::size3;
 	using Super::size4;
 	using Super::size5;
 	using Super::size6;
-	using Super::size_of;
-	using Super::swap6;
 	using Super::u1;
 	using Super::u2;
 	using Super::u3;
 	using Super::u4;
 	using Super::u5;
 	using Super::u6;
+
+protected: // Types
+
+	using Super::assign;
+	using Super::clear_move;
+	using Super::initialize;
+	using Super::move_if;
+	using Super::resize;
+	using Super::shift_set;
+	using Super::shift_only_set;
+	using Super::size_of;
+	using Super::swap6;
+
 	using Super::data_;
 	using Super::I1_;
 	using Super::I2_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6S.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6S.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6S.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Array6S.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Array6S.hh
@@ -60,12 +60,15 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::slice_k;
+
 	using Super::contiguous_;
 	using Super::data_;
 	using Super::data_beg_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayInitializer.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayInitializer.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayInitializer.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayInitializer.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayRS.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayRS.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayRS.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayRS.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayRS.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayRS.hh
@@ -59,12 +59,15 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::overlap;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::slice_k;
+
 	using Super::contiguous_;
 	using Super::data_;
 	using Super::data_beg_;

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.functions.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayS.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayTail.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayTail.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ArrayTail.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ArrayTail.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/BArray.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/BArray.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/BArray.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/BArray.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Backspace.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Backspace.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Backspace.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Backspace.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/CArray.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/CArray.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/CArray.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/CArray.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/CArrayA.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/CArrayA.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/CArrayA.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/CArrayA.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/CArrayP.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/CArrayP.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/CArrayP.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/CArrayP.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Chunk.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Chunk.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ChunkExponent.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ChunkExponent.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ChunkVector.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ChunkVector.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ChunkVector.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ChunkVector.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Cstring.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Cstring.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Cstring.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Cstring.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Cstring.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Cstring.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/DimensionSlice.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/DimensionSlice.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/DimensionSlice.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/DimensionSlice.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Fmath.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Fmath.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Fmath.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Fmath.hh
@@ -108,7 +108,7 @@ using std::min;
 // min( short, short, short )
 inline
 short int
-min( short int a, short int b, short int c )
+min( short int const a, short int const b, short int const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -125,7 +125,7 @@ min( short int const a, short int const b, short int const c, short int const d,
 // min( int, int, int )
 inline
 int
-min( int a, int b, int c )
+min( int const a, int const b, int const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -142,7 +142,7 @@ min( int const a, int const b, int const c, int const d, Ts const &... o )
 // min( long, long, long )
 inline
 long int
-min( long int a, long int b, long int c )
+min( long int const a, long int const b, long int const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -159,7 +159,7 @@ min( long int const a, long int const b, long int const c, long int const d, Ts 
 // min( unsigned short, unsigned short, unsigned short )
 inline
 unsigned short int
-min( unsigned short int a, unsigned short int b, unsigned short int c )
+min( unsigned short int const a, unsigned short int const b, unsigned short int const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -176,7 +176,7 @@ min( unsigned short int const a, unsigned short int const b, unsigned short int 
 // min( unsigned, unsigned, unsigned )
 inline
 unsigned int
-min( unsigned int a, unsigned int b, unsigned int c )
+min( unsigned int const a, unsigned int const b, unsigned int const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -193,7 +193,7 @@ min( unsigned int const a, unsigned int const b, unsigned int const c, unsigned 
 // min( unsigned long, unsigned long, unsigned long )
 inline
 unsigned long int
-min( unsigned long int a, unsigned long int b, unsigned long int c )
+min( unsigned long int const a, unsigned long int const b, unsigned long int const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -210,7 +210,7 @@ min( unsigned long int const a, unsigned long int const b, unsigned long int con
 // min( float, float, float )
 inline
 float
-min( float a, float b, float c )
+min( float const a, float const b, float const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -227,7 +227,7 @@ min( float const a, float const b, float const c, float const d, Ts const &... o
 // min( double, double, double )
 inline
 double
-min( double a, double b, double c )
+min( double const a, double const b, double const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -244,7 +244,7 @@ min( double const a, double const b, double const c, double const d, Ts const &.
 // min( long double, long double, long double )
 inline
 long double
-min( long double a, long double b, long double c )
+min( long double const a, long double const b, long double const c )
 {
 	return ( a < b ? ( a < c ? a : c ) : ( b < c ? b : c ) );
 }
@@ -356,7 +356,7 @@ using std::max;
 // max( short, short, short )
 inline
 short int
-max( short int a, short int b, short int c )
+max( short int const a, short int const b, short int const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }
@@ -373,7 +373,7 @@ max( short int const a, short int const b, short int const c, short int const d,
 // max( int, int, int )
 inline
 int
-max( int a, int b, int c )
+max( int const a, int const b, int const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }
@@ -390,7 +390,7 @@ max( int const a, int const b, int const c, int const d, Ts const &... o )
 // max( long, long, long )
 inline
 long int
-max( long int a, long int b, long int c )
+max( long int const a, long int const b, long int const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }
@@ -407,7 +407,7 @@ max( long int const a, long int const b, long int const c, long int const d, Ts 
 // max( unsigned short, unsigned short, unsigned short )
 inline
 unsigned short int
-max( unsigned short int a, unsigned short int b, unsigned short int c )
+max( unsigned short int const a, unsigned short int const b, unsigned short int const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }
@@ -424,7 +424,7 @@ max( unsigned short int const a, unsigned short int const b, unsigned short int 
 // max( unsigned, unsigned, unsigned )
 inline
 unsigned int
-max( unsigned int a, unsigned int b, unsigned int c )
+max( unsigned int const a, unsigned int const b, unsigned int const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }
@@ -441,7 +441,7 @@ max( unsigned int const a, unsigned int const b, unsigned int const c, unsigned 
 // max( unsigned long, unsigned long, unsigned long )
 inline
 unsigned long int
-max( unsigned long int a, unsigned long int b, unsigned long int c )
+max( unsigned long int const a, unsigned long int const b, unsigned long int const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }
@@ -458,7 +458,7 @@ max( unsigned long int const a, unsigned long int const b, unsigned long int con
 // max( float, float, float )
 inline
 float
-max( float a, float b, float c )
+max( float const a, float const b, float const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }
@@ -475,7 +475,7 @@ max( float const a, float const b, float const c, float const d, Ts const &... o
 // max( double, double, double )
 inline
 double
-max( double a, double b, double c )
+max( double const a, double const b, double const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }
@@ -492,7 +492,7 @@ max( double const a, double const b, double const c, double const d, Ts const &.
 // max( long double, long double, long double )
 inline
 long double
-max( long double a, long double b, long double c )
+max( long double const a, long double const b, long double const c )
 {
 	return ( a < b ? ( b < c ? c : b ) : ( a < c ? c : a ) );
 }

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Format.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Format.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Format.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Format.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/FormattedIO.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/FormattedIO.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/GlobalStreams.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/GlobalStreams.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/GlobalStreams.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/GlobalStreams.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IOFlags.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IOFlags.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IOFlags.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IOFlags.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IOFlags.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IOFlags.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Index.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Index.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Index.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Index.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Index.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Index.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexRange.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexSlice.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexSlice.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexSlice.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexSlice.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/IndexSlice.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/IndexSlice.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/InitializerSentinel.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/InitializerSentinel.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Inquire.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Inquire.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Inquire.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Inquire.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray.all.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray.all.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray.all.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray.all.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray.functions.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray1.hh
@@ -65,13 +65,16 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::l;
 	using Super::u;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::j1;
+
 	using Super::array_;
 	using Super::pmem_;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray2.hh
@@ -57,14 +57,17 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::l;
 	using Super::u;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::j1;
 	using Super::j2;
+
 	using Super::array_;
 	using Super::pmem_;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray3.hh
@@ -57,15 +57,18 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::l;
 	using Super::u;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::j1;
 	using Super::j2;
 	using Super::j3;
+
 	using Super::array_;
 	using Super::pmem_;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray4.hh
@@ -57,16 +57,19 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::l;
 	using Super::u;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::j1;
 	using Super::j2;
 	using Super::j3;
 	using Super::j4;
+
 	using Super::array_;
 	using Super::pmem_;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray5.hh
@@ -57,17 +57,20 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::l;
 	using Super::u;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::j1;
 	using Super::j2;
 	using Super::j3;
 	using Super::j4;
 	using Super::j5;
+
 	using Super::array_;
 	using Super::pmem_;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArray6.hh
@@ -57,18 +57,21 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::l;
 	using Super::u;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
 	using Super::j1;
 	using Super::j2;
 	using Super::j3;
 	using Super::j4;
 	using Super::j5;
 	using Super::j6;
+
 	using Super::array_;
 	using Super::pmem_;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArrayR.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArrayR.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArrayR.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArrayR.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/MArrayR.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/MArrayR.hh
@@ -57,12 +57,15 @@ public: // Types
 	typedef  typename Super::Size  Size;
 	typedef  typename Super::Difference  Difference;
 
-	// Using
-	using Super::in_range;
 	using Super::isize;
 	using Super::l;
 	using Super::u;
 	using Super::size;
+
+protected: // Types
+
+	using Super::in_range;
+
 	using Super::array_;
 	using Super::pmem_;
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ObjexxFCL.Project.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ObjexxFCL.Project.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ObjexxFCL.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ObjexxFCL.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ObjexxFCL.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ObjexxFCL.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Omit.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Omit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Omit.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Omit.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Omit.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Omit.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Optional.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Optional.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Optional.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Optional.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Print.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Print.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Print.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Print.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Print.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Print.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ProxySentinel.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ProxySentinel.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Read.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Read.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Read.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Read.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Read.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Read.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Reference.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Reference.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Reference.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Reference.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Required.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Required.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Required.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Required.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Rewind.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Rewind.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Rewind.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Rewind.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/SetWrapper.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/SetWrapper.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/SetWrapper.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/SetWrapper.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Sticky.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Sticky.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Sticky.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Sticky.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Stream.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Stream.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Stream.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Stream.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Stream.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Stream.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Time_Date.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Time_Date.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Time_Date.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Time_Date.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/TraitsA.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/TraitsA.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/TraitsB.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/TraitsB.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/TraitsE.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/TraitsE.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/TraitsF.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/TraitsF.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/TraitsG.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/TraitsG.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/TraitsI.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/TraitsI.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/TraitsLD.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/TraitsLD.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/TypeTraits.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/TypeTraits.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Vector2.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Vector2.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Vector2.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Vector2.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Vector3.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Vector3.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Vector3.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Vector3.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Vector4.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Vector4.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Vector4.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Vector4.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Write.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Write.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Write.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Write.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/Write.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/Write.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/align.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/align.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/array.iterator.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/array.iterator.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/bit.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/bit.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/byte.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/byte.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/byte.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/byte.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/char.constants.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/char.constants.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/char.constants.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/char.constants.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/char.functions.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/char.functions.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/char.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/char.functions.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/environment.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/environment.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/environment.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/environment.cc
@@ -24,7 +24,7 @@ void
 get_environment_variable( std::string const & name, Optional< std::string > value, Optional< int > length, Optional< int > status, Optional< bool const > trim_name )
 {
 	std::string val;
-	char const * const cval( getenv( name.c_str() ) );
+	char const * const cval( std::getenv( name.c_str() ) );
 	if ( cval ) val = cval;
 	if ( ( ! trim_name.present() ) || ( trim_name() ) ) rstrip( val ); // Strip any trailing spaces
 	if ( value.present() ) value = val;
@@ -46,7 +46,7 @@ get_environment_variable( std::string const & name, Optional< std::string > valu
 std::string
 get_env_var( std::string const & name )
 {
-	char const * const cval( getenv( name.c_str() ) );
+	char const * const cval( std::getenv( name.c_str() ) );
 	return ( cval != nullptr ? cval : "" );
 }
 
@@ -54,7 +54,7 @@ get_env_var( std::string const & name )
 std::string::size_type
 getenvqq( std::string const & name, std::string & value )
 {
-	char const * const cval( getenv( name.c_str() ) );
+	char const * const cval( std::getenv( name.c_str() ) );
 	value = ( cval != nullptr ? cval : "" );
 	return value.length();
 }

--- a/third_party/ObjexxFCL/src/ObjexxFCL/environment.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/environment.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/floops.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/floops.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/fmt.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/fmt.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/fmt.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/fmt.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/fmt.manipulators.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/fmt.manipulators.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/gio.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/gio.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/gio.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/gio.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/gio_Fmt.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/gio_Fmt.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/gio_Fmt.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/gio_Fmt.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/member.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/member.functions.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/noexcept.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/noexcept.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/numeric.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/numeric.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/numeric.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/numeric.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/random.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/random.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/random.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/random.cc
@@ -24,7 +24,7 @@ namespace { // Internal shared global
 std::default_random_engine random_generator;
 }
 
-// Random float on [0,1]
+// Random int on [0,1]
 std::int32_t
 IRANDM()
 {
@@ -32,7 +32,7 @@ IRANDM()
 	return distribution( random_generator );
 }
 
-// Random float on [0,1]
+// Random int on [0,1]
 std::int32_t
 IRANDM( int const iflag )
 {

--- a/third_party/ObjexxFCL/src/ObjexxFCL/random.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/random.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/rvalue_cast.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/rvalue_cast.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/sbyte.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/sbyte.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/sbyte.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/sbyte.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/stream.functions.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/stream.functions.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/stream.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/stream.functions.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/string.constants.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/string.constants.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/string.constants.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/string.constants.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.hh
@@ -354,6 +354,28 @@ is_digit( std::string const & s )
 	}
 }
 
+// string has a Lowercase Character?
+inline
+bool
+has_lower( std::string const & s )
+{
+	for ( char const c : s ) {
+		if ( std::islower( c ) != 0 ) return true;
+	}
+	return false;
+}
+
+// string has an Uppercase Character?
+inline
+bool
+has_upper( std::string const & s )
+{
+	for ( char const c : s ) {
+		if ( std::isupper( c ) != 0 ) return true;
+	}
+	return false;
+}
+
 // string has a string?
 inline
 bool

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ubyte.fwd.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ubyte.fwd.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/ubyte.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/ubyte.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/src/ObjexxFCL/vectorize.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/vectorize.hh
@@ -9,7 +9,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Array.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Array1.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array1.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Array1.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array1.unit.cc
@@ -670,62 +670,76 @@ static void dimension_initializer_function( Array1D_int & A )
 
 TEST( Array1Test, Dimension )
 {
-	Array1D_int A( 3 );
-	EXPECT_EQ( 1, A.l() );
-	EXPECT_EQ( 3, A.u() );
-	EXPECT_EQ( 3u, A.size() );
+	{
+		Array1D_int A;
+		EXPECT_EQ( 1, A.l() );
+		EXPECT_EQ( 0, A.u() );
+		EXPECT_EQ( 0u, A.size() );
 
-	A.dimension( { 3, 7 } );
-	EXPECT_EQ( 3, A.l() );
-	EXPECT_EQ( 7, A.u() );
-	EXPECT_EQ( 5u, A.size() );
+		A.dimension( 9 );
+		EXPECT_EQ( 1, A.l() );
+		EXPECT_EQ( 9, A.u() );
+		EXPECT_EQ( 9u, A.size() );
+	}
 
-	A.dimension( { 2, 4 }, 17 );
-	EXPECT_EQ( 2, A.l() );
-	EXPECT_EQ( 4, A.u() );
-	EXPECT_EQ( 3u, A.size() );
-	EXPECT_EQ( 17, A( 2 ) );
-	EXPECT_EQ( 17, A( 3 ) );
-	EXPECT_EQ( 17, A( 4 ) );
+	{
+		Array1D_int A( 3 );
+		EXPECT_EQ( 1, A.l() );
+		EXPECT_EQ( 3, A.u() );
+		EXPECT_EQ( 3u, A.size() );
 
-	A.dimension( { 1, 5 }, 42 );
-	EXPECT_EQ( 1, A.l() );
-	EXPECT_EQ( 5, A.u() );
-	EXPECT_EQ( 5u, A.size() );
-	EXPECT_EQ( 42, A( 1 ) );
-	EXPECT_EQ( 42, A( 2 ) );
-	EXPECT_EQ( 42, A( 3 ) );
-	EXPECT_EQ( 42, A( 4 ) );
-	EXPECT_EQ( 42, A( 5 ) );
+		A.dimension( { 3, 7 } );
+		EXPECT_EQ( 3, A.l() );
+		EXPECT_EQ( 7, A.u() );
+		EXPECT_EQ( 5u, A.size() );
 
-	A.dimension( { 4, 6 }, dimension_initializer_function );
-	EXPECT_EQ( 4, A.l() );
-	EXPECT_EQ( 6, A.u() );
-	EXPECT_EQ( 3u, A.size() );
-	EXPECT_EQ( 44, A( 4 ) );
-	EXPECT_EQ( 55, A( 5 ) );
-	EXPECT_EQ( 66, A( 6 ) );
+		A.dimension( { 2, 4 }, 17 );
+		EXPECT_EQ( 2, A.l() );
+		EXPECT_EQ( 4, A.u() );
+		EXPECT_EQ( 3u, A.size() );
+		EXPECT_EQ( 17, A( 2 ) );
+		EXPECT_EQ( 17, A( 3 ) );
+		EXPECT_EQ( 17, A( 4 ) );
 
-	A.dimension( Array1D_int( { 3, 7 } ) );
-	EXPECT_EQ( 3, A.l() );
-	EXPECT_EQ( 7, A.u() );
-	EXPECT_EQ( 5u, A.size() );
+		A.dimension( { 1, 5 }, 42 );
+		EXPECT_EQ( 1, A.l() );
+		EXPECT_EQ( 5, A.u() );
+		EXPECT_EQ( 5u, A.size() );
+		EXPECT_EQ( 42, A( 1 ) );
+		EXPECT_EQ( 42, A( 2 ) );
+		EXPECT_EQ( 42, A( 3 ) );
+		EXPECT_EQ( 42, A( 4 ) );
+		EXPECT_EQ( 42, A( 5 ) );
 
-	A.dimension( Array1D_int( { 2, 4 } ), 17 );
-	EXPECT_EQ( 2, A.l() );
-	EXPECT_EQ( 4, A.u() );
-	EXPECT_EQ( 3u, A.size() );
-	EXPECT_EQ( 17, A( 2 ) );
-	EXPECT_EQ( 17, A( 3 ) );
-	EXPECT_EQ( 17, A( 4 ) );
+		A.dimension( { 4, 6 }, dimension_initializer_function );
+		EXPECT_EQ( 4, A.l() );
+		EXPECT_EQ( 6, A.u() );
+		EXPECT_EQ( 3u, A.size() );
+		EXPECT_EQ( 44, A( 4 ) );
+		EXPECT_EQ( 55, A( 5 ) );
+		EXPECT_EQ( 66, A( 6 ) );
 
-	A.dimension( Array1D_int( { 4, 6 } ), dimension_initializer_function );
-	EXPECT_EQ( 4, A.l() );
-	EXPECT_EQ( 6, A.u() );
-	EXPECT_EQ( 3u, A.size() );
-	EXPECT_EQ( 44, A( 4 ) );
-	EXPECT_EQ( 55, A( 5 ) );
-	EXPECT_EQ( 66, A( 6 ) );
+		A.dimension( Array1D_int( { 3, 7 } ) );
+		EXPECT_EQ( 3, A.l() );
+		EXPECT_EQ( 7, A.u() );
+		EXPECT_EQ( 5u, A.size() );
+
+		A.dimension( Array1D_int( { 2, 4 } ), 17 );
+		EXPECT_EQ( 2, A.l() );
+		EXPECT_EQ( 4, A.u() );
+		EXPECT_EQ( 3u, A.size() );
+		EXPECT_EQ( 17, A( 2 ) );
+		EXPECT_EQ( 17, A( 3 ) );
+		EXPECT_EQ( 17, A( 4 ) );
+
+		A.dimension( Array1D_int( { 4, 6 } ), dimension_initializer_function );
+		EXPECT_EQ( 4, A.l() );
+		EXPECT_EQ( 6, A.u() );
+		EXPECT_EQ( 3u, A.size() );
+		EXPECT_EQ( 44, A( 4 ) );
+		EXPECT_EQ( 55, A( 5 ) );
+		EXPECT_EQ( 66, A( 6 ) );
+	}
 }
 
 TEST( Array1Test, Redimension )
@@ -1338,18 +1352,7 @@ TEST( Array1Test, Reserve )
 	EXPECT_EQ( 9, A( 9 ) );
 }
 
-TEST( Array1Test, Swap )
-{
-	Array1D_int A( 4, 11 );
-	Array1D_int( 5, 22 ).swap( A );
-	EXPECT_EQ( IR( 1, 5 ), A.I() );
-	EXPECT_EQ( 5u, A.size() );
-	for ( int i = A.l(); i <= A.u(); ++i ) {
-		EXPECT_EQ( 22, A( i ) );
-	}
-}
-
-TEST( Array1Test, Resize )
+TEST( Array1Test, ReserveAllocate )
 {
 	Array1D_int A;
 	A.reserve( 6u );
@@ -1363,6 +1366,17 @@ TEST( Array1Test, Resize )
 	EXPECT_EQ( 3, A.u() );
 	EXPECT_EQ( 3u, A.size() );
 	EXPECT_EQ( 3u, A.capacity() );
+}
+
+TEST( Array1Test, Swap )
+{
+	Array1D_int A( 4, 11 );
+	Array1D_int( 5, 22 ).swap( A );
+	EXPECT_EQ( IR( 1, 5 ), A.I() );
+	EXPECT_EQ( 5u, A.size() );
+	for ( int i = A.l(); i <= A.u(); ++i ) {
+		EXPECT_EQ( 22, A( i ) );
+	}
 }
 
 TEST( Array1Test, Functions )

--- a/third_party/ObjexxFCL/tst/unit/Array2.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array2.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Array3.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array3.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Array4.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array4.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Array5.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array5.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Array6.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Array6.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/ArrayInitializer.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/ArrayInitializer.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/ArrayS.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/ArrayS.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Backspace.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Backspace.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/CArray.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/CArray.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/CArrayA.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/CArrayA.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/CArrayP.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/CArrayP.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Chunk.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Chunk.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/ChunkVector.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/ChunkVector.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Cstring.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Cstring.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/DimensionSlice.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/DimensionSlice.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Fmath.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Fmath.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/GlobalStreams.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/GlobalStreams.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Index.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Index.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/IndexRange.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/IndexRange.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/IndexSlice.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/IndexSlice.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/MArray.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/MArray.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/ObjexxFCL.unit.hh
+++ b/third_party/ObjexxFCL/tst/unit/ObjexxFCL.unit.hh
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Optional.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Optional.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Print.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Print.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Read.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Read.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Reference.Optional.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Reference.Optional.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Reference.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Reference.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Required.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Required.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Sticky.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Sticky.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Stream.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Stream.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/TypeTraits.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/TypeTraits.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Vector2.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Vector2.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Vector3.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Vector3.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Vector4.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Vector4.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/Write.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/Write.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/bit.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/bit.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/byte.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/byte.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/char.functions.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/char.functions.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/floops.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/floops.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/fmt.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/fmt.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/gio.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/gio.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/main.cc
+++ b/third_party/ObjexxFCL/tst/unit/main.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/member.functions.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/member.functions.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/numeric.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/numeric.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/string.functions.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/string.functions.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/third_party/ObjexxFCL/tst/unit/ubyte.unit.cc
+++ b/third_party/ObjexxFCL/tst/unit/ubyte.unit.cc
@@ -6,7 +6,7 @@
 //
 // Language: C++
 //
-// Copyright (c) 2000-2016 Objexx Engineering, Inc. All Rights Reserved.
+// Copyright (c) 2000-2017 Objexx Engineering, Inc. All Rights Reserved.
 // Use of this source code or any derivative of it is restricted by license.
 // Licensing is available from Objexx Engineering, Inc.:  http://objexx.com
 

--- a/tst/EnergyPlus/unit/WindowManager.unit.cc
+++ b/tst/EnergyPlus/unit/WindowManager.unit.cc
@@ -161,7 +161,7 @@ TEST_F(EnergyPlusFixture, WindowFrameTest )
 	// This test will emulate NFRC 100 U-factor test
 	int winNum;
 
-	for (size_t i = 1; i <= DataSurfaces::Surface.size_; ++i) {
+	for (size_t i = 1; i <= DataSurfaces::Surface.size(); ++i) {
 		if (DataSurfaces::Surface( i ).Class == DataSurfaces::SurfaceClass_Window) {
 			winNum = i;
 		}
@@ -169,7 +169,7 @@ TEST_F(EnergyPlusFixture, WindowFrameTest )
 
 	int cNum;
 
-	for (size_t i = 1; i <= DataHeatBalance::Construct.size_; ++i) {
+	for (size_t i = 1; i <= DataHeatBalance::Construct.size(); ++i) {
 		if (DataHeatBalance::Construct( i ).TypeIsWindow) {
 			cNum = i;
 		}
@@ -257,7 +257,7 @@ TEST_F(EnergyPlusFixture, WindowFrameTest )
 
 TEST_F(EnergyPlusFixture, WindowManager_TransAndReflAtPhi)
 {
-	
+
 	Real64 const cs = 0.86603;  // Cosine of incidence angle
 	Real64 const tf0 = 0.8980; // Transmittance at zero incidence angle
 	Real64 const rf0 = 0.0810; // Front reflectance at zero incidence angle


### PR DESCRIPTION
This is a minor ObjexxFCL update. The primary change is to correct the visibility of protected Array hierarchy methods and data that were being exposed as public via using declarations in subclasses.

A few instances of such use in EnergyPlus source were fixed to use the public accessor methods.

This is purely a code cleanup: no results changes or performance impacts should occur.