### PR TITLE
Invalid Severe with CoolingTower:TwoSpeed when low speed autocalculated #5863

### DIFF
--- a/src/EnergyPlus/CondenserLoopTowers.cc
+++ b/src/EnergyPlus/CondenserLoopTowers.cc
@@ -1145,9 +1145,11 @@ namespace CondenserLoopTowers {
 					ShowSevereError( cCurrentModuleObject + " \"" + SimpleTower( TowerNum ).Name + "\". Low-speed nominal capacity must be less than the high-speed nominal capacity." );
 					ErrorsFound = true;
 				}
-				if ( SimpleTower( TowerNum ).TowerFreeConvNomCap >= SimpleTower( TowerNum ).TowerLowSpeedNomCap ) {
-					ShowSevereError( cCurrentModuleObject + " \"" + SimpleTower( TowerNum ).Name + "\". Free convection nominal capacity must be less than the low-speed nominal capacity." );
-					ErrorsFound = true;
+				if ( !SimpleTower( TowerNum ).TowerLowSpeedNomCapWasAutoSized ) {
+					if ( SimpleTower( TowerNum ).TowerFreeConvNomCap >= SimpleTower( TowerNum ).TowerLowSpeedNomCap ) {
+						ShowSevereError( cCurrentModuleObject + " \"" + SimpleTower( TowerNum ).Name + "\". Free convection nominal capacity must be less than the low-speed nominal capacity." );
+						ErrorsFound = true;
+					}
 				}
 				if ( SimpleTower( TowerNum ).TowerFreeConvNomCap > 0.0 && SimpleTower( TowerNum ).FreeConvAirFlowRate == 0.0 ) {
 					ShowSevereError( cCurrentModuleObject + " \"" + SimpleTower( TowerNum ).Name + "\". Free convection air flow must be greater than zero when tower free convection capacity is specified." );

--- a/tst/EnergyPlus/unit/CondenserLoopTowers.unit.cc
+++ b/tst/EnergyPlus/unit/CondenserLoopTowers.unit.cc
@@ -2242,5 +2242,413 @@ namespace EnergyPlus {
 
 	}
 
+	TEST_F( EnergyPlusFixture, CondenserLoopTowers_TwoSpeedTowerLowSpeedNomCapSizing ) {
+
+		Real64 LowSpeedCoolTowerNomCap( 0.0 );
+
+		std::string const idf_objects = delimited_string( {
+			"  Site:Location,",
+			"    USA IL-CHICAGO-OHARE,    !- Name",
+			"    41.77,                   !- Latitude {deg}",
+			"    -87.75,                  !- Longitude {deg}",
+			"    -6.00,                   !- Time Zone {hr}",
+			"    190;                     !- Elevation {m}",
+
+			"  SizingPeriod:DesignDay,",
+			"    CHICAGO Ann Htg 99.6% Condns DB,  !- Name",
+			"    1,                       !- Month",
+			"    21,                      !- Day of Month",
+			"    WinterDesignDay,         !- Day Type",
+			"    -20.6,                   !- Maximum Dry-Bulb Temperature {C}",
+			"    0.0,                     !- Daily Dry-Bulb Temperature Range {deltaC}",
+			"    ,                        !- Dry-Bulb Temperature Range Modifier Type",
+			"    ,                        !- Dry-Bulb Temperature Range Modifier Day Schedule Name",
+			"    Wetbulb,                 !- Humidity Condition Type",
+			"    -20.6,                   !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}",
+			"    ,                        !- Humidity Condition Day Schedule Name",
+			"    ,                        !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}",
+			"    ,                        !- Enthalpy at Maximum Dry-Bulb {J/kg}",
+			"    ,                        !- Daily Wet-Bulb Temperature Range {deltaC}",
+			"    99063.,                  !- Barometric Pressure {Pa}",
+			"    4.9,                     !- Wind Speed {m/s}",
+			"    270,                     !- Wind Direction {deg}",
+			"    No,                      !- Rain Indicator",
+			"    No,                      !- Snow Indicator",
+			"    No,                      !- Daylight Saving Time Indicator",
+			"    ASHRAEClearSky,          !- Solar Model Indicator",
+			"    ,                        !- Beam Solar Day Schedule Name",
+			"    ,                        !- Diffuse Solar Day Schedule Name",
+			"    ,                        !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub) {dimensionless}",
+			"    ,                        !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud) {dimensionless}",
+			"    0.00;                    !- Sky Clearness",
+
+			"  SizingPeriod:DesignDay,",
+			"    CHICAGO Ann Clg .4% Condns WB=>MDB,  !- Name",
+			"    7,                       !- Month",
+			"    21,                      !- Day of Month",
+			"    SummerDesignDay,         !- Day Type",
+			"    31.2,                    !- Maximum Dry-Bulb Temperature {C}",
+			"    10.7,                    !- Daily Dry-Bulb Temperature Range {deltaC}",
+			"    ,                        !- Dry-Bulb Temperature Range Modifier Type",
+			"    ,                        !- Dry-Bulb Temperature Range Modifier Day Schedule Name",
+			"    Wetbulb,                 !- Humidity Condition Type",
+			"    25.5,                    !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}",
+			"    ,                        !- Humidity Condition Day Schedule Name",
+			"    ,                        !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}",
+			"    ,                        !- Enthalpy at Maximum Dry-Bulb {J/kg}",
+			"    ,                        !- Daily Wet-Bulb Temperature Range {deltaC}",
+			"    99063.,                  !- Barometric Pressure {Pa}",
+			"    5.3,                     !- Wind Speed {m/s}",
+			"    230,                     !- Wind Direction {deg}",
+			"    No,                      !- Rain Indicator",
+			"    No,                      !- Snow Indicator",
+			"    No,                      !- Daylight Saving Time Indicator",
+			"    ASHRAEClearSky,          !- Solar Model Indicator",
+			"    ,                        !- Beam Solar Day Schedule Name",
+			"    ,                        !- Diffuse Solar Day Schedule Name",
+			"    ,                        !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub) {dimensionless}",
+			"    ,                        !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud) {dimensionless}",
+			"    1.00;                    !- Sky Clearness",
+
+			"    SimulationControl,",
+			"    no,                     !- Do Zone Sizing Calculation",
+			"    no,                     !- Do System Sizing Calculation",
+			"    Yes,                    !- Do Plant Sizing Calculation",
+			"    Yes,                    !- Run Simulation for Sizing Periods",
+			"    no;                     !- Run Simulation for Weather File Run Periods",
+
+			"  Timestep,6;",
+
+			"  ScheduleTypeLimits,",
+			"    Any Number;              !- Name",
+
+			"  Schedule:Compact,",
+			"    ALWAYS_ON,               !- Name",
+			"    On/Off,                  !- Schedule Type Limits Name",
+			"    Through: 12/31,          !- Field 1",
+			"    For: AllDays,            !- Field 2",
+			"    Until: 24:00,1;          !- Field 3",
+
+			"  ScheduleTypeLimits,",
+			"    On/Off,                  !- Name",
+			"    0,                       !- Lower Limit Value",
+			"    1,                       !- Upper Limit Value",
+			"    DISCRETE;                !- Numeric Type",
+
+			"  CoolingTower:TwoSpeed,",
+			"    TowerWaterSys CoolTower1,!- Name",
+			"    TowerWaterSys Pump-TowerWaterSys CoolTowerNode,  !- Water Inlet Node Name",
+			"    TowerWaterSys Supply Equipment Outlet Node,  !- Water Outlet Node Name",
+			"    ,                        !- Design Water Flow Rate {m3/s}",
+			"    autosize,                !- High Fan Speed Air Flow Rate {m3/s}",
+			"    autosize,                !- High Fan Speed Fan Power {W}",
+			"    ,                        !- High Fan Speed U-Factor Times Area Value {W/K}",
+			"    autocalculate,           !- Low Fan Speed Air Flow Rate {m3/s}",
+			"    0.5000,                  !- Low Fan Speed Air Flow Rate Sizing Factor",
+			"    autocalculate,           !- Low Fan Speed Fan Power {W}",
+			"    0.1600,                  !- Low Fan Speed Fan Power Sizing Factor",
+			"    ,                        !- Low Fan Speed U-Factor Times Area Value {W/K}",
+			"    0.6000,                  !- Low Fan Speed U-Factor Times Area Sizing Factor",
+			"    autocalculate,           !- Free Convection Regime Air Flow Rate {m3/s}",
+			"    0.1000,                  !- Free Convection Regime Air Flow Rate Sizing Factor",
+			"    ,                        !- Free Convection Regime U-Factor Times Area Value {W/K}",
+			"    0.1000,                  !- Free Convection U-Factor Times Area Value Sizing Factor",
+			"    NominalCapacity,         !- Performance Input Method",
+			"    1.2500,                  !- Heat Rejection Capacity and Nominal Capacity Sizing Ratio",
+			"    100000.0000,             !- High Speed Nominal Capacity {W}",
+			"    autocalculate,           !- Low Speed Nominal Capacity {W}",
+			"    0.5000,                  !- Low Speed Nominal Capacity Sizing Factor",
+			"    10000.0000,              !- Free Convection Nominal Capacity {W}",
+			"    0.1000,                  !- Free Convection Nominal Capacity Sizing Factor",
+			"    ,                        !- Design Inlet Air Dry-Bulb Temperature {C}",
+			"    ,                        !- Design Inlet Air Wet-Bulb Temperature {C}",
+			"    ,                        !- Design Approach Temperature {deltaC}",
+			"    ,                        !- Design Range Temperature {deltaC}",
+			"    0.00,                    !- Basin Heater Capacity {W/K}",
+			"    2.00,                    !- Basin Heater Setpoint Temperature {C}",
+			"    On 24/7,                 !- Basin Heater Operating Schedule Name",
+			"    SaturatedExit,           !- Evaporation Loss Mode",
+			"    0.2000,                  !- Evaporation Loss Factor {percent/K}",
+			"    0,                       !- Drift Loss Percent {percent}",
+			"    ConcentrationRatio,      !- Blowdown Calculation Mode",
+			"    3.00,                    !- Blowdown Concentration Ratio",
+			"    On 24/7,                 !- Blowdown Makeup Water Usage Schedule Name",
+			"    ,                        !- Supply Water Storage Tank Name",
+			"    ,                        !- Outdoor Air Inlet Node Name",
+			"    ,                        !- Number of Cells",
+			"    MinimalCell,             !- Cell Control",
+			"    0.3300,                  !- Cell Minimum  Water Flow Rate Fraction",
+			"    2.5000,                  !- Cell Maximum Water Flow Rate Fraction",
+			"    1.00;                    !- Sizing Factor",
+
+			"  Pump:ConstantSpeed,",
+			"    TowerWaterSys Pump,      !- Name",
+			"    TowerWaterSys Supply Inlet Node,  !- Inlet Node Name",
+			"    TowerWaterSys Pump-TowerWaterSys CoolTowerNodeviaConnector,  !- Outlet Node Name",
+			"    0.002,                !- Rated Flow Rate {m3/s}",
+			"    0.1,                  !- Rated Pump Head {Pa}",
+			"    200.0,                !- Rated Power Consumption {W}",
+			"    0.87,                    !- Motor Efficiency",
+			"    0.0,                     !- Fraction of Motor Inefficiencies to Fluid Stream",
+			"    Intermittent;            !- Pump Control Type",
+
+			"  CondenserEquipmentList,",
+			"    TowerWaterSys Equipment List,  !- Name",
+			"    CoolingTower:TwoSpeed,   !- Equipment 1 Object Type",
+			"    TowerWaterSys CoolTower1;!- Equipment 1 Name",
+
+			"  CondenserLoop,",
+			"    TowerWaterSys,           !- Name",
+			"    Water,                   !- Fluid Type",
+			"    ,                        !- User Defined Fluid Type",
+			"    TowerWaterSys Loop Operation Scheme List,  !- Condenser Equipment Operation Scheme Name",
+			"    TowerWaterSys Supply Outlet Node,  !- Condenser Loop Temperature Setpoint Node Name",
+			"    80.0,                    !- Maximum Loop Temperature {C}",
+			"    5.0,                     !- Minimum Loop Temperature {C}",
+			"    0.002,                   !- Maximum Loop Flow Rate {m3/s}",
+			"    0.0,                     !- Minimum Loop Flow Rate {m3/s}",
+			"    0.1,                     !- Condenser Loop Volume {m3}",
+			"    TowerWaterSys Supply Inlet Node,  !- Condenser Side Inlet Node Name",
+			"    TowerWaterSys Supply Outlet Node, !- Condenser Side Outlet Node Name",
+			"    TowerWaterSys Supply Branches,    !- Condenser Side Branch List Name",
+			"    TowerWaterSys Supply Connectors,  !- Condenser Side Connector List Name",
+			"    TowerWaterSys Demand Inlet Node,  !- Demand Side Inlet Node Name",
+			"    TowerWaterSys Demand Outlet Node, !- Demand Side Outlet Node Name",
+			"    TowerWaterSys Demand Branches,    !- Condenser Demand Side Branch List Name",
+			"    TowerWaterSys Demand Connectors,  !- Condenser Demand Side Connector List Name",
+			"    SequentialLoad,,;                   !- Load Distribution Scheme",
+
+			"  CondenserEquipmentOperationSchemes,",
+			"    TowerWaterSys Loop Operation Scheme List,  !- Name",
+			"    PlantEquipmentOperation:CoolingLoad,  !- Control Scheme 1 Object Type",
+			"    TowerWaterSys Operation Scheme,  !- Control Scheme 1 Name",
+			"    ALWAYS_ON;                       !- Control Scheme 1 Schedule Name",
+
+			"  PlantEquipmentOperation:CoolingLoad,",
+			"    TowerWaterSys Operation Scheme,  !- Name",
+			"    0.0,                             !- Load Range 1 Lower Limit {W}",
+			"    1000000000000,                   !- Load Range 1 Upper Limit {W}",
+			"    TowerWaterSys Equipment List;    !- Range 1 Equipment List Name",
+
+			"  SetpointManager:Scheduled,",
+			"    TowerWaterSys Setpoint Manager,  !- Name",
+			"    Temperature,                     !- Control Variable",
+			"    TowerWaterSys Temp Sch,          !- Schedule Name",
+			"    TowerWaterSys Supply Outlet Node;  !- Setpoint Node or NodeList Name",
+
+			"  Schedule:Compact,",
+			"    TowerWaterSys Temp Sch,      !- Name",
+			"    Any Number,              !- Schedule Type Limits Name",
+			"    THROUGH: 12/31,          !- Field 1",
+			"    FOR: AllDays,            !- Field 2",
+			"    UNTIL: 24:00,30.0;       !- Field 3",
+
+			"  BranchList,",
+			"    TowerWaterSys Demand Branches,       !- Name",
+			"    TowerWaterSys Demand Inlet Branch,   !- Branch 1 Name",
+			"    TowerWaterSys Demand Load Branch 1,  !- Branch 2 Name",
+			"    TowerWaterSys Demand Bypass Branch,  !- Branch 4 Name",
+			"    TowerWaterSys Demand Outlet Branch;  !- Branch 5 Name",
+
+			"  BranchList,",
+			"    TowerWaterSys Supply Branches,      !- Name",
+			"    TowerWaterSys Supply Inlet Branch,  !- Branch 1 Name",
+			"    TowerWaterSys Supply Equipment Branch 1,  !- Branch 2 Name",
+			"    TowerWaterSys Supply Equipment Bypass Branch,  !- Branch 4 Name",
+			"    TowerWaterSys Supply Outlet Branch;  !- Branch 5 Name",
+
+			"  Branch,",
+			"    TowerWaterSys Demand Bypass Branch,  !- Name",
+			"    ,                        !- Pressure Drop Curve Name",
+			"    Pipe:Adiabatic,          !- Component 1 Object Type",
+			"    TowerWaterSys Demand Bypass Pipe,  !- Component 1 Name",
+			"    TowerWaterSys Demand Bypass Pipe Inlet Node,  !- Component 1 Inlet Node Name",
+			"    TowerWaterSys Demand Bypass Pipe Outlet Node;  !- Component 1 Outlet Node Name",
+
+			"  Branch,",
+			"    TowerWaterSys Demand Inlet Branch,  !- Name",
+			"    ,                        !- Pressure Drop Curve Name",
+			"    Pipe:Adiabatic,          !- Component 1 Object Type",
+			"    TowerWaterSys Demand Inlet Pipe,  !- Component 1 Name",
+			"    TowerWaterSys Demand Inlet Node,  !- Component 1 Inlet Node Name",
+			"    TowerWaterSys Demand Inlet Pipe-TowerWaterSys Demand Mixer;  !- Component 1 Outlet Node Name",
+
+			"  Branch,",
+			"    TowerWaterSys Demand Load Branch 1,  !- Name",
+			"    ,                        !- Pressure Drop Curve Name",
+			"    LoadProfile:Plant,   !- Component 1 Object Type",
+			"    Load Profile 1,      !- Component 1 Name",
+			"    Demand Load Profile 1 Inlet Node,  !- Component 1 Inlet Node Name",
+			"    Demand Load Profile 1 Outlet Node;  !- Component 1 Outlet Node Name",
+
+			"  LoadProfile:Plant,",
+			"    Load Profile 1,          !- Name",
+			"    Demand Load Profile 1 Inlet Node,  !- Inlet Node Name",
+			"    Demand Load Profile 1 Outlet Node,  !- Outlet Node Name",
+			"    Load Profile 1 Load Schedule,  !- Load Schedule Name",
+			"    0.002,                   !- Peak Flow Rate {m3/s}",
+			"    Load Profile 1 Flow Frac Schedule;  !- Flow Rate Fraction Schedule Name",
+
+			"  Schedule:Compact,",
+			"    Load Profile 1 Load Schedule,  !- Name",
+			"    Any Number,              !- Schedule Type Limits Name",
+			"    THROUGH: 12/31,          !- Field 1",
+			"    FOR: AllDays,            !- Field 2",
+			"    UNTIL: 24:00,0.0;        !- Field 3",
+
+			"  Schedule:Compact,",
+			"    Load Profile 1 Flow Frac Schedule,  !- Name",
+			"    Any Number,              !- Schedule Type Limits Name",
+			"    THROUGH: 12/31,          !- Field 1",
+			"    FOR: AllDays,            !- Field 2",
+			"    UNTIL: 24:00,1.0;        !- Field 3",
+
+			"  Branch,",
+			"    TowerWaterSys Demand Outlet Branch,  !- Name",
+			"    ,                        !- Pressure Drop Curve Name",
+			"    Pipe:Adiabatic,          !- Component 1 Object Type",
+			"    TowerWaterSys Demand Outlet Pipe,  !- Component 1 Name",
+			"    TowerWaterSys Demand Mixer-TowerWaterSys Demand Outlet Pipe,  !- Component 1 Inlet Node Name",
+			"    TowerWaterSys Demand Outlet Node;  !- Component 1 Outlet Node Name",
+
+			"  Branch,",
+			"    TowerWaterSys Supply Equipment Branch 1,  !- Name",
+			"    ,                        !- Pressure Drop Curve Name",
+			"    CoolingTower:TwoSpeed,  !- Component 1 Object Type",
+			"    TowerWaterSys CoolTower1,!- Component 1 Name",
+			"    TowerWaterSys Pump-TowerWaterSys CoolTowerNode,  !- Component 1 Inlet Node Name",
+			"    TowerWaterSys Supply Equipment Outlet Node;  !- Component 1 Outlet Node Name",
+
+			"  Branch,",
+			"    TowerWaterSys Supply Equipment Bypass Branch,  !- Name",
+			"    ,                        !- Pressure Drop Curve Name",
+			"    Pipe:Adiabatic,          !- Component 1 Object Type",
+			"    TowerWaterSys Supply Equipment Bypass Pipe,  !- Component 1 Name",
+			"    TowerWaterSys Supply Equip Bypass Inlet Node,  !- Component 1 Inlet Node Name",
+			"    TowerWaterSys Supply Equip Bypass Outlet Node;  !- Component 1 Outlet Node Name",
+
+			"  Branch,",
+			"    TowerWaterSys Supply Inlet Branch,  !- Name",
+			"    ,                        !- Pressure Drop Curve Name",
+			"    Pump:ConstantSpeed,      !- Component 1 Object Type",
+			"    TowerWaterSys Pump,      !- Component 1 Name",
+			"    TowerWaterSys Supply Inlet Node,  !- Component 1 Inlet Node Name",
+			"    TowerWaterSys Pump-TowerWaterSys CoolTowerNodeviaConnector;  !- Component 1 Outlet Node Name",
+
+			"  Branch,",
+			"    TowerWaterSys Supply Outlet Branch,  !- Name",
+			"    ,                        !- Pressure Drop Curve Name",
+			"    Pipe:Adiabatic,          !- Component 1 Object Type",
+			"    TowerWaterSys Supply Outlet Pipe,  !- Component 1 Name",
+			"    TowerWaterSys Supply Mixer-TowerWaterSys Supply Outlet Pipe,  !- Component 1 Inlet Node Name",
+			"    TowerWaterSys Supply Outlet Node;  !- Component 1 Outlet Node Name",
+
+			"  OutdoorAir:Node,",
+			"    TowerWaterSys CoolTower OA ref Node;  !- Name",
+
+			"  ConnectorList,",
+			"    TowerWaterSys Demand Connectors,  !- Name",
+			"    Connector:Splitter,      !- Connector 1 Object Type",
+			"    TowerWaterSys Demand Splitter,  !- Connector 1 Name",
+			"    Connector:Mixer,         !- Connector 2 Object Type",
+			"    TowerWaterSys Demand Mixer;  !- Connector 2 Name",
+
+			"  ConnectorList,",
+			"    TowerWaterSys Supply Connectors,  !- Name",
+			"    Connector:Splitter,      !- Connector 1 Object Type",
+			"    TowerWaterSys Supply Splitter,  !- Connector 1 Name",
+			"    Connector:Mixer,         !- Connector 2 Object Type",
+			"    TowerWaterSys Supply Mixer;  !- Connector 2 Name",
+
+			"  Connector:Splitter,",
+			"    TowerWaterSys Demand Splitter,  !- Name",
+			"    TowerWaterSys Demand Inlet Branch,  !- Inlet Branch Name",
+			"    TowerWaterSys Demand Load Branch 1,  !- Outlet Branch 1 Name",
+			"    TowerWaterSys Demand Bypass Branch;  !- Outlet Branch 3 Name",
+
+			"  Connector:Splitter,",
+			"    TowerWaterSys Supply Splitter,  !- Name",
+			"    TowerWaterSys Supply Inlet Branch,  !- Inlet Branch Name",
+			"    TowerWaterSys Supply Equipment Branch 1,  !- Outlet Branch 1 Name",
+			"    TowerWaterSys Supply Equipment Bypass Branch;  !- Outlet Branch 3 Name",
+
+			"  Connector:Mixer,",
+			"    TowerWaterSys Demand Mixer,  !- Name",
+			"    TowerWaterSys Demand Outlet Branch,  !- Outlet Branch Name",
+			"    TowerWaterSys Demand Load Branch 1,  !- Inlet Branch 1 Name",
+			"    TowerWaterSys Demand Bypass Branch;  !- Inlet Branch 3 Name",
+
+			"  Connector:Mixer,",
+			"    TowerWaterSys Supply Mixer,  !- Name",
+			"    TowerWaterSys Supply Outlet Branch,  !- Outlet Branch Name",
+			"    TowerWaterSys Supply Equipment Branch 1,  !- Inlet Branch 1 Name",
+			"    TowerWaterSys Supply Equipment Bypass Branch;  !- Inlet Branch 3 Name",
+
+			"  Pipe:Adiabatic,",
+			"    TowerWaterSys Demand Bypass Pipe,  !- Name",
+			"    TowerWaterSys Demand Bypass Pipe Inlet Node,  !- Inlet Node Name",
+			"    TowerWaterSys Demand Bypass Pipe Outlet Node;  !- Outlet Node Name",
+
+			"  Pipe:Adiabatic,",
+			"    TowerWaterSys Demand Inlet Pipe,  !- Name",
+			"    TowerWaterSys Demand Inlet Node,  !- Inlet Node Name",
+			"    TowerWaterSys Demand Inlet Pipe-TowerWaterSys Demand Mixer;  !- Outlet Node Name",
+
+			"  Pipe:Adiabatic,",
+			"    TowerWaterSys Demand Outlet Pipe,  !- Name",
+			"    TowerWaterSys Demand Mixer-TowerWaterSys Demand Outlet Pipe,  !- Inlet Node Name",
+			"    TowerWaterSys Demand Outlet Node;  !- Outlet Node Name",
+
+			"  Pipe:Adiabatic,",
+			"    TowerWaterSys Supply Equipment Bypass Pipe,  !- Name",
+			"    TowerWaterSys Supply Equip Bypass Inlet Node,  !- Inlet Node Name",
+			"    TowerWaterSys Supply Equip Bypass Outlet Node;  !- Outlet Node Name",
+
+			"  Pipe:Adiabatic,",
+			"    TowerWaterSys Supply Outlet Pipe,  !- Name",
+			"    TowerWaterSys Supply Mixer-TowerWaterSys Supply Outlet Pipe,  !- Inlet Node Name",
+			"    TowerWaterSys Supply Outlet Node;  !- Outlet Node Name"
+
+
+		} );
+		ASSERT_FALSE( process_idf( idf_objects ) );
+		SimulationManager::PostIPProcessing();
+
+		bool ErrorsFound = false;
+
+		DataGlobals::BeginSimFlag = true;
+		SimulationManager::GetProjectData();
+		OutputReportPredefined::SetPredefinedTables();
+
+		OutputProcessor::TimeValue.allocate( 2 );
+		OutputProcessor::SetupTimePointers( "Zone", DataGlobals::TimeStepZone ); // Set up Time pointer for HB/Zone Simulation
+		OutputProcessor::SetupTimePointers( "HVAC", DataHVACGlobals::TimeStepSys );
+		createFacilityElectricPowerServiceObject();
+		OutputProcessor::GetReportVariableInput();
+		PlantManager::CheckIfAnyPlant();
+		BranchInputManager::ManageBranchInput(); // just gets input and returns.
+
+		DataGlobals::DoingSizing = false;
+		DataGlobals::KickOffSimulation = true;
+
+		WeatherManager::ResetEnvironmentCounter();
+		SimulationManager::SetupSimulation( ErrorsFound );
+
+		// get inputs of cooling tower object
+		CondenserLoopTowers::GetTowerInput();
+		// check the low speed nominal capacity field is autosized
+		EXPECT_TRUE( CondenserLoopTowers::SimpleTower( 1 ).TowerLowSpeedNomCapWasAutoSized );
+		// check user input value for high speed nominal capacity
+		EXPECT_DOUBLE_EQ( CondenserLoopTowers::SimpleTower( 1 ).TowerNominalCapacity, 100000.0 );
+
+		// autosized other input fields of cooling tower
+		CondenserLoopTowers::SizeTower( 1 );	
+		// size low speed nominal capacity
+		LowSpeedCoolTowerNomCap = CondenserLoopTowers::SimpleTower( 1 ).TowerNominalCapacity * CondenserLoopTowers::SimpleTower( 1 ).TowerLowSpeedNomCapSizingFactor;
+		EXPECT_DOUBLE_EQ( CondenserLoopTowers::SimpleTower( 1 ).TowerLowSpeedNomCap, LowSpeedCoolTowerNomCap );
+		// check the low speed nominal capacity is higher than that of free convection nominal capacity
+		EXPECT_GT( CondenserLoopTowers::SimpleTower( 1 ).TowerLowSpeedNomCap, CondenserLoopTowers::SimpleTower( 1 ).TowerFreeConvNomCap );
+
+	}
 
 }


### PR DESCRIPTION
Issue #5863

The two speed cooling tower Low Speed Nominal Capacity input field is auto-sized it leads to fatal out if the Free Convection nominal capacity field is hard sized. Added a check logic to avoid the fatal failure. The unit test added demonstrates the same.

Pull request overview
---------------------

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
