### PR TITLE
Add warning when resource in LifeCycleCost:UsePriceEscalation has no cost

### DIFF
--- a/src/EnergyPlus/EconomicLifeCycleCost.cc
+++ b/src/EnergyPlus/EconomicLifeCycleCost.cc
@@ -900,7 +900,6 @@ namespace EconomicLifeCycleCost {
 		// na
 
 		// USE STATEMENTS:
-		// na
 
 		// Locals
 		// SUBROUTINE ARGUMENT DEFINITIONS:
@@ -1459,6 +1458,14 @@ namespace EconomicLifeCycleCost {
 					}
 				}
 				CashFlow( jCost ).yrAmount( kYear ) = annualCost;
+			}
+		}
+		// generate a warning if resource referenced was not used
+		for ( int nUsePriceEsc = 1; nUsePriceEsc <= numUsePriceEscalation; ++nUsePriceEsc ) {
+			int curResource = UsePriceEscalation( nUsePriceEsc ).resource - ResourceTypeInitialOffset;
+			if ( !resourceCostNotZero( curResource ) ) {
+				ShowWarningError( "The resource referenced by LifeCycleCost:UsePriceEscalation= \"" + UsePriceEscalation( nUsePriceEsc ).name + "\" has no energy cost. " );
+				ShowContinueError( "... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff." );
 			}
 		}
 	}

--- a/src/EnergyPlus/EconomicLifeCycleCost.cc
+++ b/src/EnergyPlus/EconomicLifeCycleCost.cc
@@ -1463,7 +1463,7 @@ namespace EconomicLifeCycleCost {
 		// generate a warning if resource referenced was not used
 		for ( int nUsePriceEsc = 1; nUsePriceEsc <= numUsePriceEscalation; ++nUsePriceEsc ) {
 			int curResource = UsePriceEscalation( nUsePriceEsc ).resource - ResourceTypeInitialOffset;
-			if ( !resourceCostNotZero( curResource ) ) {
+			if ( !resourceCostNotZero( curResource ) && DataGlobals::DoWeathSim ) {
 				ShowWarningError( "The resource referenced by LifeCycleCost:UsePriceEscalation= \"" + UsePriceEscalation( nUsePriceEsc ).name + "\" has no energy cost. " );
 				ShowContinueError( "... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff." );
 			}


### PR DESCRIPTION
Addresses part of #6144 related to adding the warning message.

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
