### PR TITLE
Fix build warning and test file typo

### DIFF
--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
@@ -261,7 +261,6 @@ namespace ZoneAirLoopEquipmentManager {
 		using NodeInputManager::GetOnlySingleNode;
 		using namespace DataLoopNode;
 		using BranchNodeConnections::SetUpCompSets;
-		using DataZoneEquipment::ZoneEquipConfig;
 		using DualDuct::GetDualDuctOutdoorAirRecircUse;
 
 		// Locals

--- a/testfiles/CMakeLists.txt
+++ b/testfiles/CMakeLists.txt
@@ -31,7 +31,7 @@ ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooledDemandLimiting.idf EPW_FILE USA_IL_Ch
 ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooledDemandLimiting_FixedRateVentilation.idf EPW_FILE USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw)
 ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooledDemandLimiting_ReductionRatioVentilation.idf EPW_FILE USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw)
 ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooledWithCoupledInGradeSlab.idf EPW_FILE USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw)
-ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooledWithDOASAirloop.idf EPW_FILE USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw)
+ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooledWithDOASAirLoop.idf EPW_FILE USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw)
 ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooled_UniformLoading.idf EPW_FILE USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw)
 ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooled_VRPSizing.idf EPW_FILE USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw)
 ADD_SIMULATION_TEST(IDF_FILE 5ZoneAirCooled_VRPSizing_MaxZd.idf EPW_FILE USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw)


### PR DESCRIPTION
Build warning and typo recently got introduced.  Easy fixes.  Verified locally.  Merging in now to avoid lots of CI time.