### PR TITLE
Earth Tube One Per Zone Limit Error

### DIFF
--- a/src/EnergyPlus/EarthTube.cc
+++ b/src/EnergyPlus/EarthTube.cc
@@ -237,7 +237,6 @@ namespace EarthTube {
 		int NumNumber;
 		int IOStat;
 		int Loop;
-		int Loop1;
 		Array1D_bool RepVarSet;
 
 		RepVarSet.dimension( NumOfZones, true );
@@ -416,10 +415,11 @@ namespace EarthTube {
 	
 	void
 	CheckEarthTubesInZones
-		( std::string const ZoneName, // name of zone for error reporting
-		  std::string const FieldName, // name of earth tube in input
-		  bool & ErrorsFound // Found a problem
-		)
+	(
+		std::string const ZoneName, // name of zone for error reporting
+		std::string const FieldName, // name of earth tube in input
+		bool & ErrorsFound // Found a problem
+	)
 	{
 
 		int Loop;

--- a/src/EnergyPlus/EarthTube.cc
+++ b/src/EnergyPlus/EarthTube.cc
@@ -405,16 +405,7 @@ namespace EarthTube {
 			}
 		}
 
-		// Check to make sure there is only on ventilation statement per zone
-		for ( Loop = 1; Loop <= TotEarthTube; ++Loop ) {
-			for ( Loop1 = Loop + 1; Loop1 <= TotEarthTube - 1; ++Loop1 ) {
-				if ( EarthTubeSys( Loop ).ZonePtr == EarthTubeSys( Loop1 ).ZonePtr ) {
-					ShowSevereError( cAlphaArgs( 1 ) + " is assigned to more than one " + cCurrentModuleObject );
-					ShowContinueError( "Only one such assignment is allowed." );
-					ErrorsFound = true;
-				}
-			}
-		}
+		CheckEarthTubesInZones( cAlphaArgs( 1 ), cCurrentModuleObject, ErrorsFound );
 
 		if ( ErrorsFound ) {
 			ShowFatalError( cCurrentModuleObject + ": Errors getting input.  Program terminates." );
@@ -422,6 +413,33 @@ namespace EarthTube {
 
 	}
 
+	
+	void
+	CheckEarthTubesInZones
+		( std::string const ZoneName, // name of zone for error reporting
+		  std::string const FieldName, // name of earth tube in input
+		  bool & ErrorsFound // Found a problem
+		)
+	{
+
+		int Loop;
+		int Loop1;
+		
+		// Check to make sure there is only one earth tube statement per zone
+		for ( Loop = 1; Loop <= TotEarthTube - 1; ++Loop ) {
+			for ( Loop1 = Loop + 1; Loop1 <= TotEarthTube; ++Loop1 ) {
+				if ( EarthTubeSys( Loop ).ZonePtr == EarthTubeSys( Loop1 ).ZonePtr ) {
+					ShowSevereError( ZoneName + " has more than one " + FieldName + " associated with it.");
+					ShowContinueError( "Only one " + FieldName + " is allowed per zone.  Check the definitions of " +  FieldName );
+					ShowContinueError( "in your input file and make sure that there is only one defined for each zone.");
+					ErrorsFound = true;
+				}
+			}
+		}
+
+		
+	}
+	
 	void
 	CalcEarthTube()
 	{

--- a/src/EnergyPlus/EarthTube.hh
+++ b/src/EnergyPlus/EarthTube.hh
@@ -194,6 +194,13 @@ namespace EarthTube {
 	GetEarthTube( bool & ErrorsFound ); // If errors found in input
 
 	void
+	CheckEarthTubesInZones
+		( std::string const ZoneName, // name of zone for error reporting
+	 	  std::string const FieldName, // name of earth tube in input
+		  bool & ErrorsFound // Found a problem
+		);
+	
+	void
 	CalcEarthTube();
 
 	void

--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -43,6 +43,7 @@ set( test_src
   DOASEffectOnZoneSizing.unit.cc
   DualDuct.unit.cc
   DXCoils.unit.cc
+  EarthTube.unit.cc
   EconomicTariff.unit.cc
   EconomicLifeCycleCost.unit.cc
   ElectricBaseboardRadiator.unit.cc

--- a/tst/EnergyPlus/unit/EarthTube.unit.cc
+++ b/tst/EnergyPlus/unit/EarthTube.unit.cc
@@ -94,7 +94,10 @@ namespace EnergyPlus {
 	EarthTubeSys( 3 ).ZonePtr = 1;
 	CheckEarthTubesInZones( ZoneName, InputName, ErrorsFound );
 	EXPECT_EQ( ErrorsFound, true );
-		
+	
+	EarthTubeSys.deallocate();
+	TotEarthTube = 0;
+	
 	}
 	
 }

--- a/tst/EnergyPlus/unit/EarthTube.unit.cc
+++ b/tst/EnergyPlus/unit/EarthTube.unit.cc
@@ -1,0 +1,100 @@
+// EnergyPlus, Copyright (c) 1996-2017, The Board of Trustees of the University of Illinois and
+// The Regents of the University of California, through Lawrence Berkeley National Laboratory
+// (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights
+// reserved.
+//
+// NOTICE: This Software was developed under funding from the U.S. Department of Energy and the
+// U.S. Government consequently retains certain rights. As such, the U.S. Government has been
+// granted for itself and others acting on its behalf a paid-up, nonexclusive, irrevocable,
+// worldwide license in the Software to reproduce, distribute copies to the public, prepare
+// derivative works, and perform publicly and display publicly, and to permit others to do so.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted
+// provided that the following conditions are met:
+//
+// (1) Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//
+// (2) Redistributions in binary form must reproduce the above copyright notice, this list of
+//     conditions and the following disclaimer in the documentation and/or other materials
+//     provided with the distribution.
+//
+// (3) Neither the name of the University of California, Lawrence Berkeley National Laboratory,
+//     the University of Illinois, U.S. Dept. of Energy nor the names of its contributors may be
+//     used to endorse or promote products derived from this software without specific prior
+//     written permission.
+//
+// (4) Use of EnergyPlus(TM) Name. If Licensee (i) distributes the software in stand-alone form
+//     without changes from the version obtained under this License, or (ii) Licensee makes a
+//     reference solely to the software portion of its product, Licensee must refer to the
+//     software as "EnergyPlus version X" software, where "X" is the version number Licensee
+//     obtained under this License and may not use a different name for the software. Except as
+//     specifically required in this Section (4), Licensee shall not use in a company name, a
+//     product name, in advertising, publicity, or other promotional activities any name, trade
+//     name, trademark, logo, or other designation of "EnergyPlus", "E+", "e+" or confusingly
+//     similar designation, without the U.S. Department of Energy's prior written consent.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// EnergyPlus::EarthTube Unit Tests
+
+// Google Test Headers
+#include <gtest/gtest.h>
+
+// EnergyPlus Headers
+#include "Fixtures/EnergyPlusFixture.hh"
+#include <EnergyPlus/EarthTube.hh>
+#include <DataHeatBalFanSys.hh>
+#include <EnergyPlus/UtilityRoutines.hh>
+#include <DataEnvironment.hh>
+#include "Fixtures/EnergyPlusFixture.hh"
+#include <ObjexxFCL/gio.hh>
+
+using namespace EnergyPlus;
+using namespace EnergyPlus::EarthTube;
+using namespace EnergyPlus::DataHeatBalFanSys;
+using namespace ObjexxFCL;
+using namespace DataGlobals;
+using namespace EnergyPlus::DataEnvironment;
+
+namespace EnergyPlus {
+	
+
+	TEST_F( EnergyPlusFixture, EarthTube_CheckEarthTubesInZonesTest )
+	{
+
+	// AUTHOR: R. Strand, UIUC
+	// DATE WRITTEN: June 2017
+	
+	// Set subroutine arguments
+	std::string ZoneName = "ZONE 1";
+	std::string InputName = "ZoneEarthtube";
+	bool ErrorsFound = false;
+	
+	// Allocate and set earth tube parameters necessary to run the tests
+	TotEarthTube = 3;
+	EarthTubeSys.allocate( TotEarthTube );
+	EarthTubeSys( 1 ).ZonePtr = 1;
+	EarthTubeSys( 2 ).ZonePtr = 2;
+	EarthTubeSys( 3 ).ZonePtr = 3;
+	
+	// First case--no conflicts, only one earth tube per zone (ErrorsFound = false)
+	CheckEarthTubesInZones( ZoneName, InputName, ErrorsFound );
+	EXPECT_EQ( ErrorsFound, false );
+
+	// Second case--conflict with the last earth tube and first (ErrorsFound = true)
+	EarthTubeSys( 3 ).ZonePtr = 1;
+	CheckEarthTubesInZones( ZoneName, InputName, ErrorsFound );
+	EXPECT_EQ( ErrorsFound, true );
+		
+	}
+	
+}


### PR DESCRIPTION
Pull request overview
---------------------
This work fixes a problem in the earth tube summarized by GitHub Issue #6182.  In this defect, the code that checks to see that there is only one earth tube per zone is not working properly.  It is actually possible to put two earth tubes in a zone provided that the last earth tube in the input file gets assigned to a zone that already has an earth tube.  The problem is this shouldn't be allowed and then this basically overwrites the results of the first earth tube on a zone.  The problem only occurs when the second earth tube in a zone is the last earth tube in the input file, but still should not be allowed.  This work fixes this problem.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ x ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ x ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue #6182.

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces