### PR TITLE
Fix SQLite errors table to include fatal errors generated inside main loop's partial transaction 

### DIFF
--- a/src/EnergyPlus/SQLiteProcedures.cc
+++ b/src/EnergyPlus/SQLiteProcedures.cc
@@ -347,6 +347,14 @@ void SQLite::sqliteCommit()
 	}
 }
 
+bool SQLite::sqliteWithinTransaction()
+{
+	if ( m_writeOutputToSQLite ) {
+		return SQLiteProcedures::sqliteWithinTransaction();
+	}
+	return false;
+}
+
 void SQLite::sqliteWriteMessage(const std::string & message)
 {
 	if ( m_writeOutputToSQLite ) {
@@ -2805,6 +2813,11 @@ int SQLiteProcedures::sqliteStepCommand(sqlite3_stmt * stmt)
 int SQLiteProcedures::sqliteResetCommand(sqlite3_stmt * stmt)
 {
 	return sqlite3_reset(stmt);
+}
+
+bool SQLiteProcedures::sqliteWithinTransaction()
+{
+	return ( sqlite3_get_autocommit(m_connection) == 0 );
 }
 
 // int SQLiteProcedures::sqliteClearBindings(sqlite3_stmt * stmt)

--- a/src/EnergyPlus/SQLiteProcedures.hh
+++ b/src/EnergyPlus/SQLiteProcedures.hh
@@ -87,6 +87,7 @@ protected:
 	bool sqliteStepValidity( int const rc );
 	int sqliteStepCommand(sqlite3_stmt * stmt);
 	int sqliteResetCommand(sqlite3_stmt * stmt);
+	bool sqliteWithinTransaction();
 	// int sqliteClearBindings(sqlite3_stmt * stmt);
 	// int sqliteFinalizeCommand(sqlite3_stmt * stmt);
 
@@ -137,6 +138,9 @@ public:
 
 	// Commit a transaction
 	void sqliteCommit();
+
+	// Within a current transaction
+	bool sqliteWithinTransaction();
 
 	void createSQLiteReportDictionaryRecord(
 		int const reportVariableReportID,

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -861,6 +861,7 @@ ShowFatalError(
 	ShowErrorMessage( " ..... Last severe error=" + LastSevereError, OutUnit1, OutUnit2 );
 	if ( sqlite ) {
 		sqlite->createSQLiteErrorRecord( 1, 2, ErrorMessage, 1 );
+		if( sqlite->sqliteWithinTransaction() ) sqlite->sqliteCommit();
 	}
 	throw std::runtime_error( ErrorMessage );
 

--- a/tst/EnergyPlus/unit/SQLite.unit.cc
+++ b/tst/EnergyPlus/unit/SQLite.unit.cc
@@ -183,6 +183,14 @@ namespace EnergyPlus {
 		EXPECT_EQ(3ul, result.size());
 	}
 
+	TEST_F( SQLiteFixture, SQLiteProcedures_sqliteWithinTransaction ) {
+		EXPECT_FALSE( sqlite_test->sqliteWithinTransaction() );
+		sqlite_test->sqliteBegin();
+		EXPECT_TRUE( sqlite_test->sqliteWithinTransaction() );
+		sqlite_test->sqliteCommit();
+		EXPECT_FALSE( sqlite_test->sqliteWithinTransaction() );
+	}
+
 	TEST_F( SQLiteFixture, SQLiteProcedures_createSQLiteReportDictionaryRecord )
 	{
 		sqlite_test->sqliteBegin();


### PR DESCRIPTION
Pull request overview
---------------------

Commit SQLite transaction during fatal error.  Fixes #5927

This issue arose due to #5927 where newly trapped EMS errors caused a
fatal error message. However, this was within the ManageSimulation()
main loop which is part of a transaction, meaning the errors were not
committed when a fatal error happened. This addresses that by calling
commit if it is currently within a transaction during fatal error
handling.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Code style (parentheses padding, variable names)
 - [x] Functional code review (it has to work!)
 - [x] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [x] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
