### PR TITLE
Fix basement zone z-origin in RefBldgLargeOffice* files

### DIFF
--- a/testfiles/RefBldgLargeOfficeNew2004_Chicago-ReturnReset.idf
+++ b/testfiles/RefBldgLargeOfficeNew2004_Chicago-ReturnReset.idf
@@ -609,7 +609,7 @@
     0.0000,                  !- Direction of Relative North {deg}
     0.0000,                  !- X Origin {m}
     0.0400,                  !- Y Origin {m}
-    0.2000,                  !- Z Origin {m}
+    0.0000,                  !- Z Origin {m}
     1,                       !- Type
     1,                       !- Multiplier
     ,                        !- Ceiling Height {m}

--- a/testfiles/RefBldgLargeOfficeNew2004_Chicago.idf
+++ b/testfiles/RefBldgLargeOfficeNew2004_Chicago.idf
@@ -608,7 +608,7 @@
     0.0000,                  !- Direction of Relative North {deg}
     0.0000,                  !- X Origin {m}
     0.0400,                  !- Y Origin {m}
-    0.2000,                  !- Z Origin {m}
+    0.0000,                  !- Z Origin {m}
     1,                       !- Type
     1,                       !- Multiplier
     ,                        !- Ceiling Height {m}


### PR DESCRIPTION
Pull request overview
---------------------
In helpdesk ticket #12285, user notes:

> The large Office Reference Building Model has a basement zone with a Z origin of 0.2 m. The ceiling surface has Z coordinates of 0 which places that surface at 0.2m. However the ground floor's floor surface is at 0.0m. Thus these two zones and their surfaces do overlap by 0.2m in Z direction. 

This is addressed here by changing the basement zone z origin to 0.0.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
