### PR TITLE
Low Temperature Radiant Water Systems Autosize Tube Length Correction

### DIFF
--- a/doc/input-output-reference/src/overview/group-radiative-convective-units.tex
+++ b/doc/input-output-reference/src/overview/group-radiative-convective-units.tex
@@ -1011,7 +1011,7 @@ This field is the inside diameter of the tubes through which water is circulated
 
 \paragraph{Field: Hydronic Tubing Length}\label{field-hydronic-tubing-length}
 
-This field is the total length of pipe embedded in the surface named above in the surface name field. The length of the tube should be entered in meters and is used to determine the effectiveness of heat transfer from the fluid being circulated through the tubes and the tube/surface. Longer tubing lengths result in more heat will be transferred to/from the radiant surface to the circulating fluid. Note that if the user elects to autosize this field that a standard zone thermostat such as would be used for a forced air system must be defined as autosizing calculations are based on the zone thermostat value and not on the radiant system control values.
+This field is the total length of pipe embedded in the surface named above in the surface name field. The length of the tube should be entered in meters and is used to determine the effectiveness of heat transfer from the fluid being circulated through the tubes and the tube/surface. Longer tubing lengths result in more heat will be transferred to/from the radiant surface to the circulating fluid. Note that if the user elects to autosize this field that a standard zone thermostat such as would be used for a forced air system must be defined as autosizing calculations are based on the zone thermostat value and not on the radiant system control values. In addition, when the user opts to autosize this calculation, the tube spacing from the construction of each surface associated with this system is used along with each individual surface area to make an approximation of the tubing length.  
 
 \paragraph{Field: Temperature Control Type}\label{field-temperature-control-type}
 
@@ -1253,7 +1253,7 @@ This field is the inside diameter of the tubes through which water is circulated
 
 \paragraph{Field: Hydronic Tubing Length}\label{field-hydronic-tubing-length-1}
 
-This field is the total length of pipe embedded in the surface named above in the surface name field. The length of the tube should be entered in meters and is used to determine the effectiveness of heat transfer from the fluid being circulated through the tubes and the tube/surface. Longer tubing lengths result in more heat being transferred to/from the radiant surface to the circulating fluid. This field is autosizable.
+This field is the total length of pipe embedded in the surface named above in the surface name field. The length of the tube should be entered in meters and is used to determine the effectiveness of heat transfer from the fluid being circulated through the tubes and the tube/surface. Longer tubing lengths result in more heat being transferred to/from the radiant surface to the circulating fluid. Note that if the user elects to autosize this field that a standard zone thermostat such as would be used for a forced air system must be defined as autosizing calculations are based on the zone thermostat value and not on the radiant system control values. In addition, when the user opts to autosize this calculation, the tube spacing from the construction of each surface associated with this system is used along with each individual surface area to make an approximation of the tubing length.
 
 \paragraph{Field: Temperature Control Type}\label{field-temperature-control-type-1}
 

--- a/src/EnergyPlus/LowTempRadiantSystem.hh
+++ b/src/EnergyPlus/LowTempRadiantSystem.hh
@@ -547,6 +547,12 @@ namespace LowTempRadiantSystem {
 		int const SystemType // Type of radiant system: hydronic, constant flow, or electric
 	);
 
