### PR TITLE
Refix new error message for Output:Table:Monthly and Annual don't have proper order for aggregation types 

### DIFF
--- a/src/EnergyPlus/OutputReportTabular.hh
+++ b/src/EnergyPlus/OutputReportTabular.hh
@@ -629,6 +629,9 @@ namespace OutputReportTabular {
 	void
 	InitializeTabularMonthly();
 
+	bool
+	isInvalidAggregationOrder();
+
 	void
 	GetInputTabularTimeBins();
 

--- a/src/EnergyPlus/OutputReportTabularAnnual.cc
+++ b/src/EnergyPlus/OutputReportTabularAnnual.cc
@@ -71,6 +71,7 @@
 #include <General.hh>
 #include <SQLiteProcedures.hh>
 #include <ScheduleManager.hh>
+#include <DisplayRoutines.hh>
 
 
 namespace EnergyPlus {
@@ -244,6 +245,65 @@ namespace EnergyPlus {
 				}
 				tableRowIndex++;
 			}
+		}
+
+		void
+		checkAggregationOrderForAnnual( )
+		{
+			std::vector<AnnualTable>::iterator annualTableIt;
+			bool invalidAggregationOrderFound = false;
+			if ( !DataGlobals::DoWeathSim ) {// if no weather simulation than no reading of MonthlyInput array
+				return;
+			}
+			for ( annualTableIt = annualTables.begin( ); annualTableIt != annualTables.end( ); ++annualTableIt ) {
+				if ( annualTableIt->invalidAggregationOrder( ) ) {
+					invalidAggregationOrderFound = true;
+				}
+			}
+			if ( invalidAggregationOrderFound ) {
+				ShowFatalError( "OutputReportTabularAnnual: Invalid aggregations detected, no simulation performed." );
+			}
+		}
+
+		// Generate an error message if an advanced aggregation kind columns don't follow the appropriate column - Glazer 2017 
+		bool
+		AnnualTable::invalidAggregationOrder( )
+		{
+			std::vector<AnnualFieldSet>::iterator fldStIt;
+			bool foundMinOrMax = false;
+			bool foundHourAgg = false;
+			bool missingMaxOrMinError = false;
+			bool missingHourAggError = false;
+			for ( fldStIt = m_annualFields.begin( ); fldStIt != m_annualFields.end( ); ++fldStIt ) {
+				if ( ( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::maximum ) ||
+					 ( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::minimum ) ) {
+					foundMinOrMax = true;
+				} else if ( ( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::hoursNonZero ) ||
+					        ( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::hoursZero ) ||
+							( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::hoursPositive ) ||
+							( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::hoursNonPositive ) ||
+							( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::hoursNegative ) ||
+							( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::hoursNonNegative ) ){
+					foundHourAgg = true;
+				} else if ( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::valueWhenMaxMin ){
+					if ( !foundMinOrMax ) {
+						missingMaxOrMinError = true;
+					}
+				} else if ( ( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::sumOrAverageHoursShown ) ||
+					        ( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::maximumDuringHoursShown ) ||
+							( fldStIt->m_aggregate == AnnualFieldSet::AggregationKind::minimumDuringHoursShown ) ){
+					if ( !foundHourAgg ) {
+						missingHourAggError = true;
+					}
+				}
+			}
+			if ( missingMaxOrMinError ) {
+				ShowSevereError( "The Output:Table:Annual report named=\"" + m_name + "\" has a valueWhenMaxMin aggregation type for a column without a previous column that uses either the minimum or maximum aggregation types. The report will not be generated." );
+			}
+			if ( missingHourAggError ) {
+				ShowSevereError( "The Output:Table:Annual report named=\"" + m_name + "\" has a --DuringHoursShown aggregation type for a column without a previous field that uses one of the Hour-- aggregation types. The report will not be generated." );
+			}
+			return ( missingHourAggError || missingMaxOrMinError );
 		}
 
 

--- a/src/EnergyPlus/OutputReportTabularAnnual.hh
+++ b/src/EnergyPlus/OutputReportTabularAnnual.hh
@@ -76,6 +76,9 @@ namespace OutputReportTabularAnnual {
 	GetInputTabularAnnual();
 
 	void
+	checkAggregationOrderForAnnual();
+
+	void
 	GatherAnnualResultsForTimeStep( int kindOfTypeStep );
 
 	void
@@ -129,6 +132,9 @@ public:
 
 	void
 	setupGathering();
+
+	bool
+	invalidAggregationOrder();
 
 	void
 	gatherForTimestep( int kindOfTypeStep );

--- a/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
+++ b/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
@@ -5973,3 +5973,40 @@ TEST_F( SQLiteFixture, WriteVeriSumTableAreasTest ) {
 	EXPECT_EQ( "      114.72", tabularData[103][10] ); // window opening area
 
 }
+
+
+TEST_F( EnergyPlusFixture, OutputReportTabularMonthly_invalidAggregationOrder )
+{
+	std::string const idf_objects = delimited_string( {
+		"Version,8.3;",
+		"Output:Table:Monthly,",
+		"Space Gains Annual Report, !- Name",
+		"2, !-  Digits After Decimal",
+		"Exterior Lights Electric Energy, !- Variable or Meter 1 Name",
+		"SumOrAverageDuringHoursShown, !- Aggregation Type for Variable or Meter 1",
+		"Exterior Lights Electric Power, !- Variable or Meter 2 Name",
+		"Maximum, !- Aggregation Type for Variable or Meter 2",
+		"Exterior Lights Electric Power, !- Variable or Meter 2 Name",
+		"Minimum; !- Aggregation Type for Variable or Meter 2",
+
+	} );
+
+	ASSERT_FALSE( process_idf( idf_objects ) );
+
+	Real64 extLitUse;
+
+	SetupOutputVariable( "Exterior Lights Electric Energy [J]", extLitUse, "Zone", "Sum", "Lite1", _, "Electricity", "Exterior Lights", "General" );
+	SetupOutputVariable( "Exterior Lights Electric Energy [J]", extLitUse, "Zone", "Sum", "Lite2", _, "Electricity", "Exterior Lights", "General" );
+	SetupOutputVariable( "Exterior Lights Electric Energy [J]", extLitUse, "Zone", "Sum", "Lite3", _, "Electricity", "Exterior Lights", "General" );
+
+	DataGlobals::DoWeathSim = true;
+	DataGlobals::TimeStepZone = 0.25;
+
+	GetInputTabularMonthly( );
+	EXPECT_EQ( MonthlyInputCount, 1 );
+	InitializeTabularMonthly( );
+
+	EXPECT_TRUE(isInvalidAggregationOrder());
+
+}
+


### PR DESCRIPTION
Add new error message for Output:Table:Monthly and Output:Table:Annual when the advanced aggregation types (such as MaximumDuringHoursShown and SumOrAverageDuringHoursShown) are used when the corresponding aggregation type is not used in an earlier column (such as Maximum or HoursNonZero).

This resolves #5911 and #6084

This was originally in pull request #6039 but was generating false positive error messages when Ouput:Table:Monthly was using variables that did not exist, see #6084. This was pull from the 8.7 release #6085. Added new line of code to prevent false positive and cleaned up some other error messaging logic so that the variable that was missing gets reported.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
