### PR TITLE
Output informational error messages

### DIFF
--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -1150,6 +1150,9 @@ ShowMessage(
 		ShowErrorMessage( " *************", OutUnit1, OutUnit2 );
 	} else {
 		ShowErrorMessage( " ************* " + Message, OutUnit1, OutUnit2 );
+		if ( sqlite ) {
+			sqlite->createSQLiteErrorRecord( 1, -1, Message, 0 );
+		}
 	}
 
 }


### PR DESCRIPTION
Pull request overview
---------------------
Fixes #5318

This outputs informational messages during ShowMessage() function call
to sqlite. Now the whole error file is replicated in the sqlite Errors
table. This addresses #5318 since “Output:PreprocessorMessage”
informational messages call ShowMessage().

Since Warnings, Severe Errors, and Fatal Errors used 0, 1, 2 respectively in the sqlite Errors table, the informational messages now use -1 as the error code in the Errors table. I think makes the most sense since they are informational and it allows for easy queries to determine between informational and all the rest.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Code style (parentheses padding, variable names)
 - [x] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [x] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