+	Real64
+	SizeRadSysTubeLength(
+		int const RadSysType, // type of system (hydronic or constant flow)
+		int const RadSysNum   // index number for radiant system
+	);
+	
 	void
 	CalcLowTempHydrRadiantSystem(
 		int const RadSysNum, // name of the low temperature radiant system

--- a/tst/EnergyPlus/unit/LowTempRadiantSystem.unit.cc
+++ b/tst/EnergyPlus/unit/LowTempRadiantSystem.unit.cc
@@ -245,6 +245,13 @@ TEST_F( LowTempRadiantSystemTest, SizeLowTempRadiantVariableFlow )
 	HydrRadSys( RadSysNum ).TubeLength = AutoSize;
 	HydrRadSys( RadSysNum ).TotalSurfaceArea = 1500.0;
 	ExpectedResult3 = HydrRadSys( RadSysNum ).TotalSurfaceArea / 0.15;
+	HydrRadSys( RadSysNum ).SurfacePtr.allocate( 1 );
+	HydrRadSys( RadSysNum ).SurfacePtr( 1 ) = 1;
+	Surface.allocate( 1 );
+	Surface( 1 ).Construction = 1;
+	Surface( 1 ).Area = 1500.0;
+	Construct.allocate( 1 );
+	Construct( 1 ).ThicknessPerpend = 0.075;
 
 	SizeLowTempRadiantSystem( RadSysNum, SystemType );
 	EXPECT_NEAR( ExpectedResult1, HydrRadSys( RadSysNum ).WaterVolFlowMaxHeat, 0.1 );
@@ -319,6 +326,14 @@ TEST_F( LowTempRadiantSystemTest, SizeCapacityLowTempRadiantVariableFlow )
 	FinalZoneSizing( CurZoneEqNum ).NonAirSysDesCoolLoad = 2200.0;
 	ExpectedResult2 = FinalZoneSizing( CurZoneEqNum ).NonAirSysDesCoolLoad;
 
+	HydrRadSys( RadSysNum ).SurfacePtr.allocate( 1 );
+	HydrRadSys( RadSysNum ).SurfacePtr( 1 ) = 1;
+	Surface.allocate( 1 );
+	Surface( 1 ).Construction = 1;
+	Surface( 1 ).Area = 1500.0;
+	Construct.allocate( 1 );
+	Construct( 1 ).ThicknessPerpend = 0.075;
+	
 	SizeLowTempRadiantSystem( RadSysNum, SystemType );
 	EXPECT_NEAR( ExpectedResult1, HydrRadSys( RadSysNum ).ScaledHeatingCapacity, 0.1 );
 	EXPECT_NEAR( ExpectedResult2, HydrRadSys( RadSysNum ).ScaledCoolingCapacity, 0.1 );
@@ -379,6 +394,15 @@ TEST_F( LowTempRadiantSystemTest, SizeLowTempRadiantConstantFlow )
 	ExpectedResult1 = FinalZoneSizing( CurZoneEqNum ).NonAirSysDesHeatLoad;
 	ExpectedResult1 = ExpectedResult1 / ( PlantSizData( 1 ).DeltaT * RhoWater * CpWater );
 
+	CFloRadSys( RadSysNum ).SurfacePtr.allocate( 1 );
+	CFloRadSys( RadSysNum ).SurfacePtr( 1 ) = 1;
+	Surface.allocate( 1 );
+	Surface( 1 ).Construction = 1;
+	Surface( 1 ).Area = 150.0;
+	Construct.allocate( 1 );
+	Construct( 1 ).ThicknessPerpend = 0.075;
+	
+	
 	SizeLowTempRadiantSystem( RadSysNum, SystemType );
 	EXPECT_NEAR( ExpectedResult1, CFloRadSys( RadSysNum ).WaterVolFlowMax, 0.001 );
 
@@ -1146,7 +1170,7 @@ TEST_F( EnergyPlusFixture, AutosizeLowTempRadiantVariableFlowTest ) {
 	ChilledWaterFlowRate = CoolingCapacity / ( PlantSizData( 2 ).DeltaT * Cp * Density );
 	// tuble length sizing calculation
 	HydrRadSys( RadSysNum ).TotalSurfaceArea = Surface( HydrRadSys( RadSysNum ).SurfacePtr( 1 ) ).Area;
-	TubeLengthDes = HydrRadSys( RadSysNum ).TotalSurfaceArea / 0.15;
+	TubeLengthDes = HydrRadSys( RadSysNum ).TotalSurfaceArea / 0.1524; // tube length uses the construction perpendicular spacing
 
 	// do autosize calculations
 	SizeLowTempRadiantSystem( RadSysNum, RadSysTypes( 1 ).SystemType );
@@ -1560,4 +1584,111 @@ TEST_F( LowTempRadiantSystemTest, CalcLowTempHydrRadiantSystem_OperationMode )
 	Schedule.deallocate( );
 	DataHeatBalFanSys::MAT.deallocate( );
 
+}
+
+TEST_F( LowTempRadiantSystemTest, SizeRadSysTubeLengthTest )
+{
+	// # Low Temperature Radiant System (variable and constant flow) autosizing tube length issue #6202
+	Real64 FuncCalc;
+	int RadSysType;
+	
+	RadSysNum = 1;
+	LowTempRadiantSystem::clear_state( );
+
+	HydrRadSys.allocate( 3 );
+	CFloRadSys.allocate( 3 );
+	
+	HydrRadSys( 1 ).NumOfSurfaces = 1;
+	HydrRadSys( 1 ).SurfacePtr.allocate( 1 );
+	HydrRadSys( 1 ).SurfacePtr( 1 ) = 1;
+	HydrRadSys( 2 ).NumOfSurfaces = 2;
+	HydrRadSys( 2 ).SurfacePtr.allocate( 2 );
+	HydrRadSys( 2 ).SurfacePtr( 1 ) = 1;
+	HydrRadSys( 2 ).SurfacePtr( 2 ) = 2;
+	HydrRadSys( 3 ).NumOfSurfaces = 1;
+	HydrRadSys( 3 ).SurfacePtr.allocate( 1 );
+	HydrRadSys( 3 ).SurfacePtr( 1 ) = 3;
+
+	
+	CFloRadSys( 1 ).NumOfSurfaces = 1;
+	CFloRadSys( 1 ).SurfacePtr.allocate( 1 );
+	CFloRadSys( 1 ).SurfacePtr( 1 ) = 1;
+	CFloRadSys( 2 ).NumOfSurfaces = 2;
+	CFloRadSys( 2 ).SurfacePtr.allocate( 2 );
+	CFloRadSys( 2 ).SurfacePtr( 1 ) = 1;
+	CFloRadSys( 2 ).SurfacePtr( 2 ) = 2;
+	CFloRadSys( 3 ).NumOfSurfaces = 1;
+	CFloRadSys( 3 ).SurfacePtr.allocate( 1 );
+	CFloRadSys( 3 ).SurfacePtr( 1 ) = 3;
+	
+	Surface.allocate( 3 );
+	Surface( 1 ).Construction = 1;
+	Surface( 1 ).Area = 100.0;
+	Surface( 2 ).Construction = 2;
+	Surface( 2 ).Area = 200.0;
+	Surface( 3 ).Construction = 3;
+	Surface( 3 ).Area = 300.0;
+	
+	Construct.allocate( 3 );
+	Construct( 1 ).ThicknessPerpend = 0.05;
+	Construct( 2 ).ThicknessPerpend = 0.125;
+	
+	// Test 1: Hydronic radiant system 1 (one surface)
+	RadSysType = HydronicSystem;
+	RadSysNum = 1;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 1000.0, 0.1 );
+
+	// Test 2: Hydronic radiant system 2 (two surfaces)
+	RadSysType = HydronicSystem;
+	RadSysNum = 2;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 1800.0, 0.1 );
+
+	// Test 3: Constant flow radiant system 1 (one surface)
+	RadSysType = ConstantFlowSystem;
+	RadSysNum = 1;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 1000.0, 0.1 );
+	
+	// Test 4: Constant flow radiant system 2 (two surfaces)
+	RadSysType = ConstantFlowSystem;
+	RadSysNum = 2;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 1800.0, 0.1 );
+	
+	// Test 5: Hydronic radiant system 3 (thickness out of range, low side)
+	RadSysType = HydronicSystem;
+	RadSysNum = 3;
+	Construct( 3 ).ThicknessPerpend = 0.004;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 2000.0, 0.1 );
+
+	// Test 6: Hydronic radiant system 3 (thickness out of range, high side)
+	RadSysType = HydronicSystem;
+	RadSysNum = 3;
+	Construct( 3 ).ThicknessPerpend = 0.6;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 2000.0, 0.1 );
+	
+	// Test 7: Constant flow radiant system 3 (thickness out of range, low side)
+	RadSysType = ConstantFlowSystem;
+	RadSysNum = 3;
+	Construct( 3 ).ThicknessPerpend = 0.004;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 2000.0, 0.1 );
+	
+	// Test 8: Constant flow radiant system 3 (thickness out of range, high side)
+	RadSysType = ConstantFlowSystem;
+	RadSysNum = 3;
+	Construct( 3 ).ThicknessPerpend = 0.6;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 2000.0, 0.1 );
+	
+	// Test 9: Wrong system type
+	RadSysType = 0;
+	RadSysNum = 1;
+	FuncCalc = SizeRadSysTubeLength( RadSysType, RadSysNum );
+	EXPECT_NEAR( FuncCalc, 60.0, 0.1 );
+	
 }


### PR DESCRIPTION
This commit includes the fix, the units tests, and documentation
modifications to address this issue.

Pull request overview
---------------------
This work addresses GitHub Issue #6202.  In this issue, a user noted that when EnergyPlus autosizes the tube length for a water based radiant system it uses a tube spacing of 0.15m for all cases.  This is not necessary since the user enters a tube spacing in their input file as part of the construction definition.  This fix will now use the construction definition information and will only resort to using a tube spacing of 0.15m when information has not been entered or the spacing is not within realistic boundaries.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue #6202 

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces