### PR TITLE
Fixup idd units

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -7049,7 +7049,7 @@ MaterialProperty:PhaseChangeHysteresis,
   N2 , \field Liquid State Thermal Conductivity
        \note The thermal conductivity used by this material when the material is fully liquid
        \required-field
-       \units W/mK
+       \units W/m-K
        \type real
        \minimum> 0
   N3 , \field Liquid State Density
@@ -7085,7 +7085,7 @@ MaterialProperty:PhaseChangeHysteresis,
   N8 , \field Solid State Thermal Conductivity
        \note The thermal conductivity used by this material when the material is fully solid
        \required-field
-       \units W/mK
+       \units W/m-K
        \type real
        \minimum> 0
   N9 , \field Solid State Density
@@ -20642,7 +20642,7 @@ GasEquipment,
   N3 , \field Power per Person
        \type real
        \minimum 0
-       \units W/Person
+       \units W/person
        \ip-units Btu/h-person
   N4 , \field Fraction Latent
        \type real
@@ -20722,7 +20722,7 @@ HotWaterEquipment,
   N3 , \field Power per Person
        \type real
        \minimum 0
-       \units W/Person
+       \units W/person
        \ip-units Btu/h-person
   N4 , \field Fraction Latent
        \type real
@@ -20789,7 +20789,7 @@ SteamEquipment,
   N3 , \field Power per Person
        \type real
        \minimum 0
-       \units W/Person
+       \units W/person
        \ip-units Btu/h-person
   N4 , \field Fraction Latent
        \type real
@@ -20871,7 +20871,7 @@ OtherEquipment,
        \ip-units Btu/h-ft2
   N3 , \field Power per Person
        \type real
-       \units W/Person
+       \units W/person
        \ip-units Btu/h-person
   N4 , \field Fraction Latent
        \type real
@@ -35069,7 +35069,7 @@ ZoneHVAC:Baseboard:RadiantConvective:Water,
        \type real
        \maximum 10.0
        \minimum> 0.0
-       \units Kg/s
+       \units kg/s
        \default 0.063
   A5,  \field Heating Design Capacity Method
        \type choice
@@ -44632,7 +44632,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note must be lower than or equal to the highest speed number
    N3,  \field Gross Rated Total Cooling Capacity At Selected Nominal Speed Level
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \autosizable
         \default autosize
@@ -44723,7 +44723,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note throughout the entire simulation.
    N13, \field Speed 1 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
         \required-field
@@ -44788,7 +44788,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N19, \field Speed 2 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N20, \field Speed 2 Reference Unit Gross Rated Sensible Heat Ratio
@@ -44843,7 +44843,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N25, \field Speed 3 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N26, \field Speed 3 Reference Unit Gross Rated Sensible Heat Ratio
@@ -44898,7 +44898,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N31, \field Speed 4 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N32, \field Speed 4 Reference Unit Gross Rated Sensible Heat Ratio
@@ -44953,7 +44953,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N37, \field Speed 5 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N38, \field Speed 5 Reference Unit Gross Rated Sensible Heat Ratio
@@ -45008,7 +45008,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N43, \field Speed 6 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N44, \field Speed 6 Reference Unit Gross Rated Sensible Heat Ratio
@@ -45063,7 +45063,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N49, \field Speed 7 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N50, \field Speed 7 Reference Unit Gross Rated Sensible Heat Ratio
@@ -45118,7 +45118,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N55, \field Speed 8 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N56, \field Speed 8 Reference Unit Gross Rated Sensible Heat Ratio
@@ -45173,7 +45173,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N61, \field Speed 9 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N62, \field Speed 9 Reference Unit Gross Rated Sensible Heat Ratio
@@ -45230,7 +45230,7 @@ Coil:Cooling:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N67, \field Speed 10 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N68, \field Speed 10 Reference Unit Gross Rated Sensible Heat Ratio
@@ -47241,7 +47241,7 @@ Coil:Heating:DX:VariableSpeed,
         \default 2
         \note must be lower than or equal to the highest speed number
    N3,  \field Rated Heating Capacity At Selected Nominal Speed Level
-        \units w
+        \units W
         \type real
         \autosizable
         \default autosize
@@ -47323,7 +47323,7 @@ Coil:Heating:DX:VariableSpeed,
         \ip-units W
    N12, \field Speed 1 Reference Unit Gross Rated Heating Capacity
        \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
         \required-field
