### PR TITLE
Move ResetNodeData to resolve reverse DD issue for IT equipment model and cleanup on 5ZoneCAV_MaxTemp

### DIFF
--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -380,10 +380,10 @@ namespace HVACManager {
 		NumOfSysTimeSteps = 1;
 		FracTimeStepZone = TimeStepSys / TimeStepZone;
 
+		SetOutAirNodes();
+
 		bool anyEMSRan;
 		ManageEMS( emsCallFromBeginTimestepBeforePredictor, anyEMSRan ); //calling point
-
-		SetOutAirNodes();
 
 		ManageRefrigeratedCaseRacks();
 

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -380,10 +380,10 @@ namespace HVACManager {
 		NumOfSysTimeSteps = 1;
 		FracTimeStepZone = TimeStepSys / TimeStepZone;
 
-		SetOutAirNodes();
-
 		bool anyEMSRan;
 		ManageEMS( emsCallFromBeginTimestepBeforePredictor, anyEMSRan ); //calling point
+
+		SetOutAirNodes();
 
 		ManageRefrigeratedCaseRacks();
 

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -360,7 +360,6 @@ namespace HVACManager {
 		}
 
 		if ( BeginEnvrnFlag && MyEnvrnFlag ) {
-			ResetNodeData();
 			AirLoopsSimOnce = false;
 			MyEnvrnFlag = false;
 			InitVentReportFlag = true;

--- a/src/EnergyPlus/SimulationManager.cc
+++ b/src/EnergyPlus/SimulationManager.cc
@@ -499,6 +499,8 @@ namespace SimulationManager {
 				isFinalYear = true;
 			}
 
+			HVACManager::ResetNodeData(); // Reset here, because some zone calcs rely on node data (e.g. ZoneITEquip)
+
 			bool anyEMSRan;
 			ManageEMS( emsCallFromBeginNewEvironment, anyEMSRan ); // calling point
 

--- a/src/EnergyPlus/ZonePlenum.cc
+++ b/src/EnergyPlus/ZonePlenum.cc
@@ -766,6 +766,16 @@ namespace ZonePlenum {
 				Node( ZoneNodeNum ).HumRat = OutHumRat;
 				Node( ZoneNodeNum ).Enthalpy = PsyHFnTdbW( Node( ZoneNodeNum ).Temp, Node( ZoneNodeNum ).HumRat );
 
+				ZoneRetPlenCond( PlenumZoneNum ).ZoneTemp = 20.0;
+				ZoneRetPlenCond( PlenumZoneNum ).ZoneHumRat = 0.0;
+				ZoneRetPlenCond( PlenumZoneNum ).ZoneEnthalpy = 0.0;
+				ZoneRetPlenCond( PlenumZoneNum ).InletTemp = 0.0;
+				ZoneRetPlenCond( PlenumZoneNum ).InletHumRat = 0.0;
+				ZoneRetPlenCond( PlenumZoneNum ).InletEnthalpy = 0.0;
+				ZoneRetPlenCond( PlenumZoneNum ).InletPressure = 0.0;
+				ZoneRetPlenCond( PlenumZoneNum ).InletMassFlowRate = 0.0;
+				ZoneRetPlenCond( PlenumZoneNum ).InletMassFlowRateMaxAvail = 0.0;
+				ZoneRetPlenCond( PlenumZoneNum ).InletMassFlowRateMinAvail = 0.0;
 			}
 
 			InitAirZoneReturnPlenumEnvrnFlag = false;
@@ -881,6 +891,16 @@ namespace ZonePlenum {
 				Node( ZoneNodeNum ).HumRat = OutHumRat;
 				Node( ZoneNodeNum ).Enthalpy = PsyHFnTdbW( Node( ZoneNodeNum ).Temp, Node( ZoneNodeNum ).HumRat );
 
+				ZoneSupPlenCond( PlenumZoneNum ).ZoneTemp = 20.0;
+				ZoneSupPlenCond( PlenumZoneNum ).ZoneHumRat = 0.0;
+				ZoneSupPlenCond( PlenumZoneNum ).ZoneEnthalpy = 0.0;
+				ZoneSupPlenCond( PlenumZoneNum ).InletTemp = 0.0;
+				ZoneSupPlenCond( PlenumZoneNum ).InletHumRat = 0.0;
+				ZoneSupPlenCond( PlenumZoneNum ).InletEnthalpy = 0.0;
+				ZoneSupPlenCond( PlenumZoneNum ).InletPressure = 0.0;
+				ZoneSupPlenCond( PlenumZoneNum ).InletMassFlowRate = 0.0;
+				ZoneSupPlenCond( PlenumZoneNum ).InletMassFlowRateMaxAvail = 0.0;
+				ZoneSupPlenCond( PlenumZoneNum ).InletMassFlowRateMinAvail = 0.0;
 			}
 
 			MyEnvrnFlag = false;

--- a/testfiles/1ZoneDataCenterCRAC_wPumpedDXCoolingCoil.idf
+++ b/testfiles/1ZoneDataCenterCRAC_wPumpedDXCoolingCoil.idf
@@ -1265,7 +1265,11 @@
 
   EnergyManagementSystem:Program,
     CalcPUE,                 !- Name
-    set PUE = whole_building_power / IT_Equip_power;  !- Program Line 1
+    IF IT_Equip_power > 0.0, !- Program Line 1
+    set PUE = whole_building_power / IT_Equip_power,  !- Program Line 2
+    ELSE,                    !- Program Line 3
+    set PUE = 0.0,           !- Program Line 4
+    ENDIF;                   !- Program Line 5
 
   Output:Variable,*,PUE,Hourly;
 

--- a/testfiles/2ZoneDataCenterHVAC_wEconomizer.idf
+++ b/testfiles/2ZoneDataCenterHVAC_wEconomizer.idf
@@ -3096,7 +3096,11 @@
 
   EnergyManagementSystem:Program,
     CalculatePUE,            !- Name
-    set PUE_Value = Whole_Building_Power / IT_Equip_Power;  !- Program Line 1
+    IF IT_Equip_power > 0.0, !- Program Line 1
+    set PUE_Value = whole_building_power / IT_Equip_power,  !- Program Line 2
+    ELSE,                    !- Program Line 3
+    set PUE_Value = 0.0,     !- Program Line 4
+    ENDIF;                   !- Program Line 5
 
   OutputControl:Table:Style,
     HTML;                    !- Column Separator

--- a/testfiles/5ZoneCAV_MaxTemp.idf
+++ b/testfiles/5ZoneCAV_MaxTemp.idf
@@ -3055,7 +3055,7 @@
     ReheatCoilAvailSched,    !- Availability Schedule Name
     SPACE1-1 In Node,        !- Air Outlet Node Name
     SPACE1-1 Zone Coil Air In Node,  !- Air Inlet Node Name
-    0.3,                     !- Maximum Air Flow Rate {m3/s}
+    autosize,                !- Maximum Air Flow Rate {m3/s}
     Coil:Heating:Water,      !- Reheat Coil Object Type
     SPACE1-1 Zone Coil,      !- Reheat Coil Name
     autosize,                !- Maximum Hot Water or Steam Flow Rate {m3/s}

--- a/tst/EnergyPlus/unit/InternalHeatGains.unit.cc
+++ b/tst/EnergyPlus/unit/InternalHeatGains.unit.cc
@@ -55,6 +55,9 @@
 #include <ScheduleManager.hh>
 #include <DataGlobals.hh>
 #include <DataHeatBalance.hh>
+#include <DataHeatBalFanSys.hh>
+#include <HVACManager.hh>
+#include <DataLoopNode.hh>
 #include <ExteriorEnergyUse.hh>
 
 #include "Fixtures/EnergyPlusFixture.hh"
@@ -301,4 +304,140 @@ TEST_F( EnergyPlusFixture, InternalHeatGains_AllowBlankFieldsForAdaptiveComfortM
 
 	EXPECT_FALSE( InternalHeatGains::ErrorsFound );
 
+}
+
+TEST_F(EnergyPlusFixture, InternalHeatGains_ElectricEquipITE_BeginEnvironmentReset) {
+
+	std::string const idf_objects = delimited_string({
+		"Version,8.5;",
+
+		"Zone,Zone1;",
+
+		"ElectricEquipment:ITE:AirCooled,",
+		"  Data Center Servers,     !- Name",
+		"  Zone1,                   !- Zone Name",
+		"  Watts/Unit,              !- Design Power Input Calculation Method",
+		"  500,                     !- Watts per Unit {W}",
+		"  100,                     !- Number of Units",
+		"  ,                        !- Watts per Zone Floor Area {W/m2}",
+		"  ,  !- Design Power Input Schedule Name",
+		"  ,  !- CPU Loading  Schedule Name",
+		"  Data Center Servers Power fLoadTemp,  !- CPU Power Input Function of Loading and Air Temperature Curve Name",
+		"  0.4,                     !- Design Fan Power Input Fraction",
+		"  0.0001,                  !- Design Fan Air Flow Rate per Power Input {m3/s-W}",
+		"  Data Center Servers Airflow fLoadTemp,  !- Air Flow Function of Loading and Air Temperature Curve Name",
+		"  ECM FanPower fFlow,      !- Fan Power Input Function of Flow Curve Name",
+		"  15,                      !- Design Entering Air Temperature {C}",
+		"  A3,                      !- Environmental Class",
+		"  AdjustedSupply,          !- Air Inlet Connection Type",
+		"  ,                        !- Air Inlet Room Air Model Node Name",
+		"  ,                        !- Air Outlet Room Air Model Node Name",
+		"  Main Zone Inlet Node,    !- Supply Air Node Name",
+		"  0.1,                     !- Design Recirculation Fraction",
+		"  Data Center Recirculation fLoadTemp,  !- Recirculation Function of Loading and Supply Temperature Curve Name",
+		"  0.9,                     !- Design Electric Power Supply Efficiency",
+		"  UPS Efficiency fPLR,     !- Electric Power Supply Efficiency Function of Part Load Ratio Curve Name",
+		"  1,                       !- Fraction of Electric Power Supply Losses to Zone",
+		"  ITE-CPU,                 !- CPU End-Use Subcategory",
+		"  ITE-Fans,                !- Fan End-Use Subcategory",
+		"  ITE-UPS;                 !- Electric Power Supply End-Use Subcategory",
+		"",
+		"Curve:Quadratic,",
+		"  ECM FanPower fFlow,      !- Name",
+		"  0.0,                     !- Coefficient1 Constant",
+		"  1.0,                     !- Coefficient2 x",
+		"  0.0,                     !- Coefficient3 x**2",
+		"  0.0,                     !- Minimum Value of x",
+		"  99.0;                    !- Maximum Value of x",
+		"",
+		"Curve:Quadratic,",
+		"  UPS Efficiency fPLR,     !- Name",
+		"  1.0,                     !- Coefficient1 Constant",
+		"  0.0,                     !- Coefficient2 x",
+		"  0.0,                     !- Coefficient3 x**2",
+		"  0.0,                     !- Minimum Value of x",
+		"  99.0;                    !- Maximum Value of x",
+		"",
+		"Curve:Biquadratic,",
+		"  Data Center Servers Power fLoadTemp,  !- Name",
+		"  -1.0,                    !- Coefficient1 Constant",
+		"  1.0,                     !- Coefficient2 x",
+		"  0.0,                     !- Coefficient3 x**2",
+		"  0.06667,                 !- Coefficient4 y",
+		"  0.0,                     !- Coefficient5 y**2",
+		"  0.0,                     !- Coefficient6 x*y",
+		"  0.0,                     !- Minimum Value of x",
+		"  1.5,                     !- Maximum Value of x",
+		"  -10,                     !- Minimum Value of y",
+		"  99.0,                    !- Maximum Value of y",
+		"  0.0,                     !- Minimum Curve Output",
+		"  99.0,                    !- Maximum Curve Output",
+		"  Dimensionless,           !- Input Unit Type for X",
+		"  Temperature,             !- Input Unit Type for Y",
+		"  Dimensionless;           !- Output Unit Type",
+		"",
+		"Curve:Biquadratic,",
+		"  Data Center Servers Airflow fLoadTemp,  !- Name",
+		"  -1.4,                    !- Coefficient1 Constant",
+		"  0.9,                     !- Coefficient2 x",
+		"  0.0,                     !- Coefficient3 x**2",
+		"  0.1,                     !- Coefficient4 y",
+		"  0.0,                     !- Coefficient5 y**2",
+		"  0.0,                     !- Coefficient6 x*y",
+		"  0.0,                     !- Minimum Value of x",
+		"  1.5,                     !- Maximum Value of x",
+		"  -10,                     !- Minimum Value of y",
+		"  99.0,                    !- Maximum Value of y",
+		"  0.0,                     !- Minimum Curve Output",
+		"  99.0,                    !- Maximum Curve Output",
+		"  Dimensionless,           !- Input Unit Type for X",
+		"  Temperature,             !- Input Unit Type for Y",
+		"  Dimensionless;           !- Output Unit Type",
+		"",
+		"Curve:Biquadratic,",
+		"  Data Center Recirculation fLoadTemp,  !- Name",
+		"  1.0,                     !- Coefficient1 Constant",
+		"  0.0,                     !- Coefficient2 x",
+		"  0.0,                     !- Coefficient3 x**2",
+		"  0.0,                     !- Coefficient4 y",
+		"  0.0,                     !- Coefficient5 y**2",
+		"  0.0,                     !- Coefficient6 x*y",
+		"  0.0,                     !- Minimum Value of x",
+		"  1.5,                     !- Maximum Value of x",
+		"  -10,                     !- Minimum Value of y",
+		"  99.0,                    !- Maximum Value of y",
+		"  0.0,                     !- Minimum Curve Output",
+		"  99.0,                    !- Maximum Curve Output",
+		"  Dimensionless,           !- Input Unit Type for X",
+		"  Temperature,             !- Input Unit Type for Y",
+		"  Dimensionless;           !- Output Unit Type",
+	
+	});
+
+	ASSERT_FALSE( process_idf( idf_objects ) );
+	EXPECT_FALSE( has_err_output() );
+
+	bool ErrorsFound( false );
+
+	HeatBalanceManager::GetZoneData( ErrorsFound );
+	ASSERT_FALSE( ErrorsFound );
+	DataHeatBalFanSys::MAT.allocate( 1 );
+	DataHeatBalFanSys::ZoneAirHumRat.allocate( 1 );
+
+	DataHeatBalFanSys::MAT( 1 ) = 24.0;
+	DataHeatBalFanSys::ZoneAirHumRat( 1 ) = 0.008;
+
+	InternalHeatGains::GetInternalHeatGainsInput();
+	InternalHeatGains::CalcZoneITEq();
+	Real64 InitialPower = DataHeatBalance::ZoneITEq( 1 ).CPUPower + DataHeatBalance::ZoneITEq( 1 ).FanPower + DataHeatBalance::ZoneITEq( 1 ).UPSPower;
+
+	DataLoopNode::Node( 1 ).Temp = 45.0;
+	InternalHeatGains::CalcZoneITEq();
+	Real64 NewPower = DataHeatBalance::ZoneITEq( 1 ).CPUPower + DataHeatBalance::ZoneITEq( 1 ).FanPower + DataHeatBalance::ZoneITEq( 1 ).UPSPower;
+	ASSERT_NE( InitialPower, NewPower );
+	HVACManager::ResetNodeData();
+
+	InternalHeatGains::CalcZoneITEq();
+	NewPower = DataHeatBalance::ZoneITEq( 1 ).CPUPower + DataHeatBalance::ZoneITEq( 1 ).FanPower + DataHeatBalance::ZoneITEq( 1 ).UPSPower;
+	ASSERT_EQ( InitialPower, NewPower );
 }


### PR DESCRIPTION
Pull request overview
---------------------
ElectricEquipment:ITE:AirCooled uses a node temperature to compute the IT equipment power consumption and more.  On BeginEnvrnFlag, the node data needs to be reset before the IT equipment is computed.  So, `ResetNodeData` has been moved from `HVACManager` up into `SimulationManager`.  This should clear up revese design day issues (#5120) for 1ZoneDataCenterCRAC_wPumpedDXCoolingCoil and 2ZoneDataCenterHVAC_wEconomizer, and possibly others.

These changes caused a divide by zero in the EMS PUE calcs in 1ZoneDataCenterCRAC_wPumpedDXCoolingCoil.  Add div-by-zero protection in both 1ZoneDataCenterCRAC_wPumpedDXCoolingCoil and 2ZoneDataCenterHVAC_wEconomizer EMS programs.

5ZoneCAV_MaxTemp is almost all autosized, but there was a stray hard flow rate in one of the terminal units.  

Move SetOutAirNodes to be before emsCallFromBeginTimestepBeforePredictor, because original move of ResetNodeData caused some EMS files to show diffs.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
