### PR TITLE
Decrease Documentation Margins

### DIFF
--- a/doc/header.tex
+++ b/doc/header.tex
@@ -3,7 +3,7 @@
 \usepackage{amssymb,amsmath}
 \usepackage{mathspec}
 \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
-\usepackage[margin=1.0in]{geometry}
+\usepackage[margin=0.5in]{geometry}
 % fixltx2e has been merged into LaTeX2e proper
 % see: https://latex-project.org/ltnews/ltnews22.pdf
 % \usepackage{fixltx2e}

--- a/doc/header.tex
+++ b/doc/header.tex
@@ -3,7 +3,7 @@
 \usepackage{amssymb,amsmath}
 \usepackage{mathspec}
 \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
-\usepackage[margin=0.5in]{geometry}
+\usepackage[margin=0.5in, top=1in]{geometry}
 % fixltx2e has been merged into LaTeX2e proper
 % see: https://latex-project.org/ltnews/ltnews22.pdf
 % \usepackage{fixltx2e}

--- a/doc/header.tex
+++ b/doc/header.tex
@@ -3,7 +3,7 @@
 \usepackage{amssymb,amsmath}
 \usepackage{mathspec}
 \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
-\usepackage[margin=0.5in, top=1in]{geometry}
+\usepackage[margin=0.75in, top=1in]{geometry}
 % fixltx2e has been merged into LaTeX2e proper
 % see: https://latex-project.org/ltnews/ltnews22.pdf
 % \usepackage{fixltx2e}


### PR DESCRIPTION
Left, right, and bottom margins all set to 0.5".  Top was left at 1" because of the way the header is placed on the page.  Content fills page better.  Engineering reference went down about 150 pages, not that that was any motivation for this.  