@@ -47371,7 +47371,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N15, \field Speed 2 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N16, \field Speed 2 Reference Unit Gross Rated Heating COP
@@ -47412,7 +47412,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N18, \field Speed 3 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N19, \field Speed 3 Reference Unit Gross Rated Heating COP
@@ -47453,7 +47453,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N21, \field Speed 4 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N22, \field Speed 4 Reference Unit Gross Rated Heating COP
@@ -47494,7 +47494,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N24, \field Speed 5 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N25, \field Speed 5 Reference Unit Gross Rated Heating COP
@@ -47535,7 +47535,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N27, \field Speed 6 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N28, \field Speed 6 Reference Unit Gross Rated Heating COP
@@ -47576,7 +47576,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N30, \field Speed 7 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N31, \field Speed 7 Reference Unit Gross Rated Heating COP
@@ -47617,7 +47617,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N33, \field Speed 8 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N34, \field Speed 8 Reference Unit Gross Rated Heating COP
@@ -47658,7 +47658,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N36, \field Speed 9 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N37, \field Speed 9 Reference Unit Gross Rated Heating COP
@@ -47699,7 +47699,7 @@ Coil:Heating:DX:VariableSpeed,
         \note ffa = Fraction of the full load Air Flow
    N39, \field Speed 10 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N40, \field Speed 10 Reference Unit Gross Rated Heating COP
@@ -48221,7 +48221,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note must be lower than or equal to the highest speed number
    N3,  \field Gross Rated Total Cooling Capacity At Selected Nominal Speed Level
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \autosizable
         \default autosize
@@ -48262,7 +48262,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note PLR = part load ratio (cooling load/steady state capacity)
    N9,  \field Speed 1 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
         \required-field
@@ -48351,7 +48351,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N15, \field Speed 2 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N16, \field Speed 2 Reference Unit Gross Rated Sensible Heat Ratio
@@ -48427,7 +48427,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N21, \field Speed 3 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N22, \field Speed 3 Reference Unit Gross Rated Sensible Heat Ratio
@@ -48510,7 +48510,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N27, \field Speed 4 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N28, \field Speed 4 Reference Unit Gross Rated Sensible Heat Ratio
@@ -48593,7 +48593,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N33, \field Speed 5 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N34, \field Speed 5 Reference Unit Gross Rated Sensible Heat Ratio
@@ -48676,7 +48676,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N39, \field Speed 6 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N40, \field Speed 6 Reference Unit Gross Rated Sensible Heat Ratio
@@ -48759,7 +48759,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N45, \field Speed 7 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N46, \field Speed 7 Reference Unit Gross Rated Sensible Heat Ratio
@@ -48842,7 +48842,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N51, \field Speed 8 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N52, \field Speed 8 Reference Unit Gross Rated Sensible Heat Ratio
@@ -48925,7 +48925,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N57, \field Speed 9 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N58, \field Speed 9 Reference Unit Gross Rated Sensible Heat Ratio
@@ -49008,7 +49008,7 @@ Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the condenser (C)
    N63, \field Speed 10 Reference Unit Gross Rated Total Cooling Capacity
         \note Total cooling capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N64, \field Speed 10 Reference Unit Gross Rated Sensible Heat Ratio
@@ -49203,7 +49203,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \default 2
         \note must be lower than or equal to the highest speed number
    N3,  \field Rated Heating Capacity At Selected Nominal Speed Level
-        \units w
+        \units W
         \type real
         \autosizable
         \default autosize
@@ -49228,7 +49228,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note PLR = part load ratio (heating load/steady state capacity)
    N6,  \field Speed 1 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
         \required-field
