### PR TITLE
Change HW coil UA sizing to use UA = 1 when loads are very small

### DIFF
--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -1147,7 +1147,6 @@ namespace ReportSizingManager {
 					} else {
 						AutosizeDes = FinalZoneSizing( CurZoneEqNum ).DesHeatMassFlow;
 					}
-					bCheckForZero = false;
 				} else if (SizingType == WaterHeatingCoilUASizing) {
 					if ( DataCapacityUsedForSizing > 0.0 ) {
 						Par( 1 ) = DataCapacityUsedForSizing;
@@ -1951,7 +1950,6 @@ namespace ReportSizingManager {
 						}
 					}
 					AutosizeDes *= StdRhoAir;
-					bCheckForZero = false;
 				} else if (SizingType == WaterHeatingCoilUASizing) {
 					if ( DataCapacityUsedForSizing >= SmallLoad ) {
 						Par( 1 ) = DataCapacityUsedForSizing;

--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -1148,7 +1148,7 @@ namespace ReportSizingManager {
 						AutosizeDes = FinalZoneSizing( CurZoneEqNum ).DesHeatMassFlow;
 					}
 				} else if (SizingType == WaterHeatingCoilUASizing) {
-					if ( DataCapacityUsedForSizing > 0.0 ) {
+					if ( DataCapacityUsedForSizing > 0.0 && DataWaterFlowUsedForSizing > 0.0 && DataFlowUsedForSizing > 0.0 ) {
 						Par( 1 ) = DataCapacityUsedForSizing;
 						Par( 2 ) = double( DataCoilNum );
 						Par( 3 ) = double( DataFanOpMode ); //fan operating mode
@@ -1207,12 +1207,12 @@ namespace ReportSizingManager {
 						}
 					} else {
 						AutosizeDes = 1.0;
-						if ( DataWaterFlowUsedForSizing > 0.0 ) {
-							DataErrorsFound = true;
-							ShowSevereError( "The design coil load is zero for Coil:Heating:Water " + CompName );
+						if ( DataWaterFlowUsedForSizing > 0.0 && DataCapacityUsedForSizing == 0.0 ) {
+							ShowWarningError( "The design coil load used for UA sizing is zero for Coil:Heating:Water " + CompName );
 							ShowContinueError( "An autosize value for UA cannot be calculated" );
 							ShowContinueError( "Input a value for UA, change the heating design day, or raise" );
 							ShowContinueError( "  the zone heating design supply air temperature" );
+							ShowContinueError( "Water coil UA is set to 1 and the simulation continues." );
 						}
 					}
 				} else if (SizingType == MaxHeaterOutletTempSizing) {
@@ -1951,7 +1951,7 @@ namespace ReportSizingManager {
 					}
 					AutosizeDes *= StdRhoAir;
 				} else if (SizingType == WaterHeatingCoilUASizing) {
-					if ( DataCapacityUsedForSizing >= SmallLoad ) {
+					if( DataCapacityUsedForSizing >= SmallLoad && DataWaterFlowUsedForSizing > 0.0 && DataFlowUsedForSizing > 0.0 ) {
 						Par( 1 ) = DataCapacityUsedForSizing;
 						Par( 2 ) = double( DataCoilNum );
 						Par( 3 ) = double( DataFanOpMode ); //fan operating mode
@@ -1996,12 +1996,12 @@ namespace ReportSizingManager {
 						}
 					} else {
 						AutosizeDes = 1.0;
-						if ( DataWaterFlowUsedForSizing > 0.0 ) {
-							DataErrorsFound = true;
-							ShowSevereError( "The design coil load is zero for Coil:Heating:Water " + CompName );
+						if ( DataWaterFlowUsedForSizing > 0.0 && DataCapacityUsedForSizing < SmallLoad ) {
+							ShowWarningError( "The design coil load used for UA sizing is too small for Coil:Heating:Water " + CompName );
 							ShowContinueError( "An autosize value for UA cannot be calculated" );
 							ShowContinueError( "Input a value for UA, change the heating design day, or raise" );
 							ShowContinueError( "  the system heating design supply air temperature" );
+							ShowContinueError( "Water coil UA is set to 1 and the simulation continues." );
 						}
 					}
 				} else if (SizingType == MaxHeaterOutletTempSizing) {

--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -1147,6 +1147,7 @@ namespace ReportSizingManager {
 					} else {
 						AutosizeDes = FinalZoneSizing( CurZoneEqNum ).DesHeatMassFlow;
 					}
+					bCheckForZero = false;
 				} else if (SizingType == WaterHeatingCoilUASizing) {
 					if ( DataCapacityUsedForSizing > 0.0 ) {
 						Par( 1 ) = DataCapacityUsedForSizing;
@@ -1950,6 +1951,7 @@ namespace ReportSizingManager {
 						}
 					}
 					AutosizeDes *= StdRhoAir;
+					bCheckForZero = false;
 				} else if (SizingType == WaterHeatingCoilUASizing) {
 					if ( DataCapacityUsedForSizing >= SmallLoad ) {
 						Par( 1 ) = DataCapacityUsedForSizing;

--- a/src/EnergyPlus/WaterCoils.cc
+++ b/src/EnergyPlus/WaterCoils.cc
@@ -2141,6 +2141,7 @@ namespace WaterCoils {
 					DataFanOpMode = ContFanCycCoil;
 					TempSize = WaterCoil ( CoilNum ).UACoil;
 
+					DataFlowUsedForSizing = WaterCoil( CoilNum ).InletAirMassFlowRate;
 					DesCoilWaterInTempSaved = WaterCoil( DataCoilNum ).InletWaterTemp;
 					if ( DesCoilWaterInTempSaved < DesCoilHWInletTempMin ) {
 						// at low coil design water inlet temp, sizing has convergence issue hence slightly higher water inlet temperature
@@ -2148,28 +2149,22 @@ namespace WaterCoils {
 						EstimateCoilInletWaterTemp( DataCoilNum, DataFanOpMode, 1.0, DataCapacityUsedForSizing, DesCoilInletWaterTempUsed );
 						WaterCoil( DataCoilNum ).InletWaterTemp = DesCoilInletWaterTempUsed;
 					}
-					// sizing of coil UA requires non-zero air and water flow rate at the coil's respective inlet nodes
-					if ( WaterCoil( CoilNum ).InletAirMassFlowRate > 0.0 && WaterCoil( CoilNum ).InletWaterMassFlowRate > 0.0 ) {
-						RequestSizing( CompType, CompName, WaterHeatingCoilUASizing, SizingString, TempSize, bPRINT, RoutineName );
-						if( DesCoilWaterInTempSaved < DesCoilHWInletTempMin ) {
-							ShowWarningError( "Autosizing of heating coil UA for Coil:Heating:Water \"" + CompName + "\"" );
-							ShowContinueError( " Plant design loop exit temperature = " + TrimSigDigits( PlantSizData( DataPltSizHeatNum ).ExitTemp, 2 ) + " C" );
-							ShowContinueError( " Plant design loop exit temperature is low for design load and leaving air temperature anticipated." );
-							ShowContinueError( " Heating coil UA-value is sized using coil water inlet temperature = " + TrimSigDigits( DesCoilInletWaterTempUsed, 2 ) + " C" );
-							WaterCoil( DataCoilNum ).InletWaterTemp = DesCoilWaterInTempSaved; // reset the Design Coil Inlet Water Temperature 
-						}
-					} else {
-						// else UA sizing will fail RegulaFalsi with -2 and report a frustrating warning message (see ReportSizingManager: SizingType == WaterHeatingCoilUASizing)
-						TempSize = 1.0;
-						WaterCoil( CoilNum ).UACoilVariable = TempSize;
-						if ( WaterCoil( CoilNum ).UACoil == AutoSize ) {
-							ReportSizingOutput( CompType, CompName, "Design Size " + SizingString, TempSize );
-						} else {
-							ReportSizingOutput( CompType, CompName, "User-Specified " + SizingString, TempSize );
-						}
-
+					// must set DataCapacityUsedForSizing, DataWaterFlowUsedForSizing and DataFlowUsedForSizing to size UA. Any value of 0 will result in UA = 1.
+					RequestSizing( CompType, CompName, WaterHeatingCoilUASizing, SizingString, TempSize, bPRINT, RoutineName );
+					if( DesCoilWaterInTempSaved < DesCoilHWInletTempMin ) {
+						ShowWarningError( "Autosizing of heating coil UA for Coil:Heating:Water \"" + CompName + "\"" );
+						ShowContinueError( " Plant design loop exit temperature = " + TrimSigDigits( PlantSizData( DataPltSizHeatNum ).ExitTemp, 2 ) + " C" );
+						ShowContinueError( " Plant design loop exit temperature is low for design load and leaving air temperature anticipated." );
+						ShowContinueError( " Heating coil UA-value is sized using coil water inlet temperature = " + TrimSigDigits( DesCoilInletWaterTempUsed, 2 ) + " C" );
+						WaterCoil( DataCoilNum ).InletWaterTemp = DesCoilWaterInTempSaved; // reset the Design Coil Inlet Water Temperature 
 					}
-					WaterCoil ( CoilNum ).UACoil = TempSize;
+					WaterCoil( CoilNum ).UACoil = TempSize;
+					// if coil UA did not size due to one of these variables being 0, must set UACoilVariable to avoid crash later on
+					if ( DataCapacityUsedForSizing == 0.0 || DataWaterFlowUsedForSizing == 0.0 || DataFlowUsedForSizing == 0.0 ) {
+						if ( WaterCoil( CoilNum ).UACoilVariable == AutoSize ) {
+							WaterCoil( CoilNum ).UACoilVariable = TempSize;
+						}
+					}
 					WaterCoil( CoilNum ).DesWaterHeatingCoilRate = DataCapacityUsedForSizing;
 					WaterCoil( DataCoilNum ).InletWaterTemp = DesCoilWaterInTempSaved; // reset the Design Coil Inlet Water Temperature 
 				}

--- a/tst/EnergyPlus/unit/WaterCoils.unit.cc
+++ b/tst/EnergyPlus/unit/WaterCoils.unit.cc
@@ -465,6 +465,165 @@ TEST_F( WaterCoilsTest, CoilHeatingWaterUASizing )
 
 }
 
+TEST_F( WaterCoilsTest, CoilHeatingWaterLowAirFlowUASizing ) {
+	InitializePsychRoutines();
+	OutBaroPress = 101325.0;
+	StdRhoAir = PsyRhoAirFnPbTdbW( OutBaroPress, 20.0, 0.0 );
+	int write_stat;
+
+	OutputFileInits = GetNewUnitNumber();
+	{ IOFlags flags; flags.ACTION( "write" ); flags.STATUS( "UNKNOWN" ); gio::open( OutputFileInits, "eplusout.eio", flags ); write_stat = flags.ios(); }
+
+	// set up sizing flags
+	SysSizingRunDone = true;
+
+	// set up plant sizing
+	NumPltSizInput = 1;
+	PlantSizData( 1 ).PlantLoopName = "HotWaterLoop";
+	PlantSizData( 1 ).ExitTemp = 60.0;
+	PlantSizData( 1 ).DeltaT = 10.0;
+
+	// set up plant loop
+	for( int l = 1; l <= TotNumLoops; ++l ) {
+		auto & loop( PlantLoop( l ) );
+		loop.LoopSide.allocate( 2 );
+		auto & loopside( PlantLoop( 1 ).LoopSide( 1 ) );
+		loopside.TotalBranches = 1;
+		loopside.Branch.allocate( 1 );
+		auto & loopsidebranch( PlantLoop( 1 ).LoopSide( 1 ).Branch( 1 ) );
+		loopsidebranch.TotalComponents = 1;
+		loopsidebranch.Comp.allocate( 1 );
+	}
+	PlantLoop( 1 ).Name = "HotWaterLoop";
+	PlantLoop( 1 ).FluidName = "FluidWaterLoop";
+	PlantLoop( 1 ).FluidIndex = 1;
+	PlantLoop( 1 ).FluidName = "WATER";
+	PlantLoop( 1 ).FluidIndex = 1;
+
+	// set up sizing data
+	FinalSysSizing( 1 ).DesMainVolFlow = 1.00;
+	FinalSysSizing( 1 ).HeatSupTemp = 40.0;
+	FinalSysSizing( 1 ).HeatOutTemp = 5.0;
+	FinalSysSizing( 1 ).HeatRetTemp = 20.0;
+	FinalSysSizing( 1 ).HeatOAOption = 1;
+
+	// set up water coil
+	int CoilNum = 1;
+	WaterCoil( CoilNum ).Name = "Water Heating Coil";
+	WaterCoil( CoilNum ).WaterLoopNum = 1;
+	WaterCoil( CoilNum ).WaterCoilType = CoilType_Heating;
+	WaterCoil( CoilNum ).WaterCoilType_Num = WaterCoil_SimpleHeating;  // Coil:Heating:Water
+	WaterCoil( CoilNum ).WaterCoilModel = CoilType_Heating;
+	WaterCoil( CoilNum ).SchedPtr = DataGlobals::ScheduleAlwaysOn;
+
+	WaterCoil( CoilNum ).RequestingAutoSize = true;
+	WaterCoil( CoilNum ).DesAirVolFlowRate = AutoSize;
+	WaterCoil( CoilNum ).UACoil = AutoSize;
+	WaterCoil( CoilNum ).MaxWaterVolFlowRate = AutoSize;
+	WaterCoil( CoilNum ).CoilPerfInpMeth = UAandFlow;
+	WaterCoil( CoilNum ).DesInletAirTemp = AutoSize;
+	WaterCoil( CoilNum ).DesOutletAirTemp = AutoSize;
+	WaterCoil( CoilNum ).DesInletWaterTemp = AutoSize;
+	WaterCoil( CoilNum ).DesInletAirHumRat = AutoSize;
+	WaterCoil( CoilNum ).DesOutletAirHumRat = AutoSize;
+
+	WaterCoilNumericFields( CoilNum ).FieldNames( 2 ) = "Maximum Water Flow Rate";
+	WaterCoil( CoilNum ).WaterInletNodeNum = 1;
+	PlantLoop( 1 ).LoopSide( 1 ).Branch( 1 ).Comp( 1 ).NodeNumIn = WaterCoil( CoilNum ).WaterInletNodeNum;
+
+	CurZoneEqNum = 0;
+	CurSysNum = 1;
+	CurOASysNum = 0;
+	DataWaterLoopNum = 1;
+	NumOfGlycols = 1;
+
+	MyUAAndFlowCalcFlag.allocate( 1 );
+	MyUAAndFlowCalcFlag( 1 ) = true;
+
+	MySizeFlag.allocate( 1 );
+	MySizeFlag( 1 ) = true;
+
+	// run water coil sizing
+	SizeWaterCoil( CoilNum );
+	EXPECT_DOUBLE_EQ( 1.0, WaterCoil( CoilNum ).DesAirVolFlowRate );
+
+	Real64 CpAirStd = 0.0;
+	Real64 DesMassFlow = 0.0;
+	Real64 DesCoilHeatingLoad = 0.0;
+
+	CpAirStd = PsyCpAirFnWTdb( 0.0, 20.0 );
+	DesMassFlow = WaterCoil( CoilNum ).DesAirVolFlowRate * StdRhoAir;
+	DesCoilHeatingLoad = CpAirStd * DesMassFlow * ( 40.0 - 5.0 );
+
+	// check heating coil design load
+	EXPECT_DOUBLE_EQ( DesCoilHeatingLoad, WaterCoil( CoilNum ).DesWaterHeatingCoilRate );
+
+	Real64 Cp = 0;
+	Real64 rho = 0;
+	Real64 DesWaterFlowRate = 0;
+
+	Cp = GetSpecificHeatGlycol( PlantLoop( 1 ).FluidName, DataGlobals::HWInitConvTemp, PlantLoop( 1 ).FluidIndex, "Unit Test" );
+	rho = GetDensityGlycol( PlantLoop( 1 ).FluidName, DataGlobals::CWInitConvTemp, PlantLoop( 1 ).FluidIndex, "Unit Test" );
+	DesWaterFlowRate = WaterCoil( CoilNum ).DesWaterHeatingCoilRate / ( 10.0 * Cp * rho );
+
+	// check heating coil design water flow rate
+	EXPECT_DOUBLE_EQ( DesWaterFlowRate, WaterCoil( CoilNum ).MaxWaterVolFlowRate );
+
+	// check coil UA-value sizing
+	EXPECT_NEAR( 1435.00, WaterCoil( CoilNum ).UACoil, 0.01 );
+
+	// test single zone VAV reheat coil sizing
+	CurZoneEqNum = 1;
+	CurSysNum = 0;
+	TermUnitSizing.allocate( 1 );
+	TermUnitSizing( CurZoneEqNum ).AirVolFlow = WaterCoil( CoilNum ).DesAirVolFlowRate / 1500.0; // DesAirVolFlowRate = 1.0 so TU air flow = 0.00067 (lower than 0.001)
+	TermUnitSizing( CurZoneEqNum ).MaxHWVolFlow = WaterCoil( CoilNum ).MaxWaterVolFlowRate / 1500.0;
+	TermUnitSizing( CurZoneEqNum ).MinFlowFrac = 0.5;
+	DataSizing::TermUnitSingDuct = true;
+
+	WaterCoil( CoilNum ).DesAirVolFlowRate = AutoSize;
+	WaterCoil( CoilNum ).UACoil = AutoSize;
+	WaterCoil( CoilNum ).MaxWaterVolFlowRate = AutoSize;
+	WaterCoil( CoilNum ).CoilPerfInpMeth = UAandFlow;
+	WaterCoil( CoilNum ).DesInletAirTemp = AutoSize;
+	WaterCoil( CoilNum ).DesOutletAirTemp = AutoSize;
+	WaterCoil( CoilNum ).DesInletWaterTemp = AutoSize;
+	WaterCoil( CoilNum ).DesInletAirHumRat = AutoSize;
+	WaterCoil( CoilNum ).DesOutletAirHumRat = AutoSize;
+
+	SysSizingRunDone = false;
+	ZoneSizingRunDone = true;
+	NumZoneSizingInput = 1;
+	ZoneSizingInput.allocate( 1 );
+	ZoneSizingInput( 1 ).ZoneNum = 1;
+	ZoneEqSizing.allocate( 1 );
+	ZoneEqSizing( CurZoneEqNum ).SizingMethod.allocate( 20 );
+	ZoneEqSizing( CurZoneEqNum ).SizingMethod( DataHVACGlobals::HeatingAirflowSizing ) = DataHVACGlobals::HeatingAirflowSizing;
+	ZoneEqSizing( CurZoneEqNum ).CoolingAirVolFlow = 0.0;
+	ZoneEqSizing( CurZoneEqNum ).HeatingAirVolFlow = 1.0;
+	FinalZoneSizing.allocate( 1 );
+	FinalZoneSizing( CurZoneEqNum ).DesCoolVolFlow = 0.0;
+	FinalZoneSizing( CurZoneEqNum ).DesHeatVolFlow = 0.00095;
+	FinalZoneSizing( CurZoneEqNum ).DesHeatCoilInTempTU = 10.0;
+	FinalZoneSizing( CurZoneEqNum ).ZoneTempAtHeatPeak = 21.0;
+	FinalZoneSizing( CurZoneEqNum ).DesHeatCoilInHumRatTU = 0.006;
+	FinalZoneSizing( CurZoneEqNum ).ZoneHumRatAtHeatPeak = 0.008;
+
+	MySizeFlag( 1 ) = true;
+	// run water coil sizing
+	SizeWaterCoil( CoilNum );
+
+	// water flow rate should be non-zero, and air flow rate being so small will get set to 0 during sizing
+	EXPECT_GT( WaterCoil( CoilNum ).InletWaterMassFlowRate, 0.0 );
+	EXPECT_EQ( 0.0, WaterCoil( CoilNum ).InletAirMassFlowRate );
+	// check coil UA-value sizing
+	EXPECT_NEAR( 1.0, WaterCoil( CoilNum ).UACoil, 0.0001 ); // TU air flow is too low to size, set to 0, so UA is set to 1.0
+
+	// Close and delete eio output file
+	{ IOFlags flags; flags.DISPOSE( "DELETE" ); gio::close( OutputFileInits, flags ); }
+
+}
+
 TEST_F( WaterCoilsTest, CoilHeatingWaterUASizingLowHwaterInletTemp )
 {
 	InitializePsychRoutines();


### PR DESCRIPTION
Pull request overview
---------------------
Very low loads can result in a calculated HW coil air flow rate that is less than 0.001 m3/s which makes it difficult or impossible to calculate a coil UA value. When loads are very small, set the coil UA to 1 so that the simulation can proceed. This low UA value is representative of a very small coil as calculated by the simulation sizing routine. This change corrects #6088. Minimal or no differences in results are expected. 

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Code style (parentheses padding, variable names)
 - [x] Functional code review (it has to work!)
 - [x] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
