### PR TITLE
ZoneHVAC:Baseboard:RadiantConvective:Electric user-specified and design sizes are reporting the same value #5890

### DIFF
--- a/src/EnergyPlus/ElectricBaseboardRadiator.cc
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.cc
@@ -712,6 +712,7 @@ namespace ElectricBaseboardRadiator {
 		std::string CompType; // component type
 		std::string SizingString; // input field sizing description (e.g., Nominal Capacity)
 		Real64 TempSize; // autosized value of coil input field
+		Real64 FracOfAutoSzCap; // fraction of autosized capacity
 		int FieldNum = 1; // IDD numeric field number where input field description is found
 		int SizingMethod; // Integer representation of sizing method name (e.g., CoolingAirflowSizing, HeatingAirflowSizing, CoolingCapacitySizing, HeatingCapacitySizing, etc.)
 		bool PrintFlag; // TRUE when sizing information is reported in the eio file
@@ -743,18 +744,23 @@ namespace ElectricBaseboardRadiator {
 						ZoneEqSizing( CurZoneEqNum ).DesHeatingLoad = ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity;
 					}
 					ZoneEqSizing( CurZoneEqNum ).HeatingCapacity = true;
-					TempSize = ZoneEqSizing( CurZoneEqNum ).DesHeatingLoad;
+					TempSize = ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity;
 				} else if ( CapSizingMethod == CapacityPerFloorArea ) {
-					ZoneEqSizing( CurZoneEqNum ).HeatingCapacity = true;
-					ZoneEqSizing( CurZoneEqNum ).DesHeatingLoad = ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity * Zone( DataZoneNumber ).FloorArea;
-					TempSize = ZoneEqSizing( CurZoneEqNum ).DesHeatingLoad;
+					if ( ZoneSizingRunDone ) {
+						ZoneEqSizing( CurZoneEqNum ).HeatingCapacity = true;
+						ZoneEqSizing( CurZoneEqNum ).DesHeatingLoad = FinalZoneSizing( CurZoneEqNum ).NonAirSysDesHeatLoad;
+					}
+					TempSize = ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity * Zone( DataZoneNumber ).FloorArea;
 					DataScalableCapSizingON = true;
 				} else if ( CapSizingMethod == FractionOfAutosizedHeatingCapacity ) {
 					CheckZoneSizing(CompType, CompName);
 					ZoneEqSizing( CurZoneEqNum ).HeatingCapacity = true;
 					DataFracOfAutosizedHeatingCapacity = ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity;
 					ZoneEqSizing( CurZoneEqNum ).DesHeatingLoad = FinalZoneSizing( CurZoneEqNum ).NonAirSysDesHeatLoad;
-					TempSize = AutoSize;
+					FracOfAutoSzCap = AutoSize;
+					RequestSizing( CompType, CompName, SizingMethod, SizingString, FracOfAutoSzCap, false, RoutineName );
+					TempSize = FracOfAutoSzCap;
+					DataFracOfAutosizedHeatingCapacity = 1.0;
 					DataScalableCapSizingON = true;
 				} else {
 					TempSize = ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity;

--- a/tst/EnergyPlus/unit/ElectricBaseboardRadiator.unit.cc
+++ b/tst/EnergyPlus/unit/ElectricBaseboardRadiator.unit.cc
@@ -58,238 +58,596 @@
 #include <EnergyPlus/ScheduleManager.hh>
 #include <EnergyPlus/SurfaceGeometry.hh>
 
+#include <EnergyPlus/DataSizing.hh>
+#include <EnergyPlus/DataHVACGlobals.hh>
 
 using namespace EnergyPlus;
 
+namespace EnergyPlus {
 
-TEST_F( EnergyPlusFixture, RadConvElecBaseboard_Test1 ) {
-	// this unit test is related to issue #5806, the input is configured to allow running get input on two electric radiative convective baseboards and check that they have their zone index pointers setup
-	std::string const idf_objects = delimited_string( {
-		" Version,8.5;",
+	TEST_F( EnergyPlusFixture, RadConvElecBaseboard_Test1 ) {
+		// this unit test is related to issue #5806, the input is configured to allow running get input on two electric radiative convective baseboards and check that they have their zone index pointers setup
+		std::string const idf_objects = delimited_string( {
+			" Version,8.5;",
 
-		"  Zone,",
-		"    SPACE2-1,                !- Name",
-		"    0,                       !- Direction of Relative North {deg}",
-		"    0,                       !- X Origin {m}",
-		"    0,                       !- Y Origin {m}",
-		"    0,                       !- Z Origin {m}",
-		"    1,                       !- Type",
-		"    1,                       !- Multiplier",
-		"    2.438400269,             !- Ceiling Height {m}",
-		"    103.311355591;           !- Volume {m3}",
+			"  Zone,",
+			"    SPACE2-1,                !- Name",
+			"    0,                       !- Direction of Relative North {deg}",
+			"    0,                       !- X Origin {m}",
+			"    0,                       !- Y Origin {m}",
+			"    0,                       !- Z Origin {m}",
+			"    1,                       !- Type",
+			"    1,                       !- Multiplier",
+			"    2.438400269,             !- Ceiling Height {m}",
+			"    103.311355591;           !- Volume {m3}",
 
-		"  Zone,",
-		"    SPACE4-1,                !- Name",
-		"    0,                       !- Direction of Relative North {deg}",
-		"    0,                       !- X Origin {m}",
-		"    0,                       !- Y Origin {m}",
-		"    0,                       !- Z Origin {m}",
-		"    1,                       !- Type",
-		"    1,                       !- Multiplier",
-		"    2.438400269,             !- Ceiling Height {m}",
-		"    103.311355591;           !- Volume {m3}",
+			"  Zone,",
+			"    SPACE4-1,                !- Name",
+			"    0,                       !- Direction of Relative North {deg}",
+			"    0,                       !- X Origin {m}",
+			"    0,                       !- Y Origin {m}",
+			"    0,                       !- Z Origin {m}",
+			"    1,                       !- Type",
+			"    1,                       !- Multiplier",
+			"    2.438400269,             !- Ceiling Height {m}",
+			"    103.311355591;           !- Volume {m3}",
 
-		"  ZoneHVAC:EquipmentConnections,",
-		"    SPACE2-1,                !- Zone Name",
-		"    SPACE2-1 Eq,             !- Zone Conditioning Equipment List Name",
-		"    SPACE2-1 in node,       !- Zone Air Inlet Node or NodeList Name",
-		"    ,                        !- Zone Air Exhaust Node or NodeList Name",
-		"    SPACE2-1 Node,           !- Zone Air Node Name",
-		"    SPACE2-1 ret node;       !- Zone Return Air Node Name",
+			"  ZoneHVAC:EquipmentConnections,",
+			"    SPACE2-1,                !- Zone Name",
+			"    SPACE2-1 Eq,             !- Zone Conditioning Equipment List Name",
+			"    SPACE2-1 in node,       !- Zone Air Inlet Node or NodeList Name",
+			"    ,                        !- Zone Air Exhaust Node or NodeList Name",
+			"    SPACE2-1 Node,           !- Zone Air Node Name",
+			"    SPACE2-1 ret node;       !- Zone Return Air Node Name",
 
-		"  ZoneHVAC:EquipmentConnections,",
-		"    SPACE4-1,                !- Zone Name",
-		"    SPACE4-1 Eq,             !- Zone Conditioning Equipment List Name",
-		"    SPACE4-1 in node,       !- Zone Air Inlet Node or NodeList Name",
-		"    ,                        !- Zone Air Exhaust Node or NodeList Name",
-		"    SPACE4-1 Node,           !- Zone Air Node Name",
-		"    SPACE4-1 ret node;       !- Zone Return Air Node Name",
+			"  ZoneHVAC:EquipmentConnections,",
+			"    SPACE4-1,                !- Zone Name",
+			"    SPACE4-1 Eq,             !- Zone Conditioning Equipment List Name",
+			"    SPACE4-1 in node,       !- Zone Air Inlet Node or NodeList Name",
+			"    ,                        !- Zone Air Exhaust Node or NodeList Name",
+			"    SPACE4-1 Node,           !- Zone Air Node Name",
+			"    SPACE4-1 ret node;       !- Zone Return Air Node Name",
 
-		"  ZoneHVAC:EquipmentList,",
-		"    SPACE2-1 Eq,             !- Name",
-		"    ZoneHVAC:Baseboard:RadiantConvective:Electric,  !- Zone Equipment 1 Object Type",
-		"    SPACE2-1 Baseboard,      !- Zone Equipment 1 Name",
-		"    1,                       !- Zone Equipment 1 Cooling Sequence",
-		"    1;                       !- Zone Equipment 1 Heating or No-Load Sequence",
+			"  ZoneHVAC:EquipmentList,",
+			"    SPACE2-1 Eq,             !- Name",
+			"    ZoneHVAC:Baseboard:RadiantConvective:Electric,  !- Zone Equipment 1 Object Type",
+			"    SPACE2-1 Baseboard,      !- Zone Equipment 1 Name",
+			"    1,                       !- Zone Equipment 1 Cooling Sequence",
+			"    1;                       !- Zone Equipment 1 Heating or No-Load Sequence",
 
-		"  ZoneHVAC:EquipmentList,",
-		"    SPACE4-1 Eq,             !- Name",
-		"    ZoneHVAC:Baseboard:RadiantConvective:Electric,  !- Zone Equipment 1 Object Type",
-		"    SPACE4-1 Baseboard,      !- Zone Equipment 1 Name",
-		"    1,                       !- Zone Equipment 1 Cooling Sequence",
-		"    1;                       !- Zone Equipment 1 Heating or No-Load Sequence",
+			"  ZoneHVAC:EquipmentList,",
+			"    SPACE4-1 Eq,             !- Name",
+			"    ZoneHVAC:Baseboard:RadiantConvective:Electric,  !- Zone Equipment 1 Object Type",
+			"    SPACE4-1 Baseboard,      !- Zone Equipment 1 Name",
+			"    1,                       !- Zone Equipment 1 Cooling Sequence",
+			"    1;                       !- Zone Equipment 1 Heating or No-Load Sequence",
 
-		" ZoneHVAC:Baseboard:RadiantConvective:Electric,",
-		"    SPACE2-1 Baseboard,      !- Name",
-		"    always_on,    !- Availability Schedule Name",
-		"    HeatingDesignCapacity,   !- Heating Design Capacity Method",
-		"    1000.0,                !- Heating Design Capacity {W}",
-		"    ,                        !- Heating Design Capacity Per Floor Area {W/m2}",
-		"    ,                        !- Fraction of Autosized Heating Design Capacity",
-		"    0.97,                    !- Efficiency",
-		"    0.2,                     !- Fraction Radiant",
-		"    0.3,                     !- Fraction of Radiant Energy Incident on People",
-		"    RIGHT-1,                 !- Surface 1 Name",
-		"    0.7;                     !- Fraction of Radiant Energy to Surface 1",
+			" ZoneHVAC:Baseboard:RadiantConvective:Electric,",
+			"    SPACE2-1 Baseboard,      !- Name",
+			"    always_on,    !- Availability Schedule Name",
+			"    HeatingDesignCapacity,   !- Heating Design Capacity Method",
+			"    1000.0,                !- Heating Design Capacity {W}",
+			"    ,                        !- Heating Design Capacity Per Floor Area {W/m2}",
+			"    ,                        !- Fraction of Autosized Heating Design Capacity",
+			"    0.97,                    !- Efficiency",
+			"    0.2,                     !- Fraction Radiant",
+			"    0.3,                     !- Fraction of Radiant Energy Incident on People",
+			"    RIGHT-1,                 !- Surface 1 Name",
+			"    0.7;                     !- Fraction of Radiant Energy to Surface 1",
 
-		"  BuildingSurface:Detailed,",
-		"    RIGHT-1,                 !- Name",
-		"    WALL,                    !- Surface Type",
-		"    WALL-1,                  !- Construction Name",
-		"    SPACE2-1,                !- Zone Name",
-		"    Outdoors,                !- Outside Boundary Condition",
-		"    ,                        !- Outside Boundary Condition Object",
-		"    SunExposed,              !- Sun Exposure",
-		"    WindExposed,             !- Wind Exposure",
-		"    0.50000,                 !- View Factor to Ground",
-		"    4,                       !- Number of Vertices",
-		"    30.5,0.0,2.4,  !- X,Y,Z ==> Vertex 1 {m}",
-		"    30.5,0.0,0.0,  !- X,Y,Z ==> Vertex 2 {m}",
-		"    30.5,15.2,0.0,  !- X,Y,Z ==> Vertex 3 {m}",
-		"    30.5,15.2,2.4;  !- X,Y,Z ==> Vertex 4 {m}",
+			"  BuildingSurface:Detailed,",
+			"    RIGHT-1,                 !- Name",
+			"    WALL,                    !- Surface Type",
+			"    WALL-1,                  !- Construction Name",
+			"    SPACE2-1,                !- Zone Name",
+			"    Outdoors,                !- Outside Boundary Condition",
+			"    ,                        !- Outside Boundary Condition Object",
+			"    SunExposed,              !- Sun Exposure",
+			"    WindExposed,             !- Wind Exposure",
+			"    0.50000,                 !- View Factor to Ground",
+			"    4,                       !- Number of Vertices",
+			"    30.5,0.0,2.4,  !- X,Y,Z ==> Vertex 1 {m}",
+			"    30.5,0.0,0.0,  !- X,Y,Z ==> Vertex 2 {m}",
+			"    30.5,15.2,0.0,  !- X,Y,Z ==> Vertex 3 {m}",
+			"    30.5,15.2,2.4;  !- X,Y,Z ==> Vertex 4 {m}",
 
 
-		"  ZoneHVAC:Baseboard:RadiantConvective:Electric,",
-		"    SPACE4-1 Baseboard,      !- Name",
-		"    always_on,    !- Availability Schedule Name",
-		"    HeatingDesignCapacity,   !- Heating Design Capacity Method",
-		"    1000.0,                !- Heating Design Capacity {W}",
-		"    ,                        !- Heating Design Capacity Per Floor Area {W/m2}",
-		"    ,                        !- Fraction of Autosized Heating Design Capacity",
-		"    0.97,                    !- Efficiency",
-		"    0.2,                     !- Fraction Radiant",
-		"    0.3,                     !- Fraction of Radiant Energy Incident on People",
-		"    LEFT-1,                  !- Surface 1 Name",
-		"    0.7;                     !- Fraction of Radiant Energy to Surface 1",
+			"  ZoneHVAC:Baseboard:RadiantConvective:Electric,",
+			"    SPACE4-1 Baseboard,      !- Name",
+			"    always_on,    !- Availability Schedule Name",
+			"    HeatingDesignCapacity,   !- Heating Design Capacity Method",
+			"    1000.0,                !- Heating Design Capacity {W}",
+			"    ,                        !- Heating Design Capacity Per Floor Area {W/m2}",
+			"    ,                        !- Fraction of Autosized Heating Design Capacity",
+			"    0.97,                    !- Efficiency",
+			"    0.2,                     !- Fraction Radiant",
+			"    0.3,                     !- Fraction of Radiant Energy Incident on People",
+			"    LEFT-1,                  !- Surface 1 Name",
+			"    0.7;                     !- Fraction of Radiant Energy to Surface 1",
 
-		"  BuildingSurface:Detailed,",
-		"    LEFT-1,                  !- Name",
-		"    WALL,                    !- Surface Type",
-		"    WALL-1,                  !- Construction Name",
-		"    SPACE4-1,                !- Zone Name",
-		"    Outdoors,                !- Outside Boundary Condition",
-		"    ,                        !- Outside Boundary Condition Object",
-		"    SunExposed,              !- Sun Exposure",
-		"    WindExposed,             !- Wind Exposure",
-		"    0.50000,                 !- View Factor to Ground",
-		"    4,                       !- Number of Vertices",
-		"    0.0,15.2,2.4,  !- X,Y,Z ==> Vertex 1 {m}",
-		"    0.0,15.2,0.0,  !- X,Y,Z ==> Vertex 2 {m}",
-		"    0.0,0.0,0.0,  !- X,Y,Z ==> Vertex 3 {m}",
-		"    0.0,0.0,2.4;  !- X,Y,Z ==> Vertex 4 {m}",
+			"  BuildingSurface:Detailed,",
+			"    LEFT-1,                  !- Name",
+			"    WALL,                    !- Surface Type",
+			"    WALL-1,                  !- Construction Name",
+			"    SPACE4-1,                !- Zone Name",
+			"    Outdoors,                !- Outside Boundary Condition",
+			"    ,                        !- Outside Boundary Condition Object",
+			"    SunExposed,              !- Sun Exposure",
+			"    WindExposed,             !- Wind Exposure",
+			"    0.50000,                 !- View Factor to Ground",
+			"    4,                       !- Number of Vertices",
+			"    0.0,15.2,2.4,  !- X,Y,Z ==> Vertex 1 {m}",
+			"    0.0,15.2,0.0,  !- X,Y,Z ==> Vertex 2 {m}",
+			"    0.0,0.0,0.0,  !- X,Y,Z ==> Vertex 3 {m}",
+			"    0.0,0.0,2.4;  !- X,Y,Z ==> Vertex 4 {m}",
 
-		"  ScheduleTypeLimits,",
-		"    Fraction,                !- Name",
-		"    0.0,                     !- Lower Limit Value",
-		"    1.0,                     !- Upper Limit Value",
-		"    CONTINUOUS;              !- Numeric Type",
+			"  ScheduleTypeLimits,",
+			"    Fraction,                !- Name",
+			"    0.0,                     !- Lower Limit Value",
+			"    1.0,                     !- Upper Limit Value",
+			"    CONTINUOUS;              !- Numeric Type",
 
-		"  Schedule:Compact,",
-		"    always_on,    !- Name",
-		"    Fraction,                !- Schedule Type Limits Name",
-		"    Through: 12/31,          !- Field 1",
-		"    For: AllDays,            !- Field 2",
-		"    Until: 24:00,1.0;        !- Field 3"
+			"  Schedule:Compact,",
+			"    always_on,    !- Name",
+			"    Fraction,                !- Schedule Type Limits Name",
+			"    Through: 12/31,          !- Field 1",
+			"    For: AllDays,            !- Field 2",
+			"    Until: 24:00,1.0;        !- Field 3"
 
-		"SurfaceConvectionAlgorithm:Inside,TARP;",
+			"SurfaceConvectionAlgorithm:Inside,TARP;",
 
-		"SurfaceConvectionAlgorithm:Outside,DOE-2;",
+			"SurfaceConvectionAlgorithm:Outside,DOE-2;",
 
-		"HeatBalanceAlgorithm,ConductionTransferFunction;",
+			"HeatBalanceAlgorithm,ConductionTransferFunction;",
 
-		"ZoneAirHeatBalanceAlgorithm,",
-		"    AnalyticalSolution;      !- Algorithm",
+			"ZoneAirHeatBalanceAlgorithm,",
+			"    AnalyticalSolution;      !- Algorithm",
 
-		"  Construction,",
-		"    WALL-1,                  !- Name",
-		"    WD01,                    !- Outside Layer",
-		"    PW03,                    !- Layer 2",
-		"    IN02,                    !- Layer 3",
-		"    GP01;                    !- Layer 4",
+			"  Construction,",
+			"    WALL-1,                  !- Name",
+			"    WD01,                    !- Outside Layer",
+			"    PW03,                    !- Layer 2",
+			"    IN02,                    !- Layer 3",
+			"    GP01;                    !- Layer 4",
 
-		"  Material,",
-		"    WD01,                    !- Name",
-		"    MediumSmooth,            !- Roughness",
-		"    1.9099999E-02,           !- Thickness {m}",
-		"    0.1150000,               !- Conductivity {W/m-K}",
-		"    513.0000,                !- Density {kg/m3}",
-		"    1381.000,                !- Specific Heat {J/kg-K}",
-		"    0.9000000,               !- Thermal Absorptance",
-		"    0.7800000,               !- Solar Absorptance",
-		"    0.7800000;               !- Visible Absorptance",
+			"  Material,",
+			"    WD01,                    !- Name",
+			"    MediumSmooth,            !- Roughness",
+			"    1.9099999E-02,           !- Thickness {m}",
+			"    0.1150000,               !- Conductivity {W/m-K}",
+			"    513.0000,                !- Density {kg/m3}",
+			"    1381.000,                !- Specific Heat {J/kg-K}",
+			"    0.9000000,               !- Thermal Absorptance",
+			"    0.7800000,               !- Solar Absorptance",
+			"    0.7800000;               !- Visible Absorptance",
 
-		"  Material,",
-		"    PW03,                    !- Name",
-		"    MediumSmooth,            !- Roughness",
-		"    1.2700000E-02,           !- Thickness {m}",
-		"    0.1150000,               !- Conductivity {W/m-K}",
-		"    545.0000,                !- Density {kg/m3",
-		"    1213.000,                !- Specific Heat {J/kg-K}",
-		"    0.9000000,               !- Thermal Absorptance",
-		"    0.7800000,               !- Solar Absorptance",
-		"    0.7800000;               !- Visible Absorptance",
+			"  Material,",
+			"    PW03,                    !- Name",
+			"    MediumSmooth,            !- Roughness",
+			"    1.2700000E-02,           !- Thickness {m}",
+			"    0.1150000,               !- Conductivity {W/m-K}",
+			"    545.0000,                !- Density {kg/m3",
+			"    1213.000,                !- Specific Heat {J/kg-K}",
+			"    0.9000000,               !- Thermal Absorptance",
+			"    0.7800000,               !- Solar Absorptance",
+			"    0.7800000;               !- Visible Absorptance",
 
-		"  Material,",
-		"    IN02,                    !- Name",
-		"    Rough,                   !- Roughness",
-		"    9.0099998E-02,           !- Thickness {m}",
-		"    4.3000001E-02,           !- Conductivity {W/m-K}",
-		"    10.00000,                !- Density {kg/m3}",
-		"    837.0000,                !- Specific Heat {J/kg-K}",
-		"    0.9000000,               !- Thermal Absorptance",
-		"    0.7500000,               !- Solar Absorptance",
-		"    0.7500000;               !- Visible Absorptance",
+			"  Material,",
+			"    IN02,                    !- Name",
+			"    Rough,                   !- Roughness",
+			"    9.0099998E-02,           !- Thickness {m}",
+			"    4.3000001E-02,           !- Conductivity {W/m-K}",
+			"    10.00000,                !- Density {kg/m3}",
+			"    837.0000,                !- Specific Heat {J/kg-K}",
+			"    0.9000000,               !- Thermal Absorptance",
+			"    0.7500000,               !- Solar Absorptance",
+			"    0.7500000;               !- Visible Absorptance",
 
-		"  Material,",
-		"    GP01,                    !- Name",
-		"    MediumSmooth,            !- Roughness",
-		"    1.2700000E-02,           !- Thickness {m}",
-		"    0.1600000,               !- Conductivity {W/m-K}",
-		"    801.0000,                !- Density {kg/m3}",
-		"    837.0000,                !- Specific Heat {J/kg-K}",
-		"    0.9000000,               !- Thermal Absorptance",
-		"    0.7500000,               !- Solar Absorptance",
-		"    0.7500000;               !- Visible Absorptance",
+			"  Material,",
+			"    GP01,                    !- Name",
+			"    MediumSmooth,            !- Roughness",
+			"    1.2700000E-02,           !- Thickness {m}",
+			"    0.1600000,               !- Conductivity {W/m-K}",
+			"    801.0000,                !- Density {kg/m3}",
+			"    837.0000,                !- Specific Heat {J/kg-K}",
+			"    0.9000000,               !- Thermal Absorptance",
+			"    0.7500000,               !- Solar Absorptance",
+			"    0.7500000;               !- Visible Absorptance",
 
-	} );
+		} );
 
-	ASSERT_FALSE( process_idf( idf_objects ) );
+		ASSERT_FALSE( process_idf( idf_objects ) );
 
-	DataGlobals::NumOfTimeStepInHour = 1; // must initialize this to get schedules initialized
-	DataGlobals::MinutesPerTimeStep = 60; // must initialize this to get schedules initialized
-	ScheduleManager::ProcessScheduleInput(); // read schedules
-	
-	bool errorsFound( false );
-	HeatBalanceManager::GetProjectControlData( errorsFound ); // read project control data
-	EXPECT_FALSE( errorsFound ); // expect no errors
+		DataGlobals::NumOfTimeStepInHour = 1; // must initialize this to get schedules initialized
+		DataGlobals::MinutesPerTimeStep = 60; // must initialize this to get schedules initialized
+		ScheduleManager::ProcessScheduleInput(); // read schedules
 
-	errorsFound = false;
-	HeatBalanceManager::GetMaterialData( errorsFound ); // read material data
-	EXPECT_FALSE( errorsFound ); // expect no errors
+		bool errorsFound( false );
+		HeatBalanceManager::GetProjectControlData( errorsFound ); // read project control data
+		EXPECT_FALSE( errorsFound ); // expect no errors
 
-	errorsFound = false;
-	HeatBalanceManager::GetConstructData( errorsFound ); // read construction data
-	EXPECT_FALSE( errorsFound ); // expect no errors
+		errorsFound = false;
+		HeatBalanceManager::GetMaterialData( errorsFound ); // read material data
+		EXPECT_FALSE( errorsFound ); // expect no errors
 
-	HeatBalanceManager::GetZoneData( errorsFound );
-	ASSERT_FALSE( errorsFound );
+		errorsFound = false;
+		HeatBalanceManager::GetConstructData( errorsFound ); // read construction data
+		EXPECT_FALSE( errorsFound ); // expect no errors
 
-	SurfaceGeometry::CosZoneRelNorth.allocate( 2 );
-	SurfaceGeometry::SinZoneRelNorth.allocate( 2 );
-	SurfaceGeometry::CosZoneRelNorth( 1 ) = std::cos( -DataHeatBalance::Zone( 1 ).RelNorth * DataGlobals::DegToRadians );
-	SurfaceGeometry::CosZoneRelNorth( 2 ) = std::cos( -DataHeatBalance::Zone( 2 ).RelNorth * DataGlobals::DegToRadians );
-	SurfaceGeometry::SinZoneRelNorth( 1 ) = std::sin( -DataHeatBalance::Zone( 1 ).RelNorth * DataGlobals::DegToRadians );
-	SurfaceGeometry::SinZoneRelNorth( 2 ) = std::sin( -DataHeatBalance::Zone( 2 ).RelNorth * DataGlobals::DegToRadians );
-	SurfaceGeometry::CosBldgRelNorth = 1.0;
-	SurfaceGeometry::SinBldgRelNorth = 0.0;
-	
-	SurfaceGeometry::GetSurfaceData( errorsFound );
-	ASSERT_FALSE( errorsFound );
+		HeatBalanceManager::GetZoneData( errorsFound );
+		ASSERT_FALSE( errorsFound );
 
-	DataZoneEquipment::GetZoneEquipmentData1();
+		SurfaceGeometry::CosZoneRelNorth.allocate( 2 );
+		SurfaceGeometry::SinZoneRelNorth.allocate( 2 );
+		SurfaceGeometry::CosZoneRelNorth( 1 ) = std::cos( -DataHeatBalance::Zone( 1 ).RelNorth * DataGlobals::DegToRadians );
+		SurfaceGeometry::CosZoneRelNorth( 2 ) = std::cos( -DataHeatBalance::Zone( 2 ).RelNorth * DataGlobals::DegToRadians );
+		SurfaceGeometry::SinZoneRelNorth( 1 ) = std::sin( -DataHeatBalance::Zone( 1 ).RelNorth * DataGlobals::DegToRadians );
+		SurfaceGeometry::SinZoneRelNorth( 2 ) = std::sin( -DataHeatBalance::Zone( 2 ).RelNorth * DataGlobals::DegToRadians );
+		SurfaceGeometry::CosBldgRelNorth = 1.0;
+		SurfaceGeometry::SinBldgRelNorth = 0.0;
 
-	ElectricBaseboardRadiator::GetElectricBaseboardInput();
-	EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( 1 ).ZonePtr , 1 );
-	EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( 2 ).ZonePtr , 2 );
+		SurfaceGeometry::GetSurfaceData( errorsFound );
+		ASSERT_FALSE( errorsFound );
 
+		DataZoneEquipment::GetZoneEquipmentData1();
+
+		ElectricBaseboardRadiator::GetElectricBaseboardInput();
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( 1 ).ZonePtr, 1 );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( 2 ).ZonePtr, 2 );
+
+	}
+
+	TEST_F( EnergyPlusFixture, ElectricBaseboardRadConv_SizingTest ) {
+		// this unit test is related to issue #5890
+		int BaseboardNum( 0 );
+		int CntrlZoneNum( 0 );
+		bool FirstHVACIteration( false );
+
+		std::string const idf_objects = delimited_string( {
+			" Version,8.7;",
+
+			"  Zone,",
+			"    SPACE2-1,                !- Name",
+			"    0,                       !- Direction of Relative North {deg}",
+			"    0,                       !- X Origin {m}",
+			"    0,                       !- Y Origin {m}",
+			"    0,                       !- Z Origin {m}",
+			"    1,                       !- Type",
+			"    1,                       !- Multiplier",
+			"    2.438400269,             !- Ceiling Height {m}",
+			"    103.311355591;           !- Volume {m3}",
+
+			"  Zone,",
+			"    SPACE3-1,                !- Name",
+			"    0,                       !- Direction of Relative North {deg}",
+			"    0,                       !- X Origin {m}",
+			"    0,                       !- Y Origin {m}",
+			"    0,                       !- Z Origin {m}",
+			"    1,                       !- Type",
+			"    1,                       !- Multiplier",
+			"    2.438400269,             !- Ceiling Height {m}",
+			"    103.311355591;           !- Volume {m3}",
+
+			"  Zone,",
+			"    SPACE4-1,                !- Name",
+			"    0,                       !- Direction of Relative North {deg}",
+			"    0,                       !- X Origin {m}",
+			"    0,                       !- Y Origin {m}",
+			"    0,                       !- Z Origin {m}",
+			"    1,                       !- Type",
+			"    1,                       !- Multiplier",
+			"    2.438400269,             !- Ceiling Height {m}",
+			"    103.311355591;           !- Volume {m3}",
+
+			"  ZoneHVAC:EquipmentConnections,",
+			"    SPACE2-1,                !- Zone Name",
+			"    SPACE2-1 Eq,             !- Zone Conditioning Equipment List Name",
+			"    SPACE2-1 in node,        !- Zone Air Inlet Node or NodeList Name",
+			"    ,                        !- Zone Air Exhaust Node or NodeList Name",
+			"    SPACE2-1 Node,           !- Zone Air Node Name",
+			"    SPACE2-1 ret node;       !- Zone Return Air Node Name",
+
+			"  ZoneHVAC:EquipmentConnections,",
+			"    SPACE3-1,                !- Zone Name",
+			"    SPACE3-1 Eq,             !- Zone Conditioning Equipment List Name",
+			"    SPACE3-1 in node,        !- Zone Air Inlet Node or NodeList Name",
+			"    ,                        !- Zone Air Exhaust Node or NodeList Name",
+			"    SPACE3-1 Node,           !- Zone Air Node Name",
+			"    SPACE3-1 ret node;       !- Zone Return Air Node Name",
+
+			"  ZoneHVAC:EquipmentConnections,",
+			"    SPACE4-1,                !- Zone Name",
+			"    SPACE4-1 Eq,             !- Zone Conditioning Equipment List Name",
+			"    SPACE4-1 in node,       !- Zone Air Inlet Node or NodeList Name",
+			"    ,                        !- Zone Air Exhaust Node or NodeList Name",
+			"    SPACE4-1 Node,           !- Zone Air Node Name",
+			"    SPACE4-1 ret node;       !- Zone Return Air Node Name",
+
+			"  ZoneHVAC:EquipmentList,",
+			"    SPACE2-1 Eq,             !- Name",
+			"    ZoneHVAC:Baseboard:RadiantConvective:Electric,  !- Zone Equipment 1 Object Type",
+			"    SPACE2-1 Baseboard,      !- Zone Equipment 1 Name",
+			"    1,                       !- Zone Equipment 1 Cooling Sequence",
+			"    1;                       !- Zone Equipment 1 Heating or No-Load Sequence",
+
+			"  ZoneHVAC:EquipmentList,",
+			"    SPACE3-1 Eq,             !- Name",
+			"    ZoneHVAC:Baseboard:RadiantConvective:Electric,  !- Zone Equipment 1 Object Type",
+			"    SPACE3-1 Baseboard,      !- Zone Equipment 1 Name",
+			"    1,                       !- Zone Equipment 1 Cooling Sequence",
+			"    1;                       !- Zone Equipment 1 Heating or No-Load Sequence",
+
+			"  ZoneHVAC:EquipmentList,",
+			"    SPACE4-1 Eq,             !- Name",
+			"    ZoneHVAC:Baseboard:RadiantConvective:Electric,  !- Zone Equipment 1 Object Type",
+			"    SPACE4-1 Baseboard,      !- Zone Equipment 1 Name",
+			"    1,                       !- Zone Equipment 1 Cooling Sequence",
+			"    1;                       !- Zone Equipment 1 Heating or No-Load Sequence",
+
+			" ZoneHVAC:Baseboard:RadiantConvective:Electric,",
+			"    SPACE2-1 Baseboard,      !- Name",
+			"    always_on,               !- Availability Schedule Name",
+			"    HeatingDesignCapacity,   !- Heating Design Capacity Method",
+			"    1000.0,                  !- Heating Design Capacity {W}",
+			"    ,                        !- Heating Design Capacity Per Floor Area {W/m2}",
+			"    ,                        !- Fraction of Autosized Heating Design Capacity",
+			"    0.97,                    !- Efficiency",
+			"    0.2,                     !- Fraction Radiant",
+			"    0.3,                     !- Fraction of Radiant Energy Incident on People",
+			"    RIGHT-1,                 !- Surface 1 Name",
+			"    0.7;                     !- Fraction of Radiant Energy to Surface 1",
+
+			"  BuildingSurface:Detailed,",
+			"    RIGHT-1,                 !- Name",
+			"    WALL,                    !- Surface Type",
+			"    WALL-1,                  !- Construction Name",
+			"    SPACE2-1,                !- Zone Name",
+			"    Outdoors,                !- Outside Boundary Condition",
+			"    ,                        !- Outside Boundary Condition Object",
+			"    SunExposed,              !- Sun Exposure",
+			"    WindExposed,             !- Wind Exposure",
+			"    0.50000,                 !- View Factor to Ground",
+			"    4,                       !- Number of Vertices",
+			"    30.5,0.0,2.4,   !- X,Y,Z ==> Vertex 1 {m}",
+			"    30.5,0.0,0.0,   !- X,Y,Z ==> Vertex 2 {m}",
+			"    30.5,15.2,0.0,  !- X,Y,Z ==> Vertex 3 {m}",
+			"    30.5,15.2,2.4;  !- X,Y,Z ==> Vertex 4 {m}",
+
+			"  ZoneHVAC:Baseboard:RadiantConvective:Electric,",
+			"    SPACE3-1 Baseboard,      !- Name",
+			"    always_on,               !- Availability Schedule Name",
+			"    CapacityPerFloorArea,    !- Heating Design Capacity Method",
+			"    ,                        !- Heating Design Capacity {W}",
+			"    30.0,                    !- Heating Design Capacity Per Floor Area {W/m2}",
+			"    ,                        !- Fraction of Autosized Heating Design Capacity",
+			"    0.97,                    !- Efficiency",
+			"    0.2,                     !- Fraction Radiant",
+			"    0.3,                     !- Fraction of Radiant Energy Incident on People",
+			"    FRONT-1,                 !- Surface 1 Name",
+			"    0.7;                     !- Fraction of Radiant Energy to Surface 1",
+
+			"  BuildingSurface:Detailed,",
+			"    FRONT-1,                  !- Name",
+			"    WALL,                    !- Surface Type",
+			"    WALL-1,                  !- Construction Name",
+			"    SPACE3-1,                !- Zone Name",
+			"    Outdoors,                !- Outside Boundary Condition",
+			"    ,                        !- Outside Boundary Condition Object",
+			"    SunExposed,              !- Sun Exposure",
+			"    WindExposed,             !- Wind Exposure",
+			"    0.50000,                 !- View Factor to Ground",
+			"    4,                       !- Number of Vertices",
+			"    0.0, 0.0, 2.4,    !- X,Y,Z ==> Vertex 1 {m}",
+			"    0.0, 0.0, 0.0,    !- X,Y,Z ==> Vertex 2 {m}",
+			"    20.0, 0.0, 0.0,   !- X,Y,Z ==> Vertex 3 {m}",
+			"    20.0, 0.0, 2.4;   !- X,Y,Z ==> Vertex 4 {m}",
+
+			"  ZoneHVAC:Baseboard:RadiantConvective:Electric,",
+			"    SPACE4-1 Baseboard,      !- Name",
+			"    always_on,               !- Availability Schedule Name",
+			"    FractionOfAutosizedHeatingCapacity,   !- Heating Design Capacity Method",
+			"    ,                        !- Heating Design Capacity {W}",
+			"    ,                        !- Heating Design Capacity Per Floor Area {W/m2}",
+			"    0.5,                     !- Fraction of Autosized Heating Design Capacity",
+			"    0.97,                    !- Efficiency",
+			"    0.2,                     !- Fraction Radiant",
+			"    0.3,                     !- Fraction of Radiant Energy Incident on People",
+			"    LEFT-1,                  !- Surface 1 Name",
+			"    0.7;                     !- Fraction of Radiant Energy to Surface 1",
+
+			"  BuildingSurface:Detailed,",
+			"    LEFT-1,                  !- Name",
+			"    WALL,                    !- Surface Type",
+			"    WALL-1,                  !- Construction Name",
+			"    SPACE4-1,                !- Zone Name",
+			"    Outdoors,                !- Outside Boundary Condition",
+			"    ,                        !- Outside Boundary Condition Object",
+			"    SunExposed,              !- Sun Exposure",
+			"    WindExposed,             !- Wind Exposure",
+			"    0.50000,                 !- View Factor to Ground",
+			"    4,                       !- Number of Vertices",
+			"    0.0,15.2,2.4,  !- X,Y,Z ==> Vertex 1 {m}",
+			"    0.0,15.2,0.0,  !- X,Y,Z ==> Vertex 2 {m}",
+			"    0.0,0.0,0.0,   !- X,Y,Z ==> Vertex 3 {m}",
+			"    0.0,0.0,2.4;   !- X,Y,Z ==> Vertex 4 {m}",
+			
+			"  ScheduleTypeLimits,",
+			"    Fraction,                !- Name",
+			"    0.0,                     !- Lower Limit Value",
+			"    1.0,                     !- Upper Limit Value",
+			"    CONTINUOUS;              !- Numeric Type",
+
+			"  Schedule:Compact,",
+			"    always_on,               !- Name",
+			"    Fraction,                !- Schedule Type Limits Name",
+			"    Through: 12/31,          !- Field 1",
+			"    For: AllDays,            !- Field 2",
+			"    Until: 24:00,1.0;        !- Field 3"
+
+			"SurfaceConvectionAlgorithm:Inside,TARP;",
+
+			"SurfaceConvectionAlgorithm:Outside,DOE-2;",
+
+			"HeatBalanceAlgorithm,ConductionTransferFunction;",
+
+			"ZoneAirHeatBalanceAlgorithm,",
+			"    AnalyticalSolution;      !- Algorithm",
+
+			"  Construction,",
+			"    WALL-1,                  !- Name",
+			"    WD01,                    !- Outside Layer",
+			"    PW03,                    !- Layer 2",
+			"    IN02,                    !- Layer 3",
+			"    GP01;                    !- Layer 4",
+
+			"  Material,",
+			"    WD01,                    !- Name",
+			"    MediumSmooth,            !- Roughness",
+			"    1.9099999E-02,           !- Thickness {m}",
+			"    0.1150000,               !- Conductivity {W/m-K}",
+			"    513.0000,                !- Density {kg/m3}",
+			"    1381.000,                !- Specific Heat {J/kg-K}",
+			"    0.9000000,               !- Thermal Absorptance",
+			"    0.7800000,               !- Solar Absorptance",
+			"    0.7800000;               !- Visible Absorptance",
+
+			"  Material,",
+			"    PW03,                    !- Name",
+			"    MediumSmooth,            !- Roughness",
+			"    1.2700000E-02,           !- Thickness {m}",
+			"    0.1150000,               !- Conductivity {W/m-K}",
+			"    545.0000,                !- Density {kg/m3",
+			"    1213.000,                !- Specific Heat {J/kg-K}",
+			"    0.9000000,               !- Thermal Absorptance",
+			"    0.7800000,               !- Solar Absorptance",
+			"    0.7800000;               !- Visible Absorptance",
+
+			"  Material,",
+			"    IN02,                    !- Name",
+			"    Rough,                   !- Roughness",
+			"    9.0099998E-02,           !- Thickness {m}",
+			"    4.3000001E-02,           !- Conductivity {W/m-K}",
+			"    10.00000,                !- Density {kg/m3}",
+			"    837.0000,                !- Specific Heat {J/kg-K}",
+			"    0.9000000,               !- Thermal Absorptance",
+			"    0.7500000,               !- Solar Absorptance",
+			"    0.7500000;               !- Visible Absorptance",
+
+			"  Material,",
+			"    GP01,                    !- Name",
+			"    MediumSmooth,            !- Roughness",
+			"    1.2700000E-02,           !- Thickness {m}",
+			"    0.1600000,               !- Conductivity {W/m-K}",
+			"    801.0000,                !- Density {kg/m3}",
+			"    837.0000,                !- Specific Heat {J/kg-K}",
+			"    0.9000000,               !- Thermal Absorptance",
+			"    0.7500000,               !- Solar Absorptance",
+			"    0.7500000;               !- Visible Absorptance",
+
+		} );
+
+		ASSERT_FALSE( process_idf( idf_objects ) );
+
+		DataGlobals::NumOfTimeStepInHour = 1; // must initialize this to get schedules initialized
+		DataGlobals::MinutesPerTimeStep = 60; // must initialize this to get schedules initialized
+		ScheduleManager::ProcessScheduleInput(); // read schedules
+
+		bool errorsFound( false );
+		HeatBalanceManager::GetProjectControlData( errorsFound ); // read project control data
+		EXPECT_FALSE( errorsFound ); // expect no errors
+
+		errorsFound = false;
+		HeatBalanceManager::GetMaterialData( errorsFound ); // read material data
+		EXPECT_FALSE( errorsFound ); // expect no errors
+
+		errorsFound = false;
+		HeatBalanceManager::GetConstructData( errorsFound ); // read construction data
+		EXPECT_FALSE( errorsFound ); // expect no errors
+
+		HeatBalanceManager::GetZoneData( errorsFound );
+		ASSERT_FALSE( errorsFound );
+
+		SurfaceGeometry::CosZoneRelNorth.allocate( 3 );
+		SurfaceGeometry::SinZoneRelNorth.allocate( 3 );
+		SurfaceGeometry::CosZoneRelNorth( 1 ) = std::cos( -DataHeatBalance::Zone( 1 ).RelNorth * DataGlobals::DegToRadians );
+		SurfaceGeometry::CosZoneRelNorth( 2 ) = std::cos( -DataHeatBalance::Zone( 2 ).RelNorth * DataGlobals::DegToRadians );
+		SurfaceGeometry::CosZoneRelNorth( 3 ) = std::cos( -DataHeatBalance::Zone( 3 ).RelNorth * DataGlobals::DegToRadians );
+		SurfaceGeometry::SinZoneRelNorth( 1 ) = std::sin( -DataHeatBalance::Zone( 1 ).RelNorth * DataGlobals::DegToRadians );
+		SurfaceGeometry::SinZoneRelNorth( 2 ) = std::sin( -DataHeatBalance::Zone( 2 ).RelNorth * DataGlobals::DegToRadians );	
+		SurfaceGeometry::SinZoneRelNorth( 3 ) = std::sin( -DataHeatBalance::Zone( 3 ).RelNorth * DataGlobals::DegToRadians );
+
+		SurfaceGeometry::CosBldgRelNorth = 1.0;
+		SurfaceGeometry::SinBldgRelNorth = 0.0;
+
+		SurfaceGeometry::GetSurfaceData( errorsFound );
+		ASSERT_FALSE( errorsFound );
+
+		DataZoneEquipment::GetZoneEquipmentData1();
+		// get electric baseboard inputs
+		ElectricBaseboardRadiator::GetElectricBaseboardInput();
+
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( 1 ).ZonePtr, 1 );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( 2 ).ZonePtr, 2 );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( 3 ).ZonePtr, 3 );
+
+		DataSizing::FinalZoneSizing.allocate( 3 );
+		DataSizing::ZoneEqSizing.allocate( 3 );	
+		DataSizing::ZoneSizingRunDone = true;
+
+		BaseboardNum = 1;
+		CntrlZoneNum = 1;
+		DataSizing::CurZoneEqNum = CntrlZoneNum;
+		FirstHVACIteration = true;
+		DataSizing::ZoneEqSizing( CntrlZoneNum ).SizingMethod.allocate( DataHVACGlobals::NumOfSizingTypes );
+		DataSizing::ZoneEqSizing( CntrlZoneNum ).SizingMethod( DataHVACGlobals::HeatingCapacitySizing ) = ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).HeatingCapMethod;
+		DataSizing::FinalZoneSizing( CntrlZoneNum ).NonAirSysDesHeatLoad = 2000.0;
+		// do electric baseboard sizing	
+		ElectricBaseboardRadiator::SizeElectricBaseboard( BaseboardNum );
+		// check user specified hardsized nominal capacity
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity, 1000.0 );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).NominalCapacity, 1000.0 );
+		// check nominal capacity autosize
+		ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity = DataSizing::AutoSize;
+		ElectricBaseboardRadiator::SizeElectricBaseboard( BaseboardNum );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).NominalCapacity, 2000.0 );
+
+		BaseboardNum = 2;
+		CntrlZoneNum = 2;
+		DataSizing::CurZoneEqNum = CntrlZoneNum;
+		FirstHVACIteration = true;
+		DataSizing::ZoneEqSizing( CntrlZoneNum ).SizingMethod.allocate( DataHVACGlobals::NumOfSizingTypes );
+		DataSizing::ZoneEqSizing( CntrlZoneNum ).SizingMethod( DataHVACGlobals::HeatingCapacitySizing ) = ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).HeatingCapMethod;
+		DataSizing::FinalZoneSizing( CntrlZoneNum ).NonAirSysDesHeatLoad = 2000.0;
+		DataHeatBalance::Zone( CntrlZoneNum ).FloorArea = 100.0;
+		// do electric baseboard sizing
+		ElectricBaseboardRadiator::SizeElectricBaseboard( BaseboardNum );
+		// check user specified hardsized nominal capacity
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity, 30.0 );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).NominalCapacity, 3000.0 );
+		// check nominal capacity autosize
+		ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).HeatingCapMethod = DataSizing::HeatingDesignCapacity;
+		ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity = DataSizing::AutoSize;
+		ElectricBaseboardRadiator::SizeElectricBaseboard( BaseboardNum );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).NominalCapacity, 2000.0 );
+
+		BaseboardNum = 3;
+		CntrlZoneNum = 3;
+		DataSizing::CurZoneEqNum = CntrlZoneNum;
+		FirstHVACIteration = true;
+		DataSizing::ZoneEqSizing( CntrlZoneNum ).SizingMethod.allocate( DataHVACGlobals::NumOfSizingTypes );
+		DataSizing::ZoneEqSizing( CntrlZoneNum ).SizingMethod( DataHVACGlobals::HeatingCapacitySizing ) = ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).HeatingCapMethod;
+		DataSizing::FinalZoneSizing( CntrlZoneNum ).NonAirSysDesHeatLoad = 3000.0;
+		DataHeatBalance::Zone( CntrlZoneNum ).FloorArea = 100.0;
+		// do electric baseboard sizing
+		ElectricBaseboardRadiator::SizeElectricBaseboard( BaseboardNum );
+		// check user specified hardsized nominal capacity
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity, 0.50 );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).NominalCapacity, 1500.0 );
+		// check nominal capacity autosize
+		ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).HeatingCapMethod = DataSizing::HeatingDesignCapacity;
+		ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).ScaledHeatingCapacity = DataSizing::AutoSize;
+		ElectricBaseboardRadiator::SizeElectricBaseboard( BaseboardNum );
+		EXPECT_EQ( ElectricBaseboardRadiator::ElecBaseboard( BaseboardNum ).NominalCapacity, 3000.0 );
+
+	}
 }


### PR DESCRIPTION
Issue #5890

Now the user specified and design sizing values are reported correctly (they can be different). Also scale-able capacity sizing methods (Capacity per floor area and fraction of autosized heating capacity) now report the autosized heating capacity. 

Pull request overview
---------------------
This defect has been fixed. The defect file now reports both user specified and autosized heating capacities for all the three heating capacity sizing methods. New defect file has been added to show the other sizing methods (scale-able sizing). Diffs shown in one of the example file is expected.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)