@@ -49311,7 +49311,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N11, \field Speed 2 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N12, \field Speed 2 Reference Unit Gross Rated Heating COP
@@ -49383,7 +49383,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N16, \field Speed 3 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N17, \field Speed 3 Reference Unit Gross Rated Heating COP
@@ -49461,7 +49461,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N21, \field Speed 4 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N22, \field Speed 4 Reference Unit Gross Rated Heating COP
@@ -49539,7 +49539,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N26, \field Speed 5 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N27, \field Speed 5 Reference Unit Gross Rated Heating COP
@@ -49617,7 +49617,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N31, \field Speed 6 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N32, \field Speed 6 Reference Unit Gross Rated Heating COP
@@ -49695,7 +49695,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N36, \field Speed 7 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N37, \field Speed 7 Reference Unit Gross Rated Heating COP
@@ -49773,7 +49773,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N41, \field Speed 8 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N42, \field Speed 8 Reference Unit Gross Rated Heating COP
@@ -49851,7 +49851,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N46, \field Speed 9 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N47, \field Speed 9 Reference Unit Gross Rated Heating COP
@@ -49929,7 +49929,7 @@ Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \note ewt = water entering temperature seen by the evaporator (C)
    N51, \field Speed 10 Reference Unit Gross Rated Heating Capacity
         \note Heating capacity not accounting for the effect of supply air fan heat
-        \units w
+        \units W
         \type real
         \minimum 0
    N52, \field Speed 10 Reference Unit Gross Rated Heating COP
@@ -69107,7 +69107,7 @@ HeatExchanger:FluidToFluid,
         \default Ideal
    N3 , \field Heat Exchanger U-Factor Times Area Value
         \type real
-        \units W/k
+        \units W/K
         \minimum> 0.0
         \autosizable
         \required-field
@@ -79092,7 +79092,7 @@ Generator:CombustionTurbine,
        \note typical value .9
        \maximum 2
   N7, \field Maximum Exhaust Flow per Unit of Power Output
-      \units (Kg/s)/W
+      \units (kg/s)/W
   N8, \field Design Minimum Exhaust Temperature
        \units C
   N9, \field Design Air Inlet Temperature

--- a/scripts/dev/validate_idd_units.py
+++ b/scripts/dev/validate_idd_units.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import sys
+
+
+class ReadingMode:
+    FindTranslatedUnits = 1
+    FindNonTranslatedUnits = 2
+    ScanFieldUnits = 3
+
+
+class Problem:
+    def __init__(self, line_num, detail):
+        self.line_num = line_num
+        self.detail = detail
+
+    def __str__(self):
+        return "Line # %s: %s" % (self.line_num, self.detail)
+
+idd_file = sys.argv[1]
+idd_lines = open(idd_file).readlines()
+
+# I don't really want to add an ignore list, but so be it:
+ignore_list = ["hh:mm", "kgWater/kgDryAir"]
+
+original_units = []
+reading_mode = ReadingMode.FindTranslatedUnits
+line_num = 0
+problem_unit_lines = []
+for line in idd_lines:
+    line = line.strip()
+    line_num += 1
+    if reading_mode == ReadingMode.FindTranslatedUnits:
+        if line.startswith("!      ") and "=>   " in line:
+            tokens = line.split(" ")
+            real_tokens = [t for t in tokens if t]
+            original_units.append(real_tokens[1])
+        elif "! Units fields that are not translated" in line:
+            reading_mode = ReadingMode.FindNonTranslatedUnits
+    elif reading_mode == ReadingMode.FindNonTranslatedUnits:
+        if line.startswith("!      "):
+            tokens = line.split(" ")
+            real_tokens = [t for t in tokens if t]
+            original_units.append(real_tokens[1])
+        else:
+            reading_mode = ReadingMode.ScanFieldUnits
+    elif reading_mode == ReadingMode.ScanFieldUnits:
+        if "\units " in line:
+            tokens = line.split(" ")
+            real_tokens = [t for t in tokens if t]
+            if not len(real_tokens) == 2:
+                problem_unit_lines.append(Problem(line_num, "Unexpected number of unit specifications"))
+                continue
+            if real_tokens[1] not in original_units and real_tokens[1] not in ignore_list:
+                problem_unit_lines.append(Problem(line_num, "Unexpected unit type found: " + real_tokens[1]))
+
+for problem in problem_unit_lines:
+    print(str(problem))


### PR DESCRIPTION
I accidentally brought in a bad unit in the PCM work.  This fixes that.

But not only that.  I also wrote a script to validate the units fields in the IDD against the units specified in the IDD header.  It illuminated a bunch more.  Almost entirely just capitalization.  So I cleaned them up.

I added this script to the repo, but I haven't integrated it with CI yet.  It will be straightforward to do so.  Then we'll get meaningful warnings anytime someone (me) tries to put in an invalid unit type.