### PR TITLE
PV Zone Multiplier Fix

### DIFF
--- a/src/EnergyPlus/DataPhotovoltaics.hh
+++ b/src/EnergyPlus/DataPhotovoltaics.hh
@@ -406,6 +406,7 @@ namespace DataPhotovoltaics {
 		std::string SurfaceName; // named surface in heat balance domain
 		std::string PerfObjName;
 		int SurfacePtr; // index for named surface
+		int Zone; // index for zone (for getting any zone multipliers)
 		int PVModelType; // type of performance modeling, Simple, TRNSYS or Equivalent 1-diode, or Sandia/King model
 		int CellIntegrationMode; // how are PV cells integrated with other E+ modeling
 		Real64 NumModNSeries; // number of modules in series in one string
@@ -427,6 +428,7 @@ namespace DataPhotovoltaics {
 		// Default Constructor
 		PVArrayStruct() :
 			SurfacePtr( 0 ),
+			Zone( 0 ),
 			PVModelType( 0 ),
 			CellIntegrationMode( 0 ),
 			NumModNSeries( 1.0 ),

--- a/src/EnergyPlus/Photovoltaics.hh
+++ b/src/EnergyPlus/Photovoltaics.hh
@@ -104,6 +104,11 @@ namespace Photovoltaics {
 
 	void
 	GetPVInput();
+	
+	int
+	GetPVZone(
+		int const SurfNum
+	);
 
 	// **************************************
 

--- a/tst/EnergyPlus/unit/Photovoltaics.unit.cc
+++ b/tst/EnergyPlus/unit/Photovoltaics.unit.cc
@@ -114,25 +114,24 @@ TEST_F( EnergyPlusFixture, PV_ReportPV_ZoneIndexNonZero )
 	
 	// Test 1: Zone 1--PV has multiplier, Zone index already set
 	EnergyPlus::DataPhotovoltaics::PVarray( 1 ).Report.DCPower = 1000.0;
+	EnergyPlus::DataPhotovoltaics::PVarray( 1 ).Zone = Photovoltaics::GetPVZone( EnergyPlus::DataPhotovoltaics::PVarray( 1 ).SurfacePtr );
 	Photovoltaics::ReportPV( 1 );
+	EXPECT_EQ( EnergyPlus::DataPhotovoltaics::PVarray( 1 ).Zone, 1 );
 	EXPECT_NEAR( EnergyPlus::DataPhotovoltaics::PVarray( 1 ).Report.DCPower, 5000.0, 0.1 );
 	
 	// Test 2: Zone 2--PV has multiplier, Zone index not set yet
 	EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Report.DCPower = 1000.0;
+	EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Zone = Photovoltaics::GetPVZone( EnergyPlus::DataPhotovoltaics::PVarray( 2 ).SurfacePtr );
 	Photovoltaics::ReportPV( 2 );
+	EXPECT_EQ( EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Zone, 2 );
 	EXPECT_NEAR( EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Report.DCPower, 10000.0, 0.1 );
-	EXPECT_EQ( DataSurfaces::Surface( 2 ).Zone, 2 );
 	
-	// Test 3: Zone 2--PV has multiplier, Zone index set by previous pass through ReportPV
-	EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Report.DCPower = 500.0;
-	Photovoltaics::ReportPV( 2 );
-	EXPECT_NEAR( EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Report.DCPower, 5000.0, 0.1 );
-
-	// Test 4: Zone 3--PV not attached to any zone, Zone Index does not get reset
+	// Test 3: Zone 3--PV not attached to any zone, Zone Index does not get set
 	EnergyPlus::DataPhotovoltaics::PVarray( 3 ).Report.DCPower = 1000.0;
+	EnergyPlus::DataPhotovoltaics::PVarray( 3 ).Zone = Photovoltaics::GetPVZone( EnergyPlus::DataPhotovoltaics::PVarray( 3 ).SurfacePtr );
 	Photovoltaics::ReportPV( 3 );
+	EXPECT_EQ( EnergyPlus::DataPhotovoltaics::PVarray( 3 ).Zone, 0 );
 	EXPECT_NEAR( EnergyPlus::DataPhotovoltaics::PVarray( 3 ).Report.DCPower, 1000.0, 0.1 );
-	EXPECT_EQ( DataSurfaces::Surface( 3 ).Zone, 0 );
 
 }
 

--- a/tst/EnergyPlus/unit/Photovoltaics.unit.cc
+++ b/tst/EnergyPlus/unit/Photovoltaics.unit.cc
@@ -51,6 +51,9 @@
 
 // EnergyPlus Headers
 #include <Photovoltaics.hh>
+#include <DataPhotovoltaics.hh>
+#include <DataHeatBalance.hh>
+#include <DataSurfaces.hh>
 
 #include "Fixtures/EnergyPlusFixture.hh"
 
@@ -73,3 +76,63 @@ TEST_F( EnergyPlusFixture, PV_Sandia_AirMassAtHighZenith )
 	EXPECT_NEAR( airMass, 26.24135, 0.1 );
 
 }
+
+TEST_F( EnergyPlusFixture, PV_ReportPV_ZoneIndexNonZero )
+{
+	// unit test for issue #6222, test to make sure zone index in surface on which PV is placed is not zero so zone multiplier is applied properly
+	
+	EnergyPlus::DataPhotovoltaics::PVarray.deallocate();
+	DataHeatBalance::Zone.deallocate();
+	DataSurfaces::Surface.deallocate();
+	
+	EnergyPlus::DataPhotovoltaics::PVarray.allocate( 3 );
+	DataHeatBalance::Zone.allocate( 2 );
+	DataSurfaces::Surface.allocate( 3 );
+	
+	DataGlobals::NumOfZones = 2;
+	DataHeatBalance::Zone( 1 ).Name = "Zone1";
+	DataHeatBalance::Zone( 1 ).ListMultiplier = 1.0;
+	DataHeatBalance::Zone( 1 ).Multiplier = 5.0;
+	DataHeatBalance::Zone( 2 ).Name = "Zone2";
+	DataHeatBalance::Zone( 2 ).ListMultiplier = 10.0;
+	DataHeatBalance::Zone( 2 ).Multiplier = 1.0;
+	
+	EnergyPlus::DataPhotovoltaics::NumPVs = 3;
+	EnergyPlus::DataPhotovoltaics::PVarray( 1 ).SurfacePtr = 1;
+	EnergyPlus::DataPhotovoltaics::PVarray( 1 ).CellIntegrationMode = -9999;
+	EnergyPlus::DataPhotovoltaics::PVarray( 2 ).SurfacePtr = 2;
+	EnergyPlus::DataPhotovoltaics::PVarray( 2 ).CellIntegrationMode = -9999;
+	EnergyPlus::DataPhotovoltaics::PVarray( 3 ).SurfacePtr = 3;
+	EnergyPlus::DataPhotovoltaics::PVarray( 3 ).CellIntegrationMode = -9999;
+
+	DataSurfaces::Surface( 1 ).Zone = 1;
+	DataSurfaces::Surface( 1 ).ZoneName = "Zone1";
+	DataSurfaces::Surface( 2 ).Zone = 0;
+	DataSurfaces::Surface( 2 ).ZoneName = "Zone2";
+	DataSurfaces::Surface( 3 ).Zone = 0;
+	DataSurfaces::Surface( 3 ).ZoneName = "None";
+	
+	// Test 1: Zone 1--PV has multiplier, Zone index already set
+	EnergyPlus::DataPhotovoltaics::PVarray( 1 ).Report.DCPower = 1000.0;
+	Photovoltaics::ReportPV( 1 );
+	EXPECT_NEAR( EnergyPlus::DataPhotovoltaics::PVarray( 1 ).Report.DCPower, 5000.0, 0.1 );
+	
+	// Test 2: Zone 2--PV has multiplier, Zone index not set yet
+	EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Report.DCPower = 1000.0;
+	Photovoltaics::ReportPV( 2 );
+	EXPECT_NEAR( EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Report.DCPower, 10000.0, 0.1 );
+	EXPECT_EQ( DataSurfaces::Surface( 2 ).Zone, 2 );
+	
+	// Test 3: Zone 2--PV has multiplier, Zone index set by previous pass through ReportPV
+	EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Report.DCPower = 500.0;
+	Photovoltaics::ReportPV( 2 );
+	EXPECT_NEAR( EnergyPlus::DataPhotovoltaics::PVarray( 2 ).Report.DCPower, 5000.0, 0.1 );
+
+	// Test 4: Zone 3--PV not attached to any zone, Zone Index does not get reset
+	EnergyPlus::DataPhotovoltaics::PVarray( 3 ).Report.DCPower = 1000.0;
+	Photovoltaics::ReportPV( 3 );
+	EXPECT_NEAR( EnergyPlus::DataPhotovoltaics::PVarray( 3 ).Report.DCPower, 1000.0, 0.1 );
+	EXPECT_EQ( DataSurfaces::Surface( 3 ).Zone, 0 );
+
+}
+


### PR DESCRIPTION
Pull request overview
---------------------
This work addresses GitHub Issue #6222 which showed that the zone multiplier was not being applied to the PV arrays.  This fixes the problem so that the zone multiplier is applied properly when PV surfaces are part of a zone.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ x ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ x ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue #6222 

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
