### PR TITLE
Change fatal error to warning message when negative zone volume

### DIFF
--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -9080,8 +9080,11 @@ namespace SurfaceGeometry {
 			}
 
 			if ( Zone( ZoneNum ).Volume <= 0.0 ) {
-				ShowSevereError( "Indicated Zone Volume <= 0.0 for Zone=" + Zone( ZoneNum ).Name );
-				ShowContinueError( "Zone Volume calculated was=" + RoundSigDigits( Zone( ZoneNum ).Volume, 2 ) );
+				ShowWarningError( "Indicated Zone Volume <= 0.0 for Zone=" + Zone( ZoneNum ).Name );
+				ShowContinueError( "The calculated Zone Volume was=" + RoundSigDigits( Zone( ZoneNum ).Volume, 2 ) );
+				ShowContinueError( "The simulation will continue with the Zone Volume set to 10.0 m3. ");
+				ShowContinueError( "...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual zones." );
+				Zone( ZoneNum ).Volume =  10.;
 			}
 
 			if ( ShowZoneSurfaces ) {
@@ -9129,15 +9132,6 @@ namespace SurfaceGeometry {
 			} else if ( countNotFullyEnclosedZones > 1 ) {
 				ShowWarningError( "CalculateZoneVolume: " + RoundSigDigits( countNotFullyEnclosedZones ) + " zones are not fully enclosed. For more details use:  Output:Diagnostics,DisplayExtrawarnings; " );
 			}
-		}
-
-		ErrorFlag = false;
-		for ( ZoneNum = 1; ZoneNum <= NumOfZones; ++ZoneNum ) {
-			if ( Zone( ZoneNum ).Volume <= 0.0 ) ErrorFlag = true;
-		}
-		if ( ErrorFlag ) {
-			ShowSevereError( "All ZONE Volumes must be > 0.0" );
-			ErrorsFound = true;
 		}
 
 	}

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -506,7 +506,7 @@ namespace SurfaceGeometry {
 
 		}
 
-		CalculateZoneVolume( ErrorsFound, ZoneCeilingHeightEntered ); // Calculate Zone Volumes
+		CalculateZoneVolume( ZoneCeilingHeightEntered ); // Calculate Zone Volumes
 
 		// Calculate zone centroid (and min/max x,y,z for zone)
 		for ( ZoneNum = 1; ZoneNum <= NumOfZones; ++ZoneNum ) {
@@ -8867,7 +8867,6 @@ namespace SurfaceGeometry {
 	// Calculates the volume (m3) of a zone using the surfaces as possible.
 	void
 	CalculateZoneVolume(
-		bool & ErrorsFound, // If errors found in input
 		Array1S_bool const CeilingHeightEntered
 	)
 	{
@@ -8911,7 +8910,6 @@ namespace SurfaceGeometry {
 		Real64 SurfCount; // Surface Count
 		int SurfNum; // Loop counter for surfaces
 		int ZoneNum; // Loop counter for Zones
-		bool ErrorFlag;
 		Array1D_int surfacenotused;
 		int notused;
 		int NFaces;

--- a/src/EnergyPlus/SurfaceGeometry.hh
+++ b/src/EnergyPlus/SurfaceGeometry.hh
@@ -346,7 +346,6 @@ namespace SurfaceGeometry {
 
 	void
 	CalculateZoneVolume(
-		bool & ErrorsFound, // If errors found in input
 		Array1S_bool const CeilingHeightEntered
 	);
 

--- a/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
+++ b/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
@@ -2558,7 +2558,6 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_SimpleBox_test )
 	 ShowMessage( "Begin Test: SurfaceGeometryUnitTests, CalculateZoneVolume_SimpleBox_test" );
 	 using DataGlobals::NumOfZones;
 
-	 bool foundError;
 	 Array1D_bool enteredCeilingHeight;
 	 NumOfZones = 1;
 	 enteredCeilingHeight.dimension( NumOfZones, false );
@@ -2623,10 +2622,8 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_SimpleBox_test )
 	 Surface( 6 ).Vertex( 3 ) = Vector( 10., 0., 3. );
 	 Surface( 6 ).Vertex( 4 ) = Vector( 10., 8., 3. );
 
-	 foundError = false;
-	 CalculateZoneVolume( foundError, enteredCeilingHeight );
+	 CalculateZoneVolume( enteredCeilingHeight );
 	 EXPECT_EQ( 240., Zone(1).Volume );
-	 EXPECT_FALSE( foundError );
 
 
  }
@@ -2636,7 +2633,6 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxOneWallMissing_test )
 	ShowMessage( "Begin Test: SurfaceGeometryUnitTests, CalculateZoneVolume_BoxOneWallMissing_test" );
 	using DataGlobals::NumOfZones;
 
-	bool foundError;
 	Array1D_bool enteredCeilingHeight;
 	NumOfZones = 1;
 	enteredCeilingHeight.dimension( NumOfZones, false );
@@ -2692,14 +2688,11 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxOneWallMissing_test )
 	Surface( 5 ).Vertex( 3 ) = Vector( 10., 0., 3. );
 	Surface( 5 ).Vertex( 4 ) = Vector( 10., 8., 3. );
 
