### PR TITLE
Addressed missing component sizing output row in SQL database 

### DIFF
--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -185,7 +185,9 @@ namespace ReportSizingManager {
 
 		// add to SQL output
 		if ( sqlite ) sqlite->addSQLiteComponentSizingRecord( CompType, CompName, VarDesc, VarValue );
-
+		if ( present( UsrDesc ) && present( UsrValue ) ) {
+			if ( sqlite ) sqlite->addSQLiteComponentSizingRecord( CompType, CompName, UsrDesc, UsrValue );
+		}
 	}
 
 	void

--- a/src/Transition/OutputRulesFiles/OutputChanges8-7-0-to-8-8-0.md
+++ b/src/Transition/OutputRulesFiles/OutputChanges8-7-0-to-8-8-0.md
@@ -1,0 +1,15 @@
+Output Changes
+==============
+
+This file documents the structural changes on the output of EnergyPlus that could affect interfaces, etc.
+
+### Description
+
+This will eventually become a more structured file, but currently it isn't clear what format is best. As an intermediate solution, and to allow the form to be formed organically, this plain text file is being used. Entries should be clearly delimited.  It isn't expected that there will be but maybe a couple each release at most. Entries should also include some reference back to the repo.  At least a PR number or whatever.
+
+### Adds new record of User-specified component sizing output to SQLite output file. 
+
+The SQLite component sizing out put file used to have the "Design Size * " only, now if present it adds a record of the "User-Specified  Value " to ComponentSizes category Table of SQLite file. 
+
+See [6147](https://github.com/NREL/EnergyPlus/pull/6147)
+

--- a/src/Transition/OutputRulesFiles/OutputChanges8-7-0-to-8-8-0.md
+++ b/src/Transition/OutputRulesFiles/OutputChanges8-7-0-to-8-8-0.md
@@ -7,9 +7,9 @@ This file documents the structural changes on the output of EnergyPlus that coul
 
 This will eventually become a more structured file, but currently it isn't clear what format is best. As an intermediate solution, and to allow the form to be formed organically, this plain text file is being used. Entries should be clearly delimited.  It isn't expected that there will be but maybe a couple each release at most. Entries should also include some reference back to the repo.  At least a PR number or whatever.
 
-### Adds new record of User-specified component sizing output to SQLite output file. 
+### Adds additional records of User-Specified component sizing output to SQLite output file. 
 
-The SQLite component sizing out put file used to have the "Design Size * " only, now if present it adds a record of the "User-Specified  Value " to ComponentSizes category Table of SQLite file. 
+In the Component Sizing table report, autosized fields may report values for "Design Size", "User-Specified", or both.  Previously, for fields with both values, only the "Design Size" value was included in the Component Sizing table in the SQLite output.  Now both values are included in the SQLite output.
 
 See [6147](https://github.com/NREL/EnergyPlus/pull/6147)
 

--- a/tst/EnergyPlus/unit/ReportSizingManager.unit.cc
+++ b/tst/EnergyPlus/unit/ReportSizingManager.unit.cc
@@ -53,10 +53,8 @@
 #include <ObjexxFCL/gio.hh>
 
 #include "Fixtures/EnergyPlusFixture.hh"
-#include "Fixtures/SQLiteFixture.hh"
 
 // EnergyPlus Headers
-#include <EnergyPlus/Boilers.hh>
 #include <EnergyPlus/DataEnvironment.hh>
 #include <EnergyPlus/DataPrecisionGlobals.hh>
 #include <EnergyPlus/DataSizing.hh>
@@ -67,11 +65,9 @@
 #include <EnergyPlus/DataZoneEquipment.hh>
 #include <EnergyPlus/Psychrometrics.hh>
 #include <EnergyPlus/ReportSizingManager.hh>
-//#include <SQLiteProcedures.hh>;
 
 using namespace EnergyPlus;
 using namespace ObjexxFCL;
-using namespace EnergyPlus::Boilers;
 using namespace EnergyPlus::DataAirSystems;
 using namespace EnergyPlus::DataGlobals;
 using namespace EnergyPlus::DataEnvironment;
@@ -81,7 +77,6 @@ using namespace EnergyPlus::DataZoneEquipment;
 using namespace EnergyPlus::Fans;
 using namespace EnergyPlus::Psychrometrics;
 using namespace EnergyPlus::ReportSizingManager;
-//using namespace EnergyPlus::SQLiteProcedures;
 
 TEST_F( EnergyPlusFixture, ReportSizingManager_GetCoilDesFlowT )
 {

--- a/tst/EnergyPlus/unit/ReportSizingManager.unit.cc
+++ b/tst/EnergyPlus/unit/ReportSizingManager.unit.cc
@@ -53,6 +53,7 @@
 #include <ObjexxFCL/gio.hh>
 
 #include "Fixtures/EnergyPlusFixture.hh"
+#include "Fixtures/SQLiteFixture.hh"
 
 // EnergyPlus Headers
 #include <EnergyPlus/DataEnvironment.hh>
@@ -354,7 +355,7 @@ TEST_F( EnergyPlusFixture, ReportSizingManager_RequestSizingZone ) {
 
 }
 
-TEST_F( EnergyPlusFixture, ReportSizingManager_ReportSizingOutputTest ) {
+TEST_F( SQLiteFixture, ReportSizingManager_SQLiteRecordReportSizingOutputTest ) {
 	// issue #6112
 	std::string CompName;
 	std::string CompType;
@@ -363,15 +364,27 @@ TEST_F( EnergyPlusFixture, ReportSizingManager_ReportSizingOutputTest ) {
 	Real64 VarValue;
 	Real64 UsrValue;
 
+	EnergyPlus::sqlite = std::move( sqlite_test );
+
 	// input values
 	CompType = "BOILER:HOTWATER";
 	CompName = "RESIDENTIAL BOILER ELECTRIC";
-	VarDesc = "Design Size Nominal Capacity[W]";
+	VarDesc = "Design Size Nominal Capacity [W]";
 	VarValue = 105977.98934;
-	UsrDesc = "User-Specified Nominal Capacity[W]";
+	UsrDesc = "User-Specified Nominal Capacity [W]";
 	UsrValue = 26352.97405;
-
-	// boiler hot water autosizing and userspecified nominal capacity reporting
+	// boiler hot water autosizing and userspecified nominal capacity reporting to SQLite output
 	ReportSizingManager::ReportSizingOutput( CompType, CompName, VarDesc, VarValue, UsrDesc, UsrValue );
-	
+	// get the sqlite output
+	sqlite_test = std::move( EnergyPlus::sqlite );
+	// query the sqLite
+	auto result = queryResult( "SELECT * FROM ComponentSizes;", "ComponentSizes" );
+	sqlite_test->sqliteCommit();
+	// check that there are two sizing result records
+	ASSERT_EQ( 2ul, result.size() );
+	std::vector<std::string> testResult0{ "1", "BOILER:HOTWATER", "RESIDENTIAL BOILER ELECTRIC", "Design Size Nominal Capacity", "105977.98934", "W" };
+	std::vector<std::string> testResult1{ "2", "BOILER:HOTWATER", "RESIDENTIAL BOILER ELECTRIC", "User-Specified Nominal Capacity", "26352.97405", "W" };
+	EXPECT_EQ( testResult0, result[0] );
+	EXPECT_EQ( testResult1, result[1] );
+
 }

--- a/tst/EnergyPlus/unit/ReportSizingManager.unit.cc
+++ b/tst/EnergyPlus/unit/ReportSizingManager.unit.cc
@@ -53,8 +53,10 @@
 #include <ObjexxFCL/gio.hh>
 
 #include "Fixtures/EnergyPlusFixture.hh"
+#include "Fixtures/SQLiteFixture.hh"
 
 // EnergyPlus Headers
+#include <EnergyPlus/Boilers.hh>
 #include <EnergyPlus/DataEnvironment.hh>
 #include <EnergyPlus/DataPrecisionGlobals.hh>
 #include <EnergyPlus/DataSizing.hh>
@@ -65,9 +67,11 @@
 #include <EnergyPlus/DataZoneEquipment.hh>
 #include <EnergyPlus/Psychrometrics.hh>
 #include <EnergyPlus/ReportSizingManager.hh>
+//#include <SQLiteProcedures.hh>;
 
 using namespace EnergyPlus;
 using namespace ObjexxFCL;
+using namespace EnergyPlus::Boilers;
 using namespace EnergyPlus::DataAirSystems;
 using namespace EnergyPlus::DataGlobals;
 using namespace EnergyPlus::DataEnvironment;
@@ -77,6 +81,7 @@ using namespace EnergyPlus::DataZoneEquipment;
 using namespace EnergyPlus::Fans;
 using namespace EnergyPlus::Psychrometrics;
 using namespace EnergyPlus::ReportSizingManager;
+//using namespace EnergyPlus::SQLiteProcedures;
 
 TEST_F( EnergyPlusFixture, ReportSizingManager_GetCoilDesFlowT )
 {
@@ -352,4 +357,26 @@ TEST_F( EnergyPlusFixture, ReportSizingManager_RequestSizingZone ) {
 	ZoneEqSizing.deallocate();
 	ZoneSizingInput.deallocate();
 
+}
+
+TEST_F( EnergyPlusFixture, ReportSizingManager_ReportSizingOutputTest ) {
+	// issue #6112
+	std::string CompName;
+	std::string CompType;
+	std::string VarDesc;
+	std::string UsrDesc;
+	Real64 VarValue;
+	Real64 UsrValue;
+
+	// input values
+	CompType = "BOILER:HOTWATER";
+	CompName = "RESIDENTIAL BOILER ELECTRIC";
+	VarDesc = "Design Size Nominal Capacity[W]";
+	VarValue = 105977.98934;
+	UsrDesc = "User-Specified Nominal Capacity[W]";
+	UsrValue = 26352.97405;
+
+	// boiler hot water autosizing and userspecified nominal capacity reporting
+	ReportSizingManager::ReportSizingOutput( CompType, CompName, VarDesc, VarValue, UsrDesc, UsrValue );
+	
 }

--- a/tst/EnergyPlus/unit/SQLite.unit.cc
+++ b/tst/EnergyPlus/unit/SQLite.unit.cc
@@ -1021,18 +1021,4 @@ namespace EnergyPlus {
 		EXPECT_EQ(stringType5, stringTypes[5]);
 	}
 
-	TEST_F( SQLiteFixture, SQLiteProcedures_addSQLiteComponentDesignAndUserSizingRecord ) {
-		// verifies design and user specified sizing values are reported to SQLite output
-		sqlite_test->sqliteBegin();
-		sqlite_test->addSQLiteComponentSizingRecord( "Boiler:HotWater", "RESIDENTIAL BOILER ELECTRIC", "Design Size Nominal Capacity [W]", 105977.98934 );
-		sqlite_test->addSQLiteComponentSizingRecord( "Boiler:HotWater", "RESIDENTIAL BOILER ELECTRIC", "User-Specified Nominal Capacity [W]", 26352.97405 );
-		auto result = queryResult( "SELECT * FROM ComponentSizes;", "ComponentSizes" );
-		sqlite_test->sqliteCommit();
-
-		ASSERT_EQ( 2ul, result.size() );
-		std::vector<std::string> testResult0{ "1", "Boiler:HotWater", "RESIDENTIAL BOILER ELECTRIC", "Design Size Nominal Capacity", "105977.98934", "W" };
-		std::vector<std::string> testResult1{ "2", "Boiler:HotWater", "RESIDENTIAL BOILER ELECTRIC", "User-Specified Nominal Capacity", "26352.97405", "W" };
-		EXPECT_EQ( testResult0, result[0] );
-		EXPECT_EQ( testResult1, result[1] );
-	}
 }

--- a/tst/EnergyPlus/unit/SQLite.unit.cc
+++ b/tst/EnergyPlus/unit/SQLite.unit.cc
@@ -1020,4 +1020,19 @@ namespace EnergyPlus {
 		EXPECT_EQ(stringType4, stringTypes[4]);
 		EXPECT_EQ(stringType5, stringTypes[5]);
 	}
+
+	TEST_F( SQLiteFixture, SQLiteProcedures_addSQLiteComponentDesignAndUserSizingRecord ) {
+		// verifies design and user specified sizing values are reported to SQLite output
+		sqlite_test->sqliteBegin();
+		sqlite_test->addSQLiteComponentSizingRecord( "Boiler:HotWater", "RESIDENTIAL BOILER ELECTRIC", "Design Size Nominal Capacity [W]", 105977.98934 );
+		sqlite_test->addSQLiteComponentSizingRecord( "Boiler:HotWater", "RESIDENTIAL BOILER ELECTRIC", "User-Specified Nominal Capacity [W]", 26352.97405 );
+		auto result = queryResult( "SELECT * FROM ComponentSizes;", "ComponentSizes" );
+		sqlite_test->sqliteCommit();
+
+		ASSERT_EQ( 2ul, result.size() );
+		std::vector<std::string> testResult0{ "1", "Boiler:HotWater", "RESIDENTIAL BOILER ELECTRIC", "Design Size Nominal Capacity", "105977.98934", "W" };
+		std::vector<std::string> testResult1{ "2", "Boiler:HotWater", "RESIDENTIAL BOILER ELECTRIC", "User-Specified Nominal Capacity", "26352.97405", "W" };
+		EXPECT_EQ( testResult0, result[0] );
+		EXPECT_EQ( testResult1, result[1] );
+	}
 }

--- a/tst/EnergyPlus/unit/SQLite.unit.cc
+++ b/tst/EnergyPlus/unit/SQLite.unit.cc
@@ -1020,5 +1020,4 @@ namespace EnergyPlus {
 		EXPECT_EQ(stringType4, stringTypes[4]);
 		EXPECT_EQ(stringType5, stringTypes[5]);
 	}
-
 }


### PR DESCRIPTION
Issue #6112

Addressed Report Sizing Output does not always report/tabulate user specified sizing variable to sql output file.

Pull request overview
---------------------
This is a defect. Report Sizing Output does not always report/tabulate user specified sizing variable to sql output file. This fix may produce diffs in sql output file. Defect file has been added.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
  
### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Code style (parentheses padding, variable names)
 - [x] Functional code review (it has to work!)
 - [x] If defect, results of running current develop vs this branch should exhibit the fix
 - [x] CI status: all green or justified
 - [x] Performance: CI Linux results include performance check -- verify this
 - [x] Unit Test(s)
 - C++ checks:
   - [x] Argument types
   - [x] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes n/a
 - [x] If output changes, including tabular output structure, add to output rules file for interfaces

