### PR TITLE
Fix DElight's Flaky Nature

### DIFF
--- a/.decent_ci-Linux.yaml
+++ b/.decent_ci-Linux.yaml
@@ -11,7 +11,7 @@ compilers:
     s3_upload_bucket: energyplus
 
   - name: cppcheck
-    compiler_extra_flags: --enable=warning  --suppress="*:*gtest*" --suppress="constStatement:*Objex*" --suppress="cppcheckError:*" --suppress="uninitvar:*" --suppress="syntaxError:*" --suppress="*:*sqlite*" --suppress="invalidscanf:*DElight*" --suppress="uninitMemberVar:*DElight*" --suppress="invalidScanfArgType_int:*DElight*" --suppress="uninitMemberVar:*jsoncpp*" --suppress="*:*re2*" --suppress="*:*eigen*"
+    compiler_extra_flags: --enable=warning  --suppress="*:*gtest*" --suppress="constStatement:*Objex*" --suppress="cppcheckError:*" --suppress="uninitvar:*" --suppress="syntaxError:*" --suppress="*:*sqlite*" --suppress="uninitMemberVar:*jsoncpp*" --suppress="*:*re2*" --suppress="*:*eigen*"
 
   - name: "gcc"
     version: "4.8"


### PR DESCRIPTION
Step 1: There were warnings being suppressed in the cppcheck settings.  Probably because like 3 years ago when cppcheck was first added, leaving them on showed a bazillion errors, and we didn't have the time to clean them up.  Now we may be more able to do so.  I'm especially curious about the `uninitMemberVar` warning that was purposely disabled.  Here's to hoping I find some uninitialized variables in DElight that are causing the flakiness.  