-	foundError = false;
-
 	Zone( 1 ).FloorArea = 80.;
 	Zone( 1 ).CeilingHeight = 3.;
 
-	CalculateZoneVolume( foundError, enteredCeilingHeight );
+	CalculateZoneVolume( enteredCeilingHeight );
 	EXPECT_EQ( 240., Zone( 1 ).Volume );
-	EXPECT_FALSE( foundError );
 
 }
 
@@ -2709,7 +2702,6 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoCeiling_test )
 	ShowMessage( "Begin Test: SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoCeiling_test" );
 	using DataGlobals::NumOfZones;
 
-	bool foundError;
 	Array1D_bool enteredCeilingHeight;
 	NumOfZones = 1;
 	enteredCeilingHeight.dimension( NumOfZones, false );
@@ -2765,15 +2757,11 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoCeiling_test )
 	Surface( 5 ).Vertex( 3 ) = Vector( 10., 8, 0. );
 	Surface( 5 ).Vertex( 4 ) = Vector( 10., 0, 0. );
 
-	foundError = false;
-
 	Zone( 1 ).FloorArea = 80.;
 	Zone( 1 ).CeilingHeight =  3.;
 
-	CalculateZoneVolume( foundError, enteredCeilingHeight );
+	CalculateZoneVolume( enteredCeilingHeight );
 	EXPECT_EQ( 240., Zone( 1 ).Volume );
-	EXPECT_FALSE( foundError );
-
 
 }
 
@@ -2782,7 +2770,6 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoFloor_test )
 	ShowMessage( "Begin Test: SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoFloor_test" );
 	using DataGlobals::NumOfZones;
 
-	bool foundError;
 	Array1D_bool enteredCeilingHeight;
 	NumOfZones = 1;
 	enteredCeilingHeight.dimension( NumOfZones, false );
@@ -2838,14 +2825,12 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoFloor_test )
 	Surface( 5 ).Vertex( 3 ) = Vector( 10., 0., 3. );
 	Surface( 5 ).Vertex( 4 ) = Vector( 10., 8., 3. );
 
-	foundError = false;
 
 	Zone( 1 ).CeilingArea = 80.;
 	Zone( 1 ).CeilingHeight = 3.;
 
-	CalculateZoneVolume( foundError, enteredCeilingHeight );
+	CalculateZoneVolume( enteredCeilingHeight );
 	EXPECT_EQ( 240., Zone( 1 ).Volume );
-	EXPECT_FALSE( foundError );
 }
 
 TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoCeilingFloor_test )
@@ -2853,7 +2838,6 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoCeilingFloor_test )
 	ShowMessage( "Begin Test: SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoFloor_test" );
 	using DataGlobals::NumOfZones;
 
-	bool foundError;
 	Array1D_bool enteredCeilingHeight;
 	NumOfZones = 1;
 	enteredCeilingHeight.dimension( NumOfZones, false );
@@ -2907,11 +2891,9 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoCeilingFloor_test )
 	Surface( 4 ).Vertex( 3 ) = Vector( 10., 8., 0. );
 	Surface( 4 ).Vertex( 4 ) = Vector( 10., 8., 3. );
 
-	foundError = false;
 
-	CalculateZoneVolume( foundError, enteredCeilingHeight );
+	CalculateZoneVolume( enteredCeilingHeight );
 	EXPECT_EQ( 240., Zone( 1 ).Volume );
-	EXPECT_FALSE( foundError );
 }
 
 TEST( SurfaceGeometryUnitTests, MakeRectangularVertices )

--- a/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
+++ b/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
@@ -2914,4 +2914,115 @@ TEST( SurfaceGeometryUnitTests, CalculateZoneVolume_BoxNoCeilingFloor_test )
 	EXPECT_FALSE( foundError );
 }
 
+TEST( SurfaceGeometryUnitTests, MakeRectangularVertices )
+{
+	int surfNum = 1;
+	int zoneNum = 1;
+	SurfaceTmp.allocate( surfNum );
+	SurfaceTmp( surfNum ).Class = SurfaceClass_Wall;
+	SurfaceTmp( surfNum ).Zone = zoneNum;
+	SurfaceTmp( surfNum ).Azimuth = 0.; 
+	SurfaceTmp( surfNum ).Tilt = 90.;
+	SurfaceTmp( surfNum ).Sides = 4;
+	SurfaceTmp( surfNum ).Vertex.allocate( 4 );
+
+	Zone.allocate( zoneNum );
+	Zone( zoneNum ).RelNorth = 0.;
+
+	CosZoneRelNorth.allocate( zoneNum );
+	SinZoneRelNorth.allocate( zoneNum );
+	CosZoneRelNorth( zoneNum ) = std::cos( -Zone( zoneNum ).RelNorth * DataGlobals::DegToRadians );
+	SinZoneRelNorth( zoneNum ) = std::sin( -Zone( zoneNum ).RelNorth * DataGlobals::DegToRadians );
+
+	CosBldgRelNorth = 1.0;
+	SinBldgRelNorth = 0.0;
+
+	// facing north
+
+	MakeRectangularVertices( 1, 0., 0., 0., 5., 3.,false);
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 1 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 1 ).y, 0.001 );
+	EXPECT_NEAR( 3., SurfaceTmp( surfNum ).Vertex( 1 ).z, 0.001 );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).y, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).z, 0.001 );
+
+	EXPECT_NEAR( -5., SurfaceTmp( surfNum ).Vertex( 3 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 3 ).y, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 3 ).z, 0.001 );
+
+	EXPECT_NEAR( -5., SurfaceTmp( surfNum ).Vertex( 4 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 4 ).y, 0.001 );
+	EXPECT_NEAR( 3., SurfaceTmp( surfNum ).Vertex( 4 ).z, 0.001 );
+
+	// facing east
+
+	SurfaceTmp( surfNum ).Azimuth = 90.;
+
+	MakeRectangularVertices( 1, 0., 0., 0., 5., 3., false );
+
+	EXPECT_NEAR( 0, SurfaceTmp( surfNum ).Vertex( 1 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 1 ).y, 0.001 );
+	EXPECT_NEAR( 3., SurfaceTmp( surfNum ).Vertex( 1 ).z, 0.001 );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).y, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).z, 0.001 );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 3 ).x, 0.001 );
+	EXPECT_NEAR( 5., SurfaceTmp( surfNum ).Vertex( 3 ).y, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 3 ).z, 0.001 );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 4 ).x, 0.001 );
+	EXPECT_NEAR( 5., SurfaceTmp( surfNum ).Vertex( 4 ).y, 0.001 );
+	EXPECT_NEAR( 3., SurfaceTmp( surfNum ).Vertex( 4 ).z, 0.001 );
+
+	// facing south
+
+	SurfaceTmp( surfNum ).Azimuth = 180.;
+
+	MakeRectangularVertices( 1, 0., 0., 0., 5., 3., false );
+
+	EXPECT_NEAR( 0, SurfaceTmp( surfNum ).Vertex( 1 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 1 ).y, 0.001 );
+	EXPECT_NEAR( 3., SurfaceTmp( surfNum ).Vertex( 1 ).z, 0.001 );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).y, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).z, 0.001 );
+
+	EXPECT_NEAR( 5., SurfaceTmp( surfNum ).Vertex( 3 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 3 ).y, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 3 ).z, 0.001 );
+
+	EXPECT_NEAR( 5., SurfaceTmp( surfNum ).Vertex( 4 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 4 ).y, 0.001 );
+	EXPECT_NEAR( 3., SurfaceTmp( surfNum ).Vertex( 4 ).z, 0.001 );
+
+	// facing west
+
+	SurfaceTmp( surfNum ).Azimuth = 270.;
+
+	MakeRectangularVertices( 1, 0., 0., 0., 5., 3., false );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 1 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 1 ).y, 0.001 );
+	EXPECT_NEAR( 3., SurfaceTmp( surfNum ).Vertex( 1 ).z, 0.001 );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).x, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).y, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 2 ).z, 0.001 );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 3 ).x, 0.001 );
+	EXPECT_NEAR( -5., SurfaceTmp( surfNum ).Vertex( 3 ).y, 0.001 );
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 3 ).z, 0.001 );
+
+	EXPECT_NEAR( 0., SurfaceTmp( surfNum ).Vertex( 4 ).x, 0.001 );
+	EXPECT_NEAR( -5., SurfaceTmp( surfNum ).Vertex( 4 ).y, 0.001 );
+	EXPECT_NEAR( 3., SurfaceTmp( surfNum ).Vertex( 4 ).z, 0.001 );
+
+
+}
 


### PR DESCRIPTION
Previously a severe error and fatal error were thrown if a negative zone volume was reported. It is difficult to get a negative zone volume due to existing checks and when it occurs, something is seriously wrong with the geometry of the surfaces making up the zone. Now a warning message is issued with directions on how to get additional information and the zone volume is set to 10m3.

Note: in order to reproduce this error, I needed to temporarily change the code on lines 486 and 505 of SurfaceGeometry and then modify a zone to have a negative ceiling height and a positive floor area.

Addresses #6266 

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
