### PR TITLE
What if we add lcov ignore to fatal calls?

### DIFF
--- a/src/EnergyPlus/AirflowNetworkBalanceManager.cc
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.cc
@@ -814,7 +814,7 @@ namespace AirflowNetworkBalanceManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 
 		// *** Read AirflowNetwork simulation parameters
@@ -827,7 +827,7 @@ namespace AirflowNetworkBalanceManager {
 			return;
 		}
 		if ( NumAirflowNetwork > 1 ) {
-			ShowFatalError( RoutineName + "Only one (\"1\") " + CurrentModuleObject + " object per simulation is allowed." );
+			ShowFatalError( RoutineName + "Only one (\"1\") " + CurrentModuleObject + " object per simulation is allowed." );  // LCOV_EXCL_LINE
 		}
 
 		SimObjectError = false;
@@ -872,7 +872,7 @@ namespace AirflowNetworkBalanceManager {
 				} else {
 					ShowSevereError( RoutineName + "More AirLoopHVACs are found. Currently only one (\"1\") AirLoopHVAC object per simulation is allowed when using AirflowNetwork Distribution Systems" );
 				}
-				ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );
+				ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -1006,7 +1006,7 @@ namespace AirflowNetworkBalanceManager {
 		}
 
 		if ( SimObjectError ) {
-			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 
 		AirflowNetworkSimu.MaxIteration = Numbers( 1 );
@@ -1084,7 +1084,7 @@ namespace AirflowNetworkBalanceManager {
 			}
 		} else {
 			ShowSevereError( RoutineName + "For an AirflowNetwork Simulation, at least one " + CurrentModuleObject + " object is required but none were found." );
-			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 
 		// ==> Zone data validation
@@ -1185,7 +1185,7 @@ namespace AirflowNetworkBalanceManager {
 					}
 				}
 				if ( MultizoneZoneData( i ).ASH55PeopleInd == 0 ) {
-					ShowFatalError( "ASHRAE55 ventilation control for zone " + MultizoneZoneData( i ).ZoneName + " requires a people object with respective model calculations." );
+					ShowFatalError( "ASHRAE55 ventilation control for zone " + MultizoneZoneData( i ).ZoneName + " requires a people object with respective model calculations." );  // LCOV_EXCL_LINE
 				}
 			} else if ( SELECT_CASE_var == "CEN15251ADAPTIVE" ) {
 				// Check that for the given zone, there is a people object for which CEN-15251 calculations are carried out
@@ -1197,7 +1197,7 @@ namespace AirflowNetworkBalanceManager {
 					}
 				}
 				if ( MultizoneZoneData( i ).CEN15251PeopleInd == 0 ) {
-					ShowFatalError( "CEN15251 ventilation control for zone " + MultizoneZoneData( i ).ZoneName + " requires a people object with respective model calculations." );
+					ShowFatalError( "CEN15251 ventilation control for zone " + MultizoneZoneData( i ).ZoneName + " requires a people object with respective model calculations." );  // LCOV_EXCL_LINE
 				}
 			} else {
 			}}
@@ -1423,7 +1423,7 @@ namespace AirflowNetworkBalanceManager {
 			} else {
 				ShowSevereError( RoutineName + CurrentModuleObject + " object, " + cAlphaFields( 1 ) + " = " + MultizoneSurfaceData( i ).SurfName );
 				ShowContinueError( "..Zone for inside surface must be defined in a AirflowNetwork:MultiZone:Zone object.  Could not find Zone = " + Zone( Surface( MultizoneSurfaceData( i ).SurfNum ).Zone ).Name );
-				ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );
+				ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 			}
 
 			// Calculate equivalent width and height
@@ -2271,7 +2271,7 @@ namespace AirflowNetworkBalanceManager {
 			}
 		}
 
-		if ( ErrorsFound ) ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );
+		if ( ErrorsFound ) ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 
 		// Write wind pressure coefficients in the EIO file
 		gio::write( OutputFileInits, fmtA ) << "! <AirflowNetwork Model:Wind Direction>, Wind Direction #1 to n (degree)";
@@ -2327,15 +2327,15 @@ namespace AirflowNetworkBalanceManager {
 
 		// If no zone object, exit
 		if ( AirflowNetworkNumOfZones == 0 ) {
-			ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 		// If zone node number =0, exit.
 		for ( j = 1; j <= AirflowNetworkNumOfSurfaces; ++j ) {
 			if ( MultizoneSurfaceData( j ).NodeNums( 1 ) == 0 && ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );
+				ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 			}
 			if ( MultizoneSurfaceData( j ).NodeNums( 2 ) == 0 && ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );
+				ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -2472,7 +2472,7 @@ namespace AirflowNetworkBalanceManager {
 			if ( !SameString( SimAirNetworkKey, "MultizoneWithoutDistribution" ) ) {
 				ShowSevereError( RoutineName + CurrentModuleObject + " model requires Simulation Control = MultizoneWithoutDistribution, while the input choice is " + SimAirNetworkKey + "." );
 				ErrorsFound = true;
-				ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object." " Previous error(s) cause program termination." );
+				ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object." " Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -2856,7 +2856,7 @@ namespace AirflowNetworkBalanceManager {
 					this_VF_object.LinkageSurfaceData( surfNum ).SurfaceNum = FindItemInList( Alphas( surfNum + 1 ), Surface );
 
 					if ( this_VF_object.LinkageSurfaceData( surfNum ).SurfaceNum == 0 ) {
-						ShowFatalError( "Surface " + Alphas( surfNum + 1 ) + " not found. See: " + CurrentModuleObject + " " + this_VF_object.LinkageName );
+						ShowFatalError( "Surface " + Alphas( surfNum + 1 ) + " not found. See: " + CurrentModuleObject + " " + this_VF_object.LinkageName );  // LCOV_EXCL_LINE
 					}
 
 					// Surface view factor
@@ -3057,7 +3057,7 @@ namespace AirflowNetworkBalanceManager {
 		NumOfOAFans = GetNumObjectsFound( CurrentModuleObject );
 		if ( NumOfOAFans > 1 ) {
 			ShowSevereError( RoutineName + "More " + CurrentModuleObject + " are found. Currently only one( \"1\") " + CurrentModuleObject + " object per simulation is allowed when using AirflowNetwork Distribution Systems." );
-			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 		if ( NumOfOAFans > 0 ) {
 			DisSysCompOutdoorAirData.allocate( NumOfOAFans );
@@ -3103,7 +3103,7 @@ namespace AirflowNetworkBalanceManager {
 		NumOfReliefFans = GetNumObjectsFound( CurrentModuleObject );
 		if ( NumOfReliefFans > 1 ) {
 			ShowSevereError( RoutineName + "More " + CurrentModuleObject + " are found. Currently only one( \"1\") " + CurrentModuleObject + " object per simulation is allowed when using AirflowNetwork Distribution Systems." );
-			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 		if ( NumOfReliefFans > 0 ) {
 			DisSysCompReliefAirData.allocate( NumOfReliefFans );
@@ -3149,7 +3149,7 @@ namespace AirflowNetworkBalanceManager {
 		NumOfPressureControllers = GetNumObjectsFound( CurrentModuleObject );
 		if ( NumOfPressureControllers > 1 ) {
 			ShowSevereError( RoutineName + "More " + CurrentModuleObject + " are found. Currently only one( \"1\") " + CurrentModuleObject + " object per simulation is allowed when using AirflowNetwork Distribution Systems." );
-			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting " + CurrentModuleObject + " object. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( NumOfPressureControllers > 0 ) {
@@ -4072,7 +4072,7 @@ namespace AirflowNetworkBalanceManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 
 		Alphas.deallocate();
@@ -4568,7 +4568,7 @@ namespace AirflowNetworkBalanceManager {
 		if ( OneTimeFlag ) {
 			OneTimeFlag = false;
 			if ( ErrorsFound ) {
-				ShowFatalError( "GetAirflowNetworkInput: Program terminates for preceding reason(s)." );
+				ShowFatalError( "GetAirflowNetworkInput: Program terminates for preceding reason(s)." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -4742,7 +4742,7 @@ namespace AirflowNetworkBalanceManager {
 							}
 						}
 					} else if ( SolFla == -2 ) {
-						ShowFatalError( "Zone pressure control failed using an exhaust fan: no solution is reached, for " + PressureControllerData( 1 ).Name );
+						ShowFatalError( "Zone pressure control failed using an exhaust fan: no solution is reached, for " + PressureControllerData( 1 ).Name );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -4802,7 +4802,7 @@ namespace AirflowNetworkBalanceManager {
 							}
 						}
 					} else if ( SolFla == -2 ) {
-						ShowFatalError( "Zone pressure control failed using relief air: no solution is reached, for " + PressureControllerData( 1 ).Name );
+						ShowFatalError( "Zone pressure control failed using relief air: no solution is reached, for " + PressureControllerData( 1 ).Name );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -5088,7 +5088,7 @@ namespace AirflowNetworkBalanceManager {
 
 		if ( AirflowNetworkNumOfSingleSideZones == 0 ) { //do the standard surface average coefficient calculation
 			// Create the array of wind directions
-			
+
 
 			// Create a curve for each facade
 			for ( FacadeNum = 1; FacadeNum <= 5; ++FacadeNum ) {
@@ -5156,7 +5156,7 @@ namespace AirflowNetworkBalanceManager {
 
 			// Calculate the wind pressure coefficients vs. wind direction for each external node
 			// The wind pressure coeffients are stored temporarily in the "valsByFacade" vector and then
-			// converted into a table near the end of this else. There will be at least seven profiles 
+			// converted into a table near the end of this else. There will be at least seven profiles
 			// (four sides plus one roof plus two for each pair of windows). The name is thus a little
 			// misleading, as it isn't really the values by facade once you get beyond the first five.
 			std::vector< std::vector< Real64 > > valsByFacade( 5 );
@@ -5619,7 +5619,7 @@ namespace AirflowNetworkBalanceManager {
 					ShowContinueErrorTimeStamp( "" );
 					ShowContinueError( "The sum of the airflows entering the zone is greater than the airflows leaving the zone (e.g., wind and stack effect)." );
 					ShowContinueError( "Please check wind speed or reduce values of \"Window/Door Opening Factor, or Crack Factor\" defined in AirflowNetwork:MultiZone:Surface objects." );
-					ShowFatalError( "AirflowNetwork: The previous error causes termination." );
+					ShowFatalError( "AirflowNetwork: The previous error causes termination." );  // LCOV_EXCL_LINE
 				}
 
 				if ( AirflowNetworkLinkageData( i ).ZoneNum < 0 ) {
@@ -5848,7 +5848,7 @@ namespace AirflowNetworkBalanceManager {
 					NT = AirflowNetworkNodeData( AirflowNetworkLinkageData( i ).NodeNums( 2 ) ).EPlusNodeNum;
 				}
 				if ( ( NF == 0 ) || ( NT == 0 ) ) {
-					ShowFatalError( "Node number in the primary air loop is not found in AIRFLOWNETWORK:DISTRIBUTION:NODE = " + AirflowNetworkLinkageData( i ).Name );
+					ShowFatalError( "Node number in the primary air loop is not found in AIRFLOWNETWORK:DISTRIBUTION:NODE = " + AirflowNetworkLinkageData( i ).Name );  // LCOV_EXCL_LINE
 				}
 				if ( AirflowNetworkLinkSimu( i ).FLOW > 0.0 ) {
 					LF = AirflowNetworkLinkageData( i ).NodeNums( 1 );
@@ -5928,7 +5928,7 @@ namespace AirflowNetworkBalanceManager {
 		// Check singularity
 		for ( i = 1; i <= AirflowNetworkNumOfNodes; ++i ) {
 			if ( MA( ( i - 1 ) * AirflowNetworkNumOfNodes + i ) < 1.0e-6 ) {
-				ShowFatalError( "CalcAirflowNetworkHeatBalance: A diagonal entity is zero in AirflowNetwork matrix at node " + AirflowNetworkNodeData( i ).Name );
+				ShowFatalError( "CalcAirflowNetworkHeatBalance: A diagonal entity is zero in AirflowNetwork matrix at node " + AirflowNetworkNodeData( i ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -6118,7 +6118,7 @@ namespace AirflowNetworkBalanceManager {
 					NT = AirflowNetworkNodeData( AirflowNetworkLinkageData( i ).NodeNums( 2 ) ).EPlusNodeNum;
 				}
 				if ( ( NF == 0 ) || ( NT == 0 ) ) {
-					ShowFatalError( "Node number in the primary air loop is not found in AIRFLOWNETWORK:DISTRIBUTION:NODE = " + AirflowNetworkLinkageData( i ).Name );
+					ShowFatalError( "Node number in the primary air loop is not found in AIRFLOWNETWORK:DISTRIBUTION:NODE = " + AirflowNetworkLinkageData( i ).Name );  // LCOV_EXCL_LINE
 				}
 				if ( AirflowNetworkLinkSimu( i ).FLOW > 0.0 ) {
 					LF = AirflowNetworkLinkageData( i ).NodeNums( 1 );
@@ -6196,7 +6196,7 @@ namespace AirflowNetworkBalanceManager {
 		// Check singularity
 		for ( i = 1; i <= AirflowNetworkNumOfNodes; ++i ) {
 			if ( MA( ( i - 1 ) * AirflowNetworkNumOfNodes + i ) < 1.0e-6 ) {
-				ShowFatalError( "CalcAirflowNetworkMoisBalance: A diagonal entity is zero in AirflowNetwork matrix at node " + AirflowNetworkNodeData( i ).Name );
+				ShowFatalError( "CalcAirflowNetworkMoisBalance: A diagonal entity is zero in AirflowNetwork matrix at node " + AirflowNetworkNodeData( i ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -6409,7 +6409,7 @@ namespace AirflowNetworkBalanceManager {
 		// Check singularity
 		for ( i = 1; i <= AirflowNetworkNumOfNodes; ++i ) {
 			if ( MA( ( i - 1 ) * AirflowNetworkNumOfNodes + i ) < 1.0e-6 ) {
-				ShowFatalError( "CalcAirflowNetworkCO2Balance: A diagonal entity is zero in AirflowNetwork matrix at node " + AirflowNetworkNodeData( i ).Name );
+				ShowFatalError( "CalcAirflowNetworkCO2Balance: A diagonal entity is zero in AirflowNetwork matrix at node " + AirflowNetworkNodeData( i ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -6622,7 +6622,7 @@ namespace AirflowNetworkBalanceManager {
 		// Check singularity
 		for ( i = 1; i <= AirflowNetworkNumOfNodes; ++i ) {
 			if ( MA( ( i - 1 ) * AirflowNetworkNumOfNodes + i ) < 1.0e-6 ) {
-				ShowFatalError( "CalcAirflowNetworkGCBalance: A diagonal entity is zero in AirflowNetwork matrix at node " + AirflowNetworkNodeData( i ).Name );
+				ShowFatalError( "CalcAirflowNetworkGCBalance: A diagonal entity is zero in AirflowNetwork matrix at node " + AirflowNetworkNodeData( i ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -8388,7 +8388,7 @@ namespace AirflowNetworkBalanceManager {
 
 			OneTimeFlag = false;
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Program terminates for preceding reason(s)." );
+				ShowFatalError( RoutineName + "Program terminates for preceding reason(s)." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -8540,7 +8540,7 @@ namespace AirflowNetworkBalanceManager {
 
 			OneTimeFlag = false;
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Program terminates for preceding reason(s)." );
+				ShowFatalError( RoutineName + "Program terminates for preceding reason(s)." );  // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/EnergyPlus/AirflowNetworkSolver.cc
+++ b/src/EnergyPlus/AirflowNetworkSolver.cc
@@ -825,7 +825,7 @@ namespace AirflowNetworkSolver {
 			ShowWarningError( "AirflowNetwork: SOLVER, Changing values for initialization flag, Relative airflow convergence, Absolute airflow convergence, Convergence acceleration limit or Maximum Iteration Number may solve the problem." );
 			ShowContinueErrorTimeStamp( "" );
 			ShowContinueError( "..Iterations=" + RoundSigDigits( ITER ) + ", Max allowed=" + RoundSigDigits( AirflowNetworkSimu.MaxIteration ) );
-			ShowFatalError( "AirflowNetwork: SOLVER, The previous error causes termination." );
+			ShowFatalError( "AirflowNetwork: SOLVER, The previous error causes termination." );  // LCOV_EXCL_LINE
 		} else {
 			ShowRecurringWarningErrorAtEnd( "AirFlowNetwork: Too many iterations (SOLVZP) in AirflowNetwork simulation continues.", AirflowNetworkSimu.ExtLargeOpeningErrIndex );
 		}
@@ -1928,7 +1928,7 @@ namespace AirflowNetworkSolver {
 			k = 5 * ( j - 1 ) + 1;
 			BX = DisSysCompDetFanData( CompNum ).Coeff( k );
 			BY = DisSysCompDetFanData( CompNum ).Coeff( k + 1 ) + BX * ( DisSysCompDetFanData( CompNum ).Coeff( k + 2 ) + BX * ( DisSysCompDetFanData( CompNum ).Coeff( k + 3 ) + BX * DisSysCompDetFanData( CompNum ).Coeff( k + 4 ) ) ) - PRISE;
-			if ( BY < 0.0 ) ShowFatalError( "Out of range, too low in an AirflowNetwork detailed Fan" );
+			if ( BY < 0.0 ) ShowFatalError( "Out of range, too low in an AirflowNetwork detailed Fan" );  // LCOV_EXCL_LINE
 
 			while ( true ) {
 				DX = DisSysCompDetFanData( CompNum ).Coeff( k + 5 );
@@ -1936,7 +1936,7 @@ namespace AirflowNetworkSolver {
 				if ( LIST >= 4 ) gio::write( Unit21, Format_901 ) << " fp0:" << j << BX << BY << DX << DY;
 				if ( BY * DY <= 0.0 ) break;
 				++j;
-				if ( j > NumCur ) ShowFatalError( "Out of range, too high (FAN) in ADS simulation" );
+				if ( j > NumCur ) ShowFatalError( "Out of range, too high (FAN) in ADS simulation" );  // LCOV_EXCL_LINE
 				k += 5;
 				BX = DX;
 				BY = DY;
@@ -1946,7 +1946,7 @@ namespace AirflowNetworkSolver {
 			CY = 0.0;
 Label40: ;
 			++L;
-			if ( L > 100 ) ShowFatalError( "Too many iterations (FAN) in AirflowNtework simulation" );
+			if ( L > 100 ) ShowFatalError( "Too many iterations (FAN) in AirflowNtework simulation" );  // LCOV_EXCL_LINE
 			CCY = CY;
 			CX = BX - BY * ( ( DX - BX ) / ( DY - BY ) );
 			CY = DisSysCompDetFanData( CompNum ).Coeff( k + 1 ) + CX * ( DisSysCompDetFanData( CompNum ).Coeff( k + 2 ) + CX * ( DisSysCompDetFanData( CompNum ).Coeff( k + 3 ) + CX * DisSysCompDetFanData( CompNum ).Coeff( k + 4 ) ) ) - PRISE;
@@ -3835,7 +3835,7 @@ Label90: ;
 				ShowContinueError( "(e.g., AirflowNetwork:Multizone:SurfaceCrack, AirflowNetwork:Multizone:Component:SimpleOpening, etc.), to an external" );
 				ShowContinueError( "node (AirflowNetwork:MultiZone:Surface)." );
 				ShowContinueError( "Please send your input file and weather file to EnergyPlus support/development team for further investigation." );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 			AD( k ) = 1.0 / ( AD( k ) - SUMD );
 			JHK = JHK1;
@@ -4285,7 +4285,7 @@ Label90: ;
 				HFact = MultizoneCompDetOpeningData( CompNum ).HeightFac1 + ( Fact - MultizoneCompDetOpeningData( CompNum ).OpenFac1 ) / ( MultizoneCompDetOpeningData( CompNum ).OpenFac2 - MultizoneCompDetOpeningData( CompNum ).OpenFac1 ) * ( MultizoneCompDetOpeningData( CompNum ).HeightFac2 - MultizoneCompDetOpeningData( CompNum ).HeightFac1 );
 				Cfact = MultizoneCompDetOpeningData( CompNum ).DischCoeff1 + ( Fact - MultizoneCompDetOpeningData( CompNum ).OpenFac1 ) / ( MultizoneCompDetOpeningData( CompNum ).OpenFac2 - MultizoneCompDetOpeningData( CompNum ).OpenFac1 ) * ( MultizoneCompDetOpeningData( CompNum ).DischCoeff2 - MultizoneCompDetOpeningData( CompNum ).DischCoeff1 );
 			} else {
-				ShowFatalError( "Open Factor is above the maximum input range for opening factors in AirflowNetwork:MultiZone:Component:DetailedOpening = " + MultizoneCompDetOpeningData( CompNum ).Name );
+				ShowFatalError( "Open Factor is above the maximum input range for opening factors in AirflowNetwork:MultiZone:Component:DetailedOpening = " + MultizoneCompDetOpeningData( CompNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -4299,7 +4299,7 @@ Label90: ;
 				HFact = MultizoneCompDetOpeningData( CompNum ).HeightFac2 + ( Fact - MultizoneCompDetOpeningData( CompNum ).OpenFac2 ) / ( MultizoneCompDetOpeningData( CompNum ).OpenFac3 - MultizoneCompDetOpeningData( CompNum ).OpenFac2 ) * ( MultizoneCompDetOpeningData( CompNum ).HeightFac3 - MultizoneCompDetOpeningData( CompNum ).HeightFac2 );
 				Cfact = MultizoneCompDetOpeningData( CompNum ).DischCoeff2 + ( Fact - MultizoneCompDetOpeningData( CompNum ).OpenFac2 ) / ( MultizoneCompDetOpeningData( CompNum ).OpenFac3 - MultizoneCompDetOpeningData( CompNum ).OpenFac2 ) * ( MultizoneCompDetOpeningData( CompNum ).DischCoeff3 - MultizoneCompDetOpeningData( CompNum ).DischCoeff2 );
 			} else {
-				ShowFatalError( "Open Factor is above the maximum input range for opening factors in AirflowNetwork:MultiZone:Component:DetailedOpening = " + MultizoneCompDetOpeningData( CompNum ).Name );
+				ShowFatalError( "Open Factor is above the maximum input range for opening factors in AirflowNetwork:MultiZone:Component:DetailedOpening = " + MultizoneCompDetOpeningData( CompNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -4317,7 +4317,7 @@ Label90: ;
 				HFact = MultizoneCompDetOpeningData( CompNum ).HeightFac3 + ( Fact - MultizoneCompDetOpeningData( CompNum ).OpenFac3 ) / ( MultizoneCompDetOpeningData( CompNum ).OpenFac4 - MultizoneCompDetOpeningData( CompNum ).OpenFac3 ) * ( MultizoneCompDetOpeningData( CompNum ).HeightFac4 - MultizoneCompDetOpeningData( CompNum ).HeightFac3 );
 				Cfact = MultizoneCompDetOpeningData( CompNum ).DischCoeff3 + ( Fact - MultizoneCompDetOpeningData( CompNum ).OpenFac3 ) / ( MultizoneCompDetOpeningData( CompNum ).OpenFac4 - MultizoneCompDetOpeningData( CompNum ).OpenFac3 ) * ( MultizoneCompDetOpeningData( CompNum ).DischCoeff4 - MultizoneCompDetOpeningData( CompNum ).DischCoeff3 );
 			} else {
-				ShowFatalError( "Open Factor is above the maximum input range for opening factors in AirflowNetwork:MultiZone:Component:DetailedOpening = " + MultizoneCompDetOpeningData( CompNum ).Name );
+				ShowFatalError( "Open Factor is above the maximum input range for opening factors in AirflowNetwork:MultiZone:Component:DetailedOpening = " + MultizoneCompDetOpeningData( CompNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/EnergyPlus/BaseboardElectric.cc
+++ b/src/EnergyPlus/BaseboardElectric.cc
@@ -181,17 +181,17 @@ namespace BaseboardElectric {
 		if ( CompIndex == 0 ) {
 			BaseboardNum = FindItemInList( EquipName, Baseboard, &BaseboardParams::EquipName );
 			if ( BaseboardNum == 0 ) {
-				ShowFatalError( "SimElectricBaseboard: Unit not found=" + EquipName );
+				ShowFatalError( "SimElectricBaseboard: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BaseboardNum;
 		} else {
 			BaseboardNum = CompIndex;
 			if ( BaseboardNum > NumBaseboards || BaseboardNum < 1 ) {
-				ShowFatalError( "SimElectricBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumBaseboards ) + ", Entered Unit name=" + EquipName );
+				ShowFatalError( "SimElectricBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumBaseboards ) + ", Entered Unit name=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( BaseboardNum ) ) {
 				if ( EquipName != Baseboard( BaseboardNum ).EquipName ) {
-					ShowFatalError( "SimElectricBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + Baseboard( BaseboardNum ).EquipName );
+					ShowFatalError( "SimElectricBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + Baseboard( BaseboardNum ).EquipName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( BaseboardNum ) = false;
 			}
@@ -395,7 +395,7 @@ namespace BaseboardElectric {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found in getting input.  Preceding condition(s) cause termination." );
+				ShowFatalError( RoutineName + "Errors found in getting input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/EnergyPlus/BaseboardRadiator.cc
+++ b/src/EnergyPlus/BaseboardRadiator.cc
@@ -203,17 +203,17 @@ namespace BaseboardRadiator {
 		if ( CompIndex == 0 ) {
 			BaseboardNum = FindItemInList( EquipName, Baseboard, &BaseboardParams::EquipID );
 			if ( BaseboardNum == 0 ) {
-				ShowFatalError( "SimBaseboard: Unit not found=" + EquipName );
+				ShowFatalError( "SimBaseboard: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BaseboardNum;
 		} else {
 			BaseboardNum = CompIndex;
 			if ( BaseboardNum > NumBaseboards || BaseboardNum < 1 ) {
-				ShowFatalError( "SimBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumBaseboards ) + ", Entered Unit name=" + EquipName );
+				ShowFatalError( "SimBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumBaseboards ) + ", Entered Unit name=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( BaseboardNum ) ) {
 				if ( EquipName != Baseboard( BaseboardNum ).EquipID ) {
-					ShowFatalError( "SimBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + Baseboard( BaseboardNum ).EquipID );
+					ShowFatalError( "SimBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + Baseboard( BaseboardNum ).EquipID );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( BaseboardNum ) = false;
 			}
@@ -443,7 +443,7 @@ namespace BaseboardRadiator {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found in getting input.  Preceding condition(s) cause termination." );
+				ShowFatalError( RoutineName + "Errors found in getting input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -543,7 +543,7 @@ namespace BaseboardRadiator {
 			errFlag = false;
 			ScanPlantLoopsForObject( Baseboard( BaseboardNum ).EquipID, Baseboard( BaseboardNum ).EquipType, Baseboard( BaseboardNum ).LoopNum, Baseboard( BaseboardNum ).LoopSideNum, Baseboard( BaseboardNum ).BranchNum, Baseboard( BaseboardNum ).CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitBaseboard: Program terminated for previous conditions." );
+				ShowFatalError( "InitBaseboard: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 			}
 			SetLoopIndexFlag( BaseboardNum ) = false;
 		}
@@ -678,7 +678,7 @@ namespace BaseboardRadiator {
 		if ( PltSizHeatNum > 0 ) {
 
 			DataScalableCapSizingON = false;
-			
+
 			if ( CurZoneEqNum > 0 ) {
 
 				if ( Baseboard( BaseboardNum ).WaterVolFlowRateMax == AutoSize ) {
@@ -894,7 +894,7 @@ namespace BaseboardRadiator {
 		RegisterPlantCompDesignFlow( Baseboard( BaseboardNum ).WaterInletNode, Baseboard( BaseboardNum ).WaterVolFlowRateMax );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "SizeBaseboard: Preceding sizing errors cause program termination" );
+			ShowFatalError( "SizeBaseboard: Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1256,20 +1256,20 @@ namespace BaseboardRadiator {
 		if ( CompIndex == 0 ) {
 			BaseboardNum = FindItemInList( BaseboardName, Baseboard, &BaseboardParams::EquipID );
 			if ( BaseboardNum == 0 ) {
-				ShowFatalError( "UpdateBaseboardPlantConnection: Invalid Unit Specified " + cCMO_BBRadiator_Water + "=\"" + BaseboardName + "\"" );
+				ShowFatalError( "UpdateBaseboardPlantConnection: Invalid Unit Specified " + cCMO_BBRadiator_Water + "=\"" + BaseboardName + "\"" );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BaseboardNum;
 		} else {
 			BaseboardNum = CompIndex;
 			if ( BaseboardNum > NumBaseboards || BaseboardNum < 1 ) {
-				ShowFatalError( "UpdateBaseboardPlantConnection:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of baseboards=" + TrimSigDigits( NumBaseboards ) + ", Entered baseboard name=" + BaseboardName );
+				ShowFatalError( "UpdateBaseboardPlantConnection:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of baseboards=" + TrimSigDigits( NumBaseboards ) + ", Entered baseboard name=" + BaseboardName );  // LCOV_EXCL_LINE
 			}
 			if ( KickOffSimulation ) {
 				if ( BaseboardName != Baseboard( BaseboardNum ).EquipID ) {
-					ShowFatalError( "UpdateBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + Baseboard( BaseboardNum ).EquipID );
+					ShowFatalError( "UpdateBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + Baseboard( BaseboardNum ).EquipID );  // LCOV_EXCL_LINE
 				}
 				if ( BaseboardTypeNum != TypeOf_Baseboard_Conv_Water ) {
-					ShowFatalError( "UpdateBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + ccSimPlantEquipTypes( BaseboardTypeNum ) );
+					ShowFatalError( "UpdateBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + ccSimPlantEquipTypes( BaseboardTypeNum ) );  // LCOV_EXCL_LINE
 				}
 			}
 		}

--- a/src/EnergyPlus/BoilerSteam.cc
+++ b/src/EnergyPlus/BoilerSteam.cc
@@ -210,17 +210,17 @@ namespace BoilerSteam {
 		if ( CompIndex == 0 ) {
 			BoilerNum = FindItemInList( BoilerName, Boiler );
 			if ( BoilerNum == 0 ) {
-				ShowFatalError( "SimBoiler: Unit not found=" + BoilerName );
+				ShowFatalError( "SimBoiler: Unit not found=" + BoilerName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BoilerNum;
 		} else {
 			BoilerNum = CompIndex;
 			if ( BoilerNum > NumBoilers || BoilerNum < 1 ) {
-				ShowFatalError( "SimBoiler:  Invalid CompIndex passed=" + TrimSigDigits( BoilerNum ) + ", Number of Units=" + TrimSigDigits( NumBoilers ) + ", Entered Unit name=" + BoilerName );
+				ShowFatalError( "SimBoiler:  Invalid CompIndex passed=" + TrimSigDigits( BoilerNum ) + ", Number of Units=" + TrimSigDigits( NumBoilers ) + ", Entered Unit name=" + BoilerName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( BoilerNum ) ) {
 				if ( BoilerName != Boiler( BoilerNum ).Name ) {
-					ShowFatalError( "SimBoiler: Invalid CompIndex passed=" + TrimSigDigits( BoilerNum ) + ", Unit name=" + BoilerName + ", stored Unit Name for that index=" + Boiler( BoilerNum ).Name );
+					ShowFatalError( "SimBoiler: Invalid CompIndex passed=" + TrimSigDigits( BoilerNum ) + ", Unit name=" + BoilerName + ", stored Unit Name for that index=" + Boiler( BoilerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( BoilerNum ) = false;
 			}
@@ -437,12 +437,12 @@ namespace BoilerSteam {
 			if ( NumAlphas > 4 ) {
 				Boiler( BoilerNum ).EndUseSubcategory = cAlphaArgs( 5 );
 			} else {
-				Boiler( BoilerNum ).EndUseSubcategory = "General"; 
+				Boiler( BoilerNum ).EndUseSubcategory = "General";
 			}
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in processing " + cCurrentModuleObject + " input." );
+			ShowFatalError( RoutineName + "Errors found in processing " + cCurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 		for ( BoilerNum = 1; BoilerNum <= NumBoilers; ++BoilerNum ) {
@@ -540,7 +540,7 @@ namespace BoilerSteam {
 			errFlag = false;
 			ScanPlantLoopsForObject( Boiler( BoilerNum ).Name, TypeOf_Boiler_Steam, Boiler( BoilerNum ).LoopNum, Boiler( BoilerNum ).LoopSideNum, Boiler( BoilerNum ).BranchNum, Boiler( BoilerNum ).CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitBoiler: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitBoiler: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			MyFlag( BoilerNum ) = false;
@@ -755,7 +755,7 @@ namespace BoilerSteam {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/Boilers.cc
+++ b/src/EnergyPlus/Boilers.cc
@@ -224,17 +224,17 @@ namespace Boilers {
 		if ( CompIndex == 0 ) {
 			BoilerNum = FindItemInList( BoilerName, Boiler );
 			if ( BoilerNum == 0 ) {
-				ShowFatalError( "SimBoiler: Unit not found=" + BoilerName );
+				ShowFatalError( "SimBoiler: Unit not found=" + BoilerName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BoilerNum;
 		} else {
 			BoilerNum = CompIndex;
 			if ( BoilerNum > NumBoilers || BoilerNum < 1 ) {
-				ShowFatalError( "SimBoiler:  Invalid CompIndex passed=" + TrimSigDigits( BoilerNum ) + ", Number of Units=" + TrimSigDigits( NumBoilers ) + ", Entered Unit name=" + BoilerName );
+				ShowFatalError( "SimBoiler:  Invalid CompIndex passed=" + TrimSigDigits( BoilerNum ) + ", Number of Units=" + TrimSigDigits( NumBoilers ) + ", Entered Unit name=" + BoilerName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( BoilerNum ) ) {
 				if ( BoilerName != Boiler( BoilerNum ).Name ) {
-					ShowFatalError( "SimBoiler: Invalid CompIndex passed=" + TrimSigDigits( BoilerNum ) + ", Unit name=" + BoilerName + ", stored Unit Name for that index=" + Boiler( BoilerNum ).Name );
+					ShowFatalError( "SimBoiler: Invalid CompIndex passed=" + TrimSigDigits( BoilerNum ) + ", Unit name=" + BoilerName + ", stored Unit Name for that index=" + Boiler( BoilerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( BoilerNum ) = false;
 			}
@@ -527,7 +527,7 @@ namespace Boilers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in processing " + cCurrentModuleObject + " input." );
+			ShowFatalError( RoutineName + "Errors found in processing " + cCurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 		for ( BoilerNum = 1; BoilerNum <= NumBoilers; ++BoilerNum ) {
@@ -610,7 +610,7 @@ namespace Boilers {
 			errFlag = false;
 			ScanPlantLoopsForObject( Boiler( BoilerNum ).Name, TypeOf_Boiler_Simple, Boiler( BoilerNum ).LoopNum, Boiler( BoilerNum ).LoopSideNum, Boiler( BoilerNum ).BranchNum, Boiler( BoilerNum ).CompNum, _, Boiler( BoilerNum ).TempUpLimitBoilerOut, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitBoiler: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitBoiler: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ( Boiler( BoilerNum ).FlowMode == LeavingSetPointModulated ) || ( Boiler( BoilerNum ).FlowMode == ConstantFlow ) ) {
@@ -841,7 +841,7 @@ namespace Boilers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -941,22 +941,22 @@ namespace Boilers {
 			if ( EquipFlowCtrl == ControlType_SeriesActive ) BoilerMassFlowRate = Node( BoilerInletNode ).MassFlowRate;
 			return;
 		}
-		
+
 		//If there is a fault of boiler fouling (zrp_Nov2016)
 		if( Boiler( BoilerNum ).FaultyBoilerFoulingFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = Boiler( BoilerNum ).FaultyBoilerFoulingIndex;
 			Real64 NomCap_ff = BoilerNomCap;
 			Real64 BoilerEff_ff = BoilerEff;
-			
+
 			//calculate the Faulty Boiler Fouling Factor using fault information
 			Boiler( BoilerNum ).FaultyBoilerFoulingFactor = FaultsBoilerFouling( FaultIndex ).CalFoulingFactor();
-			
+
 			//update the boiler nominal capacity at faulty cases
 			BoilerNomCap = NomCap_ff * Boiler( BoilerNum ).FaultyBoilerFoulingFactor;
 			BoilerEff = BoilerEff_ff * Boiler( BoilerNum ).FaultyBoilerFoulingFactor;
-			
+
 		}
- 
+
 		//Set the current load equal to the boiler load
 		BoilerLoad = MyLoad;
 

--- a/src/EnergyPlus/BranchInputManager.cc
+++ b/src/EnergyPlus/BranchInputManager.cc
@@ -293,7 +293,7 @@ namespace BranchInputManager {
 		//  Find this BranchList in the master BranchList Names
 		Found = FindItemInList( BranchListName, BranchList );
 		if ( Found == 0 ) {
-			ShowFatalError( "GetBranchList: BranchList Name not found=" + BranchListName );
+			ShowFatalError( "GetBranchList: BranchList Name not found=" + BranchListName );  // LCOV_EXCL_LINE
 		}
 
 		// Set data
@@ -320,7 +320,7 @@ namespace BranchInputManager {
 		}
 
 		if ( ErrFound ) {
-			ShowFatalError( "GetBranchList: preceding condition(s) causes program termination." );
+			ShowFatalError( "GetBranchList: preceding condition(s) causes program termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -374,7 +374,7 @@ namespace BranchInputManager {
 		//  Find this BranchList in the master BranchList Names
 		Found = FindItemInList( BranchListName, BranchList );
 		if ( Found == 0 ) {
-			ShowFatalError( "NumBranchesInBranchList: BranchList Name not found=" + BranchListName );
+			ShowFatalError( "NumBranchesInBranchList: BranchList Name not found=" + BranchListName );  // LCOV_EXCL_LINE
 		}
 
 		NumBranchesInBranchList = BranchList( Found ).NumOfBranchNames;
@@ -452,7 +452,7 @@ namespace BranchInputManager {
 			ShowSevereError( "GetBranchData: Component List arrays not big enough to hold Number of Components" );
 			ShowContinueError( "Input BranchName=" + BranchName + ", in Loop=" + LoopName );
 			ShowContinueError( "Max Component Array size=" + TrimSigDigits( MinCompsAllowed ) + ", but input size=" + TrimSigDigits( NumComps ) );
-			ShowFatalError( "Program terminates due to preceding conditions." );
+			ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 		}
 
 		for ( Count = 1; Count <= NumComps; ++Count ) {
@@ -889,7 +889,7 @@ namespace BranchInputManager {
 		if ( not_blank( ConnectorListName ) ) {
 			Count = FindItemInList( ConnectorListName, ConnectorLists );
 			if ( Count == 0 ) {
-				ShowFatalError( "GetConnectorList: Connector List not found=" + ConnectorListName );
+				ShowFatalError( "GetConnectorList: Connector List not found=" + ConnectorListName );  // LCOV_EXCL_LINE
 			}
 			Connectoid = ConnectorLists( Count );
 			if ( present( NumInList ) ) {
@@ -985,12 +985,12 @@ namespace BranchInputManager {
 			Count = FindItemInList( Connectoid.ConnectorName( 1 ), Mixers );
 			if ( present( MixerNumber ) ) ++MixerNumber;
 			if ( Count == 0 ) {
-				ShowFatalError( "GetLoopMixer: No Mixer Found=" + Connectoid.ConnectorName( 1 ) );
+				ShowFatalError( "GetLoopMixer: No Mixer Found=" + Connectoid.ConnectorName( 1 ) );  // LCOV_EXCL_LINE
 			}
 		} else if ( SameString( Connectoid.ConnectorType( 2 ), cMIXER ) ) {
 			Count = FindItemInList( Connectoid.ConnectorName( 2 ), Mixers );
 			if ( Count == 0 ) {
-				ShowFatalError( "GetLoopMixer: No Mixer Found=" + Connectoid.ConnectorName( 2 ) );
+				ShowFatalError( "GetLoopMixer: No Mixer Found=" + Connectoid.ConnectorName( 2 ) );  // LCOV_EXCL_LINE
 			}
 		} else {
 			Count = 0;
@@ -1033,7 +1033,7 @@ namespace BranchInputManager {
 				if ( NumInletNodes > isize( InletNodeNames ) || NumInletNodes > isize( InletNodeNums ) ) {
 					ShowSevereError( "GetLoopMixer: Connector:Mixer=" + MixerName + " contains too many inlets for size of Inlet Array." );
 					ShowContinueError( "Max array size=" + TrimSigDigits( size( InletNodeNames ) ) + ", Mixer statement inlets=" + TrimSigDigits( NumInletNodes ) );
-					ShowFatalError( "Program terminates due to preceding condition." );
+					ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 				}
 				InletNodeNums = 0;
 				InletNodeNames = "";
@@ -1130,19 +1130,19 @@ namespace BranchInputManager {
 
 		if ( ConnectorListName == BlankString ) {
 			ShowSevereError( "GetLoopSplitter: ConnectorListName is blank.  LoopName=" + LoopName );
-			ShowFatalError( "Program terminates due to previous condition." );
+			ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 		}
 		GetConnectorList( ConnectorListName, Connectoid, ConnectorNumber );
 		if ( SameString( Connectoid.ConnectorType( 1 ), cSPLITTER ) ) {
 			Count = FindItemInList( Connectoid.ConnectorName( 1 ), Splitters );
 			if ( present( SplitterNumber ) ) ++SplitterNumber;
 			if ( Count == 0 ) {
-				ShowFatalError( "GetLoopSplitter: No Splitter Found=" + Connectoid.ConnectorName( 1 ) );
+				ShowFatalError( "GetLoopSplitter: No Splitter Found=" + Connectoid.ConnectorName( 1 ) );  // LCOV_EXCL_LINE
 			}
 		} else if ( SameString( Connectoid.ConnectorType( 2 ), cSPLITTER ) ) {
 			Count = FindItemInList( Connectoid.ConnectorName( 2 ), Splitters );
 			if ( Count == 0 ) {
-				ShowFatalError( "GetLoopSplitter: No Splitter Found=" + Connectoid.ConnectorName( 2 ) );
+				ShowFatalError( "GetLoopSplitter: No Splitter Found=" + Connectoid.ConnectorName( 2 ) );  // LCOV_EXCL_LINE
 			}
 		} else {
 			Count = 0;
@@ -1185,7 +1185,7 @@ namespace BranchInputManager {
 				if ( NumOutletNodes > isize( OutletNodeNames ) || NumOutletNodes > isize( OutletNodeNums ) ) {
 					ShowSevereError( "GetLoopSplitter: Connector:Splitter=" + SplitterName + " contains too many outlets for size of Outlet Array." );
 					ShowContinueError( "Max array size=" + TrimSigDigits( size( OutletNodeNames ) ) + ", Splitter statement outlets=" + TrimSigDigits( NumOutletNodes ) );
-					ShowFatalError( "Program terminates due to preceding condition." );
+					ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 				}
 				OutletNodeNums = 0;
 				OutletNodeNames = "";
@@ -1993,7 +1993,7 @@ namespace BranchInputManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetConnectorListInput: Program terminates for preceding conditions." );
+			ShowFatalError( "GetConnectorListInput: Program terminates for preceding conditions." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2147,7 +2147,7 @@ namespace BranchInputManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetSplitterInput: Fatal Errors Found in " + CurrentModuleObject + ", program terminates." );
+			ShowFatalError( "GetSplitterInput: Fatal Errors Found in " + CurrentModuleObject + ", program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		//  Everything supposed to be good.  Now make sure all branches in Splitter on same side of loop.
@@ -2226,7 +2226,7 @@ namespace BranchInputManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetSplitterInput: Fatal Errors Found in " + CurrentModuleObject + ", program terminates." );
+			ShowFatalError( "GetSplitterInput: Fatal Errors Found in " + CurrentModuleObject + ", program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2382,7 +2382,7 @@ namespace BranchInputManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetMixerInput: Fatal Errors Found in " + CurrentModuleObject + ", program terminates." );
+			ShowFatalError( "GetMixerInput: Fatal Errors Found in " + CurrentModuleObject + ", program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		//  Everything supposed to be good.  Now make sure all branches in Splitter on same side of loop.
@@ -2460,7 +2460,7 @@ namespace BranchInputManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetMixerInput: Fatal Errors Found in " + CurrentModuleObject + ", program terminates." );
+			ShowFatalError( "GetMixerInput: Fatal Errors Found in " + CurrentModuleObject + ", program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/CTElectricGenerator.cc
+++ b/src/EnergyPlus/CTElectricGenerator.cc
@@ -165,16 +165,16 @@ namespace CTElectricGenerator {
 		//SELECT and CALL MODELS
 		if ( GeneratorIndex == 0 ) {
 			GenNum = FindItemInList( GeneratorName, CTGenerator );
-			if ( GenNum == 0 ) ShowFatalError( "SimCTGenerator: Specified Generator not one of Valid COMBUSTION Turbine Generators " + GeneratorName );
+			if ( GenNum == 0 ) ShowFatalError( "SimCTGenerator: Specified Generator not one of Valid COMBUSTION Turbine Generators " + GeneratorName );  // LCOV_EXCL_LINE
 			GeneratorIndex = GenNum;
 		} else {
 			GenNum = GeneratorIndex;
 			if ( GenNum > NumCTGenerators || GenNum < 1 ) {
-				ShowFatalError( "SimCTGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Number of CT Engine Generators=" + TrimSigDigits( NumCTGenerators ) + ", Generator name=" + GeneratorName );
+				ShowFatalError( "SimCTGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Number of CT Engine Generators=" + TrimSigDigits( NumCTGenerators ) + ", Generator name=" + GeneratorName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( GenNum ) ) {
 				if ( GeneratorName != CTGenerator( GenNum ).Name ) {
-					ShowFatalError( "SimCTGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + CTGenerator( GenNum ).Name );
+					ShowFatalError( "SimCTGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + CTGenerator( GenNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( GenNum ) = false;
 			}
@@ -240,7 +240,7 @@ namespace CTElectricGenerator {
 		if ( InitLoopEquip ) {
 			CompNum = FindItemInList( CompName, CTGenerator );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimCTPlantHeatRecovery: CT Generator Unit not found=" + CompName );
+				ShowFatalError( "SimCTPlantHeatRecovery: CT Generator Unit not found=" + CompName );  // LCOV_EXCL_LINE
 				return;
 			}
 			MinCap = 0.0;
@@ -472,7 +472,7 @@ namespace CTElectricGenerator {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( GeneratorNum = 1; GeneratorNum <= NumCTGenerators; ++GeneratorNum ) {
@@ -833,7 +833,7 @@ namespace CTElectricGenerator {
 			errFlag = false;
 			ScanPlantLoopsForObject( CTGenerator( GeneratorNum ).Name, TypeOf_Generator_CTurbine, CTGenerator( GeneratorNum ).HRLoopNum, CTGenerator( GeneratorNum ).HRLoopSideNum, CTGenerator( GeneratorNum ).HRBranchNum, CTGenerator( GeneratorNum ).HRCompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitCTGenerators: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitCTGenerators: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			MyPlantScanFlag( GeneratorNum ) = false;
 		}

--- a/src/EnergyPlus/ChilledCeilingPanelSimple.cc
+++ b/src/EnergyPlus/ChilledCeilingPanelSimple.cc
@@ -96,7 +96,7 @@ namespace CoolingPanelSimple {
 
 	// REFERENCES:
     // Existing code for hot water baseboard models (radiant-convective variety)
-    
+
 	// USE STATEMENTS:
 	// Using/Aliasing
 	using namespace DataGlobals;
@@ -132,11 +132,11 @@ namespace CoolingPanelSimple {
 
 	// Autosizing variables
 	Array1D_bool MySizeFlagCoolPanel;
-	
+
 	// Other variables
 	static bool GetInputFlag( true ); // One time get input flag
 	static bool MyOneTimeFlag( true );
-	
+
 	//SUBROUTINE SPECIFICATIONS FOR MODULE Simple Chilled Ceiling Panel
 	// Object Data
 	Array1D< CoolingPanelParams > CoolingPanel;
@@ -161,7 +161,7 @@ namespace CoolingPanelSimple {
 		CoolingPanelSysNumericFields.deallocate();
 		MySizeFlagCoolPanel.deallocate();
 	}
-	
+
 	void
 	SimCoolingPanel(
 		std::string const & EquipName,
@@ -206,17 +206,17 @@ namespace CoolingPanelSimple {
 		if ( CompIndex == 0 ) {
 			CoolingPanelNum = FindItemInList( EquipName, CoolingPanel, &CoolingPanelParams::EquipID, NumCoolingPanels );
 			if ( CoolingPanelNum == 0 ) {
-				ShowFatalError( "SimCoolingPanelSimple: Unit not found=" + EquipName );
+				ShowFatalError( "SimCoolingPanelSimple: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CoolingPanelNum;
 		} else {
 			CoolingPanelNum = CompIndex;
 			if ( CoolingPanelNum > NumCoolingPanels || CoolingPanelNum < 1 ) {
-				ShowFatalError( "SimCoolingPanelSimple:  Invalid CompIndex passed=" + TrimSigDigits( CoolingPanelNum ) + ", Number of Units=" + TrimSigDigits( NumCoolingPanels ) + ", Entered Unit name=" + EquipName );
+				ShowFatalError( "SimCoolingPanelSimple:  Invalid CompIndex passed=" + TrimSigDigits( CoolingPanelNum ) + ", Number of Units=" + TrimSigDigits( NumCoolingPanels ) + ", Entered Unit name=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( CoolingPanelNum ) ) {
 				if ( EquipName != CoolingPanel( CoolingPanelNum ).EquipID ) {
-					ShowFatalError( "SimCoolingPanelSimple: Invalid CompIndex passed=" + TrimSigDigits( CoolingPanelNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + CoolingPanel( CoolingPanelNum ).EquipID );
+					ShowFatalError( "SimCoolingPanelSimple: Invalid CompIndex passed=" + TrimSigDigits( CoolingPanelNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + CoolingPanel( CoolingPanelNum ).EquipID );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( CoolingPanelNum ) = false;
 			}
@@ -245,7 +245,7 @@ namespace CoolingPanelSimple {
 			} else {
 				ShowSevereError( "SimCoolingPanelSimple: Errors in CoolingPanel=" + CoolingPanel( CoolingPanelNum ).EquipID );
 				ShowContinueError( "Invalid or unimplemented equipment type=" + TrimSigDigits( CoolingPanel( CoolingPanelNum ).EquipType ) );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			}}
 
@@ -256,7 +256,7 @@ namespace CoolingPanelSimple {
 			ReportCoolingPanel( CoolingPanelNum );
 
 		} else {
-			ShowFatalError( "SimCoolingPanelSimple: Unit not found=" + EquipName );
+			ShowFatalError( "SimCoolingPanelSimple: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -345,7 +345,7 @@ namespace CoolingPanelSimple {
 			CoolingPanelSysNumericFields( CoolingPanelNum ).FieldNames.allocate( NumNumbers );
 			CoolingPanelSysNumericFields( CoolingPanelNum ).FieldNames = "";
 			CoolingPanelSysNumericFields( CoolingPanelNum ).FieldNames = cNumericFieldNames;
-			
+
 			IsNotOK = false;
 			IsBlank = false;
 			VerifyName( cAlphaArgs( 1 ), CoolingPanel, &CoolingPanelParams::EquipID, CoolingPanelNum, IsNotOK, IsBlank, cCMO_CoolingPanel_Simple + " Name" );
@@ -406,7 +406,7 @@ namespace CoolingPanelSimple {
 				ShowContinueError( "...reset to minimum value=[" + RoundSigDigits( MinWaterTempAvg, 2 ) + "]." );
 				CoolingPanel( CoolingPanelNum ).RatedZoneAirTemp = MinWaterTempAvg;
 			}
-			
+
 			CoolingPanel( CoolingPanelNum ).RatedWaterFlowRate = rNumericArgs( 3 );
 			if ( CoolingPanel( CoolingPanelNum ).RatedWaterFlowRate < 0.00001  || CoolingPanel( CoolingPanelNum ).RatedWaterFlowRate > 10.0 ) {
 				ShowWarningError( RoutineName + cCMO_CoolingPanel_Simple + "=\"" + cAlphaArgs( 1 ) + "\", " + cNumericFieldNames( 2 ) + " is an invalid Standard Water mass flow rate." );
@@ -472,7 +472,7 @@ namespace CoolingPanelSimple {
 				ShowContinueError( "Illegal " + cAlphaFieldNames( 5 ) + " = " + cAlphaArgs( 5 ) );
 				ErrorsFound = true;
 			}
-			
+
 			CoolingPanel( CoolingPanelNum ).WaterVolFlowRateMax = rNumericArgs( 7 );
 			if ( ( CoolingPanel( CoolingPanelNum ).WaterVolFlowRateMax <= MinWaterFlowRate ) && CoolingPanel( CoolingPanelNum ).WaterVolFlowRateMax != DataSizing::AutoSize ) {
 				ShowWarningError( RoutineName + cCMO_CoolingPanel_Simple + "=\"" + cAlphaArgs( 1 ) + "\", " + cNumericFieldNames( 7 ) + " was less than the allowable minimum." );
@@ -512,7 +512,7 @@ namespace CoolingPanelSimple {
 				ShowContinueError( "Occurs in Cooling Panel=" + CoolingPanel( CoolingPanelNum ).EquipID );
 				CoolingPanel( CoolingPanelNum ).ColdThrottlRange = MinThrottlingRange;
 			}
-			
+
 			CoolingPanel( CoolingPanelNum ).ColdSetptSched = cAlphaArgs( 7 );
 			CoolingPanel( CoolingPanelNum ).ColdSetptSchedPtr = GetScheduleIndex( cAlphaArgs( 7 ) );
 			if ( ( CoolingPanel( CoolingPanelNum ).ColdSetptSchedPtr == 0 ) && ( ! lAlphaFieldBlanks( 7 ) ) ) {
@@ -520,7 +520,7 @@ namespace CoolingPanelSimple {
 				ShowContinueError( "Occurs in " + RoutineName + " = " + cAlphaArgs( 1 ) );
 				ErrorsFound = true;
 			}
-			
+
 			if ( SameString( cAlphaArgs( 8 ), Off ) ) {
 				CoolingPanel( CoolingPanelNum ).CondCtrlType = CondCtrlNone;
 			} else if ( SameString( cAlphaArgs( 8 ), SimpleOff ) ) {
@@ -530,9 +530,9 @@ namespace CoolingPanelSimple {
 			} else {
 				CoolingPanel( CoolingPanelNum ).CondCtrlType = CondCtrlSimpleOff;
 			}
-			
+
 			CoolingPanel( CoolingPanelNum ).CondDewPtDeltaT = rNumericArgs( 9 );
-			
+
 			CoolingPanel( CoolingPanelNum ).FracRadiant = rNumericArgs( 10 );
 			if ( CoolingPanel( CoolingPanelNum ).FracRadiant < MinFraction ) {
 				ShowWarningError( RoutineName + cCMO_CoolingPanel_Simple + "=\"" + cAlphaArgs( 1 ) + "\", " + cNumericFieldNames( 10 ) + " was lower than the allowable minimum." );
@@ -625,7 +625,7 @@ namespace CoolingPanelSimple {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + cCMO_CoolingPanel_Simple + "Errors found getting input. Program terminates." );
+			ShowFatalError( RoutineName + cCMO_CoolingPanel_Simple + "Errors found getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		// Setup Report variables for the Coils
@@ -718,7 +718,7 @@ namespace CoolingPanelSimple {
 			MyEnvrnFlag = true;
 			MyOneTimeFlag = false;
 			SetLoopIndexFlag = true;
-			
+
 		}
 
 		if ( CoolingPanel( CoolingPanelNum ).ZonePtr <= 0 ) CoolingPanel( CoolingPanelNum ).ZonePtr = ZoneEquipConfig( ControlledZoneNumSub ).ActualZoneNum;
@@ -737,7 +737,7 @@ namespace CoolingPanelSimple {
 				errFlag = false;
 				ScanPlantLoopsForObject( CoolingPanel( CoolingPanelNum ).EquipID, CoolingPanel( CoolingPanelNum ).EquipType, CoolingPanel( CoolingPanelNum ).LoopNum, CoolingPanel( CoolingPanelNum ).LoopSideNum, CoolingPanel( CoolingPanelNum ).BranchNum, CoolingPanel( CoolingPanelNum ).CompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitCoolingPanel: Program terminated for previous conditions." );
+					ShowFatalError( "InitCoolingPanel: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				SetLoopIndexFlag( CoolingPanelNum ) = false;
 			}
@@ -748,7 +748,7 @@ namespace CoolingPanelSimple {
 				// for each cooling panel do the sizing once.
 				SizeCoolingPanel( CoolingPanelNum );
 				MySizeFlagCoolPanel( CoolingPanelNum ) = false;
-				
+
 				//set design mass flow rates
 				if ( CoolingPanel( CoolingPanelNum ).WaterInletNode > 0 ) {
 					rho = GetDensityGlycol( PlantLoop( CoolingPanel( CoolingPanelNum ).LoopNum ).FluidName, DataGlobals::CWInitConvTemp, PlantLoop( CoolingPanel( CoolingPanelNum ).LoopNum ).FluidIndex, RoutineName );
@@ -757,8 +757,8 @@ namespace CoolingPanelSimple {
 				}
 			}
 		}
-		
-		
+
+
 		// Do the Begin Environment initializations
 		if ( BeginEnvrnFlag && MyEnvrnFlag( CoolingPanelNum ) ) {
 			// Initialize
@@ -827,12 +827,12 @@ namespace CoolingPanelSimple {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rick Strand
 		//       DATE WRITTEN   Sept 2016
-		
+
 		// PURPOSE OF THIS SUBROUTINE:
 		// This subroutine sizes the simple chilled ceiling panel.  The process used here
 		// was derived from the low temperature radiant system model and adapted for
 		// cooling only.
-		
+
 		using DataSizing::DataScalableCapSizingON;
 		using DataSizing::CurZoneEqNum;
 		using DataSizing::ZoneEqSizing;
@@ -862,7 +862,7 @@ namespace CoolingPanelSimple {
 
 		// SUBROUTINE PARAMETER DEFINITIONS:
 		static std::string const RoutineName( "SizeCoolingPanel" );
-		
+
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		bool ErrorsFound( false ); // If errors detected in input
 		std::string CompName; // component name
@@ -880,27 +880,27 @@ namespace CoolingPanelSimple {
 		Real64 Cp;
 		Real64 WaterVolFlowMaxCoolDes( 0.0 ); // Design chilled water flow for reporting
 		Real64 WaterVolFlowMaxCoolUser( 0.0 ); // User hard-sized chilled water flow for reporting
-		
+
 		DesCoilLoad = 0.0;
 		DataScalableCapSizingON = false;
-		
+
 		CompType = "ZoneHVAC:CoolingPanel:RadiantConvective:Water";
 		CompName = CoolingPanel( CoolingPanelNum ).EquipID;
-		
+
 		IsAutoSize = false;
 		if ( CoolingPanel( CoolingPanelNum ).ScaledCoolingCapacity == AutoSize ) {
 			IsAutoSize = true;
 		}
-		
+
 		if ( CurZoneEqNum > 0 ) {
-			
+
 			SizingMethod = CoolingCapacitySizing;
 			FieldNum = 4;
 			PrintFlag = true;
 			SizingString = CoolingPanelSysNumericFields( CoolingPanelNum ).FieldNames( FieldNum ) + " [W]";
 			CapSizingMethod = CoolingPanel( CoolingPanelNum ).CoolingCapMethod;
 			ZoneEqSizing( CurZoneEqNum ).SizingMethod( SizingMethod ) = CapSizingMethod;
-			
+
 			if ( !IsAutoSize && !ZoneSizingRunDone ) { // simulation continue
 				if ( CapSizingMethod == CoolingDesignCapacity && CoolingPanel( CoolingPanelNum ).ScaledCoolingCapacity > 0.0 ) {
 					TempSize = CoolingPanel( CoolingPanelNum ).ScaledCoolingCapacity;
@@ -947,7 +947,7 @@ namespace CoolingPanelSimple {
 						ZoneEqSizing( CurZoneEqNum ).DesCoolingLoad = FinalZoneSizing( CurZoneEqNum ).NonAirSysDesCoolLoad;
 						TempSize = ZoneEqSizing( CurZoneEqNum ).DesCoolingLoad * CoolingPanel( CoolingPanelNum ).ScaledCoolingCapacity;
 						DataScalableCapSizingON = true;
-						
+
 					} else {
 						TempSize = CoolingPanel( CoolingPanelNum ).ScaledCoolingCapacity;
 					}
@@ -963,7 +963,7 @@ namespace CoolingPanelSimple {
 			// finally cooling capacity is saved in this variable
 			CoolingPanel( CoolingPanelNum ).ScaledCoolingCapacity = DesCoilLoad;
 		}
-		
+
 		IsAutoSize = false;
 		if ( CoolingPanel( CoolingPanelNum ).WaterVolFlowRateMax == AutoSize ) {
 			IsAutoSize = true;
@@ -990,7 +990,7 @@ namespace CoolingPanelSimple {
 						ErrorsFound = true;
 					}
 				}
-				
+
 				if ( IsAutoSize ) {
 					CoolingPanel( CoolingPanelNum ).WaterVolFlowRateMax = WaterVolFlowMaxCoolDes;
 					ReportSizingOutput( CompType, CoolingPanel( CoolingPanelNum ).EquipID, "Design Size Maximum Cold Water Flow [m3/s]", WaterVolFlowMaxCoolDes );
@@ -1009,15 +1009,15 @@ namespace CoolingPanelSimple {
 						}
 					}
 				}
-				
+
 			}
 		}
-		
+
 		RegisterPlantCompDesignFlow( CoolingPanel( CoolingPanelNum ).WaterInletNode, CoolingPanel( CoolingPanelNum ).WaterVolFlowRateMax );
 
 		bool SizeCoolingPanelUASuccess;
 		SizeCoolingPanelUASuccess = SizeCoolingPanelUA( CoolingPanelNum );
-		if ( ! SizeCoolingPanelUASuccess ) ShowFatalError( "SizeCoolingPanelUA: Program terminated for previous conditions." );
+		if ( ! SizeCoolingPanelUASuccess ) ShowFatalError( "SizeCoolingPanelUA: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -1030,13 +1030,13 @@ namespace CoolingPanelSimple {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rick Strand
 		//       DATE WRITTEN   June 2017
-		
+
 		// PURPOSE OF THIS SUBROUTINE:
 		// This subroutine sizes UA value for the simple chilled ceiling panel.
 
 		// Return value
 		bool SizeCoolingPanelUA;
-		
+
 		// These initializations are mainly the calculation of the UA value for the heat exchanger formulation of the simple cooling panel
 		Real64 Cp;
 		Real64 MDot;
@@ -1182,7 +1182,7 @@ namespace CoolingPanelSimple {
 
 		// Logical controls: if the WaterInletTemperature is higher than Tzone, do not run the panel
 		if ( WaterInletTemp >= Tzone ) CoolingPanelOn = false;
-		
+
 		// Condensation Controls based on dewpoint temperature of the zone.
 		// The assumption here is that condensation might take place if the inlet water temperature
 		// is below the dewpoint temperature of the space.  This assumption is made because we are
@@ -1194,11 +1194,11 @@ namespace CoolingPanelSimple {
 		// not calculated.  So, we can deal with this upfront rather than after calculation and then more
 		// iteration.
 		DewPointTemp = PsyTdpFnWPb( ZoneAirHumRat( ZoneNum ), OutBaroPress );
-		
+
 		if ( WaterInletTemp < ( DewPointTemp + CoolingPanel( CoolingPanelNum ).CondDewPtDeltaT ) && ( CoolingPanelOn ) ) {
-			
+
 			// Condensation is possible so invoke the three possible ways of handling this based on the user's choice...
-			
+
 			if ( CoolingPanel( CoolingPanelNum ).CondCtrlType == CondCtrlNone) {
 				// Condensation control is "off" which means don't do anything, simply let it run and ignore condensation
 			} else if ( CoolingPanel( CoolingPanelNum ).CondCtrlType == CondCtrlSimpleOff) {
@@ -1231,9 +1231,9 @@ namespace CoolingPanelSimple {
 		// The next IF block is to find the mass flow rate based on what type of control the user has requested.  Load based controls
 		// vary the flow to meet the zone load calculated by the user-defined thermostat.  Temperature based controls vary the flow
 		// based on a comparison between the control temperature and the setpoint schedule and throttling range.
-		
+
 		if ( ( CoolingPanel( CoolingPanelNum ).ControlType == ZoneTotalLoadControl ) || ( CoolingPanel( CoolingPanelNum ).ControlType == ZoneConvectiveLoadControl ) ) {
-	
+
 			if ( QZnReq < -SmallLoad && ! CurDeadBandOrSetback( ZoneNum ) && ( CoolingPanelOn ) ) {
 
 				Cp = GetSpecificHeatGlycol( PlantLoop( CoolingPanel( CoolingPanelNum ).LoopNum ).FluidName, WaterInletTemp, PlantLoop( CoolingPanel( CoolingPanelNum ).LoopNum ).FluidIndex, RoutineName );
@@ -1245,7 +1245,7 @@ namespace CoolingPanelSimple {
 				if ( CoolingPanel( CoolingPanelNum).ControlType == ZoneConvectiveLoadControl ) {
 					QZnReq = QZnReq / CoolingPanel( CoolingPanelNum ).FracConvect;
 				}
-				
+
 				// Now for a small amount of iteration.  Try to find the value of mass flow rate that will come the closest to giving
 				// the proper value for MCpEpsAct.  Limit iterations to avoid too much time wasting.
 				MCpEpsAct = QZnReq / ( WaterInletTemp - Tzone );
@@ -1281,17 +1281,17 @@ namespace CoolingPanelSimple {
 						}
 					}
 				}
-				
+
 			} else {
 				CoolingPanelOn = false;
 			}
 
 		} else { // temperature control rather than zone load control
-			
+
 			if ( CoolingPanelOn ) {
-			
+
 				SetCoolingPanelControlTemp( ControlTemp, CoolingPanelNum, ZoneNum );
-				
+
 				SetPointTemp = GetCurrentScheduleValue( CoolingPanel( CoolingPanelNum ).ColdSetptSchedPtr );
 				OffTempCool = SetPointTemp - 0.5 * CoolingPanel( CoolingPanelNum ).ColdThrottlRange;
 				FullOnTempCool = SetPointTemp + 0.5 * CoolingPanel( CoolingPanelNum ).ColdThrottlRange;
@@ -1309,14 +1309,14 @@ namespace CoolingPanelSimple {
 				WaterMassFlowRate = MassFlowFrac * WaterMassFlowRateMax;
 
 			}
-			
+
 		}
-		
+
 		if ( CoolingPanelOn ) {
 			SetComponentFlowRate( WaterMassFlowRate, CoolingPanel( CoolingPanelNum ).WaterInletNode, CoolingPanel( CoolingPanelNum ).WaterOutletNode, CoolingPanel( CoolingPanelNum ).LoopNum, CoolingPanel( CoolingPanelNum ).LoopSideNum, CoolingPanel( CoolingPanelNum ).BranchNum, CoolingPanel( CoolingPanelNum ).CompNum );
 			if ( WaterMassFlowRate <= 0.0 ) CoolingPanelOn = false;
 		}
-		
+
 		if ( CoolingPanelOn ) {
 			// Now simulate the system...
 			Cp = GetSpecificHeatGlycol( PlantLoop( CoolingPanel( CoolingPanelNum ).LoopNum ).FluidName, WaterInletTemp, PlantLoop( CoolingPanel( CoolingPanelNum ).LoopNum ).FluidIndex, RoutineName );
@@ -1330,18 +1330,18 @@ namespace CoolingPanelSimple {
 			WaterOutletTemp = CoolingPanel( CoolingPanelNum ).WaterInletTemp - ( CoolingPanelCool / ( WaterMassFlowRate * Cp ) );
 			RadHeat = CoolingPanelCool * CoolingPanel( CoolingPanelNum ).FracRadiant;
 			CoolingPanelSource( CoolingPanelNum ) = RadHeat;
-			
+
 			if ( CoolingPanel( CoolingPanelNum ).FracRadiant <= MinFrac ) {
 				LoadMet = CoolingPanelCool;
 			} else {
-				
+
 				// Now, distribute the radiant energy of all systems to the appropriate surfaces, to people, and the air
 				DistributeCoolingPanelRadGains();
 				// Now "simulate" the system by recalculating the heat balances
 				HeatBalanceSurfaceManager::CalcHeatBalanceOutsideSurf( ZoneNum );
-				
+
 				HeatBalanceSurfaceManager::CalcHeatBalanceInsideSurf( ZoneNum );
-				
+
 				// Here an assumption is made regarding radiant heat transfer to people.
 				// While the radiant heat transfer to people array will be used by the thermal comfort
 				// routines, the energy transfer to people would get lost from the perspective
@@ -1353,8 +1353,8 @@ namespace CoolingPanelSimple {
 				LoadMet = ( SumHATsurf( ZoneNum ) - ZeroSourceSumHATsurf( ZoneNum ) ) + ( CoolingPanelCool * CoolingPanel( CoolingPanelNum ).FracConvect ) + ( RadHeat * CoolingPanel( CoolingPanelNum ).FracDistribPerson );
 			}
 			CoolingPanel( CoolingPanelNum ).WaterOutletEnthalpy = CoolingPanel( CoolingPanelNum ).WaterInletEnthalpy - CoolingPanelCool / WaterMassFlowRate;
-			
-			
+
+
 		} else { // cooling panel off
 			CapacitanceWater = 0.0;
 			NTU = 0.0;
@@ -1367,7 +1367,7 @@ namespace CoolingPanelSimple {
 			CoolingPanelSource( CoolingPanelNum ) = 0.0;
 			CoolingPanel( CoolingPanelNum ).WaterOutletEnthalpy = CoolingPanel( CoolingPanelNum ).WaterInletEnthalpy;
 		}
-		
+
 		CoolingPanel( CoolingPanelNum ).WaterOutletTemp = WaterOutletTemp;
 		CoolingPanel( CoolingPanelNum ).WaterMassFlowRate = WaterMassFlowRate;
 		CoolingPanel( CoolingPanelNum ).TotPower = LoadMet;
@@ -1384,14 +1384,14 @@ namespace CoolingPanelSimple {
 		int const ZoneNum
 	)
 	{
-	
+
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rick Strand
 		//       DATE WRITTEN   July 2016
-		
+
 		// METHODOLOGY EMPLOYED:
 		// This subroutine sets the control temperature for the simple cooling panel.
-		
+
 		// Using/Aliasing
 		using DataHeatBalance::MRT;
 		using DataHeatBalance::Zone;
@@ -1411,13 +1411,13 @@ namespace CoolingPanelSimple {
 			} else { // Should never get here
 				ControlTemp = MAT( ZoneNum );
 				ShowSevereError( "Illegal control type in cooling panel system: " + CoolingPanel( CoolingPanelNum ).EquipID );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
-		
+
 	}
-	
+
 	void
 	UpdateCoolingPanel( int const CoolingPanelNum )
 	{
@@ -1546,7 +1546,7 @@ namespace CoolingPanelSimple {
 
 		// REFERENCES:
 		// Existing code for hot water baseboard models (radiant-convective variety)
-		
+
 		// Using/Aliasing
 		using General::RoundSigDigits;
 		using DataHeatBalFanSys::QCoolingPanelToPerson;
@@ -1588,7 +1588,7 @@ namespace CoolingPanelSimple {
 						ShowContinueError( "Occurs in " + cCMO_CoolingPanel_Simple + " = " + CoolingPanel( CoolingPanelNum ).EquipID );
 						ShowContinueError( "Radiation intensity = " + RoundSigDigits( ThisSurfIntensity, 2 ) + " [W/m2]" );
 						ShowContinueError( "Assign a larger surface area or more surfaces in " + cCMO_CoolingPanel_Simple );
-						ShowFatalError( "DistributeCoolingPanelRadGains:  excessive thermal radiation heat flux intensity detected" );
+						ShowFatalError( "DistributeCoolingPanelRadGains:  excessive thermal radiation heat flux intensity detected" );  // LCOV_EXCL_LINE
 					}
 				} else {
 					ShowSevereError( "DistributeCoolingPanelRadGains:  surface not large enough to receive thermal radiation heat flux" );
@@ -1596,7 +1596,7 @@ namespace CoolingPanelSimple {
 					ShowContinueError( "Surface area = " + RoundSigDigits( Surface( SurfNum ).Area, 3 ) + " [m2]" );
 					ShowContinueError( "Occurs in " + cCMO_CoolingPanel_Simple + " = " + CoolingPanel( CoolingPanelNum ).EquipID );
 					ShowContinueError( "Assign a larger surface area or more surfaces in " + cCMO_CoolingPanel_Simple );
-					ShowFatalError( "DistributeCoolingPanelRadGains:  surface not large enough to receive thermal radiation heat flux" );
+					ShowFatalError( "DistributeCoolingPanelRadGains:  surface not large enough to receive thermal radiation heat flux" );  // LCOV_EXCL_LINE
 
 				}
 			}
@@ -1617,7 +1617,7 @@ namespace CoolingPanelSimple {
 		// Existing code for hot water baseboard models (radiant-convective variety)
 
 		using DataHVACGlobals::TimeStepSys;
-		
+
 		CoolingPanel( CoolingPanelNum ).TotEnergy = CoolingPanel( CoolingPanelNum ).TotPower * TimeStepSys * SecInHour;
 		CoolingPanel( CoolingPanelNum ).Energy = CoolingPanel( CoolingPanelNum ).Power * TimeStepSys * SecInHour;
 		CoolingPanel( CoolingPanelNum ).ConvEnergy = CoolingPanel( CoolingPanelNum ).ConvPower * TimeStepSys * SecInHour;
@@ -1640,7 +1640,7 @@ namespace CoolingPanelSimple {
 
 		// REFERENCES:
 		// Existing code for hot water baseboard models (radiant-convective variety)
-		
+
 		// Using/Aliasing
 		using DataSurfaces::Surface;
 		using DataSurfaces::SurfaceWindow;

--- a/src/EnergyPlus/ChillerAbsorption.cc
+++ b/src/EnergyPlus/ChillerAbsorption.cc
@@ -139,7 +139,7 @@ namespace ChillerAbsorption {
 	Real64 EvaporatorEnergy( 0.0 ); // J - heat transfer to the evaporator coil
 	Real64 QCondenser( 0.0 ); // W - rate of heat transfer to the condenser coil
 	Real64 CondenserEnergy( 0.0 ); // J - heat transfer to the condenser coil
-	
+
 	bool GetInput( true ); // when TRUE, calls subroutine to read input file.
 
 	static std::string const BlankString;
@@ -228,17 +228,17 @@ namespace ChillerAbsorption {
 		if ( CompIndex == 0 ) {
 			ChillNum = FindItemInList( AbsorberName, BLASTAbsorber );
 			if ( ChillNum == 0 ) {
-				ShowFatalError( "SimBLASTAbsorber: Specified Absorber not one of Valid Absorption Chillers=" + AbsorberName );
+				ShowFatalError( "SimBLASTAbsorber: Specified Absorber not one of Valid Absorption Chillers=" + AbsorberName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = ChillNum;
 		} else {
 			ChillNum = CompIndex;
 			if ( ChillNum > NumBLASTAbsorbers || ChillNum < 1 ) {
-				ShowFatalError( "SimBLASTAbsorber:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumBLASTAbsorbers ) + ", Entered Unit name=" + AbsorberName );
+				ShowFatalError( "SimBLASTAbsorber:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumBLASTAbsorbers ) + ", Entered Unit name=" + AbsorberName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( ChillNum ) ) {
 				if ( AbsorberName != BLASTAbsorber( ChillNum ).Name ) {
-					ShowFatalError( "SimBLASTAbsorber: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + AbsorberName + ", stored Unit Name for that index=" + BLASTAbsorber( ChillNum ).Name );
+					ShowFatalError( "SimBLASTAbsorber: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + AbsorberName + ", stored Unit Name for that index=" + BLASTAbsorber( ChillNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( ChillNum ) = false;
 			}
@@ -284,7 +284,7 @@ namespace ChillerAbsorption {
 			UpdateAbsorberChillerComponentGeneratorSide( LoopNum, LoopSide, TypeOf_Chiller_Absorption, BLASTAbsorber( ChillNum ).GeneratorInletNodeNum, BLASTAbsorber( ChillNum ).GeneratorOutletNodeNum, BLASTAbsorber( ChillNum ).GenHeatSourceType, BLASTAbsorberReport( ChillNum ).QGenerator, BLASTAbsorberReport( ChillNum ).SteamMdot, FirstIteration );
 
 		} else {
-			ShowFatalError( "SimBLASTAbsorber: Invalid LoopNum passed=" + TrimSigDigits( LoopNum ) + ", Unit name=" + AbsorberName + ", stored chilled water loop=" + TrimSigDigits( BLASTAbsorber( ChillNum ).CWLoopNum ) + ", stored condenser water loop=" + TrimSigDigits( BLASTAbsorber( ChillNum ).CDLoopNum ) + ", stored generator loop=" + TrimSigDigits( BLASTAbsorber( ChillNum ).GenLoopNum ) );
+			ShowFatalError( "SimBLASTAbsorber: Invalid LoopNum passed=" + TrimSigDigits( LoopNum ) + ", Unit name=" + AbsorberName + ", stored chilled water loop=" + TrimSigDigits( BLASTAbsorber( ChillNum ).CWLoopNum ) + ", stored condenser water loop=" + TrimSigDigits( BLASTAbsorber( ChillNum ).CDLoopNum ) + ", stored generator loop=" + TrimSigDigits( BLASTAbsorber( ChillNum ).GenLoopNum ) );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -513,7 +513,7 @@ namespace ChillerAbsorption {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( AbsorberNum = 1; AbsorberNum <= NumBLASTAbsorbers; ++AbsorberNum ) {
@@ -650,7 +650,7 @@ namespace ChillerAbsorption {
 				InterConnectTwoPlantLoopSides( BLASTAbsorber( ChillNum ).CDLoopNum, BLASTAbsorber( ChillNum ).CDLoopSideNum, BLASTAbsorber( ChillNum ).GenLoopNum, BLASTAbsorber( ChillNum ).GenCompNum, TypeOf_Chiller_Absorption, false );
 			}
 			if ( errFlag ) {
-				ShowFatalError( "InitBLASTAbsorberModel: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitBLASTAbsorberModel: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( BLASTAbsorber( ChillNum ).FlowMode == ConstantFlow ) {
@@ -1219,7 +1219,7 @@ namespace ChillerAbsorption {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 		if ( PlantFinalSizesOkayToReport ) {
@@ -1380,18 +1380,18 @@ namespace ChillerAbsorption {
 		LoopSideNum = BLASTAbsorber( ChillNum ).CWLoopSideNum;
 
 		CpFluid = GetSpecificHeatGlycol( PlantLoop( BLASTAbsorber( ChillNum ).CWLoopNum ).FluidName, EvapInletTemp, PlantLoop( BLASTAbsorber( ChillNum ).CWLoopNum ).FluidIndex, RoutineName );
-		
+
 		//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 		if( BLASTAbsorber( ChillNum ).FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = BLASTAbsorber( ChillNum ).FaultyChillerSWTIndex;
 			Real64 EvapOutletTemp_ff = TempEvapOut;
-			
+
 			//calculate the sensor offset using fault information
 			BLASTAbsorber( ChillNum ).FaultyChillerSWTOffset = FaultsChillerSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempEvapOut
 			TempEvapOut = max( BLASTAbsorber( ChillNum ).TempLowLimitEvapOut, min( Node( EvapInletNode ).Temp, EvapOutletTemp_ff - BLASTAbsorber( ChillNum ).FaultyChillerSWTOffset ));
 			BLASTAbsorber( ChillNum ).FaultyChillerSWTOffset = EvapOutletTemp_ff - TempEvapOut;
-			
+
 		}
 
 		// If FlowLock is True, the new resolved mdot is used to update Power, QEvap, Qcond, and
@@ -1522,7 +1522,7 @@ namespace ChillerAbsorption {
 					EvapOutletTemp = Node( EvapInletNode ).Temp;
 				}
 			}
-		
+
 			//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 			if( BLASTAbsorber( ChillNum ).FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) && ( EvapMassFlowRate > 0 )){
 				//calculate directly affected variables at faulty case: EvapOutletTemp, EvapMassFlowRate, QEvaporator

--- a/src/EnergyPlus/ChillerElectricEIR.cc
+++ b/src/EnergyPlus/ChillerElectricEIR.cc
@@ -282,17 +282,17 @@ namespace ChillerElectricEIR {
 		if ( CompIndex == 0 ) {
 			EIRChillNum = FindItemInList( EIRChillerName, ElectricEIRChiller );
 			if ( EIRChillNum == 0 ) {
-				ShowFatalError( "SimElectricEIRChiller: Specified Chiller not one of Valid EIR Electric Chillers=" + EIRChillerName );
+				ShowFatalError( "SimElectricEIRChiller: Specified Chiller not one of Valid EIR Electric Chillers=" + EIRChillerName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = EIRChillNum;
 		} else {
 			EIRChillNum = CompIndex;
 			if ( EIRChillNum > NumElectricEIRChillers || EIRChillNum < 1 ) {
-				ShowFatalError( "SimElectricEIRChiller:  Invalid CompIndex passed=" + TrimSigDigits( EIRChillNum ) + ", Number of Units=" + TrimSigDigits( NumElectricEIRChillers ) + ", Entered Unit name=" + EIRChillerName );
+				ShowFatalError( "SimElectricEIRChiller:  Invalid CompIndex passed=" + TrimSigDigits( EIRChillNum ) + ", Number of Units=" + TrimSigDigits( NumElectricEIRChillers ) + ", Entered Unit name=" + EIRChillerName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( EIRChillNum ) ) {
 				if ( EIRChillerName != ElectricEIRChiller( EIRChillNum ).Name ) {
-					ShowFatalError( "SimElectricEIRChiller: Invalid CompIndex passed=" + TrimSigDigits( EIRChillNum ) + ", Unit name=" + EIRChillerName + ", stored Unit Name for that index=" + ElectricEIRChiller( EIRChillNum ).Name );
+					ShowFatalError( "SimElectricEIRChiller: Invalid CompIndex passed=" + TrimSigDigits( EIRChillNum ) + ", Unit name=" + EIRChillerName + ", stored Unit Name for that index=" + ElectricEIRChiller( EIRChillNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( EIRChillNum ) = false;
 			}
@@ -784,7 +784,7 @@ namespace ChillerElectricEIR {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( EIRChillerNum = 1; EIRChillerNum <= NumElectricEIRChillers; ++EIRChillerNum ) {
@@ -945,7 +945,7 @@ namespace ChillerElectricEIR {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "InitElectricEIRChiller: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitElectricEIRChiller: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ElectricEIRChiller( EIRChillNum ).FlowMode == ConstantFlow ) {
@@ -1413,7 +1413,7 @@ namespace ChillerElectricEIR {
 					}
 					tempHeatRecVolFlowRate = nomHeatRecVolFlowRateUser;
 				}
-			
+
 			}
 			if ( ! ElectricEIRChiller( EIRChillNum ).DesignHeatRecVolFlowRateWasAutoSized ) tempHeatRecVolFlowRate = ElectricEIRChiller( EIRChillNum ).DesignHeatRecVolFlowRate;
 			PlantUtilities::RegisterPlantCompDesignFlow( ElectricEIRChiller( EIRChillNum ).HeatRecInletNodeNum, tempHeatRecVolFlowRate );
@@ -1433,7 +1433,7 @@ namespace ChillerElectricEIR {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1652,22 +1652,22 @@ namespace ChillerElectricEIR {
 		EvapOutletTemp = Node( ElectricEIRChiller( EIRChillNum ).EvapOutletNodeNum ).Temp;
 		TempLowLimitEout = ElectricEIRChiller( EIRChillNum ).TempLowLimitEvapOut;
 		EvapMassFlowRateMax = ElectricEIRChiller( EIRChillNum ).EvapMassFlowRateMax;
-		
+
 		//If there is a fault of chiller fouling (zrp_Nov2016)
 		if( ElectricEIRChiller( EIRChillNum ).FaultyChillerFoulingFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation )){
 			int FaultIndex = ElectricEIRChiller( EIRChillNum ).FaultyChillerFoulingIndex;
 			Real64 NomCap_ff = ChillerRefCap;
 			Real64 ReferenceCOP_ff = ReferenceCOP;
-			
+
 			//calculate the Faulty Chiller Fouling Factor using fault information
 			ElectricEIRChiller( EIRChillNum ).FaultyChillerFoulingFactor = FaultsChillerFouling( FaultIndex ).CalFoulingFactor();
-			
+
 			//update the Chiller nominal capacity and COP at faulty cases
 			ChillerRefCap = NomCap_ff * ElectricEIRChiller( EIRChillNum ).FaultyChillerFoulingFactor;
 			ReferenceCOP = ReferenceCOP_ff * ElectricEIRChiller( EIRChillNum ).FaultyChillerFoulingFactor;
 
 		}
-		
+
 		// Set mass flow rates
 		if ( ElectricEIRChiller( EIRChillNum ).CondenserType == WaterCooled ) {
 			CondMassFlowRate = ElectricEIRChiller( EIRChillNum ).CondMassFlowRateMax;
@@ -1702,18 +1702,18 @@ namespace ChillerElectricEIR {
 		} else {
 			assert( false );
 		}}
-		
+
 		//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 		if( ElectricEIRChiller( EIRChillNum ).FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = ElectricEIRChiller( EIRChillNum ).FaultyChillerSWTIndex;
 			Real64 EvapOutletTempSetPoint_ff = EvapOutletTempSetPoint;
-			
+
 			//calculate the sensor offset using fault information
 			ElectricEIRChiller( EIRChillNum ).FaultyChillerSWTOffset = FaultsChillerSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the EvapOutletTempSetPoint
 			EvapOutletTempSetPoint = max( ElectricEIRChiller( EIRChillNum ).TempLowLimitEvapOut, min( Node( EvapInletNode ).Temp, EvapOutletTempSetPoint_ff - ElectricEIRChiller( EIRChillNum ).FaultyChillerSWTOffset ));
 			ElectricEIRChiller( EIRChillNum ).FaultyChillerSWTOffset = EvapOutletTempSetPoint_ff - EvapOutletTempSetPoint;
-			
+
 		}
 
 		// correct temperature if using heat recovery
@@ -1871,7 +1871,7 @@ namespace ChillerElectricEIR {
 			QEvaporator = max( 0.0, ( EvapMassFlowRate * Cp * EvapDeltaTemp ) );
 			EvapOutletTemp = EvapOutletTempSetPoint;
 		}
-		
+
 		//Check that the Evap outlet temp honors both plant loop temp low limit and also the chiller low limit
 		if ( EvapOutletTemp < TempLowLimitEout ) {
 			if ( ( Node( EvapInletNode ).Temp - TempLowLimitEout ) > DeltaTempTol ) {
@@ -2012,7 +2012,7 @@ namespace ChillerElectricEIR {
 				//DSU? maybe this could be handled earlier, check if this component has a load and an evap flow rate
 				// then if cond flow is zero, just make a request to the condenser,
 				// then just say it couldn't run until condenser loop wakes up.
-				//CALL ShowFatalError('Program Terminates due to previous error condition.')
+				//CALL ShowFatalError('Program Terminates due to previous error condition.')  // LCOV_EXCL_LINE
 			}
 		} else { //Air Cooled or Evap Cooled
 

--- a/src/EnergyPlus/ChillerExhaustAbsorption.cc
+++ b/src/EnergyPlus/ChillerExhaustAbsorption.cc
@@ -222,17 +222,17 @@ namespace ChillerExhaustAbsorption {
 		if ( CompIndex == 0 ) {
 			ChillNum = FindItemInList( AbsorberName, ExhaustAbsorber );
 			if ( ChillNum == 0 ) {
-				ShowFatalError( "SimExhaustAbsorber: Unit not found=" + AbsorberName );
+				ShowFatalError( "SimExhaustAbsorber: Unit not found=" + AbsorberName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = ChillNum;
 		} else {
 			ChillNum = CompIndex;
 			if ( ChillNum > NumExhaustAbsorbers || ChillNum < 1 ) {
-				ShowFatalError( "SimExhaustAbsorber:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumExhaustAbsorbers ) + ", Entered Unit name=" + AbsorberName );
+				ShowFatalError( "SimExhaustAbsorber:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumExhaustAbsorbers ) + ", Entered Unit name=" + AbsorberName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( ChillNum ) ) {
 				if ( AbsorberName != ExhaustAbsorber( ChillNum ).Name ) {
-					ShowFatalError( "SimExhaustAbsorber: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + AbsorberName + ", stored Unit Name for that index=" + ExhaustAbsorber( ChillNum ).Name );
+					ShowFatalError( "SimExhaustAbsorber: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + AbsorberName + ", stored Unit Name for that index=" + ExhaustAbsorber( ChillNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( ChillNum ) = false;
 			}
@@ -262,7 +262,7 @@ namespace ChillerExhaustAbsorption {
 			} else { // Error, nodes do not match
 				ShowSevereError( "SimExhaustAbsorber: Invalid call to Exhaust Absorbtion Chiller-Heater " + AbsorberName );
 				ShowContinueError( "Node connections in branch are not consistent with object nodes." );
-				ShowFatalError( "Preceding conditions cause termination." );
+				ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 			} // Operate as Chiller or Heater
 			if ( GetSizingFactor ) {
 				SizingFactor = ExhaustAbsorber( ChillNum ).SizFac;
@@ -301,7 +301,7 @@ namespace ChillerExhaustAbsorption {
 		} else { // Error, nodes do not match
 			ShowSevereError( "Invalid call to Exhaust Absorber Chiller " + AbsorberName );
 			ShowContinueError( "Node connections in branch are not consistent with object nodes." );
-			ShowFatalError( "Preceding conditions cause termination." );
+			ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -416,7 +416,7 @@ namespace ChillerExhaustAbsorption {
 			ExhaustAbsorber( AbsorberNum ).HeatSupplyNodeNum = GetOnlySingleNode( cAlphaArgs( 7 ), Get_ErrorsFound, cCurrentModuleObject, cAlphaArgs( 1 ), NodeType_Water, NodeConnectionType_Outlet, 3, ObjectIsNotParent );
 			TestCompSet( cCurrentModuleObject, cAlphaArgs( 1 ), cAlphaArgs( 6 ), cAlphaArgs( 7 ), "Hot Water Nodes" );
 			if ( Get_ErrorsFound ) {
-				ShowFatalError( "Errors found in processing node input for " + cCurrentModuleObject + '=' + cAlphaArgs( 1 ) );
+				ShowFatalError( "Errors found in processing node input for " + cCurrentModuleObject + '=' + cAlphaArgs( 1 ) );  // LCOV_EXCL_LINE
 				Get_ErrorsFound = false;
 			}
 
@@ -452,7 +452,7 @@ namespace ChillerExhaustAbsorption {
 			ExhaustAbsorber( AbsorberNum ).HeatCapFCoolCurve = GetCurveCheck( cAlphaArgs( 13 ), Get_ErrorsFound, ChillerName );
 			ExhaustAbsorber( AbsorberNum ).ThermalEnergyHeatFHPLRCurve = GetCurveCheck( cAlphaArgs( 14 ), Get_ErrorsFound, ChillerName );
 			if ( Get_ErrorsFound ) {
-				ShowFatalError( "Errors found in processing curve input for " + cCurrentModuleObject + '=' + cAlphaArgs( 1 ) );
+				ShowFatalError( "Errors found in processing curve input for " + cCurrentModuleObject + '=' + cAlphaArgs( 1 ) );  // LCOV_EXCL_LINE
 				Get_ErrorsFound = false;
 			}
 			if ( SameString( cAlphaArgs( 15 ), "LeavingCondenser" ) ) {
@@ -516,7 +516,7 @@ namespace ChillerExhaustAbsorption {
 		}
 
 		if ( Get_ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( AbsorberNum = 1; AbsorberNum <= NumExhaustAbsorbers; ++AbsorberNum ) {
@@ -641,18 +641,18 @@ namespace ChillerExhaustAbsorption {
 			errFlag = false;
 			ScanPlantLoopsForObject( ExhaustAbsorber( ChillNum ).Name, TypeOf_Chiller_ExhFiredAbsorption, ExhaustAbsorber( ChillNum ).CWLoopNum, ExhaustAbsorber( ChillNum ).CWLoopSideNum, ExhaustAbsorber( ChillNum ).CWBranchNum, ExhaustAbsorber( ChillNum ).CWCompNum, ExhaustAbsorber( ChillNum ).CHWLowLimitTemp, _, _,  ExhaustAbsorber( ChillNum ).ChillReturnNodeNum, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitExhaustAbsorber: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitExhaustAbsorber: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			ScanPlantLoopsForObject( ExhaustAbsorber( ChillNum ).Name, TypeOf_Chiller_ExhFiredAbsorption, ExhaustAbsorber( ChillNum ).HWLoopNum, ExhaustAbsorber( ChillNum ).HWLoopSideNum, ExhaustAbsorber( ChillNum ).HWBranchNum, ExhaustAbsorber( ChillNum ).HWCompNum, _, _, _, ExhaustAbsorber( ChillNum ).HeatReturnNodeNum, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitExhaustAbsorber: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitExhaustAbsorber: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ExhaustAbsorber( ChillNum ).isWaterCooled ) {
 				ScanPlantLoopsForObject( ExhaustAbsorber( ChillNum ).Name, TypeOf_Chiller_ExhFiredAbsorption, ExhaustAbsorber( ChillNum ).CDLoopNum, ExhaustAbsorber( ChillNum ).CDLoopSideNum, ExhaustAbsorber( ChillNum ).CDBranchNum, ExhaustAbsorber( ChillNum ).CDCompNum, _, _, _, ExhaustAbsorber( ChillNum ).CondReturnNodeNum, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitExhaustAbsorber: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitExhaustAbsorber: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				InterConnectTwoPlantLoopSides( ExhaustAbsorber( ChillNum ).CWLoopNum, ExhaustAbsorber( ChillNum ).CWLoopSideNum, ExhaustAbsorber( ChillNum ).CDLoopNum, ExhaustAbsorber( ChillNum ).CDLoopSideNum, TypeOf_Chiller_ExhFiredAbsorption, true );
 				InterConnectTwoPlantLoopSides( ExhaustAbsorber( ChillNum ).HWLoopNum, ExhaustAbsorber( ChillNum ).HWLoopSideNum, ExhaustAbsorber( ChillNum ).CDLoopNum, ExhaustAbsorber( ChillNum ).CDLoopSideNum, TypeOf_Chiller_ExhFiredAbsorption, true );
@@ -1107,7 +1107,7 @@ namespace ChillerExhaustAbsorption {
 		if ( ExhaustAbsorber( ChillNum ).isWaterCooled ) RegisterPlantCompDesignFlow( ExhaustAbsorber( ChillNum ).CondReturnNodeNum, tmpCondVolFlowRate );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 		if ( PlantFinalSizesOkayToReport ) {
@@ -1509,7 +1509,7 @@ namespace ChillerExhaustAbsorption {
 				} else {
 					ShowSevereError( "CalcExhaustAbsorberChillerModel: Condenser flow = 0, for Exhaust Absorber Chiller=" + ExhaustAbsorber( ChillNum ).Name );
 					ShowContinueErrorTimeStamp( "" );
-					ShowFatalError( "Program Terminates due to previous error condition." );
+					ShowFatalError( "Program Terminates due to previous error condition." );  // LCOV_EXCL_LINE
 				}
 			} else {
 				lCondSupplyTemp = lCondReturnTemp; //if air cooled condenser just set supply and return to same temperature

--- a/src/EnergyPlus/ChillerGasAbsorption.cc
+++ b/src/EnergyPlus/ChillerGasAbsorption.cc
@@ -188,17 +188,17 @@ namespace ChillerGasAbsorption {
 		if ( CompIndex == 0 ) {
 			ChillNum = FindItemInList( AbsorberName, GasAbsorber );
 			if ( ChillNum == 0 ) {
-				ShowFatalError( "SimGasAbsorber: Unit not found=" + AbsorberName );
+				ShowFatalError( "SimGasAbsorber: Unit not found=" + AbsorberName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = ChillNum;
 		} else {
 			ChillNum = CompIndex;
 			if ( ChillNum > NumGasAbsorbers || ChillNum < 1 ) {
-				ShowFatalError( "SimGasAbsorber:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumGasAbsorbers ) + ", Entered Unit name=" + AbsorberName );
+				ShowFatalError( "SimGasAbsorber:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumGasAbsorbers ) + ", Entered Unit name=" + AbsorberName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( ChillNum ) ) {
 				if ( AbsorberName != GasAbsorber( ChillNum ).Name ) {
-					ShowFatalError( "SimGasAbsorber: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + AbsorberName + ", stored Unit Name for that index=" + GasAbsorber( ChillNum ).Name );
+					ShowFatalError( "SimGasAbsorber: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + AbsorberName + ", stored Unit Name for that index=" + GasAbsorber( ChillNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( ChillNum ) = false;
 			}
@@ -229,7 +229,7 @@ namespace ChillerGasAbsorption {
 			} else { // Error, nodes do not match
 				ShowSevereError( "SimGasAbsorber: Invalid call to Gas Absorbtion Chiller-Heater " + AbsorberName );
 				ShowContinueError( "Node connections in branch are not consistent with object nodes." );
-				ShowFatalError( "Preceding conditions cause termination." );
+				ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 			} // Operate as Chiller or Heater
 			if ( GetSizingFactor ) {
 				SizingFactor = GasAbsorber( ChillNum ).SizFac;
@@ -267,7 +267,7 @@ namespace ChillerGasAbsorption {
 		} else { // Error, nodes do not match
 			ShowSevereError( "Invalid call to Gas Absorber Chiller " + AbsorberName );
 			ShowContinueError( "Node connections in branch are not consistent with object nodes." );
-			ShowFatalError( "Preceding conditions cause termination." );
+			ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -365,7 +365,7 @@ namespace ChillerGasAbsorption {
 			GasAbsorber( AbsorberNum ).HeatSupplyNodeNum = GetOnlySingleNode( cAlphaArgs( 7 ), Get_ErrorsFound, cCurrentModuleObject, cAlphaArgs( 1 ), NodeType_Water, NodeConnectionType_Outlet, 3, ObjectIsNotParent );
 			TestCompSet( cCurrentModuleObject, cAlphaArgs( 1 ), cAlphaArgs( 6 ), cAlphaArgs( 7 ), "Hot Water Nodes" );
 			if ( Get_ErrorsFound ) {
-				ShowFatalError( "Errors found in processing node input for " + cCurrentModuleObject + '=' + cAlphaArgs( 1 ) );
+				ShowFatalError( "Errors found in processing node input for " + cCurrentModuleObject + '=' + cAlphaArgs( 1 ) );  // LCOV_EXCL_LINE
 				Get_ErrorsFound = false;
 			}
 
@@ -401,7 +401,7 @@ namespace ChillerGasAbsorption {
 			GasAbsorber( AbsorberNum ).HeatCapFCoolCurve = GetCurveCheck( cAlphaArgs( 13 ), Get_ErrorsFound, ChillerName );
 			GasAbsorber( AbsorberNum ).FuelHeatFHPLRCurve = GetCurveCheck( cAlphaArgs( 14 ), Get_ErrorsFound, ChillerName );
 			if ( Get_ErrorsFound ) {
-				ShowFatalError( "Errors found in processing curve input for " + cCurrentModuleObject + '=' + cAlphaArgs( 1 ) );
+				ShowFatalError( "Errors found in processing curve input for " + cCurrentModuleObject + '=' + cAlphaArgs( 1 ) );  // LCOV_EXCL_LINE
 				Get_ErrorsFound = false;
 			}
 			if ( SameString( cAlphaArgs( 15 ), "LeavingCondenser" ) ) {
@@ -489,7 +489,7 @@ namespace ChillerGasAbsorption {
 		}
 
 		if ( Get_ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( AbsorberNum = 1; AbsorberNum <= NumGasAbsorbers; ++AbsorberNum ) {
@@ -607,18 +607,18 @@ namespace ChillerGasAbsorption {
 			errFlag = false;
 			ScanPlantLoopsForObject( GasAbsorber( ChillNum ).Name, TypeOf_Chiller_DFAbsorption, GasAbsorber( ChillNum ).CWLoopNum, GasAbsorber( ChillNum ).CWLoopSideNum, GasAbsorber( ChillNum ).CWBranchNum, GasAbsorber( ChillNum ).CWCompNum, GasAbsorber( ChillNum ).CHWLowLimitTemp, _, _, GasAbsorber( ChillNum ).ChillReturnNodeNum, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitGasAbsorber: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitGasAbsorber: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			ScanPlantLoopsForObject( GasAbsorber( ChillNum ).Name, TypeOf_Chiller_DFAbsorption, GasAbsorber( ChillNum ).HWLoopNum, GasAbsorber( ChillNum ).HWLoopSideNum, GasAbsorber( ChillNum ).HWBranchNum, GasAbsorber( ChillNum ).HWCompNum, _, _, _, GasAbsorber( ChillNum ).HeatReturnNodeNum, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitGasAbsorber: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitGasAbsorber: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( GasAbsorber( ChillNum ).isWaterCooled ) {
 				ScanPlantLoopsForObject( GasAbsorber( ChillNum ).Name, TypeOf_Chiller_DFAbsorption, GasAbsorber( ChillNum ).CDLoopNum, GasAbsorber( ChillNum ).CDLoopSideNum, GasAbsorber( ChillNum ).CDBranchNum, GasAbsorber( ChillNum ).CDCompNum, _, _, _, GasAbsorber( ChillNum ).CondReturnNodeNum, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitGasAbsorber: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitGasAbsorber: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				InterConnectTwoPlantLoopSides( GasAbsorber( ChillNum ).CWLoopNum, GasAbsorber( ChillNum ).CWLoopSideNum, GasAbsorber( ChillNum ).CDLoopNum, GasAbsorber( ChillNum ).CDLoopSideNum, TypeOf_Chiller_DFAbsorption, true );
 				InterConnectTwoPlantLoopSides( GasAbsorber( ChillNum ).HWLoopNum, GasAbsorber( ChillNum ).HWLoopSideNum, GasAbsorber( ChillNum ).CDLoopNum, GasAbsorber( ChillNum ).CDLoopSideNum, TypeOf_Chiller_DFAbsorption, true );
@@ -1067,7 +1067,7 @@ namespace ChillerGasAbsorption {
 		if ( GasAbsorber( ChillNum ).isWaterCooled ) RegisterPlantCompDesignFlow( GasAbsorber( ChillNum ).CondReturnNodeNum, tmpCondVolFlowRate );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 		if ( PlantFinalSizesOkayToReport ) {
@@ -1411,7 +1411,7 @@ namespace ChillerGasAbsorption {
 				} else {
 					ShowSevereError( "CalcGasAbsorberChillerModel: Condenser flow = 0, for Gas Absorber Chiller=" + GasAbsorber( ChillNum ).Name );
 					ShowContinueErrorTimeStamp( "" );
-					ShowFatalError( "Program Terminates due to previous error condition." );
+					ShowFatalError( "Program Terminates due to previous error condition." );  // LCOV_EXCL_LINE
 				}
 			} else {
 				lCondSupplyTemp = lCondReturnTemp; //if air cooled condenser just set supply and return to same temperature

--- a/src/EnergyPlus/ChillerIndirectAbsorption.cc
+++ b/src/EnergyPlus/ChillerIndirectAbsorption.cc
@@ -143,7 +143,7 @@ namespace ChillerIndirectAbsorption {
 	Real64 CondenserEnergy( 0.0 ); // J - heat transfer to the condenser coil
 	Real64 EnergyLossToEnvironment( 0.0 ); // J - piping energy loss from generator outlet to pump inlet
 	Real64 ChillerONOFFCyclingFrac( 0.0 ); // fraction of time chiller is on
-	
+
 	bool GetInput( true ); // when TRUE, calls subroutine to read input file.
 
 	// SUBROUTINE SPECIFICATIONS FOR MODULE:
@@ -228,16 +228,16 @@ namespace ChillerIndirectAbsorption {
 		if ( CompIndex == 0 ) {
 			ChillNum = FindItemInList( AbsorberName, IndirectAbsorber );
 			if ( ChillNum == 0 ) {
-				ShowFatalError( "SimIndirectAbsorber: Specified chiller not one of Valid Absorption Chillers=" + AbsorberName );
+				ShowFatalError( "SimIndirectAbsorber: Specified chiller not one of Valid Absorption Chillers=" + AbsorberName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = ChillNum;
 		} else {
 			ChillNum = CompIndex;
 			if ( ChillNum > NumIndirectAbsorbers || ChillNum < 1 ) {
-				ShowFatalError( "SimIndirectAbsorber:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumIndirectAbsorbers ) + ", Entered Unit name=" + AbsorberName );
+				ShowFatalError( "SimIndirectAbsorber:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumIndirectAbsorbers ) + ", Entered Unit name=" + AbsorberName );  // LCOV_EXCL_LINE
 			}
 			if ( AbsorberName != IndirectAbsorber( ChillNum ).Name ) {
-				ShowFatalError( "SimIndirectAbsorber: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + AbsorberName + ", stored Unit Name for that index=" + IndirectAbsorber( ChillNum ).Name );
+				ShowFatalError( "SimIndirectAbsorber: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + AbsorberName + ", stored Unit Name for that index=" + IndirectAbsorber( ChillNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -279,7 +279,7 @@ namespace ChillerIndirectAbsorption {
 			UpdateAbsorberChillerComponentGeneratorSide( LoopNum, LoopSide, TypeOf_Chiller_Indirect_Absorption, IndirectAbsorber( ChillNum ).GeneratorInletNodeNum, IndirectAbsorber( ChillNum ).GeneratorOutletNodeNum, IndirectAbsorber( ChillNum ).GenHeatSourceType, IndirectAbsorberReport( ChillNum ).QGenerator, IndirectAbsorberReport( ChillNum ).SteamMdot, FirstIteration );
 
 		} else {
-			ShowFatalError( "SimIndirectAbsorber: Invalid LoopNum passed=" + TrimSigDigits( LoopNum ) + ", Unit name=" + AbsorberName + ", stored chilled water loop=" + TrimSigDigits( IndirectAbsorber( ChillNum ).CWLoopNum ) + ", stored condenser water loop=" + TrimSigDigits( IndirectAbsorber( ChillNum ).CDLoopNum ) + ", stored generator loop=" + TrimSigDigits( IndirectAbsorber( ChillNum ).GenLoopNum ) );
+			ShowFatalError( "SimIndirectAbsorber: Invalid LoopNum passed=" + TrimSigDigits( LoopNum ) + ", Unit name=" + AbsorberName + ", stored chilled water loop=" + TrimSigDigits( IndirectAbsorber( ChillNum ).CWLoopNum ) + ", stored condenser water loop=" + TrimSigDigits( IndirectAbsorber( ChillNum ).CDLoopNum ) + ", stored generator loop=" + TrimSigDigits( IndirectAbsorber( ChillNum ).GenLoopNum ) );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -609,7 +609,7 @@ namespace ChillerIndirectAbsorption {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting Chiller:Absorption:Indirect" );
+			ShowFatalError( "Errors found in getting Chiller:Absorption:Indirect" );  // LCOV_EXCL_LINE
 		}
 
 		for ( AbsorberNum = 1; AbsorberNum <= NumIndirectAbsorbers; ++AbsorberNum ) {
@@ -740,7 +740,7 @@ namespace ChillerIndirectAbsorption {
 
 			}
 			if ( errFlag ) {
-				ShowFatalError( "InitIndirectAbsorpChiller: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitIndirectAbsorpChiller: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( IndirectAbsorber( ChillNum ).FlowMode == ConstantFlow ) {
@@ -1342,7 +1342,7 @@ namespace ChillerIndirectAbsorption {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 		if ( PlantFinalSizesOkayToReport ) {
@@ -1552,18 +1552,18 @@ namespace ChillerIndirectAbsorption {
 		LoopSideNum = IndirectAbsorber( ChillNum ).CWLoopSideNum;
 
 		CpFluid = GetSpecificHeatGlycol( PlantLoop( IndirectAbsorber( ChillNum ).CWLoopNum ).FluidName, EvapInletTemp, PlantLoop( IndirectAbsorber( ChillNum ).CWLoopNum ).FluidIndex, RoutineName );
-		
+
 		//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 		if( IndirectAbsorber( ChillNum ).FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = IndirectAbsorber( ChillNum ).FaultyChillerSWTIndex;
 			Real64 EvapOutletTemp_ff = TempEvapOut;
-			
+
 			//calculate the sensor offset using fault information
 			IndirectAbsorber( ChillNum ).FaultyChillerSWTOffset = FaultsChillerSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempEvapOut
 			TempEvapOut = max( IndirectAbsorber( ChillNum ).TempLowLimitEvapOut, min( Node( EvapInletNode ).Temp, EvapOutletTemp_ff - IndirectAbsorber( ChillNum ).FaultyChillerSWTOffset ));
 			IndirectAbsorber( ChillNum ).FaultyChillerSWTOffset = EvapOutletTemp_ff - TempEvapOut;
-			
+
 		}
 
 		if ( IndirectAbsorber( ChillNum ).CapFCondenserTempPtr > 0 ) {
@@ -1716,7 +1716,7 @@ namespace ChillerIndirectAbsorption {
 					EvapOutletTemp = Node( EvapInletNode ).Temp;
 				}
 			}
-		
+
 			//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 			if( IndirectAbsorber( ChillNum ).FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) && ( EvapMassFlowRate > 0 )){
 				//calculate directly affected variables at faulty case: EvapOutletTemp, EvapMassFlowRate, QEvaporator

--- a/src/EnergyPlus/ChillerReformulatedEIR.cc
+++ b/src/EnergyPlus/ChillerReformulatedEIR.cc
@@ -246,16 +246,16 @@ namespace ChillerReformulatedEIR {
 		if ( CompIndex == 0 ) {
 			EIRChillNum = FindItemInList( EIRChillerName, ElecReformEIRChiller );
 			if ( EIRChillNum == 0 ) {
-				ShowFatalError( "SimReformulatedEIRChiller: Specified Chiller not one of Valid Reformulated EIR Electric Chillers=" + EIRChillerName );
+				ShowFatalError( "SimReformulatedEIRChiller: Specified Chiller not one of Valid Reformulated EIR Electric Chillers=" + EIRChillerName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = EIRChillNum;
 		} else {
 			EIRChillNum = CompIndex;
 			if ( EIRChillNum > NumElecReformEIRChillers || EIRChillNum < 1 ) {
-				ShowFatalError( "SimReformulatedEIRChiller:  Invalid CompIndex passed=" + TrimSigDigits( EIRChillNum ) + ", Number of Units=" + TrimSigDigits( NumElecReformEIRChillers ) + ", Entered Unit name=" + EIRChillerName );
+				ShowFatalError( "SimReformulatedEIRChiller:  Invalid CompIndex passed=" + TrimSigDigits( EIRChillNum ) + ", Number of Units=" + TrimSigDigits( NumElecReformEIRChillers ) + ", Entered Unit name=" + EIRChillerName );  // LCOV_EXCL_LINE
 			}
 			if ( EIRChillerName != ElecReformEIRChiller( EIRChillNum ).Name ) {
-				ShowFatalError( "SimReformulatedEIRChiller: Invalid CompIndex passed=" + TrimSigDigits( EIRChillNum ) + ", Unit name=" + EIRChillerName + ", stored Unit Name for that index=" + ElecReformEIRChiller( EIRChillNum ).Name );
+				ShowFatalError( "SimReformulatedEIRChiller: Invalid CompIndex passed=" + TrimSigDigits( EIRChillNum ) + ", Unit name=" + EIRChillerName + ", stored Unit Name for that index=" + ElecReformEIRChiller( EIRChillNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -641,7 +641,7 @@ namespace ChillerReformulatedEIR {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( EIRChillerNum = 1; EIRChillerNum <= NumElecReformEIRChillers; ++EIRChillerNum ) {
@@ -786,7 +786,7 @@ namespace ChillerReformulatedEIR {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "InitElecReformEIRChiller: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitElecReformEIRChiller: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ElecReformEIRChiller( EIRChillNum ).FlowMode == ConstantFlow ) {
@@ -1363,7 +1363,7 @@ namespace ChillerReformulatedEIR {
 				}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2034,20 +2034,20 @@ namespace ChillerReformulatedEIR {
 		TempLowLimitEout = ElecReformEIRChiller( EIRChillNum ).TempLowLimitEvapOut;
 		EvapMassFlowRateMax = ElecReformEIRChiller( EIRChillNum ).EvapMassFlowRateMax;
 		PartLoadCurveType = ElecReformEIRChiller( EIRChillNum ).PartLoadCurveType; //zrp_Aug2014
-		
+
 		//If there is a fault of chiller fouling (zrp_Nov2016)
 		if( ElecReformEIRChiller( EIRChillNum ).FaultyChillerFoulingFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation )){
 			int FaultIndex = ElecReformEIRChiller( EIRChillNum ).FaultyChillerFoulingIndex;
 			Real64 NomCap_ff = ChillerRefCap;
 			Real64 ReferenceCOP_ff = ReferenceCOP;
-		
+
 			//calculate the Faulty Chiller Fouling Factor using fault information
 			ElecReformEIRChiller( EIRChillNum ).FaultyChillerFoulingFactor = FaultsChillerFouling( FaultIndex ).CalFoulingFactor();
-			
+
 			//update the Chiller nominal capacity and COP at faulty cases
 			ChillerRefCap = NomCap_ff * ElecReformEIRChiller( EIRChillNum ).FaultyChillerFoulingFactor;
 			ReferenceCOP = ReferenceCOP_ff * ElecReformEIRChiller( EIRChillNum ).FaultyChillerFoulingFactor;
-			
+
 		}
 
 		// Set mass flow rates
@@ -2080,18 +2080,18 @@ namespace ChillerReformulatedEIR {
 		} else {
 			assert( false );
 		}}
-		
+
 		//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 		if( ElecReformEIRChiller( EIRChillNum ).FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = ElecReformEIRChiller( EIRChillNum ).FaultyChillerSWTIndex;
 			Real64 EvapOutletTempSetPoint_ff = EvapOutletTempSetPoint;
-			
+
 			//calculate the sensor offset using fault information
 			ElecReformEIRChiller( EIRChillNum ).FaultyChillerSWTOffset = FaultsChillerSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the EvapOutletTempSetPoint
 			EvapOutletTempSetPoint = max( ElecReformEIRChiller( EIRChillNum ).TempLowLimitEvapOut, min( Node( EvapInletNode ).Temp, EvapOutletTempSetPoint_ff - ElecReformEIRChiller( EIRChillNum ).FaultyChillerSWTOffset ));
 			ElecReformEIRChiller( EIRChillNum ).FaultyChillerSWTOffset = EvapOutletTempSetPoint_ff - EvapOutletTempSetPoint;
-			
+
 		}
 
 		// correct temperature if using heat recovery
@@ -2291,7 +2291,7 @@ namespace ChillerReformulatedEIR {
 					EvapOutletTemp = Node( EvapInletNode ).Temp;
 				}
 			}
-		
+
 			//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 			if( ElecReformEIRChiller( EIRChillNum ).FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) && ( EvapMassFlowRate > 0 )){
 				//calculate directly affected variables at faulty case: EvapOutletTemp, EvapMassFlowRate, QEvaporator

--- a/src/EnergyPlus/CondenserLoopTowers.cc
+++ b/src/EnergyPlus/CondenserLoopTowers.cc
@@ -298,17 +298,17 @@ namespace CondenserLoopTowers {
 		if ( CompIndex == 0 ) {
 			TowerNum = FindItemInList( TowerName, SimpleTower );
 			if ( TowerNum == 0 ) {
-				ShowFatalError( "SimTowers: Unit not found=" + TowerName );
+				ShowFatalError( "SimTowers: Unit not found=" + TowerName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = TowerNum;
 		} else {
 			TowerNum = CompIndex;
 			if ( TowerNum > NumSimpleTowers || TowerNum < 1 ) {
-				ShowFatalError( "SimTowers:  Invalid CompIndex passed=" + TrimSigDigits( TowerNum ) + ", Number of Units=" + TrimSigDigits( NumSimpleTowers ) + ", Entered Unit name=" + TowerName );
+				ShowFatalError( "SimTowers:  Invalid CompIndex passed=" + TrimSigDigits( TowerNum ) + ", Number of Units=" + TrimSigDigits( NumSimpleTowers ) + ", Entered Unit name=" + TowerName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( TowerNum ) ) {
 				if ( TowerName != SimpleTower( TowerNum ).Name ) {
-					ShowFatalError( "SimTowers: Invalid CompIndex passed=" + TrimSigDigits( TowerNum ) + ", Unit name=" + TowerName + ", stored Unit Name for that index=" + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "SimTowers: Invalid CompIndex passed=" + TrimSigDigits( TowerNum ) + ", Unit name=" + TowerName + ", stored Unit Name for that index=" + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( TowerNum ) = false;
 			}
@@ -397,7 +397,7 @@ namespace CondenserLoopTowers {
 			ReportTowers( RunFlag, TowerNum );
 
 		} else {
-			ShowFatalError( "SimTowers: Invalid Tower Type Requested=" + TowerType );
+			ShowFatalError( "SimTowers: Invalid Tower Type Requested=" + TowerType );  // LCOV_EXCL_LINE
 
 		}} // TypeOfEquip
 
@@ -498,7 +498,7 @@ namespace CondenserLoopTowers {
 		NumVSMerkelTowers = GetNumObjectsFound( cCoolingTower_VariableSpeedMerkel );
 		NumSimpleTowers = NumSingleSpeedTowers + NumTwoSpeedTowers + NumVariableSpeedTowers + NumVSMerkelTowers;
 
-		if ( NumSimpleTowers <= 0 ) ShowFatalError( "No Cooling Tower objects found in input, however, a branch object has specified a cooling tower. Search the input for CoolingTower to determine the cause for this error." );
+		if ( NumSimpleTowers <= 0 ) ShowFatalError( "No Cooling Tower objects found in input, however, a branch object has specified a cooling tower. Search the input for CoolingTower to determine the cause for this error." );  // LCOV_EXCL_LINE
 
 		// See if load distribution manager has already gotten the input
 		if ( allocated( SimpleTower ) ) return;
@@ -606,7 +606,7 @@ namespace CondenserLoopTowers {
 				SimpleTower( TowerNum ).DesRange = 5.5;
 				SimpleTower( TowerNum ).TowerInletCondsAutoSize = true;
 			}
-			// set tower design water outlet and inlet temperatures 
+			// set tower design water outlet and inlet temperatures
 			SimpleTower( TowerNum ).DesOutletWaterTemp = SimpleTower( TowerNum ).DesInletAirWBTemp + SimpleTower( TowerNum ).DesApproach;
 			SimpleTower( TowerNum ).DesInletWaterTemp = SimpleTower( TowerNum ).DesOutletWaterTemp + SimpleTower( TowerNum ).DesRange;
 			//   Basin heater power as a function of temperature must be greater than or equal to 0
@@ -939,7 +939,7 @@ namespace CondenserLoopTowers {
 				SimpleTower( TowerNum ).DesRange = 5.5;
 				SimpleTower( TowerNum ).TowerInletCondsAutoSize = true;
 			}
-			// set tower design water outlet and inlet temperatures 
+			// set tower design water outlet and inlet temperatures
 			SimpleTower( TowerNum ).DesOutletWaterTemp = SimpleTower( TowerNum ).DesInletAirWBTemp + SimpleTower( TowerNum ).DesApproach;
 			SimpleTower( TowerNum ).DesInletWaterTemp = SimpleTower( TowerNum ).DesOutletWaterTemp + SimpleTower( TowerNum ).DesRange;
 			//   Basin heater power as a function of temperature must be greater than or equal to 0
@@ -1905,7 +1905,7 @@ namespace CondenserLoopTowers {
 				SimpleTower( TowerNum ).DesRange = 5.5;
 				SimpleTower( TowerNum ).TowerInletCondsAutoSize = true;
 			}
-			// set tower design water outlet and inlet temperatures 
+			// set tower design water outlet and inlet temperatures
 			SimpleTower( TowerNum ).DesOutletWaterTemp = SimpleTower( TowerNum ).DesInletAirWBTemp + SimpleTower( TowerNum ).DesApproach;
 			SimpleTower( TowerNum ).DesInletWaterTemp = SimpleTower( TowerNum ).DesOutletWaterTemp + SimpleTower( TowerNum ).DesRange;
 			//   Basin heater power as a function of temperature must be greater than or equal to 0
@@ -2048,7 +2048,7 @@ namespace CondenserLoopTowers {
 		} // end merkel vs tower loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting cooling tower input." );
+			ShowFatalError( "Errors found in getting cooling tower input." );  // LCOV_EXCL_LINE
 		}
 
 		// Set up output variables CurrentModuleObject='CoolingTower:SingleSpeed'
@@ -2307,7 +2307,7 @@ namespace CondenserLoopTowers {
 			// Locate the tower on the plant loops for later usage
 			ScanPlantLoopsForObject( SimpleTower( TowerNum ).Name, TypeOf_Num, SimpleTower( TowerNum ).LoopNum, SimpleTower( TowerNum ).LoopSideNum, SimpleTower( TowerNum ).BranchNum, SimpleTower( TowerNum ).CompNum, _, _, _, _, _, ErrorsFound );
 			if ( ErrorsFound ) {
-				ShowFatalError( "InitTower: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitTower: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			// check if setpoint on outlet node
@@ -2494,7 +2494,7 @@ namespace CondenserLoopTowers {
 				DesTowerInletWaterTemp = SimpleTower( TowerNum ).DesInletWaterTemp;
 				DesTowerWaterDeltaT = SimpleTower( TowerNum ).DesRange;
 				if ( PltSizCondNum > 0 ) {
-					// check the tower range against the plant sizing data 
+					// check the tower range against the plant sizing data
 					if ( abs( DesTowerWaterDeltaT - PlantSizData( PltSizCondNum ).DeltaT ) > TolTemp ) {
 						ShowWarningError( "Error when autosizing the load for cooling tower = " + SimpleTower( TowerNum ).Name + ". Tower Design Range Temperature is different from the Design Loop Delta Temperature." );
 						ShowContinueError( "Tower Design Range Temperature specified in tower = " + SimpleTower( TowerNum ).Name );
@@ -2568,7 +2568,7 @@ namespace CondenserLoopTowers {
 			} else {
 				if ( PlantFinalSizesOkayToReport ) {
 					ShowSevereError( "Autosizing error for cooling tower object = " + SimpleTower( TowerNum ).Name );
-					ShowFatalError( "Autosizing of cooling tower condenser flow rate requires a loop Sizing:Plant object." );
+					ShowFatalError( "Autosizing of cooling tower condenser flow rate requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 				}
 
 			}
@@ -2621,7 +2621,7 @@ namespace CondenserLoopTowers {
 				} else {
 					if ( PlantFinalSizesOkayToReport ) {
 							ShowSevereError( "Autosizing of cooling tower fan power requires a loop Sizing:Plant object." );
-							ShowFatalError( " Occurs in cooling tower object= " + SimpleTower( TowerNum ).Name );
+							ShowFatalError( " Occurs in cooling tower object= " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 						}
 					}
 			}
@@ -2686,7 +2686,7 @@ namespace CondenserLoopTowers {
 						ShowContinueError( "is less than or equal to the design inlet air wet-bulb temperature of " + TrimSigDigits( SimpleTowerInlet( TowerNum ).AirWetBulb, 2 ) + " C." );
 						ShowContinueError( "It is recommended that the Design Loop Exit Temperature = " + TrimSigDigits( SimpleTower( TowerNum ).DesInletAirWBTemp, 2 ) + " C plus the cooling tower design approach temperature = " + TrimSigDigits( SimpleTower( TowerNum ).DesApproach, 2 ) + "C." );
 						ShowContinueError( "If using HVACTemplate:Plant:ChilledWaterLoop, then check that input field Condenser Water Design Setpoint must be > " + TrimSigDigits( SimpleTower( TowerNum ).DesInletAirWBTemp, 2 ) + " C if autosizing the cooling tower." );
-						ShowFatalError( "Autosizing of cooling tower fails for tower = " + SimpleTower( TowerNum ).Name + '.' );
+						ShowFatalError( "Autosizing of cooling tower fails for tower = " + SimpleTower( TowerNum ).Name + '.' );  // LCOV_EXCL_LINE
 					}
 
 					Par( 1 ) = DesTowerLoad;
@@ -2705,10 +2705,10 @@ namespace CondenserLoopTowers {
 					SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 					if ( SolFla == -1 ) {
 						ShowSevereError( "Iteration limit exceeded in calculating tower UA" );
-						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 					} else if ( SolFla == -2 ) {
 						ShowSevereError( "Bad starting values for UA" );
-						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 					}
 
 					if ( PlantFirstSizesOkayToFinalize ) {
@@ -2753,7 +2753,7 @@ namespace CondenserLoopTowers {
 						ShowContinueError( "is less than or equal to the design inlet air wet-bulb temperature of " + TrimSigDigits( SimpleTowerInlet( TowerNum ).AirWetBulb, 2 ) + " C." );
 						ShowContinueError( "It is recommended that the Design Loop Exit Temperature = " + TrimSigDigits( SimpleTower( TowerNum ).DesInletAirWBTemp, 2 ) + " C plus the cooling tower design approach temperature = " + TrimSigDigits( SimpleTower( TowerNum ).DesApproach, 2 ) + "C." );
 						ShowContinueError( "If using HVACTemplate:Plant:ChilledWaterLoop, then check that input field Condenser Water Design Setpoint must be > " + TrimSigDigits( SimpleTower( TowerNum ).DesInletAirWBTemp, 2 ) + " C if autosizing the cooling tower." );
-						ShowFatalError( "Autosizing of cooling tower fails for tower = " + SimpleTower( TowerNum ).Name + '.' );
+						ShowFatalError( "Autosizing of cooling tower fails for tower = " + SimpleTower( TowerNum ).Name + '.' );  // LCOV_EXCL_LINE
 					}
 
 					Par( 1 ) = DesTowerLoad;
@@ -2772,10 +2772,10 @@ namespace CondenserLoopTowers {
 					SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 					if ( SolFla == -1 ) {
 						ShowSevereError( "Iteration limit exceeded in calculating tower UA" );
-						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 					} else if ( SolFla == -2 ) {
 						ShowSevereError( "Bad starting values for UA" );
-						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 					}
 
 					if ( PlantFirstSizesOkayToFinalize ) {
@@ -2806,7 +2806,7 @@ namespace CondenserLoopTowers {
 							"Initial U-Factor Times Area Value at High Fan Speed [W/C]", SimpleTower( TowerNum ).HighSpeedTowerUA );
 					}
 				}
-			} 		
+			}
 		}
 
 		if ( SimpleTower( TowerNum ).PerformanceInputMethod_Num == PIM_NominalCapacity ) {
@@ -2832,10 +2832,10 @@ namespace CondenserLoopTowers {
 				SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 				if ( SolFla == -1 ) {
 					ShowSevereError( "Iteration limit exceeded in calculating tower UA" );
-					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( "Bad starting values for UA" );
-					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				if ( PlantFirstSizesOkayToFinalize ) {
 					SimpleTower( TowerNum ).HighSpeedTowerUA = UA;
@@ -2963,10 +2963,10 @@ namespace CondenserLoopTowers {
 				SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 				if ( SolFla == -1 ) {
 					ShowSevereError( "Iteration limit exceeded in calculating tower UA" );
-					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( "Bad starting values for UA" );
-					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				if ( PlantFirstSizesOkayToFinalize ) {
 					SimpleTower( TowerNum ).LowSpeedTowerUA = UA;
@@ -3034,7 +3034,7 @@ namespace CondenserLoopTowers {
 				SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 				if ( SolFla == -1 ) {
 					ShowSevereError( "Iteration limit exceeded in calculating tower UA" );
-					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( "Bad starting values for UA calculations" );
 					ShowContinueError( "Tower inlet design water temperature assumed to be 35.0 C." );
@@ -3045,7 +3045,7 @@ namespace CondenserLoopTowers {
 					SimSimpleTower( TowerNum, Par( 3 ), Par( 4 ), UA0, OutWaterTemp );
 					CoolingOutput = Par( 5 ) * Par( 3 ) * ( SimpleTowerInlet( TowerNum ).WaterTemp - OutWaterTemp );
 					ShowContinueError( "Tower capacity at lower UA guess (" + TrimSigDigits( UA0, 4) + ") = " + TrimSigDigits( CoolingOutput, 0 ) + " W." );
-					
+
 					SimSimpleTower( TowerNum, Par( 3 ), Par( 4 ), UA1, OutWaterTemp );
 					CoolingOutput = Par( 5 ) * Par( 3 ) * ( SimpleTowerInlet( TowerNum ).WaterTemp - OutWaterTemp );
 					ShowContinueError( "Tower capacity at upper UA guess (" + TrimSigDigits( UA1, 4) + ") = " + TrimSigDigits( CoolingOutput, 0 ) + " W." );
@@ -3053,7 +3053,7 @@ namespace CondenserLoopTowers {
 					if ( CoolingOutput < DesTowerLoad ) {
 						ShowContinueError( "Free convection capacity should be less than tower capacity at upper UA guess." );
 					}
-					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 
 				}
 				if ( PlantFirstSizesOkayToFinalize ) {
@@ -3113,11 +3113,11 @@ namespace CondenserLoopTowers {
 				if ( SolFla == -1 ) {
 					ShowSevereError( "Iteration limit exceeded in calculating tower water flow ratio during calibration" );
 					ShowContinueError( "Inlet air wet-bulb, range, and/or approach temperature does not allow calibration of water flow rate ratio for this variable-speed cooling tower." );
-					ShowFatalError( "Cooling tower calibration failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Cooling tower calibration failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( "Bad starting values for cooling tower water flow rate ratio calibration." );
 					ShowContinueError( "Inlet air wet-bulb, range, and/or approach temperature does not allow calibration of water flow rate ratio for this variable-speed cooling tower." );
-					ShowFatalError( "Cooling tower calibration failed for tower " + SimpleTower( TowerNum ).Name + '.' );
+					ShowFatalError( "Cooling tower calibration failed for tower " + SimpleTower( TowerNum ).Name + '.' );  // LCOV_EXCL_LINE
 				}
 			} else {
 				gio::write( OutputChar2, OutputFormat2 ) << WaterFlowRateRatio;
@@ -3125,7 +3125,7 @@ namespace CondenserLoopTowers {
 				ShowSevereError( "Bad starting values for cooling tower water flow rate ratio calibration." );
 				ShowContinueError( "Design inlet air wet-bulb or range temperature must be modified to achieve the design approach" );
 				ShowContinueError( "A water flow rate ratio of " + OutputChar2 + " was calculated to yield an approach temperature of " + OutputChar + '.' );
-				ShowFatalError( "Cooling tower calibration failed for tower " + SimpleTower( TowerNum ).Name + '.' );
+				ShowFatalError( "Cooling tower calibration failed for tower " + SimpleTower( TowerNum ).Name + '.' );  // LCOV_EXCL_LINE
 			}
 
 			SimpleTower( TowerNum ).CalibratedWaterFlowRate = SimpleTower( TowerNum ).DesignWaterFlowRate / WaterFlowRatio;
@@ -3214,7 +3214,7 @@ namespace CondenserLoopTowers {
 				}
 			}
 			if ( ErrorsFound ) {
-				ShowFatalError( "InitTower: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitTower: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -3310,7 +3310,7 @@ namespace CondenserLoopTowers {
 				DesTowerInletWaterTemp = DesTowerExitWaterTemp + PlantSizData( PltSizCondNum ).DeltaT;
 				DesTowerWaterDeltaT = PlantSizData( PltSizCondNum ).DeltaT;
 			} else {
-				// set default values to replace hard wired input assumptions 
+				// set default values to replace hard wired input assumptions
 				DesTowerExitWaterTemp = SimpleTower( TowerNum ).DesOutletWaterTemp;
 				DesTowerInletWaterTemp = SimpleTower( TowerNum ).DesInletWaterTemp;
 				DesTowerWaterDeltaT = SimpleTower( TowerNum ).DesRange;
@@ -3321,7 +3321,7 @@ namespace CondenserLoopTowers {
 			DesTowerInletWaterTemp = SimpleTower( TowerNum ).DesInletWaterTemp;
 			DesTowerWaterDeltaT = SimpleTower( TowerNum ).DesRange;
 			if ( PltSizCondNum > 0 ) {
-				// check the tower range against the plant sizing data 
+				// check the tower range against the plant sizing data
 				if ( abs( DesTowerWaterDeltaT - PlantSizData( PltSizCondNum ).DeltaT ) > TolTemp ) {
 					ShowWarningError( "Error when autosizing the load for cooling tower = " + SimpleTower( TowerNum ).Name + ". Tower Design Range Temperature is different from the Design Loop Delta Temperature." );
 					ShowContinueError( "Tower Design Range Temperature specified in tower = " + SimpleTower( TowerNum ).Name );
@@ -3384,7 +3384,7 @@ namespace CondenserLoopTowers {
 					} else {
 						if ( PlantFirstSizesOkayToFinalize ) {
 							ShowSevereError( "Autosizing error for cooling tower object = " + SimpleTower( TowerNum ).Name );
-							ShowFatalError( "Autosizing of cooling tower nominal capacity requires a loop Sizing:Plant object." );
+							ShowFatalError( "Autosizing of cooling tower nominal capacity requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 						}
 					}
 				}
@@ -3485,10 +3485,10 @@ namespace CondenserLoopTowers {
 				SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 				if ( SolFla == -1 ) {
 					ShowSevereError( "Iteration limit exceeded in calculating tower UA" );
-					ShowFatalError( "calculating cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "calculating cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( "Bad starting values for UA" );
-					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				SimpleTower( TowerNum ).HighSpeedTowerUA = UA;
 				if ( PlantFinalSizesOkayToReport ) {
@@ -3516,10 +3516,10 @@ namespace CondenserLoopTowers {
 				SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 				if ( SolFla == -1 ) {
 					ShowSevereError( "Iteration limit exceeded in calculating tower free convection UA" );
-					ShowFatalError( "calculating cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "calculating cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( "Bad starting values for UA" );
-					ShowFatalError( "Autosizing of cooling tower UA failed for free convection tower " + SimpleTower( TowerNum ).Name );
+					ShowFatalError( "Autosizing of cooling tower UA failed for free convection tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				SimpleTower( TowerNum ).FreeConvTowerUA = UA;
 				if ( PlantFinalSizesOkayToReport ) {
@@ -3577,7 +3577,7 @@ namespace CondenserLoopTowers {
 					} else {
 						if ( PlantFirstSizesOkayToFinalize ) {
 							ShowSevereError( "Autosizing error for cooling tower object = " + SimpleTower( TowerNum ).Name );
-							ShowFatalError( "Autosizing of cooling tower nominal capacity requires a loop Sizing:Plant object." );
+							ShowFatalError( "Autosizing of cooling tower nominal capacity requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 						}
 					}
 				}
@@ -3652,7 +3652,7 @@ namespace CondenserLoopTowers {
 					} else {
 						if (PlantFirstSizesOkayToFinalize) {
 							ShowSevereError( "Autosizing error for cooling tower object = " + SimpleTower( TowerNum ).Name );
-							ShowFatalError( "Autosizing of cooling tower nominal capacity requires a loop Sizing:Plant object." );
+							ShowFatalError( "Autosizing of cooling tower nominal capacity requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 						}
 					}
 				}
@@ -3722,10 +3722,10 @@ namespace CondenserLoopTowers {
 					SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 					if ( SolFla == -1 ) {
 						ShowSevereError( "Iteration limit exceeded in calculating tower UA" );
-						ShowFatalError( "calculating cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+						ShowFatalError( "calculating cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 					} else if ( SolFla == -2 ) {
 						ShowSevereError( "Bad starting values for UA" );
-						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+						ShowFatalError( "Autosizing of cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 					}
 					SimpleTower( TowerNum ).HighSpeedTowerUA = UA;
 					if ( PlantFinalSizesOkayToReport ) {
@@ -3752,10 +3752,10 @@ namespace CondenserLoopTowers {
 					SolveRoot( Acc, MaxIte, SolFla, UA, SimpleTowerUAResidual, UA0, UA1, Par );
 					if ( SolFla == -1 ) {
 						ShowSevereError( "Iteration limit exceeded in calculating tower free convection UA" );
-						ShowFatalError( "calculating cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );
+						ShowFatalError( "calculating cooling tower UA failed for tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 					} else if ( SolFla == -2 ) {
 						ShowSevereError( "Bad starting values for UA" );
-						ShowFatalError( "Autosizing of cooling tower UA failed for free convection tower " + SimpleTower( TowerNum ).Name );
+						ShowFatalError( "Autosizing of cooling tower UA failed for free convection tower " + SimpleTower( TowerNum ).Name );  // LCOV_EXCL_LINE
 					}
 					SimpleTower( TowerNum ).LowSpeedTowerUA = UA;
 					if ( PlantFinalSizesOkayToReport ) {
@@ -3823,7 +3823,7 @@ namespace CondenserLoopTowers {
 						tmpNomTowerCap = 0.0; // Suppress uninitialized warnings
 						if ( PlantFirstSizesOkayToFinalize ) {
 							ShowSevereError( "Autosizing error for cooling tower object = " + SimpleTower( TowerNum ).Name );
-							ShowFatalError( "Autosizing of cooling tower nominal capacity requires a loop Sizing:Plant object." );
+							ShowFatalError( "Autosizing of cooling tower nominal capacity requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 						}
 					}
 
@@ -4061,7 +4061,7 @@ namespace CondenserLoopTowers {
 		OutletWaterTemp = Node( WaterInletNode ).Temp;
 		LoopNum = SimpleTower( TowerNum ).LoopNum;
 		LoopSideNum = SimpleTower( TowerNum ).LoopSideNum;
-		
+
 		Real64 FreeConvTowerUA = SimpleTower( TowerNum ).FreeConvTowerUA;
 		Real64 HighSpeedTowerUA = SimpleTower( TowerNum ).HighSpeedTowerUA;
 
@@ -4085,12 +4085,12 @@ namespace CondenserLoopTowers {
 		if( SimpleTower( TowerNum ).FaultyCondenserSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = SimpleTower( TowerNum ).FaultyCondenserSWTIndex;
 			Real64 TowerOutletTemp_ff = TempSetPoint;
-			
+
 			//calculate the sensor offset using fault information
 			SimpleTower( TowerNum ).FaultyCondenserSWTOffset = FaultsCondenserSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempSetPoint
 			TempSetPoint = TowerOutletTemp_ff - SimpleTower( TowerNum ).FaultyCondenserSWTOffset;
-			
+
 		}
 
 		//If there is a fault of cooling tower fouling (zrp_Jul2016)
@@ -4098,14 +4098,14 @@ namespace CondenserLoopTowers {
 			int FaultIndex = SimpleTower( TowerNum ).FaultyTowerFoulingIndex;
 			Real64 FreeConvTowerUA_ff = SimpleTower( TowerNum ).FreeConvTowerUA;
 			Real64 HighSpeedTowerUA_ff = SimpleTower( TowerNum ).HighSpeedTowerUA;
-			
+
 			//calculate the Faulty Tower Fouling Factor using fault information
 			SimpleTower( TowerNum ).FaultyTowerFoulingFactor = FaultsTowerFouling( FaultIndex ).CalFaultyTowerFoulingFactor();
-			
+
 			//update the tower UA values at faulty cases
 			FreeConvTowerUA = FreeConvTowerUA_ff * SimpleTower( TowerNum ).FaultyTowerFoulingFactor;
 			HighSpeedTowerUA = HighSpeedTowerUA_ff * SimpleTower( TowerNum ).FaultyTowerFoulingFactor;
-			
+
 		}
 
 		// Added for fluid bypass. First assume no fluid bypass
@@ -4413,10 +4413,10 @@ namespace CondenserLoopTowers {
 		OutletWaterTemp = Node( WaterInletNode ).Temp;
 		LoopNum = SimpleTower( TowerNum ).LoopNum;
 		LoopSideNum = SimpleTower( TowerNum ).LoopSideNum;
-		
+
 		Real64 FreeConvTowerUA = SimpleTower( TowerNum ).FreeConvTowerUA;
 		Real64 HighSpeedTowerUA = SimpleTower( TowerNum ).HighSpeedTowerUA;
-		
+
 		//water temperature setpoint
 		{ auto const SELECT_CASE_var( PlantLoop( LoopNum ).LoopDemandCalcScheme );
 		if ( SELECT_CASE_var == SingleSetPoint ) {
@@ -4437,12 +4437,12 @@ namespace CondenserLoopTowers {
 		if( SimpleTower( TowerNum ).FaultyCondenserSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = SimpleTower( TowerNum ).FaultyCondenserSWTIndex;
 			Real64 TowerOutletTemp_ff = TempSetPoint;
-			
+
 			//calculate the sensor offset using fault information
 			SimpleTower( TowerNum ).FaultyCondenserSWTOffset = FaultsCondenserSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempSetPoint
 			TempSetPoint = TowerOutletTemp_ff - SimpleTower( TowerNum ).FaultyCondenserSWTOffset;
-			
+
 		}
 
 		//If there is a fault of cooling tower fouling (zrp_Jul2016)
@@ -4450,14 +4450,14 @@ namespace CondenserLoopTowers {
 			int FaultIndex = SimpleTower( TowerNum ).FaultyTowerFoulingIndex;
 			Real64 FreeConvTowerUA_ff = SimpleTower( TowerNum ).FreeConvTowerUA;
 			Real64 HighSpeedTowerUA_ff = SimpleTower( TowerNum ).HighSpeedTowerUA;
-			
+
 			//calculate the Faulty Tower Fouling Factor using fault information
 			SimpleTower( TowerNum ).FaultyTowerFoulingFactor = FaultsTowerFouling( FaultIndex ).CalFaultyTowerFoulingFactor();
-			
+
 			//update the tower UA values at faulty cases
 			FreeConvTowerUA = FreeConvTowerUA_ff * SimpleTower( TowerNum ).FaultyTowerFoulingFactor;
 			HighSpeedTowerUA = HighSpeedTowerUA_ff * SimpleTower( TowerNum ).FaultyTowerFoulingFactor;
-			
+
 		}
 
 		// Do not RETURN here if flow rate is less than SmallMassFlow. Check basin heater and then RETURN.
@@ -4658,10 +4658,10 @@ namespace CondenserLoopTowers {
 		OutletWaterTemp = Node( WaterInletNode ).Temp;
 		LoopNum = SimpleTower( TowerNum ).LoopNum;
 		LoopSideNum = SimpleTower( TowerNum ).LoopSideNum;
-		
+
 		Real64 FreeConvTowerUA = SimpleTower( TowerNum ).FreeConvTowerUA;
 		Real64 HighSpeedTowerUA = SimpleTower( TowerNum ).HighSpeedTowerUA;
-		
+
 		//water temperature setpoint
 		{ auto const SELECT_CASE_var( PlantLoop( LoopNum ).LoopDemandCalcScheme );
 		if ( SELECT_CASE_var == SingleSetPoint ) {
@@ -4682,12 +4682,12 @@ namespace CondenserLoopTowers {
 		if( SimpleTower( TowerNum ).FaultyCondenserSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = SimpleTower( TowerNum ).FaultyCondenserSWTIndex;
 			Real64 TowerOutletTemp_ff = TempSetPoint;
-			
+
 			//calculate the sensor offset using fault information
 			SimpleTower( TowerNum ).FaultyCondenserSWTOffset = FaultsCondenserSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempSetPoint
 			TempSetPoint = TowerOutletTemp_ff - SimpleTower( TowerNum ).FaultyCondenserSWTOffset;
-			
+
 		}
 
 		//If there is a fault of cooling tower fouling (zrp_Jul2016)
@@ -4695,14 +4695,14 @@ namespace CondenserLoopTowers {
 			int FaultIndex = SimpleTower( TowerNum ).FaultyTowerFoulingIndex;
 			Real64 FreeConvTowerUA_ff = SimpleTower( TowerNum ).FreeConvTowerUA;
 			Real64 HighSpeedTowerUA_ff = SimpleTower( TowerNum ).HighSpeedTowerUA;
-			
+
 			//calculate the Faulty Tower Fouling Factor using fault information
 			SimpleTower( TowerNum ).FaultyTowerFoulingFactor = FaultsTowerFouling( FaultIndex ).CalFaultyTowerFoulingFactor();
-			
+
 			//update the tower UA values at faulty cases
 			FreeConvTowerUA = FreeConvTowerUA_ff * SimpleTower( TowerNum ).FaultyTowerFoulingFactor;
 			HighSpeedTowerUA = HighSpeedTowerUA_ff * SimpleTower( TowerNum ).FaultyTowerFoulingFactor;
-			
+
 		}
 
 		// Added for multi-cell. Determine the number of cells operating
@@ -5127,7 +5127,7 @@ namespace CondenserLoopTowers {
 		TwbCapped = SimpleTowerInlet( TowerNum ).AirWetBulb;
 		LoopNum = SimpleTower( TowerNum ).LoopNum;
 		LoopSideNum = SimpleTower( TowerNum ).LoopSideNum;
-		
+
 		//water temperature setpoint
 		{ auto const SELECT_CASE_var( PlantLoop( LoopNum ).LoopDemandCalcScheme );
 		if ( SELECT_CASE_var == SingleSetPoint ) {
@@ -5142,12 +5142,12 @@ namespace CondenserLoopTowers {
 		if( SimpleTower( TowerNum ).FaultyCondenserSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = SimpleTower( TowerNum ).FaultyCondenserSWTIndex;
 			Real64 TowerOutletTemp_ff = TempSetPoint;
-			
+
 			//calculate the sensor offset using fault information
 			SimpleTower( TowerNum ).FaultyCondenserSWTOffset = FaultsCondenserSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempSetPoint
 			TempSetPoint = TowerOutletTemp_ff - SimpleTower( TowerNum ).FaultyCondenserSWTOffset;
-			
+
 		}
 
 		Tr = Node( WaterInletNode ).Temp - TempSetPoint;

--- a/src/EnergyPlus/ConductionTransferFunctionCalc.cc
+++ b/src/EnergyPlus/ConductionTransferFunctionCalc.cc
@@ -510,7 +510,7 @@ namespace ConductionTransferFunctionCalc {
 							--Construct( ConstrNum ).TempAfterLayer;
 						}
 					} else { // These are not adjacent layers and there is a logic flaw here (should not happen)
-						ShowFatalError( "Combining resistance layers failed for " + Construct( ConstrNum ).Name );
+						ShowFatalError( "Combining resistance layers failed for " + Construct( ConstrNum ).Name );  // LCOV_EXCL_LINE
 						ShowContinueError( "This should never happen.  Contact EnergyPlus Support for further assistance." );
 					}
 				}
@@ -1086,7 +1086,7 @@ namespace ConductionTransferFunctionCalc {
 									CTFConvrg = false;
 								}
 							} else { // Something terribly wrong--the surface has no CTFs, not even an R-value
-								ShowFatalError( "Illegal construction definition, no CTFs calculated for " + Construct( ConstrNum ).Name );
+								ShowFatalError( "Illegal construction definition, no CTFs calculated for " + Construct( ConstrNum ).Name );  // LCOV_EXCL_LINE
 							}
 						}
 
@@ -1122,7 +1122,7 @@ namespace ConductionTransferFunctionCalc {
 							DoCTFErrorReport = true;
 							ErrorsFound = true;
 							break;
-							//            CALL ShowFatalError('Program terminated for reasons listed (InitConductionTransferFunctions) ')
+							//            CALL ShowFatalError('Program terminated for reasons listed (InitConductionTransferFunctions) ')  // LCOV_EXCL_LINE
 						}
 
 					} // ... end of CTF calculation loop.
@@ -1235,7 +1235,7 @@ namespace ConductionTransferFunctionCalc {
 		ReportCTFs( DoCTFErrorReport );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Program terminated for reasons listed (InitConductionTransferFunctions)" );
+			ShowFatalError( "Program terminated for reasons listed (InitConductionTransferFunctions)" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/ConvectionCoefficients.cc
+++ b/src/EnergyPlus/ConvectionCoefficients.cc
@@ -411,7 +411,7 @@ namespace ConvectionCoefficients {
 
 				if ( Surface( SurfNum ).ExtBoundCond == DataSurfaces::KivaFoundation ) {
 					HConvIn( SurfNum ) = SurfaceGeometry::kivaManager.getConv( SurfNum );
-					Surface( SurfNum ).TAirRef = ZoneMeanAirTemp;					
+					Surface( SurfNum ).TAirRef = ZoneMeanAirTemp;
 					continue;
 				}
 
@@ -441,7 +441,7 @@ namespace ConvectionCoefficients {
 						ManageInsideAdaptiveConvectionAlgo( SurfNum );
 
 					} else {
-						ShowFatalError( "Unhandled convection coefficient algorithm." );
+						ShowFatalError( "Unhandled convection coefficient algorithm." );  // LCOV_EXCL_LINE
 					}}
 
 				} else if ( SELECT_CASE_var == 0 ) { // Not set by user, uses Zone Setting
@@ -470,7 +470,7 @@ namespace ConvectionCoefficients {
 						// Already done above and can't be at individual surface
 
 					} else {
-						ShowFatalError( "Unhandled convection coefficient algorithm." );
+						ShowFatalError( "Unhandled convection coefficient algorithm." );  // LCOV_EXCL_LINE
 
 					}}
 
@@ -565,7 +565,7 @@ namespace ConvectionCoefficients {
 		TSky = SkyTempKelvin;
 		TGround = TAir;
 
-		
+
 
 		if ( Surface( SurfNum ).HasSurroundingSurfProperties ) {
 			SrdSurfsNum = Surface( SurfNum ).SurroundingSurfacesNum;
@@ -680,7 +680,7 @@ namespace ConvectionCoefficients {
 				ManageOutsideAdaptiveConvectionAlgo( SurfNum, HExt );
 
 			} else {
-				ShowFatalError( "InitExtConvection Coefficients: invalid parameter -- outside convection type, Surface=" + Surface( SurfNum ).Name );
+				ShowFatalError( "InitExtConvection Coefficients: invalid parameter -- outside convection type, Surface=" + Surface( SurfNum ).Name );  // LCOV_EXCL_LINE
 
 			}} // choice of algorithm type
 
@@ -790,7 +790,7 @@ namespace ConvectionCoefficients {
 				ManageOutsideAdaptiveConvectionAlgo( SurfNum, HExt );
 
 			} else {
-				ShowFatalError( "InitExtConvection Coefficients: invalid parameter -- outside convection type, Surface=" + Surface( SurfNum ).Name );
+				ShowFatalError( "InitExtConvection Coefficients: invalid parameter -- outside convection type, Surface=" + Surface( SurfNum ).Name );  // LCOV_EXCL_LINE
 
 			}} // choice of algorithm type
 
@@ -3121,7 +3121,7 @@ namespace ConvectionCoefficients {
 		} // end of 'SurfaceConvectionAlgorithm:Outside:AdaptiveModelSelections'
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found getting input.  Program termination." );
+			ShowFatalError( RoutineName + "Errors found getting input.  Program termination." );  // LCOV_EXCL_LINE
 		}
 
 		SetupAdaptiveConvectionStaticMetaData();
@@ -5492,7 +5492,7 @@ namespace ConvectionCoefficients {
 		//if ( std::isnan( HConvIn( SurfNum ) ) ) { // Use IEEE_IS_NAN when GFortran supports it
 			//// throw Error
 			//ShowSevereError( "Inside convection coefficient is out of bound = " + Surface( SurfNum ).Name );
-			//ShowFatalError( "Inside convection coefficient model number = " + TrimSigDigits( Surface( SurfNum ).IntConvHcModelEq ) );
+			//ShowFatalError( "Inside convection coefficient model number = " + TrimSigDigits( Surface( SurfNum ).IntConvHcModelEq ) );  // LCOV_EXCL_LINE
 		//}
 	}
 
@@ -6167,7 +6167,7 @@ namespace ConvectionCoefficients {
 			Hf = CalcBlockenWindward( WindSpeed, WindDir, Surface( SurfNum ).Azimuth );
 		} else if ( SELECT_CASE_var == HcExt_EmmelVertical ) {
 			Hf = CalcEmmelVertical( WindSpeed, WindDir, Surface( SurfNum ).Azimuth, SurfNum );
-		} else if ( SELECT_CASE_var == HcExt_EmmelRoof ) {			
+		} else if ( SELECT_CASE_var == HcExt_EmmelRoof ) {
 			Hf = CalcEmmelRoof( WindSpeed, WindDir, RoofLongAxisOutwardAzimuth, SurfNum );
 
 		}}

--- a/src/EnergyPlus/CoolTower.cc
+++ b/src/EnergyPlus/CoolTower.cc
@@ -422,7 +422,7 @@ namespace CoolTower {
 		lAlphaBlanks.deallocate();
 		lNumericBlanks.deallocate();
 
-		if ( ErrorsFound ) ShowFatalError( CurrentModuleObject + " errors occurred in input.  Program terminates." );
+		if ( ErrorsFound ) ShowFatalError( CurrentModuleObject + " errors occurred in input.  Program terminates." );  // LCOV_EXCL_LINE
 
 		for ( CoolTowerNum = 1; CoolTowerNum <= NumCoolTowers; ++CoolTowerNum ) {
 			SetupOutputVariable( "Zone Cooltower Sensible Heat Loss Energy", OutputProcessor::Unit::J, CoolTowerSys( CoolTowerNum ).SenHeatLoss, "System", "Sum", Zone( CoolTowerSys( CoolTowerNum ).ZonePtr ).Name );

--- a/src/EnergyPlus/CostEstimateManager.cc
+++ b/src/EnergyPlus/CostEstimateManager.cc
@@ -292,13 +292,13 @@ namespace CostEstimateManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing cost estimate input" );
+			ShowFatalError( "Errors found in processing cost estimate input" );  // LCOV_EXCL_LINE
 		}
 
 		CheckCostEstimateInput( ErrorsFound );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing cost estimate input" );
+			ShowFatalError( "Errors found in processing cost estimate input" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/CrossVentMgr.cc
+++ b/src/EnergyPlus/CrossVentMgr.cc
@@ -573,7 +573,7 @@ namespace CrossVentMgr {
 				ShowContinueError( "Surface " + AirflowNetworkLinkageData( Ctd ).Name + " in zone " + Zone( ZoneNum ).Name + " uses leakage component " + AirflowNetworkLinkageData( Ctd ).CompName );
 				ShowContinueError( "Only leakage component types AirflowNetwork:MultiZone:Component:DetailedOpening and " );
 				ShowContinueError( "AirflowNetwork:MultiZone:Surface:Crack can be used with the cross ventilation room air model" );
-				ShowFatalError( "Previous severe error causes program termination" );
+				ShowFatalError( "Previous severe error causes program termination" );  // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -339,7 +339,7 @@ namespace CurveManager {
 		}
 
 		if ( ( CurveIndex <= 0 ) || ( CurveIndex > NumCurves ) ) {
-			ShowFatalError( "CurveValue: Invalid curve passed." );
+			ShowFatalError( "CurveValue: Invalid curve passed." );  // LCOV_EXCL_LINE
 		}
 
 		{ auto const SELECT_CASE_var( PerfCurve( CurveIndex ).InterpolationType );
@@ -350,7 +350,7 @@ namespace CurveManager {
 		} else if ( SELECT_CASE_var == LagrangeInterpolationLinearExtrapolation ) {
 			CurveValue = TableLookupObject( CurveIndex, Var1, Var2, Var3, Var4, Var5 );
 		} else {
-			ShowFatalError( "CurveValue: Invalid Interpolation Type" );
+			ShowFatalError( "CurveValue: Invalid Interpolation Type" );  // LCOV_EXCL_LINE
 		}}
 
 		if ( PerfCurve( CurveIndex ).EMSOverrideOn ) CurveValue = PerfCurve( CurveIndex ).EMSOverrideCurveValue;
@@ -375,7 +375,7 @@ namespace CurveManager {
 		GetCurveInputData( GetInputErrorsFound );
 
 		if ( GetInputErrorsFound ) {
-			ShowFatalError( "GetCurveInput: Errors found in getting Curve Objects.  Preceding condition(s) cause termination." );
+			ShowFatalError( "GetCurveInput: Errors found in getting Curve Objects.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2000,7 +2000,7 @@ namespace CurveManager {
 				if ( !PerfCurve( CurveNum ).Var1MaxPresent ) {
 					PerfCurve( CurveNum ).Var1Max = maxval( TableData( TableNum ).X1 );
 				}
-			} 
+			}
 
 			// if user enters limits that exceed data range, warn that limits are based on table data
 			if ( PerfCurve( CurveNum ).InterpolationType == LinearInterpolationOfTable ) {
@@ -3385,17 +3385,17 @@ namespace CurveManager {
 				if ( endcol == 0 ) {
 					ShowWarningError( "ReadTableData: Data not found on second line in external file = " + FileName );
 					ShowContinueError( "...Check that file is ASCII text and that file is not locked by other applications." );
-					ShowFatalError( "External table data not found. Simulation will terminate." );
+					ShowFatalError( "External table data not found. Simulation will terminate." );  // LCOV_EXCL_LINE
 				} else {
 					ShowWarningError( "Second read attempt found data in external file = " + FileName );
-					ShowFatalError( "...Blank lines are not allowed. Simulation will terminate." );
+					ShowFatalError( "...Blank lines are not allowed. Simulation will terminate." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( endcol > 0 ) {
 				if ( int( NextLine[ endcol - 1 ] ) == iUnicode_end ) {
 					ShowSevereError( "ReadTableData: For Table:MultiVariableLookup \"" + PerfCurve( CurveNum ).Name + "\" external file, appears to be a Unicode or binary file." );
 					ShowContinueError( "...This file cannot be read by this program. Please save as PC or Unix file and try again" );
-					ShowFatalError( "Program terminates due to previous condition." );
+					ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -3405,7 +3405,7 @@ namespace CurveManager {
 			if ( NumIVars > 5 || NumIVars < 1 ) {
 				ShowSevereError( "ReadTableData: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
 				ShowContinueError( "...Invalid number of independent variables found in external file = " + FileName );
-				ShowFatalError( "...Only 1 to 5 independent variables are allowed." );
+				ShowFatalError( "...Only 1 to 5 independent variables are allowed." );  // LCOV_EXCL_LINE
 			}
 
 			gio::rewind( FileNum );
@@ -3441,7 +3441,7 @@ namespace CurveManager {
 			if ( NumIVars > 5 || NumIVars < 1 ) {
 				ShowSevereError( "ReadTableData: For " + CurrentModuleObject + ": " + Alphas( 1 ) );
 				ShowContinueError( "...Invalid number of independent variables." );
-				ShowFatalError( "...Only 1 to 5 independent variables are allowed." );
+				ShowFatalError( "...Only 1 to 5 independent variables are allowed." );  // LCOV_EXCL_LINE
 			}
 
 			BaseOffset = 15;
@@ -4054,7 +4054,7 @@ Label999: ;
 		ShowSevereError( "CurveManager: SearchTableDataFile: Could not open Table Data File, expecting it as file name = " + FileName );
 		ShowContinueError( "Certain run environments require a full path to be included with the file name in the input field." );
 		ShowContinueError( "Try again with putting full path and file name in the field." );
-		ShowFatalError( "Program terminates due to these conditions." );
+		ShowFatalError( "Program terminates due to these conditions." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -4540,7 +4540,7 @@ Label999: ;
 			TableValue = 0.0;
 			ShowSevereError( "Errors found in table output calculation for " + PerfCurve( CurveIndex ).Name );
 			ShowContinueError( "...Possible causes are selection of Interpolation Method or Type or Number of Independent Variables or Points." );
-			ShowFatalError( "PerformanceTableObject: Previous error causes program termination." );
+			ShowFatalError( "PerformanceTableObject: Previous error causes program termination." );  // LCOV_EXCL_LINE
 		}}
 
 		if ( PerfCurve( CurveIndex ).CurveMinPresent ) TableValue = max( TableValue, PerfCurve( CurveIndex ).CurveMin );
@@ -4836,7 +4836,7 @@ Label999: ;
 			TableValue = 0.0;
 			ShowSevereError( "Errors found in table output calculation for " + PerfCurve( CurveIndex ).Name );
 			ShowContinueError( "...Possible causes are selection of Interpolation Method or Type or Number of Independent Variables or Points." );
-			ShowFatalError( "PerformanceTableObject: Previous error causes program termination." );
+			ShowFatalError( "PerformanceTableObject: Previous error causes program termination." );  // LCOV_EXCL_LINE
 		}}
 
 		if ( PerfCurve( CurveIndex ).CurveMinPresent ) TableValue = max( TableValue, PerfCurve( CurveIndex ).CurveMin );
@@ -6081,7 +6081,7 @@ Label999: ;
 		NumPressureCurves = NumPressure;
 
 		if ( ErrsFound ) {
-			ShowFatalError( "GetPressureCurveInput: Errors found in Curve Objects.  Preceding condition(s) cause termination." );
+			ShowFatalError( "GetPressureCurveInput: Errors found in Curve Objects.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -6167,7 +6167,7 @@ Label999: ;
 				ShowContinueError( "Curve type detected: " + GenericCurveType );
 				ShowContinueError( "Generic curves should be single independent variable such that DeltaP = f(mdot)" );
 				ShowContinueError( " Therefore they should be of type: Linear, Quadratic, Cubic, Quartic, or Exponent" );
-				ShowFatalError( "Errors in pressure simulation input cause program termination" );
+				ShowFatalError( "Errors in pressure simulation input cause program termination" );  // LCOV_EXCL_LINE
 			}}
 			return;
 		}
@@ -6436,7 +6436,7 @@ Label999: ;
 	}
 
 	void
-	checkCurveIsNormalizedToOne( 
+	checkCurveIsNormalizedToOne(
 		std::string const callingRoutineObj, // calling routine with object type
 		std::string const objectName,        // parent object where curve is used
 		int const curveIndex,                // index to curve object
@@ -6518,7 +6518,7 @@ Label999: ;
 			ShowSevereError( "CurveManager::ReadTwoVarTableDataFromFile: Could not open Table Data File, expecting it as file name = " + FileName );
 			ShowContinueError( "Certain run environments require a full path to be included with the file name in the input field." );
 			ShowContinueError( "Try again with putting full path and file name in the field." );
-			ShowFatalError( "Program terminates due to these conditions." );
+			ShowFatalError( "Program terminates due to these conditions." );  // LCOV_EXCL_LINE
 		}
 
 		TableNum = PerfCurve( CurveNum ).TableIndex;
@@ -6538,7 +6538,7 @@ Label999: ;
 		}
 		if ( lineNum == 0 ) {
 			ShowSevereError( "CurveManager::ReadTwoVarTableDataFromFile: The data file is empty as file name = " + FileName );
-			ShowFatalError( "Program terminates due to these conditions." );
+			ShowFatalError( "Program terminates due to these conditions." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -6552,7 +6552,7 @@ Label999: ;
 	{
 
 		// PURPOSE OF THIS FUNCTION:
-		// Set up indenpendent varilable values the same in 3 table data 
+		// Set up indenpendent varilable values the same in 3 table data
 
 		// Using/Aliasing
 		int X1TableNum;

--- a/src/EnergyPlus/DElightManagerF.cc
+++ b/src/EnergyPlus/DElightManagerF.cc
@@ -216,7 +216,7 @@ namespace DElightManagerF {
 		{
 			IOFlags flags; flags.ACTION( "write" ); gio::open( unit, outputDelightInFileName, flags );
 			if ( flags.err() ) {
-				ShowFatalError( "DElightInputGenerator: Could not open file \"" + outputDelightInFileName + "\" for output (write)." );
+				ShowFatalError( "DElightInputGenerator: Could not open file \"" + outputDelightInFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -595,7 +595,7 @@ namespace DElightManagerF {
 
 		} // Glass Type loop
 
-		if ( ErrorsFound ) ShowFatalError( "Problems with Daylighting:DElight input, see previous error messages" );
+		if ( ErrorsFound ) ShowFatalError( "Problems with Daylighting:DElight input, see previous error messages" );  // LCOV_EXCL_LINE
 
 		gio::close( unit );
 

--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -294,17 +294,17 @@ namespace DXCoils {
 		if ( CompIndex == 0 ) {
 			DXCoilNum = FindItemInList( CompName, DXCoil );
 			if ( DXCoilNum == 0 ) {
-				ShowFatalError( "DX Coil not found=" + CompName );
+				ShowFatalError( "DX Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DXCoilNum;
 		} else {
 			DXCoilNum = CompIndex;
 			if ( DXCoilNum > NumDXCoils || DXCoilNum < 1 ) {
-				ShowFatalError( "SimDXCoil: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Number of DX Coils=" + TrimSigDigits( NumDXCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "SimDXCoil: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Number of DX Coils=" + TrimSigDigits( NumDXCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( DXCoilNum ) ) {
 				if ( ! CompName.empty() && CompName != DXCoil( DXCoilNum ).Name ) {
-					ShowFatalError( "SimDXCoil: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + DXCoil( DXCoilNum ).Name );
+					ShowFatalError( "SimDXCoil: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + DXCoil( DXCoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( DXCoilNum ) = false;
 			}
@@ -368,7 +368,7 @@ namespace DXCoils {
 		} else {
 			ShowSevereError( "Error detected in DX Coil=" + CompName );
 			ShowContinueError( "Invalid DX Coil Type=" + DXCoil( DXCoilNum ).DXCoilType );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -428,17 +428,17 @@ namespace DXCoils {
 		if ( CompIndex == 0 ) {
 			DXCoilNum = FindItemInList( CompName, DXCoil );
 			if ( DXCoilNum == 0 ) {
-				ShowFatalError( "DX Coil not found=" + CompName );
+				ShowFatalError( "DX Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DXCoilNum;
 		} else {
 			DXCoilNum = CompIndex;
 			if ( DXCoilNum > NumDXCoils || DXCoilNum < 1 ) {
-				ShowFatalError( "SimDXCoilMultiSpeed: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Number of DX Coils=" + TrimSigDigits( NumDXCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "SimDXCoilMultiSpeed: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Number of DX Coils=" + TrimSigDigits( NumDXCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( DXCoilNum ) ) {
 				if ( ! CompName.empty() && CompName != DXCoil( DXCoilNum ).Name ) {
-					ShowFatalError( "SimDXCoilMultiSpeed: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + DXCoil( DXCoilNum ).Name );
+					ShowFatalError( "SimDXCoilMultiSpeed: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + DXCoil( DXCoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( DXCoilNum ) = false;
 			}
@@ -471,7 +471,7 @@ namespace DXCoils {
 		} else {
 			ShowSevereError( "Error detected in DX Coil=" + CompName );
 			ShowContinueError( "Invalid DX Coil Type=" + DXCoil( DXCoilNum ).DXCoilType );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -564,17 +564,17 @@ namespace DXCoils {
 		if ( CompIndex == 0 ) {
 			DXCoilNum = FindItemInList( CompName, DXCoil );
 			if ( DXCoilNum == 0 ) {
-				ShowFatalError( "DX Coil not found=" + CompName );
+				ShowFatalError( "DX Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DXCoilNum;
 		} else {
 			DXCoilNum = CompIndex;
 			if ( DXCoilNum > NumDXCoils || DXCoilNum < 1 ) {
-				ShowFatalError( "SimDXCoilMultiMode: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Number of DX Coils=" + TrimSigDigits( NumDXCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "SimDXCoilMultiMode: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Number of DX Coils=" + TrimSigDigits( NumDXCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( DXCoilNum ) ) {
 				if ( ( CompName != "" ) && ( CompName != DXCoil( DXCoilNum ).Name ) ) {
-					ShowFatalError( "SimDXCoilMultiMode: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + DXCoil( DXCoilNum ).Name );
+					ShowFatalError( "SimDXCoilMultiMode: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + DXCoil( DXCoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( DXCoilNum ) = false;
 			}
@@ -617,7 +617,7 @@ namespace DXCoils {
 
 			DXCoil( DXCoilNum ).DehumidificationMode = DehumidMode;
 			if ( DehumidMode > DXCoil( DXCoilNum ).NumDehumidModes ) {
-				ShowFatalError( DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Requested enhanced dehumidification mode not available." );
+				ShowFatalError( DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Requested enhanced dehumidification mode not available." );  // LCOV_EXCL_LINE
 			}
 
 			// If a single-stage coil OR If part load is zero,
@@ -794,7 +794,7 @@ namespace DXCoils {
 		} else {
 			ShowSevereError( "Error detected in DX Coil=" + CompName );
 			ShowContinueError( "Invalid DX Coil Type=" + DXCoil( DXCoilNum ).DXCoilType );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -1233,7 +1233,7 @@ namespace DXCoils {
 
 			//Set minimum OAT for compressor operation
 			DXCoil( DXCoilNum ).MinOATCompressor = Numbers( 6 );
-			if ( NumNumbers < 6 ) DXCoil( DXCoilNum ).MinOATCompressor = minOATCompDXCooling; // input field is after min fields and won't default if field not included 
+			if ( NumNumbers < 6 ) DXCoil( DXCoilNum ).MinOATCompressor = minOATCompDXCooling; // input field is after min fields and won't default if field not included
 
 			DXCoil( DXCoilNum ).Twet_Rated( 1 ) = Numbers( 7 );
 			DXCoil( DXCoilNum ).Gamma_Rated( 1 ) = Numbers( 8 );
@@ -1427,7 +1427,7 @@ namespace DXCoils {
 		} // end of the Doe2 DX coil loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Loop over the Multimode DX Coils and get & load the data
@@ -1865,7 +1865,7 @@ namespace DXCoils {
 
 			//Set minimum OAT for compressor operation
 			DXCoil( DXCoilNum ).MinOATCompressor = Numbers( 5 );
-			if ( NumNumbers < 5 ) DXCoil( DXCoilNum ).MinOATCompressor = minOATCompDXCooling; // input field is after min fields and won't default if field not included 
+			if ( NumNumbers < 5 ) DXCoil( DXCoilNum ).MinOATCompressor = minOATCompDXCooling; // input field is after min fields and won't default if field not included
 
 			//Basin heater power as a function of temperature must be greater than or equal to 0
 			DXCoil( DXCoilNum ).BasinHeaterPowerFTempDiff = Numbers( 6 );
@@ -1900,7 +1900,7 @@ namespace DXCoils {
 		} // end of the Multimode DX coil loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		//************* Read Heat Pump (DX Heating Coil) Input **********
@@ -2291,7 +2291,7 @@ namespace DXCoils {
 		} // end of the DX heating coil loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		CurrentModuleObject = "Coil:Cooling:DX:TwoSpeed";
@@ -2795,7 +2795,7 @@ namespace DXCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Loop over the Pumped DX Water Heater Coils and get & load the data
@@ -3208,7 +3208,7 @@ namespace DXCoils {
 		} // end of the DX water heater coil loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 		// Loop over the Wrapped DX Water Heater Coils and get & load the data
 		CurrentModuleObject = cAllCoilTypes( CoilDX_HeatPumpWaterHeaterWrapped );
@@ -3525,7 +3525,7 @@ namespace DXCoils {
 		} // end of the DX water heater wrapped coil loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		// DX Multispeed cooling coil
@@ -4000,7 +4000,7 @@ namespace DXCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		// DX multispeed heating coil
@@ -4550,7 +4550,7 @@ namespace DXCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Loop over the VRF Heating Coils and get & load the data
@@ -4666,7 +4666,7 @@ namespace DXCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Loop over the VRF Cooling Coils for VRF FluidTCtrl Model_zrp 2015
@@ -4756,7 +4756,7 @@ namespace DXCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Loop over the VRF Heating Coils for VRF FluidTCtrl Model_zrp 2015
@@ -4836,7 +4836,7 @@ namespace DXCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		for ( DXCoilNum = 1; DXCoilNum <= NumDXCoils; ++DXCoilNum ) {
@@ -5291,9 +5291,9 @@ namespace DXCoils {
 					ErrorsFound = true;
 				}
 				if ( ErrorsFound ) {
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
-				
+
 				// Check for valid range of (Rated Air Volume Flow Rate / Rated Total Capacity)
 				if ( DXCoil( DXCoilNum ).DXCoilType_Num != CoilVRF_FluidTCtrl_Cooling ){ // the VolFlowPerRatedTotCap check is not applicable for VRF-FluidTCtrl coil
 					RatedVolFlowPerRatedTotCap = DXCoil( DXCoilNum ).RatedAirVolFlowRate( Mode ) / DXCoil( DXCoilNum ).RatedTotCap( Mode );
@@ -5325,7 +5325,7 @@ namespace DXCoils {
 							ErrorsFound = true;
 						}
 						if ( ErrorsFound ) {
-							ShowFatalError( "Preceding condition causes termination." );
+							ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 						}
 						// Check for valid range of (Rated Air Volume Flow Rate / Rated Total Capacity)
 						RatedVolFlowPerRatedTotCap = DXCoil( DXCoilNum ).RatedAirVolFlowRate( Mode ) / DXCoil( DXCoilNum ).RatedTotCap( Mode );
@@ -5354,12 +5354,12 @@ namespace DXCoils {
 					ErrorsFound = true;
 				}
 				if ( ErrorsFound ) {
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 				RatedHeatPumpIndoorAirTemp = 21.11; // 21.11C or 70F
 				RatedHeatPumpIndoorHumRat = 0.00881; // Humidity ratio corresponding to 70F dry bulb/60F wet bulb
 				DXCoil( DXCoilNum ).RatedAirMassFlowRate( Mode ) = DXCoil( DXCoilNum ).RatedAirVolFlowRate( Mode ) * PsyRhoAirFnPbTdbW( StdBaroPress, RatedHeatPumpIndoorAirTemp, RatedHeatPumpIndoorHumRat, RoutineName );
-				
+
 				// Check for valid range of (Rated Air Volume Flow Rate / Rated Total Capacity)
 				if ( DXCoil( DXCoilNum ).DXCoilType_Num != CoilVRF_FluidTCtrl_Heating ){ // the VolFlowPerRatedTotCap check is not applicable for VRF-FluidTCtrl coil
 					RatedVolFlowPerRatedTotCap = DXCoil( DXCoilNum ).RatedAirVolFlowRate( Mode ) / DXCoil( DXCoilNum ).RatedTotCap( Mode );
@@ -5402,7 +5402,7 @@ namespace DXCoils {
 						ErrorsFound = true;
 					}
 					if ( ErrorsFound ) {
-						ShowFatalError( "Preceding condition causes termination." );
+						ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 					}
 					// Check for valid range of (Rated Air Volume Flow Rate / Rated Total Capacity)
 					RatedVolFlowPerRatedTotCap = DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ) / DXCoil( DXCoilNum ).MSRatedTotCap( Mode );
@@ -6049,25 +6049,25 @@ namespace DXCoils {
 					if ( DXCoil( DXCoilNum ).EvapCondAirFlow2 > DXCoil( DXCoilNum ).EvapCondAirFlow( Mode ) ) {
 						ShowSevereError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Evaporative Condenser low speed air flow must be less than or equal to high speed air flow." );
 						ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).EvapCondAirFlow2, 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).EvapCondAirFlow( Mode ), 2 ) );
-						ShowFatalError( "Preceding conditions cause termination." );
+						ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 					}
 
 					if ( DXCoil( DXCoilNum ).EvapCondPumpElecNomPower2 > DXCoil( DXCoilNum ).EvapCondPumpElecNomPower( Mode ) ) {
 						ShowSevereError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Evaporative Condenser low speed pump power must be less than or equal to high speed pump power." );
 						ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).EvapCondPumpElecNomPower2, 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).EvapCondPumpElecNomPower( Mode ), 2 ) );
-						ShowFatalError( "Preceding conditions cause termination." );
+						ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 					}
 
 					if ( DXCoil( DXCoilNum ).RatedTotCap2 > DXCoil( DXCoilNum ).RatedTotCap( Mode ) ) {
 						ShowSevereError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Rated Total Cooling Capacity, Low Speed must be less than or equal to Rated Total Cooling Capacity, High Speed." );
 						ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).RatedTotCap2, 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).RatedTotCap( Mode ), 2 ) );
-						ShowFatalError( "Preceding conditions cause termination." );
+						ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 					}
 
 					if ( DXCoil( DXCoilNum ).RatedAirVolFlowRate2 > DXCoil( DXCoilNum ).RatedAirVolFlowRate( Mode ) ) {
-						ShowFatalError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Rated Air Volume Flow Rate, low speed must be less than or equal to Rated Air Volume Flow Rate, high speed." );
+						ShowFatalError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Rated Air Volume Flow Rate, low speed must be less than or equal to Rated Air Volume Flow Rate, high speed." );  // LCOV_EXCL_LINE
 						ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).RatedAirVolFlowRate2, 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).RatedAirVolFlowRate( Mode ), 2 ) );
-						ShowFatalError( "Preceding conditions cause termination." );
+						ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 					}
 				}
 
@@ -6162,7 +6162,7 @@ namespace DXCoils {
 				if ( DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ) > DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode + 1 ) ) {
 					ShowWarningError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Rated Air Flow Rate must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Rated Air Flow Rate." );
 					ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ), 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode + 1 ), 2 ) );
-					ShowFatalError( "Preceding conditions cause termination." );
+					ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -6367,7 +6367,7 @@ namespace DXCoils {
 				if ( DXCoil( DXCoilNum ).MSRatedTotCap( Mode ) > DXCoil( DXCoilNum ).MSRatedTotCap( Mode + 1 ) ) {
 					ShowWarningError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Rated Total Cooling Capacity must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Rated Total Cooling Capacity." );
 					ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).MSRatedTotCap( Mode ), 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).MSRatedTotCap( Mode + 1 ), 2 ) );
-					ShowFatalError( "Preceding conditions cause termination." );
+					ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -6477,7 +6477,7 @@ namespace DXCoils {
 				if ( DXCoil( DXCoilNum ).MSEvapCondAirFlow( Mode ) > DXCoil( DXCoilNum ).MSEvapCondAirFlow( Mode + 1 ) ) {
 					ShowWarningError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Evaporative Condenser Air Flow Rate must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Evaporative Condenser Air Flow Rate." );
 					ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).MSEvapCondAirFlow( Mode ), 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).MSEvapCondAirFlow( Mode + 1 ), 2 ) );
-					ShowFatalError( "Preceding conditions cause termination." );
+					ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -6515,7 +6515,7 @@ namespace DXCoils {
 				if ( DXCoil( DXCoilNum ).MSEvapCondPumpElecNomPower( Mode ) > DXCoil( DXCoilNum ).MSEvapCondPumpElecNomPower( Mode + 1 ) ) {
 					ShowWarningError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Rated Evaporative Condenser Pump Power Consumption must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Rated Evaporative Condenser Pump Power Consumption." );
 					ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).MSEvapCondPumpElecNomPower( Mode ), 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).MSEvapCondPumpElecNomPower( Mode + 1 ), 2 ) );
-					ShowFatalError( "Preceding conditions cause termination." );
+					ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -6626,7 +6626,7 @@ namespace DXCoils {
 				if ( DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ) > DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode + 1 ) ) {
 					ShowWarningError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Rated Air Flow Rate must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Rated Air Flow Rate." );
 					ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ), 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode + 1 ), 2 ) );
-					ShowFatalError( "Preceding conditions cause termination." );
+					ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 				}
 			}
 			// Rated Secondary Coil Airflow Rates for AirCooled condenser type
@@ -6702,7 +6702,7 @@ namespace DXCoils {
 				if ( DXCoil( DXCoilNum ).MSRatedTotCap( Mode ) > DXCoil( DXCoilNum ).MSRatedTotCap( Mode + 1 ) ) {
 					ShowWarningError( "SizeDXCoil: " + DXCoil( DXCoilNum ).DXCoilType + ' ' + DXCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Rated Total Heating Capacity must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Rated Total Heating Capacity." );
 					ShowContinueError( "Instead, " + RoundSigDigits( DXCoil( DXCoilNum ).MSRatedTotCap( Mode ), 2 ) + " > " + RoundSigDigits( DXCoil( DXCoilNum ).MSRatedTotCap( Mode + 1 ), 2 ) );
-					ShowFatalError( "Preceding conditions cause termination." );
+					ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -7046,7 +7046,7 @@ namespace DXCoils {
 		} else {
 			locFanElecPower = Fans::GetFanPower( Coil.SupplyFanIndex );
 		}
-		
+
 		// calculate evaporator total cooling capacity
 		if ( HPRTF > 0.0 ) {
 			if ( Coil.FanPowerIncludedInCOP ) {
@@ -7419,7 +7419,7 @@ namespace DXCoils {
 			//  InletAirWetBulbC = PsyTwbFnTdbWPb(InletAirDryBulbTemp,InletAirHumRat,InletAirPressure)
 			//  AirVolumeFlowRate = AirMassFlow/ PsyRhoAirFnPbTdbW(InletAirPressure,InletAirDryBulbTemp, InletAirHumRat)
 			if ( DXCoil( DXCoilNum ).RatedTotCap( Mode ) <= 0.0 ) {
-				ShowFatalError( RoutineName + DXCoil( DXCoilNum ).DXCoilType + "=\"" + DXCoil( DXCoilNum ).Name + "\" - Rated total cooling capacity is zero or less." );
+				ShowFatalError( RoutineName + DXCoil( DXCoilNum ).DXCoilType + "=\"" + DXCoil( DXCoilNum ).Name + "\" - Rated total cooling capacity is zero or less." );  // LCOV_EXCL_LINE
 			}
 			if ( DXCoil( DXCoilNum ).DXCoilType_Num == CoilDX_HeatPumpWaterHeaterPumped || DXCoil( DXCoilNum ).DXCoilType_Num == CoilDX_HeatPumpWaterHeaterWrapped ) {
 				VolFlowperRatedTotCap = AirVolumeFlowRate / DXCoil( DXCoilNum ).RatedTotCap2;
@@ -8239,7 +8239,7 @@ namespace DXCoils {
 			VolFlowperRatedTotCap = AirVolumeFlowRate / DXCoil( DXCoilNum ).RatedTotCap( Mode );
 
 			if ( DXCoil( DXCoilNum ).RatedTotCap( Mode ) <= 0.0 ) {
-				ShowFatalError( DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Rated total cooling capacity is zero or less." );
+				ShowFatalError( DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Rated total cooling capacity is zero or less." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ! FirstHVACIteration && ! WarmupFlag && ( ( VolFlowperRatedTotCap < MinOperVolFlowPerRatedTotCap( DXCT ) ) || ( VolFlowperRatedTotCap > MaxCoolVolFlowPerRatedTotCap( DXCT ) ) ) ) {
@@ -9623,7 +9623,7 @@ Label50: ;
 				}
 			}
 			ShowContinueErrorTimeStamp( "" );
-			ShowFatalError( "Check and revise the input data for this coil before rerunning the simulation." );
+			ShowFatalError( "Check and revise the input data for this coil before rerunning the simulation." );  // LCOV_EXCL_LINE
 		}
 		// Calculate slope at given conditions
 		if ( DeltaT > 0.0 ) SlopeAtConds = DeltaHumRat / DeltaT;
@@ -9718,7 +9718,7 @@ Label50: ;
 
 		// Show fatal error for specific coil that caused a CBF error
 		if ( CBFErrors ) {
-			ShowFatalError( UnitType + " \"" + UnitName + "\" Errors found in calculating coil bypass factors" );
+			ShowFatalError( UnitType + " \"" + UnitName + "\" Errors found in calculating coil bypass factors" );  // LCOV_EXCL_LINE
 		}
 
 		return CBF;
@@ -10273,19 +10273,19 @@ Label50: ;
 				ShowContinueError( "When AirMassFlow > 0.0 and CycRatio > 0.0 and SpeedNum > 1, then MSHPMassFlowRateLow and MSHPMassFlowRateHigh must also be > 0.0" );
 				ShowContinueErrorTimeStamp( "" );
 				ShowContinueError( "AirMassFlow=" + RoundSigDigits( AirMassFlow, 3 ) + ",CycRatio=" + RoundSigDigits( CycRatio, 3 ) + ",SpeedNum=" + RoundSigDigits( double( SpeedNum ), 0 ) + ", MSHPMassFlowRateLow=" + RoundSigDigits( MSHPMassFlowRateLow, 3 ) + ", MSHPMassFlowRateHigh=" + RoundSigDigits( MSHPMassFlowRateHigh, 3 ) );
-				ShowFatalError( "Preceding condition(s) causes termination." );
+				ShowFatalError( "Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 			} else {
 				ShowContinueError( "When AirMassFlow > 0.0 and CycRatio > 0.0, then MSHPMassFlowRateHigh must also be > 0.0" );
 				ShowContinueErrorTimeStamp( "" );
 				ShowContinueError( "AirMassFlow=" + RoundSigDigits( AirMassFlow, 3 ) + ",CycRatio=" + RoundSigDigits( CycRatio, 3 ) + ", MSHPMassFlowRateHigh=" + RoundSigDigits( MSHPMassFlowRateHigh, 3 ) );
-				ShowFatalError( "Preceding condition(s) causes termination." );
+				ShowFatalError( "Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 			}
 		} else if ( CycRatio > 1.0 || SpeedRatio > 1.0 ) {
 			ShowSevereError( "CalcMultiSpeedDXCoilCooling: " + DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + " Developer error - inconsistent speed ratios." );
 			ShowContinueError( "CycRatio and SpeedRatio must be between 0.0 and 1.0" );
 			ShowContinueErrorTimeStamp( "" );
 			ShowContinueError( "CycRatio=" + RoundSigDigits( CycRatio, 1 ) + ", SpeedRatio = " + RoundSigDigits( SpeedRatio, 1 ) );
-			ShowFatalError( "Preceding condition(s) causes termination." );
+			ShowFatalError( "Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		DXCoil( DXCoilNum ).PartLoadRatio = 0.0;
@@ -10912,19 +10912,19 @@ Label50: ;
 				ShowContinueError( "When AirMassFlow > 0.0 and CycRatio > 0.0 and SpeedNum > 1, then MSHPMassFlowRateLow and MSHPMassFlowRateHigh must also be > 0.0" );
 				ShowContinueErrorTimeStamp( "" );
 				ShowContinueError( "AirMassFlow=" + RoundSigDigits( AirMassFlow, 3 ) + ",CycRatio=" + RoundSigDigits( CycRatio, 3 ) + ",SpeedNum=" + RoundSigDigits( double( SpeedNum ), 0 ) + ", MSHPMassFlowRateLow=" + RoundSigDigits( MSHPMassFlowRateLow, 3 ) + ", MSHPMassFlowRateHigh=" + RoundSigDigits( MSHPMassFlowRateHigh, 3 ) );
-				ShowFatalError( "Preceding condition(s) causes termination." );
+				ShowFatalError( "Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 			} else {
 				ShowContinueError( "When AirMassFlow > 0.0 and CycRatio > 0.0, then MSHPMassFlowRateHigh must also be > 0.0" );
 				ShowContinueErrorTimeStamp( "" );
 				ShowContinueError( "AirMassFlow=" + RoundSigDigits( AirMassFlow, 3 ) + ",CycRatio=" + RoundSigDigits( CycRatio, 3 ) + ", MSHPMassFlowRateHigh=" + RoundSigDigits( MSHPMassFlowRateHigh, 3 ) );
-				ShowFatalError( "Preceding condition(s) causes termination." );
+				ShowFatalError( "Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 			}
 		} else if ( CycRatio > 1.0 || SpeedRatio > 1.0 ) {
 			ShowSevereError( "CalcMultiSpeedDXCoilHeating: " + DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + " Developer error - inconsistent speed ratios." );
 			ShowContinueError( "CycRatio and SpeedRatio must be between 0.0 and 1.0" );
 			ShowContinueErrorTimeStamp( "" );
 			ShowContinueError( "CycRatio=" + RoundSigDigits( CycRatio, 1 ) + ", SpeedRatio = " + RoundSigDigits( SpeedRatio, 1 ) );
-			ShowFatalError( "Preceding condition(s) causes termination." );
+			ShowFatalError( "Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		AirFlowRatio = 1.0;
@@ -11749,7 +11749,7 @@ Label50: ;
 				}
 
 				FanHeatCorrection = Node( FanOutletNode ).Enthalpy - Node( FanInletNode ).Enthalpy;
-				
+
 
 				NetCoolingCapRated = DXCoil( DXCoilNum ).RatedTotCap( 1 ) * TotCapTempModFac * TotCapFlowModFac - FanHeatCorrection;
 			}
@@ -12870,7 +12870,7 @@ Label50: ;
 				//     ErrorFound, Coil:Heating:DX:SingleSpeed is used in wrong type of parent object (should never get here)
 				ShowSevereError( "Configuration error in " + CompSetsParentType + " \"" + CompSetsParentName + "\"" );
 				ShowContinueError( "DX heating coil not allowed in this configuration." );
-				ShowFatalError( "Preceding condition(s) causes termination." );
+				ShowFatalError( "Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 			}
 			break;
 		}
@@ -13931,7 +13931,7 @@ Label50: ;
 		// 		ShowRecurringWarningErrorAtEnd( DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Low condenser inlet temperature error continues...", DXCoil( DXCoilNum ).LowAmbErrIndex, DXCoil( DXCoilNum ).LowTempLast, DXCoil( DXCoilNum ).LowTempLast, _, "[C]", "[C]" );
 		// 	}
 		// }
-        // 
+        //
 		// if ( DXCoil( DXCoilNum ).PrintHighAmbMessage ) { // .AND. &
 		// 	if ( CurrentEndTime > DXCoil( DXCoilNum ).CurrentEndTimeLast && TimeStepSys >= DXCoil( DXCoilNum ).TimeStepSysLast ) {
 		// 		if ( DXCoil( DXCoilNum ).HighAmbErrIndex == 0 ) {
@@ -13966,7 +13966,7 @@ Label50: ;
 		if ( ( AirMassFlow > 0.0 ) && ( GetCurrentScheduleValue( DXCoil( DXCoilNum ).SchedPtr ) > 0.0 ) && ( PartLoadRatio > 0.0 ) && ( CompOp == On ) ) { // for cycling fan, reset mass flow to full on rate
 
 			if ( DXCoil( DXCoilNum ).RatedTotCap( Mode ) <= 0.0 ) {
-				ShowFatalError( DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Rated total cooling capacity is zero or less." );
+				ShowFatalError( DXCoil( DXCoilNum ).DXCoilType + " \"" + DXCoil( DXCoilNum ).Name + "\" - Rated total cooling capacity is zero or less." );  // LCOV_EXCL_LINE
 			}
 
 			TotCap = DXCoil( DXCoilNum ).RatedTotCap( Mode );
@@ -14011,7 +14011,7 @@ Label50: ;
 			// 		DXCoil( DXCoilNum ).LowAmbBuffer2 = " ... Occurrence info = " + EnvironmentName + ", " + CurMnDy + " " + CreateSysTimeIntervalString();
 			// 	}
 			// }
-            // 
+            //
 			// // check boundary for high ambient temperature and post warnings to individual DX coil buffers to print at end of time step
 			// if ( OutdoorDryBulb > DXCoil( DXCoilNum ).MaxOATCompressor && ! WarmupFlag ) {
 			// 	DXCoil( DXCoilNum ).PrintHighAmbMessage = true;
@@ -14539,7 +14539,7 @@ Label50: ;
 			C2Tevap = DXCoil( CoilIndex ).C2Te;
 			C3Tevap = DXCoil( CoilIndex ).C3Te;
 			BF = DXCoil( CoilIndex ).RateBFVRFIUEvap;
-			
+
 			// Coil sensible heat transfer_minimum value
 			CalcVRFCoilSenCap( FlagCoolMode, CoilIndex, Tin, TeTc, SH, BF, QinSenPerFlowRate, Ts_1 );
 			To_1 = Tin - QinSenPerFlowRate / 1005;
@@ -14640,7 +14640,7 @@ Label50: ;
 			C2Tcond = DXCoil( CoilIndex ).C2Tc;
 			C3Tcond = DXCoil( CoilIndex ).C3Tc;
 			BF = DXCoil( CoilIndex ).RateBFVRFIUCond;
-			
+
 			// Coil sensible heat transfer_minimum value
 			CalcVRFCoilSenCap( FlagHeatMode, CoilIndex, Tin, TeTc, SC, BF, QinSenPerFlowRate, Ts_1 );
 			To_1 = QinSenPerFlowRate / 1005 + Tin;
@@ -14845,7 +14845,7 @@ Label50: ;
 
 		if ( OperationMode == FlagCoolMode ) {
 		//Cooling: OperationMode 0
-			
+
 			if ( present( BF ) ) {
 				BF_real = BF;
 			} else {
@@ -14861,10 +14861,10 @@ Label50: ;
 			} else {
 				SHSC_real = SH_rate;
 			}
-			
+
 			// Coil capacity at rated conditions
 			CalcVRFCoilSenCap( FlagCoolMode, CoilNum, 26, Te_rate, SH_rate, BFC_rate, Q_rate, Ts );
-			
+
 			// Coil capacity at given conditions
 			CalcVRFCoilSenCap( FlagCoolMode, CoilNum, Tinlet, TeTc_real, SHSC_real, BF_real, Q_real, Ts );
 

--- a/src/EnergyPlus/DataAirSystems.cc
+++ b/src/EnergyPlus/DataAirSystems.cc
@@ -105,7 +105,7 @@ namespace DataAirSystems {
 	// Functions
 	void
 	clear_state(){
-	
+
 		PrimaryAirSystem.deallocate();
 		DemandSideConnect.deallocate(); // Connections between loops
 		ZoneCompToPlant.deallocate(); // Connections between loops
@@ -113,7 +113,7 @@ namespace DataAirSystems {
 		ZoneSubSubCompToPlant.deallocate(); // Connections between loops
 		AirSysCompToPlant.deallocate(); // Connections between loops
 		AirSysSubCompToPlant.deallocate(); // Connections between loops
-		AirSysSubSubCompToPlant.deallocate(); // Connections 
+		AirSysSubSubCompToPlant.deallocate(); // Connections
 	}
 
 } // DataAirSystems

--- a/src/EnergyPlus/DataEnvironment.cc
+++ b/src/EnergyPlus/DataEnvironment.cc
@@ -216,7 +216,7 @@ namespace DataEnvironment {
 	std::string EnvironmentStartEnd; // Start/End dates for Environment
 	bool CurrentYearIsLeapYear( false ); // true when current year is leap year (convoluted logic dealing with
 	// whether weather file allows leap years, runperiod inputs.
-	
+
 	int varyingLocationSchedIndexLat( 0 );
 	int varyingLocationSchedIndexLong( 0 );
 	int varyingOrientationSchedIndex( 0 );
@@ -388,7 +388,7 @@ namespace DataEnvironment {
 		if ( LocalOutDryBulbTemp < -100.0 ) {
 			ShowSevereError( "OutDryBulbTempAt: outdoor drybulb temperature < -100 C" );
 			ShowContinueError( "...check heights, this height=[" + RoundSigDigits( Z, 0 ) + "]." );
-			ShowFatalError( "Program terminates due to preceding condition(s)." );
+			ShowFatalError( "Program terminates due to preceding condition(s)." );  // LCOV_EXCL_LINE
 		}
 
 		return LocalOutDryBulbTemp;
@@ -439,7 +439,7 @@ namespace DataEnvironment {
 		if ( LocalOutWetBulbTemp < -100.0 ) {
 			ShowSevereError( "OutWetBulbTempAt: outdoor wetbulb temperature < -100 C" );
 			ShowContinueError( "...check heights, this height=[" + RoundSigDigits( Z, 0 ) + "]." );
-			ShowFatalError( "Program terminates due to preceding condition(s)." );
+			ShowFatalError( "Program terminates due to preceding condition(s)." );  // LCOV_EXCL_LINE
 		}
 
 		return LocalOutWetBulbTemp;
@@ -491,7 +491,7 @@ namespace DataEnvironment {
 		if ( LocalOutDewPointTemp < -100.0 ) {
 			ShowSevereError( "OutDewPointTempAt: outdoor dewpoint temperature < -100 C" );
 			ShowContinueError( "...check heights, this height=[" + RoundSigDigits( Z, 0 ) + "]." );
-			ShowFatalError( "Program terminates due to preceding condition(s)." );
+			ShowFatalError( "Program terminates due to preceding condition(s)." );  // LCOV_EXCL_LINE
 		}
 
 		return LocalOutDewPointTemp;
@@ -604,7 +604,7 @@ namespace DataEnvironment {
 			ShowContinueError( "...according to your maximum Z height, your building is somewhere in the Stratosphere." );
 			ShowContinueError( "...look at " + Settings + " Name= " + SettingsName );
 		}
-		ShowFatalError( "Program terminates due to preceding condition(s)." );
+		ShowFatalError( "Program terminates due to preceding condition(s)." );  // LCOV_EXCL_LINE
 	}
 
 	void

--- a/src/EnergyPlus/DataHVACGlobals.cc
+++ b/src/EnergyPlus/DataHVACGlobals.cc
@@ -84,7 +84,7 @@ namespace DataHVACGlobals {
 	Real64 const BlankNumeric( -99999.0 ); // indicates numeric input field was blank
 	Real64 const RetTempMax( 60.0 ); // maximum return air temperature [deg C]
 	Real64 const RetTempMin( -30.0 ); // minimum return air temperature [deg C]
-	Real64 const DesCoilHWInletTempMin( 46.0 ); // minimum heating water coil water inlet temp for UA sizing only. [deg C] 
+	Real64 const DesCoilHWInletTempMin( 46.0 ); // minimum heating water coil water inlet temp for UA sizing only. [deg C]
 
 	// Number of Sizing types from list below
 	int const NumOfSizingTypes( 33 ); // number of sizing types
@@ -156,7 +156,7 @@ namespace DataHVACGlobals {
 	int const FanType_SimpleVAV( 2 );
 	int const FanType_SimpleOnOff( 3 );
 	int const FanType_ZoneExhaust( 4 );
-	int const FanType_ComponentModel( 5 ); // cpw22Aug2010 
+	int const FanType_ComponentModel( 5 ); // cpw22Aug2010
 	int const FanType_SystemModelObject( 6 ); // new for V8.7, simple versatile fan object
 
 	// Fan Minimum Flow Fraction Input Method
@@ -172,7 +172,7 @@ namespace DataHVACGlobals {
 	int const BypassWhenWithinEconomizerLimits( 0 ); // heat recovery controlled by economizer limits
 	int const BypassWhenOAFlowGreaterThanMinimum( 1 ); // heat recovery ON at minimum OA in economizer mode
 
-	Array1D_string const cFanTypes( NumAllFanTypes, { "Fan:ConstantVolume", "Fan:VariableVolume", "Fan:OnOff", "Fan:ZoneExhaust", "Fan:ComponentModel", "Fan:SystemModel" } ); 
+	Array1D_string const cFanTypes( NumAllFanTypes, { "Fan:ConstantVolume", "Fan:VariableVolume", "Fan:OnOff", "Fan:ZoneExhaust", "Fan:ComponentModel", "Fan:SystemModel" } );
 
 	// parameters describing unitary systems
 	int const NumUnitarySystemTypes( 7 );
@@ -226,7 +226,7 @@ namespace DataHVACGlobals {
 	int const Coil_CoolingAirToAirVariableSpeed( 30 );
 	int const Coil_HeatingAirToAirVariableSpeed( 31 );
 	int const CoilDX_HeatPumpWaterHeaterVariableSpeed( 32 );
-	
+
 	int const CoilVRF_FluidTCtrl_Cooling( 33 );
 	int const CoilVRF_FluidTCtrl_Heating( 34 );
 

--- a/src/EnergyPlus/DataHeatBalance.cc
+++ b/src/EnergyPlus/DataHeatBalance.cc
@@ -1787,7 +1787,7 @@ namespace DataHeatBalance {
 		if ( present( ScreenNumber ) ) {
 			ScNum = ScreenNumber;
 			if ( ! present( Theta ) || ! present( Phi ) ) {
-				ShowFatalError( "Syntax error, optional arguments Theta and Phi must be present when optional ScreenNumber is used." );
+				ShowFatalError( "Syntax error, optional arguments Theta and Phi must be present when optional ScreenNumber is used." );  // LCOV_EXCL_LINE
 			}
 		} else {
 			ScNum = SurfaceWindow( SurfaceNum ).ScreenNumber;

--- a/src/EnergyPlus/DataOutputs.cc
+++ b/src/EnergyPlus/DataOutputs.cc
@@ -122,7 +122,7 @@ namespace DataOutputs {
 		if ( ! pattern->ok() ) {
 			ShowSevereError( "Regular expression \"" + KeyValue + "\" for variable name \"" + VariableName + "\" in input file is incorrect" );
 			ShowContinueError( pattern->error() );
-			ShowFatalError( "Error found in regular expression. Previous error(s) cause program termination." );
+			ShowFatalError( "Error found in regular expression. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 	}
 

--- a/src/EnergyPlus/DataPlant.cc
+++ b/src/EnergyPlus/DataPlant.cc
@@ -304,7 +304,7 @@ namespace DataPlant {
 	// int const TypeOf_HPWrappedCondenser ?? 92 ??
 	int const TypeOf_FourPipeBeamAirTerminal( 93 );
 	int const TypeOf_CoolingPanel_Simple( 94 );
-	
+
 	// Parameters for General Equipment Types
 	int const NumGeneralEquipTypes( 23 );
 	Array1D_string const GeneralEquipTypes( NumGeneralEquipTypes, { "BOILER", "CHILLER", "COOLINGTOWER", "GENERATOR", "HEATEXCHANGER", "HEATPUMP", "PIPE", "PUMP", "DISTRICT", "THERMALSTORAGE", "TEMPERINGVALVE", "WATERHEATER", "WATERUSE", "DEMANDCOIL", "SOLARCOLLECTOR", "LOADPROFILE", "FLUIDCOOLER", "EVAPORATIVEFLUIDCOOLER", "GROUNDHEATEXCHANGER", "ZONEHVACDEMAND", "REFRIGERATION", "PLANTCOMPONENT", "CENTRALHEATPUMPSYSTEM" } );
@@ -602,7 +602,7 @@ namespace DataPlant {
 			} else {
 				ShowSevereError( "ScanPlantLoopsForObject: Invalid CompType passed [" + RoundSigDigits( CompType ) + "], Name=" + CompName );
 				ShowContinueError( "Valid CompTypes are in the range [1 - " + RoundSigDigits( NumSimPlantEquipTypes ) + "]." );
-				ShowFatalError( "Previous error causes program termination" );
+				ShowFatalError( "Previous error causes program termination" );  // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/EnergyPlus/DataRuntimeLanguage.cc
+++ b/src/EnergyPlus/DataRuntimeLanguage.cc
@@ -258,14 +258,14 @@ namespace DataRuntimeLanguage {
 	clear_state()
 	{
 		EMSProgram.deallocate();
-		NumProgramCallManagers = 0 ; 
-		NumSensors =  0 ; 
-		numActuatorsUsed = 0 ; 
-		numEMSActuatorsAvailable = 0 ; 
-		maxEMSActuatorsAvailable = 0 ; 
-		NumInternalVariablesUsed = 0 ; 
-		numEMSInternalVarsAvailable = 0 ; 
-		maxEMSInternalVarsAvailable = 0 ; 
+		NumProgramCallManagers = 0 ;
+		NumSensors =  0 ;
+		numActuatorsUsed = 0 ;
+		numEMSActuatorsAvailable = 0 ;
+		maxEMSActuatorsAvailable = 0 ;
+		NumInternalVariablesUsed = 0 ;
+		numEMSInternalVarsAvailable = 0 ;
+		maxEMSInternalVarsAvailable = 0 ;
 		varsAvailableAllocInc = 1000 ;
 		NumErlPrograms = 0 ;
 		NumErlSubroutines = 0 ;
@@ -274,24 +274,24 @@ namespace DataRuntimeLanguage {
 		NumErlStacks = 0 ;
 		NumExpressions = 0 ;
 		NumEMSOutputVariables = 0 ;
-		NumEMSMeteredOutputVariables = 0 ; 
+		NumEMSMeteredOutputVariables = 0 ;
 		NumErlTrendVariables = 0 ;
-		NumEMSCurveIndices = 0 ; 
-		NumEMSConstructionIndices = 0 ; 
-		NumExternalInterfaceGlobalVariables = 0 ; 
-		NumExternalInterfaceFunctionalMockupUnitImportGlobalVariables =  0 ; 
-		NumExternalInterfaceFunctionalMockupUnitExportGlobalVariables = 0 ; 
-		NumExternalInterfaceActuatorsUsed = 0 ; 
-		NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed = 0 ; 
-		NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed = 0 ; 
-		OutputEMSFileUnitNum = 0 ; 
-		OutputEDDFile = false ; 
-		OutputFullEMSTrace = false ; 
-		OutputEMSErrors = false ; 
-		OutputEMSActuatorAvailFull = false ; 
-		OutputEMSActuatorAvailSmall = false ; 
-		OutputEMSInternalVarsFull = false ; 
-		OutputEMSInternalVarsSmall = false ; 
+		NumEMSCurveIndices = 0 ;
+		NumEMSConstructionIndices = 0 ;
+		NumExternalInterfaceGlobalVariables = 0 ;
+		NumExternalInterfaceFunctionalMockupUnitImportGlobalVariables =  0 ;
+		NumExternalInterfaceFunctionalMockupUnitExportGlobalVariables = 0 ;
+		NumExternalInterfaceActuatorsUsed = 0 ;
+		NumExternalInterfaceFunctionalMockupUnitImportActuatorsUsed = 0 ;
+		NumExternalInterfaceFunctionalMockupUnitExportActuatorsUsed = 0 ;
+		OutputEMSFileUnitNum = 0 ;
+		OutputEDDFile = false ;
+		OutputFullEMSTrace = false ;
+		OutputEMSErrors = false ;
+		OutputEMSActuatorAvailFull = false ;
+		OutputEMSActuatorAvailSmall = false ;
+		OutputEMSInternalVarsFull = false ;
+		OutputEMSInternalVarsSmall = false ;
 		EMSConstructActuatorChecked.deallocate();
 		EMSConstructActuatorIsOkay.deallocate();
 		ErlVariable.deallocate(); // holds Erl variables in a structure array
@@ -306,7 +306,7 @@ namespace DataRuntimeLanguage {
 		EMSInternalVarsUsed.deallocate(); // internal data that are used
 		EMSProgramCallManager.deallocate(); // program calling managers
 		EMSActuator_lookup.clear(); // Fast duplicate lookup structure
-	
+
 	}
 
 	void

--- a/src/EnergyPlus/DataSizing.cc
+++ b/src/EnergyPlus/DataSizing.cc
@@ -323,8 +323,8 @@ namespace DataSizing {
 	Array1D< ZoneHVACSizingData > ZoneHVACSizing; // Input data for zone HVAC sizing
 	Array1D< AirTerminalSizingSpecData > AirTerminalSizingSpec; // Input data for zone HVAC sizing
 	// used only for Facility Load Component Summary
-	Array1D< FacilitySizingData > CalcFacilitySizing; // Data for zone sizing 
-	FacilitySizingData CalcFinalFacilitySizing; // Final data for zone sizing 
+	Array1D< FacilitySizingData > CalcFacilitySizing; // Data for zone sizing
+	FacilitySizingData CalcFinalFacilitySizing; // Final data for zone sizing
 
 	// Clears the global data in DataSizing.
 	// Needed for unit tests, should not be normally called.
@@ -442,7 +442,7 @@ namespace DataSizing {
 		DataDesicDehumNum = 0;
 		DataDesicRegCoil = false;
 
-		CalcFacilitySizing.deallocate(); 
+		CalcFacilitySizing.deallocate();
 		CalcFinalFacilitySizing.DOASHeatAddSeq.deallocate();
 		CalcFinalFacilitySizing.DOASLatAddSeq.deallocate();
 		CalcFinalFacilitySizing.CoolOutHumRatSeq.deallocate();
@@ -453,7 +453,7 @@ namespace DataSizing {
 		CalcFinalFacilitySizing.HeatOutTempSeq.deallocate();
 		CalcFinalFacilitySizing.HeatZoneTempSeq.deallocate();
 		CalcFinalFacilitySizing.HeatLoadSeq.deallocate();
-	
+
 		DataWaterCoilSizCoolDeltaT = 0.0;
 		DataWaterCoilSizHeatDeltaT = 0.0;
 		DataNomCapInpMeth = false;

--- a/src/EnergyPlus/DataSurfaceLists.cc
+++ b/src/EnergyPlus/DataSurfaceLists.cc
@@ -377,7 +377,7 @@ namespace DataSurfaceLists {
 
 		}
 
-		if ( ErrorsFound ) ShowFatalError( "GetSurfaceListsInputs: Program terminates due to preceding conditions." );
+		if ( ErrorsFound ) ShowFatalError( "GetSurfaceListsInputs: Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 
 	}
 

--- a/src/EnergyPlus/DataTimings.cc
+++ b/src/EnergyPlus/DataTimings.cc
@@ -286,7 +286,7 @@ namespace DataTimings {
 		}
 
 		if ( found == 0 ) {
-			ShowFatalError( "epStopTime: No element=" + ctimingElementstring );
+			ShowFatalError( "epStopTime: No element=" + ctimingElementstring );  // LCOV_EXCL_LINE
 		}
 
 		TSTOP( stoptime );
@@ -442,7 +442,7 @@ namespace DataTimings {
 		}
 
 		if ( found == 0 && ! AbortProcessing ) {
-			ShowFatalError( "epGetTimeUsed: No element=" + ctimingElementstring );
+			ShowFatalError( "epGetTimeUsed: No element=" + ctimingElementstring );  // LCOV_EXCL_LINE
 		} else {
 			ShowSevereError( "epGetTimeUsed: No element=" + ctimingElementstring );
 		}
@@ -502,7 +502,7 @@ namespace DataTimings {
 		}
 
 		if ( found == 0 ) {
-			ShowFatalError( "epGetTimeUsedperCall: No element=" + ctimingElementstring );
+			ShowFatalError( "epGetTimeUsedperCall: No element=" + ctimingElementstring );  // LCOV_EXCL_LINE
 		} else {
 			ShowSevereError( "epGetTimeUsedperCall: No element=" + ctimingElementstring );
 		}

--- a/src/EnergyPlus/DataZoneEnergyDemands.cc
+++ b/src/EnergyPlus/DataZoneEnergyDemands.cc
@@ -88,7 +88,7 @@ namespace DataZoneEnergyDemands {
 		CurDeadBandOrSetback.deallocate();
 		ZoneSysEnergyDemand.deallocate();
 		ZoneSysMoistureDemand.deallocate();
-	
+
 	}
 
 } // DataZoneEnergyDemands

--- a/src/EnergyPlus/DataZoneEquipment.cc
+++ b/src/EnergyPlus/DataZoneEquipment.cc
@@ -414,12 +414,12 @@ namespace DataZoneEquipment {
 		if ( NumOfZoneEquipLists != NumOfControlledZones ) {
 			ShowSevereError( RoutineName + "Number of Zone Equipment lists [" + TrimSigDigits( NumOfZoneEquipLists ) + "] not equal Number of Controlled Zones [" + TrimSigDigits( NumOfControlledZones ) + ']' );
 			ShowContinueError( "..Each Controlled Zone [ZoneHVAC:EquipmentConnections] must have a corresponding (unique) ZoneHVAC:EquipmentList" );
-			ShowFatalError( "GetZoneEquipment: Incorrect number of zone equipment lists" );
+			ShowFatalError( "GetZoneEquipment: Incorrect number of zone equipment lists" );  // LCOV_EXCL_LINE
 		}
 
 		if ( NumOfControlledZones > NumOfZones ) {
 			ShowSevereError( RoutineName + "Number of Controlled Zone objects [" + TrimSigDigits( NumOfControlledZones ) + "] greater than Number of Zones [" + TrimSigDigits( NumOfZones ) + ']' );
-			ShowFatalError( RoutineName + "Too many ZoneHVAC:EquipmentConnections objects." );
+			ShowFatalError( RoutineName + "Too many ZoneHVAC:EquipmentConnections objects." );  // LCOV_EXCL_LINE
 		}
 
 		InitUniqueNodeCheck( "ZoneHVAC:EquipmentConnections" );
@@ -621,7 +621,7 @@ namespace DataZoneEquipment {
 
 					} else if ( SELECT_CASE_var == "ZONEHVAC:COOLINGPANEL:RADIANTCONVECTIVE:WATER" ) { // Simple Cooling Panel
 						ZoneEquipList( ControlledZoneNum ).EquipType_Num( ZoneEquipTypeNum ) = CoolingPanel_Num;
-					
+
 					} else if ( SELECT_CASE_var == "ZONEHVAC:HIGHTEMPERATURERADIANT" ) { // High Temperature Radiators
 						ZoneEquipList( ControlledZoneNum ).EquipType_Num( ZoneEquipTypeNum ) = HiTempRadiant_Num;
 
@@ -972,7 +972,7 @@ namespace DataZoneEquipment {
 		SetupZoneEquipmentForConvectionFlowRegime();
 
 		if ( GetZoneEquipmentDataErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting Zone Equipment input." );
+			ShowFatalError( RoutineName + "Errors found in getting Zone Equipment input." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1269,7 +1269,7 @@ namespace DataZoneEquipment {
 	GetReturnAirNodeForZone(
 		std::string const & ZoneName, // Zone name to match into Controlled Zone structure
 		std::string const & NodeName  // Return air node name to match (may be blank)
-	) 
+	)
 	{
 
 		// FUNCTION INFORMATION:
@@ -1280,7 +1280,7 @@ namespace DataZoneEquipment {
 		// PURPOSE OF THIS FUNCTION:
 		// This function returns the return air node number for the indicated
 		// zone and node name.  If NodeName is blank, return the first return node number,
-		// otherwise return the node number of the matching return node name.  
+		// otherwise return the node number of the matching return node name.
 		// Returns 0 if the Zone is not a controlled zone or the node name does not match.
 
 		// Using/Aliasing
@@ -1435,7 +1435,7 @@ namespace DataZoneEquipment {
 			if ( !DataContaminantBalance::Contaminant.CO2Simulation ) {
 				ShowSevereError( "DesignSpecification:OutdoorAir=\"" + OARequirements( DSOAPtr ).Name + "\" valid Outdoor Air Method =\" IndoorAirQualityProcedure\" requires CO2 simulation." );
 				ShowContinueError( "The choice must be Yes for the field Carbon Dioxide Concentration in ZoneAirContaminantBalance" );
-				ShowFatalError( "CalcDesignSpecificationOutdoorAir: Errors found in input. Preceding condition(s) cause termination." );
+				ShowFatalError( "CalcDesignSpecificationOutdoorAir: Errors found in input. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 			MyEnvrnFlag( DSOAPtr ) = false;
 		}
@@ -1443,7 +1443,7 @@ namespace DataZoneEquipment {
 			if ( !DataContaminantBalance::Contaminant.CO2Simulation ) {
 				ShowSevereError( "DesignSpecification:OutdoorAir=\"" + OARequirements( DSOAPtr ).Name + "\" valid Outdoor Air Method =\" ProportionalControlBasedOnDesignOccupancy\" requires CO2 simulation." );
 				ShowContinueError( "The choice must be Yes for the field Carbon Dioxide Concentration in ZoneAirContaminantBalance" );
-				ShowFatalError( "CalcDesignSpecificationOutdoorAir: Errors found in input. Preceding condition(s) cause termination." );
+				ShowFatalError( "CalcDesignSpecificationOutdoorAir: Errors found in input. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 			MyEnvrnFlag( DSOAPtr ) = false;
 		}
@@ -1451,7 +1451,7 @@ namespace DataZoneEquipment {
 			if ( !DataContaminantBalance::Contaminant.CO2Simulation ) {
 				ShowSevereError( "DesignSpecification:OutdoorAir=\"" + OARequirements( DSOAPtr ).Name + "\" valid Outdoor Air Method =\" ProportionalControlBasedonOccupancySchedule\" requires CO2 simulation." );
 				ShowContinueError( "The choice must be Yes for the field Carbon Dioxide Concentration in ZoneAirContaminantBalance" );
-				ShowFatalError( "CalcDesignSpecificationOutdoorAir: Errors found in input. Preceding condition(s) cause termination." );
+				ShowFatalError( "CalcDesignSpecificationOutdoorAir: Errors found in input. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 			MyEnvrnFlag( DSOAPtr ) = false;
 		}

--- a/src/EnergyPlus/DaylightingDevices.cc
+++ b/src/EnergyPlus/DaylightingDevices.cc
@@ -668,7 +668,7 @@ namespace DaylightingDevices {
 
 			} // PipeNum
 
-			if ( ErrorsFound ) ShowFatalError( "Errors in DaylightingDevice:Tubular input." );
+			if ( ErrorsFound ) ShowFatalError( "Errors in DaylightingDevice:Tubular input." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -865,7 +865,7 @@ namespace DaylightingDevices {
 
 			} // ShelfNum
 
-			if ( ErrorsFound ) ShowFatalError( "Errors in DaylightingDevice:Shelf input." );
+			if ( ErrorsFound ) ShowFatalError( "Errors in DaylightingDevice:Shelf input." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1355,7 +1355,7 @@ namespace DaylightingDevices {
 		FindTDDPipe = 0;
 
 		if ( NumOfTDDPipes <= 0 ) {
-			ShowFatalError( "FindTDDPipe: Surface=" + Surface( WinNum ).Name + ", TDD:Dome object does not reference a valid Diffuser object....needs DaylightingDevice:Tubular of same name as Surface." );
+			ShowFatalError( "FindTDDPipe: Surface=" + Surface( WinNum ).Name + ", TDD:Dome object does not reference a valid Diffuser object....needs DaylightingDevice:Tubular of same name as Surface." );  // LCOV_EXCL_LINE
 		}
 
 		for ( PipeNum = 1; PipeNum <= NumOfTDDPipes; ++PipeNum ) {
@@ -1487,7 +1487,7 @@ namespace DaylightingDevices {
 		} else if ( Surface( Shelf( ShelfNum ).OutSurf ).Height == W ) {
 			L = Surface( Shelf( ShelfNum ).OutSurf ).Width;
 		} else {
-			ShowFatalError( "DaylightingDevice:Shelf = " + Shelf( ShelfNum ).Name + ":  Width of window and outside shelf do not match." );
+			ShowFatalError( "DaylightingDevice:Shelf = " + Shelf( ShelfNum ).Name + ":  Width of window and outside shelf do not match." );  // LCOV_EXCL_LINE
 		}
 
 		// Error if more or less than two vertices match
@@ -1501,7 +1501,7 @@ namespace DaylightingDevices {
 		if ( NumMatch < 2 ) {
 			ShowWarningError( "DaylightingDevice:Shelf = " + Shelf( ShelfNum ).Name + ":  Window and outside shelf must share two vertices.  View factor calculation may be inaccurate." );
 		} else if ( NumMatch > 2 ) {
-			ShowFatalError( "DaylightingDevice:Shelf = " + Shelf( ShelfNum ).Name + ":  Window and outside shelf share too many vertices." );
+			ShowFatalError( "DaylightingDevice:Shelf = " + Shelf( ShelfNum ).Name + ":  Window and outside shelf share too many vertices." );  // LCOV_EXCL_LINE
 		}
 
 		// Calculate exact analytical view factor from window to outside shelf

--- a/src/EnergyPlus/DaylightingManager.cc
+++ b/src/EnergyPlus/DaylightingManager.cc
@@ -312,11 +312,11 @@ namespace DaylightingManager {
 				if ( ZoneDaylight( ZoneNum ).TotalDaylRefPoints > 0 ) {
 					ShowSevereError( "DayltgAveInteriorReflectance: Multiplier > 1.0 for window " + Surface( ISurf ).Name + " in Zone=" + Surface( ISurf ).ZoneName );
 					ShowContinueError( "...not allowed since it is in a zone with daylighting." );
-					ShowFatalError( "Program terminates due to preceding conditions." );
+					ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 				} else {
 					ShowSevereError( "DayltgAveInteriorReflectance: Multiplier > 1.0 for window " + Surface( ISurf ).Name + " in Zone=" + Surface( ISurf ).ZoneName );
 					ShowContinueError( "...an adjacent Zone has daylighting. Simulation cannot proceed." );
-					ShowFatalError( "Program terminates due to preceding conditions." );
+					ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( IType == SurfaceClass_Wall || IType == SurfaceClass_Floor || IType == SurfaceClass_Roof || IType == SurfaceClass_Window || IType == SurfaceClass_Door ) {
@@ -750,7 +750,7 @@ namespace DaylightingManager {
 			OutputFileDFS = GetNewUnitNumber();
 			{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputFileDFS, DataStringGlobals::outputDfsFileName, flags ); write_stat = flags.ios(); }
 			if ( write_stat != 0 ) {
-				ShowFatalError( "CalcDayltgCoefficients: Could not open file "+DataStringGlobals::outputDfsFileName+" for output (write)." );
+				ShowFatalError( "CalcDayltgCoefficients: Could not open file "+DataStringGlobals::outputDfsFileName+" for output (write)." );  // LCOV_EXCL_LINE
 			} else {
 				gio::write( OutputFileDFS, fmtA ) << "This file contains daylight factors for all exterior windows of daylight zones.";
 				gio::write( OutputFileDFS, fmtA ) << "If only one reference point the last 4 columns in the data will be zero.";
@@ -893,7 +893,7 @@ namespace DaylightingManager {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Not all TubularDaylightDome objects have corresponding DaylightingDevice:Tubular objects. Program terminates." );
+				ShowFatalError( "Not all TubularDaylightDome objects have corresponding DaylightingDevice:Tubular objects. Program terminates." );  // LCOV_EXCL_LINE
 			}
 			VeryFirstTime = false;
 		}
@@ -1655,7 +1655,7 @@ namespace DaylightingManager {
 				if ( D1a > 0.0 && D1b > 0.0 && D1b <= HW && D1a <= WW ) {
 					ShowSevereError( "CalcDaylightCoeffRefPoints: Daylighting calculation cannot be done for zone " + Zone( ZoneNum ).Name + " because reference point #" + RoundSigDigits( iRefPoint ) + " is less than 0.15m (6\") from window plane " + Surface( IWin ).Name );
 					ShowContinueError( "Distance=[" + RoundSigDigits( ALF, 5 ) + "]. This is too close; check position of reference point." );
-					ShowFatalError( "Program terminates due to preceding condition." );
+					ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 				}
 			} else if ( ALF < 0.1524 && ExtWinType == AdjZoneExtWin ) {
 				if ( RefErrIndex( iRefPoint, IWin ) == 0 ) { // only show error message once
@@ -4073,7 +4073,7 @@ namespace DaylightingManager {
 			GeometryTransformForDaylighting(  );
 			GetInputIlluminanceMap( ErrorsFound );
 			GetLightWellData( ErrorsFound );
-			if ( ErrorsFound ) ShowFatalError( "Program terminated for above reasons, related to DAYLIGHTING" );
+			if ( ErrorsFound ) ShowFatalError( "Program terminated for above reasons, related to DAYLIGHTING" );  // LCOV_EXCL_LINE
 			DayltgSetupAdjZoneListsAndPointers();
 		}
 
@@ -4208,7 +4208,7 @@ namespace DaylightingManager {
 				// Sequentially read lines in DElight Daylight Factors Error File
 				// and process them using standard EPlus warning/error handling calls
 				// Process all error/warning messages first
-				// Then, if any error has occurred, ShowFatalError to terminate processing
+				// Then, if any error has occurred, ShowFatalError to terminate processing  // LCOV_EXCL_LINE
 				bEndofErrFile = false;
 				bRecordsOnErrFile = false;
 				while ( ! bEndofErrFile ) {
@@ -4237,7 +4237,7 @@ namespace DaylightingManager {
 				} else {
 					{ IOFlags flags; flags.DISPOSE( "DELETE" ); gio::close( iDElightErrorFile, flags ); }
 				}
-				// If any DElight Error occurred then ShowFatalError to terminate
+				// If any DElight Error occurred then ShowFatalError to terminate  // LCOV_EXCL_LINE
 				if ( iErrorFlag > 0 ) {
 					ErrorsFound = true;
 				}
@@ -4262,7 +4262,7 @@ namespace DaylightingManager {
 			}
 		}
 
-		if ( ErrorsFound ) ShowFatalError( "Program terminated for above reasons" );
+		if ( ErrorsFound ) ShowFatalError( "Program terminated for above reasons" );  // LCOV_EXCL_LINE
 
 	}
 
@@ -5094,7 +5094,7 @@ namespace DaylightingManager {
 			}
 		} // ShelfNum
 
-		if ( ErrorsFound ) ShowFatalError( "CheckTDDsAndLightShelvesInDaylitZones: Errors in DAYLIGHTING input." );
+		if ( ErrorsFound ) ShowFatalError( "CheckTDDsAndLightShelvesInDaylitZones: Errors in DAYLIGHTING input." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -9271,15 +9271,15 @@ namespace DaylightingManager {
 		return;
 
 Label901: ;
-		ShowFatalError( "ReportIllumMap: Could not open file "+ DataStringGlobals::outputMapTabFileName + MapNoString + "\" for output (write)." );
+		ShowFatalError( "ReportIllumMap: Could not open file "+ DataStringGlobals::outputMapTabFileName + MapNoString + "\" for output (write)." );  // LCOV_EXCL_LINE
 		return;
 
 Label902: ;
-		ShowFatalError( "ReportIllumMap: Could not open file "+ DataStringGlobals::outputMapCsvFileName + MapNoString + "\" for output (write)." );
+		ShowFatalError( "ReportIllumMap: Could not open file "+ DataStringGlobals::outputMapCsvFileName + MapNoString + "\" for output (write)." );  // LCOV_EXCL_LINE
 		return;
 
 Label903: ;
-		ShowFatalError( "ReportIllumMap: Could not open file "+ DataStringGlobals::outputMapTxtFileName + MapNoString + "\" for output (write)." );
+		ShowFatalError( "ReportIllumMap: Could not open file "+ DataStringGlobals::outputMapTxtFileName + MapNoString + "\" for output (write)." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -9350,7 +9350,7 @@ Label903: ;
 				while ( ios == 0 ) {
 					{ IOFlags flags; gio::read( IllumMap( MapNum ).UnitNo, FmtA, flags ) >> mapLine; ios = flags.ios(); }
 					if ( ios > 0 ) { // usually a read error
-						ShowFatalError( "CloseReportIllumMaps: Failed to read map. IOError=" + TrimSigDigits( ios ) );
+						ShowFatalError( "CloseReportIllumMaps: Failed to read map. IOError=" + TrimSigDigits( ios ) );  // LCOV_EXCL_LINE
 					} else if ( ios != 0 ) {
 						if ( NumLines == 0 ) {
 							ShowSevereError( "CloseReportIllumMaps: IllumMap=\"" + IllumMap( MapNum ).Name + "\" is empty." );
@@ -9375,15 +9375,15 @@ Label903: ;
 		return;
 
 Label901: ;
-		ShowFatalError( "CloseReportIllumMaps: Could not open file "+DataStringGlobals::outputMapTabFileName+" for output (write)." );
+		ShowFatalError( "CloseReportIllumMaps: Could not open file "+DataStringGlobals::outputMapTabFileName+" for output (write)." );  // LCOV_EXCL_LINE
 		return;
 
 Label902: ;
-		ShowFatalError( "CloseReportIllumMaps: Could not open file "+DataStringGlobals::outputMapCsvFileName+" for output (write)." );
+		ShowFatalError( "CloseReportIllumMaps: Could not open file "+DataStringGlobals::outputMapCsvFileName+" for output (write)." );  // LCOV_EXCL_LINE
 		return;
 
 Label903: ;
-		ShowFatalError( "CloseReportIllumMaps: Could not open file "+DataStringGlobals::outputMapTxtFileName+" for output (write)." );
+		ShowFatalError( "CloseReportIllumMaps: Could not open file "+DataStringGlobals::outputMapTxtFileName+" for output (write)." );  // LCOV_EXCL_LINE
 
 	}
 

--- a/src/EnergyPlus/DemandManager.cc
+++ b/src/EnergyPlus/DemandManager.cc
@@ -255,7 +255,7 @@ namespace DemandManager {
 
 					if ( DemandManagerExtIterations + DemandManagerHBIterations + DemandManagerHVACIterations > 500 ) {
 						// This error can only happen if there is a bug in the code
-						ShowFatalError( "Too many DemandManager iterations. (>500)" );
+						ShowFatalError( "Too many DemandManager iterations. (>500)" );  // LCOV_EXCL_LINE
 						break;
 					}
 				}
@@ -578,7 +578,7 @@ namespace DemandManager {
 				SetupOutputVariable( "Demand Manager Over Limit Time", OutputProcessor::Unit::hr, DemandManagerList( ListNum ).OverLimitDuration, "Zone", "Sum", DemandManagerList( ListNum ).Name );
 
 				if ( ErrorsFound ) {
-					ShowFatalError( "Errors found in processing input for " + CurrentModuleObject );
+					ShowFatalError( "Errors found in processing input for " + CurrentModuleObject );  // LCOV_EXCL_LINE
 				}
 
 			} // ListNum
@@ -1325,7 +1325,7 @@ namespace DemandManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for demand managers. Preceding condition causes termination." );
+			ShowFatalError( "Errors found in processing input for demand managers. Preceding condition causes termination." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/DesiccantDehumidifiers.cc
+++ b/src/EnergyPlus/DesiccantDehumidifiers.cc
@@ -249,16 +249,16 @@ namespace DesiccantDehumidifiers {
 		if ( CompIndex == 0 ) {
 			DesicDehumNum = FindItemInList( CompName, DesicDehum );
 			if ( DesicDehumNum == 0 ) {
-				ShowFatalError( "SimDesiccantDehumidifier: Unit not found=" + CompName );
+				ShowFatalError( "SimDesiccantDehumidifier: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DesicDehumNum;
 		} else {
 			DesicDehumNum = CompIndex;
 			if ( DesicDehumNum > NumDesicDehums || DesicDehumNum < 1 ) {
-				ShowFatalError( "SimDesiccantDehumidifier:  Invalid CompIndex passed=" + TrimSigDigits( DesicDehumNum ) + ", Number of Units=" + TrimSigDigits( NumDesicDehums ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimDesiccantDehumidifier:  Invalid CompIndex passed=" + TrimSigDigits( DesicDehumNum ) + ", Number of Units=" + TrimSigDigits( NumDesicDehums ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CompName != DesicDehum( DesicDehumNum ).Name ) {
-				ShowFatalError( "SimDesiccantDehumidifier: Invalid CompIndex passed=" + TrimSigDigits( DesicDehumNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + DesicDehum( DesicDehumNum ).Name );
+				ShowFatalError( "SimDesiccantDehumidifier: Invalid CompIndex passed=" + TrimSigDigits( DesicDehumNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + DesicDehum( DesicDehumNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -278,7 +278,7 @@ namespace DesiccantDehumidifiers {
 			CalcGenericDesiccantDehumidifier( DesicDehumNum, HumRatNeeded, FirstHVACIteration );
 
 		} else {
-			ShowFatalError( "Invalid type, Desiccant Dehumidifer=" + DesicDehum( DesicDehumNum ).DehumType );
+			ShowFatalError( "Invalid type, Desiccant Dehumidifer=" + DesicDehum( DesicDehumNum ).DehumType );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -1355,7 +1355,7 @@ namespace DesiccantDehumidifiers {
 					ShowContinueError( "The outlet node name in cooling coil = " + NodeID( DesicDehum( DesicDehumNum ).CoolingCoilOutletNode ) );
 					ShowContinueError( "For desiccant heat exchanger = " + DesicDehum( DesicDehumNum ).HXType + " \"" + DesicDehum( DesicDehumNum ).HXName + "\"" );
 					ShowContinueError( "The process air inlet node name = " + NodeID( DesicDehum( DesicDehumNum ).ProcAirInNode ) );
-					ShowFatalError( "...previous error causes program termination." );
+					ShowFatalError( "...previous error causes program termination." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -1427,9 +1427,9 @@ namespace DesiccantDehumidifiers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting Dehumidifier:Desiccant:NoFans input" );
+			ShowFatalError( "Errors found in getting Dehumidifier:Desiccant:NoFans input" );  // LCOV_EXCL_LINE
 		} else if ( ErrorsFoundGeneric ) {
-			ShowFatalError( "Errors found in getting DESICCANT DEHUMIDIFIER input" );
+			ShowFatalError( "Errors found in getting DESICCANT DEHUMIDIFIER input" );  // LCOV_EXCL_LINE
 		}
 
 		Alphas.deallocate();
@@ -1529,7 +1529,7 @@ namespace DesiccantDehumidifiers {
 					ErrorFlag = false;
 					ScanPlantLoopsForObject( DesicDehum( DesicDehumNum ).RegenCoilName, TypeOf_CoilWaterSimpleHeating, DesicDehum( DesicDehumNum ).LoopNum, DesicDehum( DesicDehumNum ).LoopSide, DesicDehum( DesicDehumNum ).BranchNum, DesicDehum( DesicDehumNum ).CompNum, _, _, _, _, _, ErrorFlag );
 					if ( ErrorFlag ) {
-						ShowFatalError( "InitDesiccantDehumidifier: Program terminated for previous conditions." );
+						ShowFatalError( "InitDesiccantDehumidifier: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 
 					ErrorFlag = false;
@@ -1545,7 +1545,7 @@ namespace DesiccantDehumidifiers {
 					ScanPlantLoopsForObject( DesicDehum( DesicDehumNum ).RegenCoilName, TypeOf_CoilSteamAirHeating, DesicDehum( DesicDehumNum ).LoopNum, DesicDehum( DesicDehumNum ).LoopSide, DesicDehum( DesicDehumNum ).BranchNum, DesicDehum( DesicDehumNum ).CompNum, _, _, _, _, _, ErrorFlag );
 
 					if ( ErrorFlag ) {
-						ShowFatalError( "InitDesiccantDehumidifier: Program terminated for previous conditions." );
+						ShowFatalError( "InitDesiccantDehumidifier: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 					ErrorFlag = false;
 					DesicDehum( DesicDehumNum ).MaxCoilFluidFlow = GetCoilMaxSteamFlowRate( DesicDehum( DesicDehumNum ).RegenCoilIndex, ErrorFlag );
@@ -1786,7 +1786,7 @@ namespace DesiccantDehumidifiers {
 					if ( HumRatNeeded <= 0.0 ) {
 						ShowSevereError( "Dehumidifier:Desiccant:NoFans: " + DesicDehum( DesicDehumNum ).Name );
 						ShowContinueError( "Invalid Leaving Max Humidity Ratio Setpoint=" + TrimSigDigits( HumRatNeeded, 8 ) );
-						ShowFatalError( "must be > 0.0" );
+						ShowFatalError( "must be > 0.0" );  // LCOV_EXCL_LINE
 					}
 
 				} else if ( SELECT_CASE_var1 == NodeHumratBypass ) {
@@ -1795,7 +1795,7 @@ namespace DesiccantDehumidifiers {
 
 				} else {
 
-					ShowFatalError( "Invalid control type in desiccant dehumidifier = " + DesicDehum( DesicDehumNum ).Name );
+					ShowFatalError( "Invalid control type in desiccant dehumidifier = " + DesicDehum( DesicDehumNum ).Name );  // LCOV_EXCL_LINE
 
 				}}
 
@@ -2035,7 +2035,7 @@ namespace DesiccantDehumidifiers {
 
 			} else {
 
-				ShowFatalError( "Invalid performance model in desiccant dehumidifier = " + TrimSigDigits( DesicDehum( DesicDehumNum ).PerformanceModel_Num ) );
+				ShowFatalError( "Invalid performance model in desiccant dehumidifier = " + TrimSigDigits( DesicDehum( DesicDehumNum ).PerformanceModel_Num ) );  // LCOV_EXCL_LINE
 
 			}} // Performance Model Part A
 
@@ -2127,7 +2127,7 @@ namespace DesiccantDehumidifiers {
 
 			} else {
 
-				ShowFatalError( "Invalid performance model in desiccant dehumidifier = " + TrimSigDigits( DesicDehum( DesicDehumNum ).PerformanceModel_Num ) );
+				ShowFatalError( "Invalid performance model in desiccant dehumidifier = " + TrimSigDigits( DesicDehum( DesicDehumNum ).PerformanceModel_Num ) );  // LCOV_EXCL_LINE
 
 				// Suppress uninitialized warnings
 				ProcAirOutTemp = 0.0;
@@ -2348,7 +2348,7 @@ namespace DesiccantDehumidifiers {
 				//     condenser waste heat is proportional to DX coil PLR
 				if ( ( DesicDehum( DesicDehumNum ).coolingCoil_TypeNum == DataHVACGlobals::CoilDX_CoolingSingleSpeed ) || ( DesicDehum( DesicDehumNum ).coolingCoil_TypeNum == DataHVACGlobals::CoilDX_CoolingTwoStageWHumControl ) ) {
 					CondenserWasteHeat = HeatReclaimDXCoil( DesicDehum( DesicDehumNum ).DXCoilIndex ).AvailCapacity;
-					HeatReclaimDXCoil( DesicDehum( DesicDehumNum ).DXCoilIndex ).AvailCapacity = 0.0;				
+					HeatReclaimDXCoil( DesicDehum( DesicDehumNum ).DXCoilIndex ).AvailCapacity = 0.0;
 				} else if ( DesicDehum( DesicDehumNum ).coolingCoil_TypeNum == DataHVACGlobals::Coil_CoolingAirToAirVariableSpeed ) {
 					CondenserWasteHeat = DataHeatBalance::HeatReclaimVS_DXCoil( DesicDehum( DesicDehumNum ).DXCoilIndex ).AvailCapacity;
 					DataHeatBalance::HeatReclaimVS_DXCoil( DesicDehum( DesicDehumNum ).DXCoilIndex ).AvailCapacity = 0.0;
@@ -2488,7 +2488,7 @@ namespace DesiccantDehumidifiers {
 						} else {
 							HVACFan::fanObjs[ DesicDehum( DesicDehumNum ).RegenFanIndex ]->simulate( _,_,_,_ );
 						}
-						
+
 						FanDeltaT = Node( DesicDehum( DesicDehumNum ).RegenFanOutNode ).Temp - Node( DesicDehum( DesicDehumNum ).RegenFanInNode ).Temp;
 						RegenSetPointTemp -= FanDeltaT;
 					}
@@ -3010,7 +3010,7 @@ namespace DesiccantDehumidifiers {
 		NumSolidDesicDehums = 0;
 		NumGenericDesicDehums = 0;
 		GetInputDesiccantDehumidifier = true;
-		InitDesiccantDehumidifierOneTimeFlag = true;	
+		InitDesiccantDehumidifierOneTimeFlag = true;
 		DesicDehum.deallocate();
 	}
 

--- a/src/EnergyPlus/DirectAirManager.cc
+++ b/src/EnergyPlus/DirectAirManager.cc
@@ -205,23 +205,23 @@ namespace DirectAirManager {
 		if ( CompIndex == 0 ) {
 			DirectAirNum = FindItemInList( EquipName, DirectAir, &DirectAirProps::EquipID );
 			if ( DirectAirNum == 0 ) {
-				ShowFatalError( "SimDirectAir: Unit not found=" + EquipName );
+				ShowFatalError( "SimDirectAir: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DirectAirNum;
 		} else {
 			DirectAirNum = CompIndex;
 			if ( DirectAirNum > NumDirectAir || DirectAirNum < 1 ) {
-				ShowFatalError( "SimDirectAir:  Invalid CompIndex passed=" + TrimSigDigits( DirectAirNum ) + ", Number of Units=" + TrimSigDigits( NumDirectAir ) + ", Entered Unit name=" + EquipName );
+				ShowFatalError( "SimDirectAir:  Invalid CompIndex passed=" + TrimSigDigits( DirectAirNum ) + ", Number of Units=" + TrimSigDigits( NumDirectAir ) + ", Entered Unit name=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( DirectAirNum ) ) {
 				if ( EquipName != DirectAir( DirectAirNum ).EquipID ) {
-					ShowFatalError( "SimDirectAir: Invalid CompIndex passed=" + TrimSigDigits( DirectAirNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + DirectAir( DirectAirNum ).EquipID );
+					ShowFatalError( "SimDirectAir: Invalid CompIndex passed=" + TrimSigDigits( DirectAirNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + DirectAir( DirectAirNum ).EquipID );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( DirectAirNum ) = false;
 			}
 		}
 		if ( DirectAirNum <= 0 ) {
-			ShowFatalError( "SimDirectAir: Unit not found=" + EquipName );
+			ShowFatalError( "SimDirectAir: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 		}
 
 		// With the correct DirectAirNum to Initialize the system
@@ -412,7 +412,7 @@ namespace DirectAirManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		//Setup output for the Direct Air Units.  This allows a comparison with
@@ -488,13 +488,13 @@ namespace DirectAirManager {
 
 			DirectAir( DirectAirNum ).ZoneEqNum = ControlledZoneNum;
 			DirectAir( DirectAirNum ).ZoneNum = ZoneEquipConfig( ControlledZoneNum ).ActualZoneNum;
-			if ( ControlledZoneNum > 0 ) { 
-				if ( DataZoneEquipment::ZoneEquipConfig( ControlledZoneNum ).AirLoopNum > 0  ) {  
-					DirectAir( DirectAirNum ).AirLoopNum = DataZoneEquipment::ZoneEquipConfig( ControlledZoneNum ).AirLoopNum; 
-					DirectAir( DirectAirNum ).CtrlZoneNum = ControlledZoneNum; 
+			if ( ControlledZoneNum > 0 ) {
+				if ( DataZoneEquipment::ZoneEquipConfig( ControlledZoneNum ).AirLoopNum > 0  ) {
+					DirectAir( DirectAirNum ).AirLoopNum = DataZoneEquipment::ZoneEquipConfig( ControlledZoneNum ).AirLoopNum;
+					DirectAir( DirectAirNum ).CtrlZoneNum = ControlledZoneNum;
 					MySizeFlag( DirectAirNum ) = false;
 				}
-			} 
+			}
 		}
 		// Do the Begin Environment initializations
 		if ( BeginEnvrnFlag && MyEnvrnFlag( DirectAirNum ) ) {
@@ -541,13 +541,13 @@ namespace DirectAirManager {
 			//The first time through set the mass flow rate to the Max
 			if ( ( Node( ZoneNode ).MassFlowRateMaxAvail > 0.0 ) && ( GetCurrentScheduleValue( DirectAir( DirectAirNum ).SchedPtr ) > 0.0 ) ) {
 				if ( ! ( SimulateAirflowNetwork > AirflowNetworkControlMultizone && AirflowNetworkFanActivated ) ) {
-					if ( DirectAir( DirectAirNum ).NoOAFlowInputFromUser ) { 
+					if ( DirectAir( DirectAirNum ).NoOAFlowInputFromUser ) {
 						Node( ZoneNode ).MassFlowRate = DirectAir( DirectAirNum ).AirMassFlowRateMax;
 						Node( ZoneNode ).MassFlowRateMaxAvail = DirectAir( DirectAirNum ).AirMassFlowRateMax;
-					} else { 
-						Node( ZoneNode ).MassFlowRate = mDotFromOARequirement; 
-						Node( ZoneNode ).MassFlowRateMaxAvail = mDotFromOARequirement; 
-					} 
+					} else {
+						Node( ZoneNode ).MassFlowRate = mDotFromOARequirement;
+						Node( ZoneNode ).MassFlowRateMaxAvail = mDotFromOARequirement;
+					}
 
 					if ( DirectAir( DirectAirNum ).EMSOverrideAirFlow ) Node( ZoneNode ).MassFlowRate = DirectAir( DirectAirNum ).EMSMassFlowRateValue;
 				}
@@ -568,13 +568,13 @@ namespace DirectAirManager {
 						} else {
 							Node( ZoneNode ).MassFlowRate = Node( ZoneNode ).MassFlowRateMaxAvail;
 						}
-					} else {  
-						Node( ZoneNode ).MassFlowRate = mDotFromOARequirement;  
-						// but also apply constraints 
-						Node( ZoneNode ).MassFlowRate = min( Node( ZoneNode ).MassFlowRate, Node( ZoneNode ).MassFlowRateMaxAvail );  
-						Node( ZoneNode ).MassFlowRate = min( Node( ZoneNode ).MassFlowRate, Node( ZoneNode ).MassFlowRateMax );  
-						Node( ZoneNode ).MassFlowRate = max( Node( ZoneNode ).MassFlowRate, Node( ZoneNode ).MassFlowRateMinAvail );  
-						Node( ZoneNode ).MassFlowRate = max( Node( ZoneNode ).MassFlowRate, Node( ZoneNode ).MassFlowRateMin ); 
+					} else {
+						Node( ZoneNode ).MassFlowRate = mDotFromOARequirement;
+						// but also apply constraints
+						Node( ZoneNode ).MassFlowRate = min( Node( ZoneNode ).MassFlowRate, Node( ZoneNode ).MassFlowRateMaxAvail );
+						Node( ZoneNode ).MassFlowRate = min( Node( ZoneNode ).MassFlowRate, Node( ZoneNode ).MassFlowRateMax );
+						Node( ZoneNode ).MassFlowRate = max( Node( ZoneNode ).MassFlowRate, Node( ZoneNode ).MassFlowRateMinAvail );
+						Node( ZoneNode ).MassFlowRate = max( Node( ZoneNode ).MassFlowRate, Node( ZoneNode ).MassFlowRateMin );
 					}
 				} else {
 					Node( ZoneNode ).MassFlowRate = 0.0;

--- a/src/EnergyPlus/DisplacementVentMgr.cc
+++ b/src/EnergyPlus/DisplacementVentMgr.cc
@@ -851,8 +851,8 @@ namespace DisplacementVentMgr {
 				//HeightFrac = min( 24.55 * std::pow( MCp_Total * 0.000833 / ( NumberOfPlumes * std::pow( PowerPerPlume, OneThird ) ), 0.6 ) / CeilingHeight, 1.0 ); //Tuned This does not vary in loop
 				//EPTeam-replaces above (cause diffs)      HeightFrac = MIN(24.55d0*(MCp_Total*0.000833d0/(NumberOfPlumes*PowerPerPlume**(1.0d0/3.d0)))**0.6 / CeilingHeight , 1.0d0)
 				HeightTransition( ZoneNum ) = HeightFrac * CeilingHeight;
-				AIRRATFloor( ZoneNum ) = Zone( ZoneNum ).Volume * min( HeightTransition( ZoneNum ), HeightFloorSubzoneTop ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATFloor( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATFloor( ZoneNum ) ) / ( TimeStepSys * SecInHour ); 
-				AIRRATOC( ZoneNum ) = Zone( ZoneNum ).Volume * ( HeightTransition( ZoneNum ) - min( HeightTransition( ZoneNum ), 0.2 ) ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATOC( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATOC( ZoneNum ) ) / ( TimeStepSys * SecInHour ); 
+				AIRRATFloor( ZoneNum ) = Zone( ZoneNum ).Volume * min( HeightTransition( ZoneNum ), HeightFloorSubzoneTop ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATFloor( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATFloor( ZoneNum ) ) / ( TimeStepSys * SecInHour );
+				AIRRATOC( ZoneNum ) = Zone( ZoneNum ).Volume * ( HeightTransition( ZoneNum ) - min( HeightTransition( ZoneNum ), 0.2 ) ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATOC( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATOC( ZoneNum ) ) / ( TimeStepSys * SecInHour );
 				AIRRATMX( ZoneNum ) = Zone( ZoneNum ).Volume * ( CeilingHeight - HeightTransition( ZoneNum ) ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATMX( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATMX( ZoneNum ) ) / ( TimeStepSys * SecInHour );
 
 				if ( UseZoneTimeStepHistory ) {
@@ -1028,7 +1028,7 @@ namespace DisplacementVentMgr {
 			} else if ( HeightComfort >= HeightMixedSubzoneAve && HeightComfort <= CeilingHeight ) {
 				TCMF( ZoneNum ) = ZTMX( ZoneNum );
 			} else {
-				ShowFatalError( "Displacement ventilation comfort height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );
+				ShowFatalError( "Displacement ventilation comfort height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -1050,7 +1050,7 @@ namespace DisplacementVentMgr {
 			} else if ( HeightThermostat >= HeightMixedSubzoneAve && HeightThermostat <= CeilingHeight ) {
 				TempTstatAir( ZoneNum ) = ZTMX( ZoneNum );
 			} else {
-				ShowFatalError( "Displacement ventilation thermostat height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );
+				ShowFatalError( "Displacement ventilation thermostat height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/EnergyPlus/DualDuct.cc
+++ b/src/EnergyPlus/DualDuct.cc
@@ -207,17 +207,17 @@ namespace DualDuct {
 		if ( CompIndex == 0 ) {
 			DamperNum = FindItemInList( CompName, Damper, &DamperDesignParams::DamperName );
 			if ( DamperNum == 0 ) {
-				ShowFatalError( "SimulateDualDuct: Damper not found=" + CompName );
+				ShowFatalError( "SimulateDualDuct: Damper not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DamperNum;
 		} else {
 			DamperNum = CompIndex;
 			if ( DamperNum > NumDampers || DamperNum < 1 ) {
-				ShowFatalError( "SimulateDualDuct: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of Dampers=" + TrimSigDigits( NumDampers ) + ", Damper name=" + CompName );
+				ShowFatalError( "SimulateDualDuct: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of Dampers=" + TrimSigDigits( NumDampers ) + ", Damper name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( DamperNum ) ) {
 				if ( CompName != Damper( DamperNum ).DamperName ) {
-					ShowFatalError( "SimulateDualDuct: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Damper name=" + CompName + ", stored Damper Name for that index=" + Damper( DamperNum ).DamperName );
+					ShowFatalError( "SimulateDualDuct: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Damper name=" + CompName + ", stored Damper Name for that index=" + Damper( DamperNum ).DamperName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( DamperNum ) = false;
 			}
@@ -251,7 +251,7 @@ namespace DualDuct {
 			// Report the current Damper
 			ReportDualDuct( DamperNum );
 		} else {
-			ShowFatalError( "SimulateDualDuct: Damper not found=" + CompName );
+			ShowFatalError( "SimulateDualDuct: Damper not found=" + CompName );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -696,7 +696,7 @@ namespace DualDuct {
 
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/EMSManager.cc
+++ b/src/EnergyPlus/EMSManager.cc
@@ -256,7 +256,7 @@ namespace EMSManager {
 				OutputEMSFileUnitNum = GetNewUnitNumber();
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputEMSFileUnitNum, DataStringGlobals::outputEddFileName, flags ); write_stat = flags.ios(); }
 				if ( write_stat != 0 ) {
-					ShowFatalError( "CheckIFAnyEMS: Could not open file "+ DataStringGlobals::outputEddFileName +" for output (write)." );
+					ShowFatalError( "CheckIFAnyEMS: Could not open file "+ DataStringGlobals::outputEddFileName +" for output (write)." );  // LCOV_EXCL_LINE
 				}
 			}
 		} else {
@@ -756,7 +756,7 @@ namespace EMSManager {
 					} else {
 						VariableNum = NewEMSVariable( cAlphaArgs( 1 ), 0 );
 						Sensor( SensorNum ).VariableNum = VariableNum;
-						ErlVariable( VariableNum ).Value.initialized = true; 
+						ErlVariable( VariableNum ).Value.initialized = true;
 					}
 				}
 
@@ -1056,7 +1056,7 @@ namespace EMSManager {
 		lNumericFieldBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting Energy Management System input. Preceding condition causes termination." );
+			ShowFatalError( "Errors found in getting Energy Management System input. Preceding condition causes termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1299,7 +1299,7 @@ namespace EMSManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing Energy Management System input. Preceding condition causes termination." );
+			ShowFatalError( "Errors found in processing Energy Management System input. Preceding condition causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( reportErrors ) {
@@ -2168,7 +2168,7 @@ namespace EMSManager {
 	void
 	checkForUnusedActuatorsAtEnd()
 	{
-		// call at end of simulation to check if any of the user's actuators were never initialized.  
+		// call at end of simulation to check if any of the user's actuators were never initialized.
 		// Could be a mistake we want to help users catch // Issue #4404.
 		for ( int actuatorUsedLoop = 1; actuatorUsedLoop <= numActuatorsUsed; ++actuatorUsedLoop ) {
 			if ( ! ErlVariable( EMSActuatorUsed( actuatorUsedLoop ).ErlVariableNum ).Value.initialized ) {
@@ -2179,9 +2179,9 @@ namespace EMSManager {
 				ShowContinueError( "EMS Actuator control type = " + EMSActuatorUsed( actuatorUsedLoop ).ControlTypeName );
 			}
 		}
-	
+
 	}
-	
+
 } // EMSManager
 
 //Moved these setup EMS actuator routines out of module to solve circular use problems between

--- a/src/EnergyPlus/EarthTube.cc
+++ b/src/EnergyPlus/EarthTube.cc
@@ -361,7 +361,7 @@ namespace EarthTube {
 		CheckEarthTubesInZones( cAlphaArgs( 1 ), cCurrentModuleObject, ErrorsFound );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( cCurrentModuleObject + ": Errors getting input.  Program terminates." );
+			ShowFatalError( cCurrentModuleObject + ": Errors getting input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/EcoRoofManager.cc
+++ b/src/EnergyPlus/EcoRoofManager.cc
@@ -605,7 +605,7 @@ namespace EcoRoofManager {
 			//   Prior experience suggests that no more than 3 iterations are likely needed
 			LeafTK = Tf + KelvinConv;
 			SoilTK = Tg + KelvinConv;
-			
+
 			for ( EcoLoop = 1; EcoLoop <= 3; ++EcoLoop ) {
 				P1 = sigmaf * ( RS * ( 1.0 - Alphaf ) + epsilonf * Latm ) - 3.0 * sigmaf * epsilonf * epsilong * Sigma * pow_4( SoilTK ) / EpsilonOne - 3.0 * ( -sigmaf * epsilonf * Sigma - sigmaf * epsilonf * epsilong * Sigma / EpsilonOne ) * pow_4( LeafTK ) + sheatf * ( 1.0 - 0.7 * sigmaf ) * ( Ta + KelvinConv ) + LAI * Rhoaf * Cf * Lef * Waf * rn * ( ( 1.0 - 0.7 * sigmaf ) / dOne ) * qa + LAI * Rhoaf * Cf * Lef * Waf * rn * ( ( ( 0.6 * sigmaf * rn ) / dOne ) - 1.0 ) * ( qsf - LeafTK * dqf ) + LAI * Rhoaf * Cf * Lef * Waf * rn * ( ( 0.1 * sigmaf * Mg ) / dOne ) * ( qsg - SoilTK * dqg );
 				P2 = 4.0 * ( sigmaf * epsilonf * epsilong * Sigma ) * pow_3( SoilTK ) / EpsilonOne + 0.1 * sigmaf * sheatf + LAI * Rhoaf * Cf * Lef * Waf * rn * ( 0.1 * sigmaf * Mg ) / dOne * dqg;

--- a/src/EnergyPlus/EconomicTariff.cc
+++ b/src/EnergyPlus/EconomicTariff.cc
@@ -344,7 +344,7 @@ namespace EconomicTariff {
 				CreateDefaultComputation();
 			}
 			Update_GetInput = false;
-			if ( ErrorsFound ) ShowFatalError( "UpdateUtilityBills: Preceding errors cause termination." );
+			if ( ErrorsFound ) ShowFatalError( "UpdateUtilityBills: Preceding errors cause termination." );  // LCOV_EXCL_LINE
 		}
 		if ( DoOutputReporting && ( KindOfSim == ksRunPeriodWeather ) ) {
 			GatherForEconomics();

--- a/src/EnergyPlus/ElectricBaseboardRadiator.cc
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.cc
@@ -164,17 +164,17 @@ namespace ElectricBaseboardRadiator {
 		if ( CompIndex == 0 ) {
 			BaseboardNum = FindItemInList( EquipName, ElecBaseboard, &ElecBaseboardParams::EquipName );
 			if ( BaseboardNum == 0 ) {
-				ShowFatalError( "SimElectricBaseboard: Unit not found=" + EquipName );
+				ShowFatalError( "SimElectricBaseboard: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BaseboardNum;
 		} else {
 			BaseboardNum = CompIndex;
 			if ( BaseboardNum > NumElecBaseboards || BaseboardNum < 1 ) {
-				ShowFatalError( "SimElectricBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumElecBaseboards ) + ", Entered Unit name=" + EquipName );
+				ShowFatalError( "SimElectricBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumElecBaseboards ) + ", Entered Unit name=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( BaseboardNum ) ) {
 				if ( EquipName != ElecBaseboard( BaseboardNum ).EquipName ) {
-					ShowFatalError( "SimElectricBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + ElecBaseboard( BaseboardNum ).EquipName );
+					ShowFatalError( "SimElectricBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + ElecBaseboard( BaseboardNum ).EquipName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( BaseboardNum ) = false;
 			}
@@ -191,7 +191,7 @@ namespace ElectricBaseboardRadiator {
 		} else {
 			ShowSevereError( "SimElecBaseboard: Errors in Baseboard=" + ElecBaseboard( BaseboardNum ).EquipName );
 			ShowContinueError( "Invalid or unimplemented equipment type=" + cCMO_BBRadiator_Electric );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -460,7 +460,7 @@ namespace ElectricBaseboardRadiator {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + cCurrentModuleObject + "Errors found getting input. Program terminates." );
+			ShowFatalError( RoutineName + cCurrentModuleObject + "Errors found getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		for ( BaseboardNum = 1; BaseboardNum <= NumElecBaseboards; ++BaseboardNum ) {
@@ -802,7 +802,7 @@ namespace ElectricBaseboardRadiator {
 				} else {
 
 					UpdateElectricBaseboardOn( AirOutletTemp, ElecBaseboard( BaseboardNum ).ElecUseRate, AirInletTemp, QBBCap, CapacitanceAir, Effic );
-	
+
 				}
 
 			} else { // zero radiant fraction, no need of recalculation of heat balances
@@ -1026,7 +1026,7 @@ namespace ElectricBaseboardRadiator {
 							ShowContinueError( "Occurs in " + cCMO_BBRadiator_Electric + " = " + ElecBaseboard( BaseboardNum ).EquipName );
 							ShowContinueError( "Radiation intensity = " + RoundSigDigits( ThisSurfIntensity, 2 ) + " [W/m2]" );
 							ShowContinueError( "Assign a larger surface area or more surfaces in " + cCMO_BBRadiator_Electric );
-							ShowFatalError( "DistributeBBElecRadGains:  excessive thermal radiation heat flux intensity detected" );
+							ShowFatalError( "DistributeBBElecRadGains:  excessive thermal radiation heat flux intensity detected" );  // LCOV_EXCL_LINE
 						}
 					} else {
 						ShowSevereError( "DistributeBBElecRadGains:  surface not large enough to receive thermal radiation heat flux" );
@@ -1034,7 +1034,7 @@ namespace ElectricBaseboardRadiator {
 						ShowContinueError( "Surface area = " + RoundSigDigits( Surface( SurfNum ).Area, 3 ) + " [m2]" );
 						ShowContinueError( "Occurs in " + cCMO_BBRadiator_Electric + " = " + ElecBaseboard( BaseboardNum ).EquipName );
 						ShowContinueError( "Assign a larger surface area or more surfaces in " + cCMO_BBRadiator_Electric );
-						ShowFatalError( "DistributeBBElecRadGains:  surface not large enough to receive thermal radiation heat flux" );
+						ShowFatalError( "DistributeBBElecRadGains:  surface not large enough to receive thermal radiation heat flux" );  // LCOV_EXCL_LINE
 					}
 				}
 			}

--- a/src/EnergyPlus/ElectricPowerServiceManager.cc
+++ b/src/EnergyPlus/ElectricPowerServiceManager.cc
@@ -275,7 +275,7 @@ namespace EnergyPlus {
 						++numPowerOutTransformers_;
 						powerOutTransformerName_ = DataIPShortCuts::cAlphaArgs( 1 );
 						powerOutTransformerObj_ = std::unique_ptr< ElectricTransformer > ( new ElectricTransformer ( powerOutTransformerName_ ) );
-					
+
 					} else {
 						ShowWarningError( "Found more than one transformer set to PowerOutFromOnsiteGeneration, however only the first one will be used." );
 					}
@@ -309,7 +309,7 @@ namespace EnergyPlus {
 
 			sumUpNumberOfStorageDevices();
 
-			checkLoadCenters(); // for issue #5302.  
+			checkLoadCenters(); // for issue #5302.
 		}
 	}
 
@@ -450,7 +450,7 @@ namespace EnergyPlus {
 
 	void
 	ElectricPowerServiceManager::checkLoadCenters() {
-	
+
 		//issue #5302, detect if storage used on more than one load center. This is really a kind of GlobalNames issue.
 		// expanded to all devices on a load center
 		bool errorsFound = false;
@@ -479,7 +479,7 @@ namespace EnergyPlus {
 			}
 		}
 
-		//then check the vectors for duplicates. 
+		//then check the vectors for duplicates.
 		for ( std::size_t i = 0; i < storageNames.size(); ++i ) {
 			for ( std::size_t j = 0; j < storageNames.size(); ++j ) {
 				if ( storageNames[ i ] == storageNames[ j ] && i != j ) {
@@ -551,7 +551,7 @@ namespace EnergyPlus {
 		}
 
 		if ( errorsFound ) { // throw fatal, these errors could fatal out in internal gains with missleading data
-			ShowFatalError( "ElectricPowerServiceManager::checkLoadCenters, preceding errors terminate program." );
+			ShowFatalError( "ElectricPowerServiceManager::checkLoadCenters, preceding errors terminate program." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -623,7 +623,7 @@ namespace EnergyPlus {
 
 			if ( ! DataIPShortCuts::lAlphaFieldBlanks( 2 ) )  {
 				generatorListName_ = DataIPShortCuts::cAlphaArgs( 2 );
-				// check that 
+				// check that
 
 				int testIndex = InputProcessor::GetObjectItemNum( "ElectricLoadCenter:Generators", generatorListName_ );
 				if ( testIndex == 0 ) {
@@ -855,7 +855,7 @@ namespace EnergyPlus {
 			InputProcessor::GetObjectItem( DataIPShortCuts::cCurrentModuleObject, genListObjectNum, DataIPShortCuts::cAlphaArgs, numAlphas, DataIPShortCuts::rNumericArgs, numNums, IOStat, DataIPShortCuts::lNumericFieldBlanks, DataIPShortCuts::lAlphaFieldBlanks, DataIPShortCuts::cAlphaFieldNames, DataIPShortCuts::cNumericFieldNames  );
 
 			//Calculate the number of generators in list
-			numGenerators = numNums / 2; // note IDD needs Min Fields = 6  
+			numGenerators = numNums / 2; // note IDD needs Min Fields = 6
 			if ( mod( ( numAlphas - 1 + numNums ), 5 ) != 0 ) ++numGenerators;
 			int alphaCount = 2;
 			for ( auto genCount = 1; genCount <= numGenerators; ++genCount) {
@@ -884,7 +884,7 @@ namespace EnergyPlus {
 		}
 
 		if ( ! errorsFound && storagePresent_ ) {
-			// call storage constructor 
+			// call storage constructor
 			storageObj =  std::unique_ptr< ElectricStorage > ( new ElectricStorage( storageName_ ) );
 		}
 
@@ -926,7 +926,7 @@ namespace EnergyPlus {
 		}
 
 		if ( errorsFound ) {
-			ShowFatalError( routineName + "Preceding errors terminate program." );
+			ShowFatalError( routineName + "Preceding errors terminate program." );  // LCOV_EXCL_LINE
 		}
 	}
 
@@ -948,7 +948,7 @@ namespace EnergyPlus {
 		} // if generators present
 		updateLoadCenterGeneratorRecords();
 		if ( bussType == ElectricBussType::dCBussInverter || bussType == ElectricBussType::dCBussInverterACStorage) {
-			inverterObj->simulate( genElectProdRate ); 
+			inverterObj->simulate( genElectProdRate );
 		}
 
 		if ( storagePresent_ ) {
@@ -996,7 +996,7 @@ namespace EnergyPlus {
 		Real64 remainingLoad          = 0.0;
 		Real64 customMeterDemand      = 0.0;
 
-		switch ( genOperationScheme_ ) 
+		switch ( genOperationScheme_ )
 		{
 
 		case GeneratorOpScheme::baseLoad: {
@@ -1389,14 +1389,14 @@ namespace EnergyPlus {
 		genElectProdRate = 0.0;
 		genElectricProd = 0.0;
 		for ( auto & g : elecGenCntrlObj ) {
-			genElectProdRate += g->electProdRate; 
+			genElectProdRate += g->electProdRate;
 			g->electricityProd = g->electProdRate * ( DataHVACGlobals::TimeStepSys * DataGlobals::SecInHour );
 			genElectricProd += g->electricityProd;
 		}
 	}
 
 	void
-	ElectPowerLoadCenter::dispatchStorage( 
+	ElectPowerLoadCenter::dispatchStorage(
 		Real64 const originalFeedInRequest // whole building remaining electric demand for this load center
 	)
 	{
@@ -1405,7 +1405,7 @@ namespace EnergyPlus {
 		switch ( bussType )
 		{
 			case ElectricBussType::notYetSet :
-			case ElectricBussType::aCBuss : 
+			case ElectricBussType::aCBuss :
 			case ElectricBussType::dCBussInverter : {
 				// do nothing, no storage to manage
 				break;
@@ -1451,14 +1451,14 @@ namespace EnergyPlus {
 			}
 			case StorageOpScheme::facilityDemandLeveling : {
 				Real64 demandTarget = facilityDemandTarget_ * ScheduleManager::GetCurrentScheduleValue( facilityDemandTargetModSchedIndex_ );
-				//compare target to 
+				//compare target to
 				Real64 deltaLoad = originalFeedInRequest - demandTarget;
 				if ( deltaLoad >= 0.0 ) {
 					//subpanel should feed main panel
 					subpanelFeedInRequest = deltaLoad;
 					subpanelDrawRequest   = 0.0;
-				} else { 
-					// subpanel should draw from main panel 
+				} else {
+					// subpanel should draw from main panel
 					subpanelFeedInRequest = 0.0;
 					subpanelDrawRequest   = std::abs( deltaLoad );
 				}
@@ -1473,7 +1473,7 @@ namespace EnergyPlus {
 		switch ( bussType )
 		{
 			case ElectricBussType::notYetSet :
-			case ElectricBussType::aCBuss : 
+			case ElectricBussType::aCBuss :
 			case ElectricBussType::dCBussInverter : {
 				// do nothing, no storage to manage
 				break;
@@ -1593,7 +1593,7 @@ namespace EnergyPlus {
 					} else if ( storOpCVGenRate > adjustedFeedInRequest ) {
 						//add to storage
 						storOpCVDischargeRate = 0.0;
-						storOpCVChargeRate    = storOpCVGenRate - adjustedFeedInRequest; 
+						storOpCVChargeRate    = storOpCVGenRate - adjustedFeedInRequest;
 						storOpIsCharging      = true;
 						storOpIsDischarging   = false;
 
@@ -1672,13 +1672,13 @@ namespace EnergyPlus {
 	{
 		demandMeterPtr_ = EnergyPlus::GetMeterIndex( demandMeterName_ );
 		if ( ( demandMeterPtr_ == 0 ) && ( genOperationScheme_ == GeneratorOpScheme::trackMeter ) ) { // throw error
-				ShowFatalError( "ElectPowerLoadCenter::setupLoadCenterMeterIndices  Did not find Meter named: " + demandMeterName_ + " in ElectricLoadCenter:Distribution named " + name_ );
+				ShowFatalError( "ElectPowerLoadCenter::setupLoadCenterMeterIndices  Did not find Meter named: " + demandMeterName_ + " in ElectricLoadCenter:Distribution named " + name_ );  // LCOV_EXCL_LINE
 		}
 
 		if ( storageScheme_ == StorageOpScheme::meterDemandStoreExcessOnSite ) {
 			trackStorageOpMeterIndex_ = EnergyPlus::GetMeterIndex( trackSorageOpMeterName_ );
-			if ( trackStorageOpMeterIndex_ == 0 ) { // 
-				ShowFatalError( "ElectPowerLoadCenter::setupLoadCenterMeterIndices  Did not find Meter named: " + trackSorageOpMeterName_ + " in ElectricLoadCenter:Distribution named " + name_ );
+			if ( trackStorageOpMeterIndex_ == 0 ) { //
+				ShowFatalError( "ElectPowerLoadCenter::setupLoadCenterMeterIndices  Did not find Meter named: " + trackSorageOpMeterName_ + " in ElectricLoadCenter:Distribution named " + name_ );  // LCOV_EXCL_LINE
 			}
 		}
 	}
@@ -1725,7 +1725,7 @@ namespace EnergyPlus {
 		}
 	}
 
-	void 
+	void
 	ElectPowerLoadCenter::reinitZoneGainsAtBeginEnvironment()
 	{
 		if (transformerObj != nullptr ){
@@ -1767,7 +1767,7 @@ namespace EnergyPlus {
 			genElectProdRate = 0.0;
 			genElectricProd = 0.0;
 			for ( auto & gc : elecGenCntrlObj ) {
-				genElectProdRate += gc->electProdRate; 
+				genElectProdRate += gc->electProdRate;
 				genElectricProd  += gc->electricityProd;
 			}
 			// no inverter, no storage, so generator production equals subpanel feed in
@@ -1783,7 +1783,7 @@ namespace EnergyPlus {
 			genElectProdRate = 0.0;
 			genElectricProd = 0.0;
 			for ( auto & gc : elecGenCntrlObj ) {
-				genElectProdRate += gc->electProdRate; 
+				genElectProdRate += gc->electProdRate;
 				genElectricProd  += gc->electricityProd;
 			}
 			if ( storageObj != nullptr ) {
@@ -1801,7 +1801,7 @@ namespace EnergyPlus {
 			genElectProdRate = 0.0;
 			genElectricProd = 0.0;
 			for ( auto & gc : elecGenCntrlObj ) {
-				genElectProdRate += gc->electProdRate; 
+				genElectProdRate += gc->electProdRate;
 				genElectricProd  += gc->electricityProd;
 			}
 
@@ -1819,7 +1819,7 @@ namespace EnergyPlus {
 			genElectProdRate = 0.0;
 			genElectricProd = 0.0;
 			for ( auto & gc : elecGenCntrlObj ) {
-				genElectProdRate += gc->electProdRate; 
+				genElectProdRate += gc->electProdRate;
 				genElectricProd  += gc->electricityProd;
 			}
 			if ( inverterObj != nullptr ) {
@@ -1839,7 +1839,7 @@ namespace EnergyPlus {
 			genElectProdRate = 0.0;
 			genElectricProd = 0.0;
 			for ( auto & gc : elecGenCntrlObj ) {
-				genElectProdRate += gc->electProdRate; 
+				genElectProdRate += gc->electProdRate;
 				genElectricProd  += gc->electricityProd;
 			}
 			if ( inverterObj != nullptr && storagePresent_  ) {
@@ -1860,7 +1860,7 @@ namespace EnergyPlus {
 		} // end switch
 		thermalProdRate = 0.0;
 		thermalProd = 0.0;
-		for ( auto & gc : elecGenCntrlObj ) { 
+		for ( auto & gc : elecGenCntrlObj ) {
 			thermalProdRate += gc->thermProdRate;
 			thermalProd     += gc->thermalProd;
 		}
@@ -2112,7 +2112,7 @@ namespace EnergyPlus {
 		int NumNums; // Number of elements in the numeric array
 		int IOStat; // IO Status when calling get input subroutine
 		bool errorsFound = false;
-		// if/when add object class name to input object this can be simplified. for now search all possible types 
+		// if/when add object class name to input object this can be simplified. for now search all possible types
 		bool foundInverter = false;
 		int testInvertIndex = 0;
 		int invertIDFObjectNum = 0;
@@ -2215,12 +2215,12 @@ namespace EnergyPlus {
 			}
 
 			} // end switch modelType
-		
+
 			SetupOutputVariable( "Inverter DC to AC Efficiency", OutputProcessor::Unit::None, efficiency_, "System", "Average", name_ );
 			SetupOutputVariable( "Inverter DC Input Electric Power", OutputProcessor::Unit::W, dCPowerIn_, "System", "Average", name_ );
 			SetupOutputVariable( "Inverter DC Input Electric Energy", OutputProcessor::Unit::J, dCEnergyIn_, "System", "Sum", name_ );
 			SetupOutputVariable( "Inverter AC Output Electric Power", OutputProcessor::Unit::W, aCPowerOut_, "System", "Average", name_ );
-			SetupOutputVariable( "Inverter AC Output Electric Energy", OutputProcessor::Unit::J, aCEnergyOut_, "System", "Sum", name_ ); 
+			SetupOutputVariable( "Inverter AC Output Electric Energy", OutputProcessor::Unit::J, aCEnergyOut_, "System", "Sum", name_ );
 			SetupOutputVariable( "Inverter Conversion Loss Power", OutputProcessor::Unit::W, conversionLossPower_, "System", "Average", name_ );
 			SetupOutputVariable( "Inverter Conversion Loss Energy", OutputProcessor::Unit::J, conversionLossEnergy_, "System", "Sum", name_ );
 			SetupOutputVariable( "Inverter Conversion Loss Decrement Energy", OutputProcessor::Unit::J, conversionLossEnergyDecrement_, "System", "Sum", name_, _, "ElectricityProduced", "POWERCONVERSION", _, "Plant" );
@@ -2255,7 +2255,7 @@ namespace EnergyPlus {
 		}
 
 		if ( errorsFound ) {
-			ShowFatalError( routineName + "Preceding errors terminate program." );
+			ShowFatalError( routineName + "Preceding errors terminate program." );  // LCOV_EXCL_LINE
 		}
 	}
 
@@ -2305,7 +2305,7 @@ namespace EnergyPlus {
 	//need to invert, find a dCPowerIn that produces the desired AC power out
 	// use last efficiency for initial guess
 		if ( efficiency_ > 0.0 ) {
-			dCPowerIn_ = powerOutOfInverter / efficiency_;		
+			dCPowerIn_ = powerOutOfInverter / efficiency_;
 		} else {
 			dCPowerIn_ = powerOutOfInverter;
 			calcEfficiency();
@@ -2372,7 +2372,7 @@ namespace EnergyPlus {
 
 				break;
 			}
-			case InverterModelType::simpleConstantEff: 
+			case InverterModelType::simpleConstantEff:
 			case InverterModelType::notYetSet: {
 				// do nothing
 				break;
@@ -2437,7 +2437,7 @@ namespace EnergyPlus {
 		heatLossesDestination_( ThermalLossDestination::heatLossNotDetermined ),
 		zoneNum_( 0 ),
 		zoneRadFract_( 0.0 ), // radiative fraction for thermal losses to zone
-		standbyPower_( 0.0 ), 
+		standbyPower_( 0.0 ),
 		maxPower_( 0.0 )
 	{
 
@@ -2446,7 +2446,7 @@ namespace EnergyPlus {
 		int NumNums; // Number of elements in the numeric array
 		int IOStat; // IO Status when calling get input subroutine
 		bool errorsFound = false;
-		// if/when add object class name to input object this can be simplified. for now search all possible types 
+		// if/when add object class name to input object this can be simplified. for now search all possible types
 
 		int testConvertIndex = InputProcessor::GetObjectItemNum( "ElectricLoadCenter:Storage:Converter",  objectName );
 
@@ -2540,11 +2540,11 @@ namespace EnergyPlus {
 		}
 
 		if ( errorsFound ) {
-			ShowFatalError( routineName + "Preceding errors terminate program." );
+			ShowFatalError( routineName + "Preceding errors terminate program." );  // LCOV_EXCL_LINE
 		}
 	}
 
-	void 
+	void
 	ACtoDCConverter::reinitAtBeginEnvironment()
 	{
 		ancillACuseRate_   = 0.0;
@@ -2553,32 +2553,32 @@ namespace EnergyPlus {
 		qdotRadZone_       = 0.0;
 	}
 
-	void 
+	void
 	ACtoDCConverter::reinitZoneGainsAtBeginEnvironment()
 	{
 		qdotConvZone_            = 0.0;
 		qdotRadZone_             = 0.0;
 	}
 
-	Real64 
+	Real64
 	ACtoDCConverter::thermLossRate() const
 	{
 		return thermLossRate_;
 	}
 
-	Real64 
+	Real64
 	ACtoDCConverter::dCPowerOut() const
 	{
 		return dCPowerOut_;
 	}
 
-	Real64 
+	Real64
 	ACtoDCConverter::dCEnergyOut() const
 	{
 		return dCEnergyOut_;
 	}
 
-	Real64 
+	Real64
 	ACtoDCConverter::aCPowerIn() const
 	{
 		return aCPowerIn_;
@@ -2601,9 +2601,9 @@ namespace EnergyPlus {
 	void
 	ACtoDCConverter::calcEfficiency()
 	{
-		switch ( modelType_ ) 
+		switch ( modelType_ )
 		{
-			case ConverterModelType::notYetSet : 
+			case ConverterModelType::notYetSet :
 			case ConverterModelType::simpleConstantEff : {
 				break;
 			}
@@ -2620,11 +2620,11 @@ namespace EnergyPlus {
 		Real64 const powerOutFromConverter
 	)
 	{
-		//need to invert, find an aCPowerIn that produces the desired DC power out  
+		//need to invert, find an aCPowerIn that produces the desired DC power out
 
 		// use last efficiency for initial guess
 		if ( ScheduleManager::GetCurrentScheduleValue( availSchedPtr_ ) > 0.0 ) {
-		
+
 			aCPowerIn_ = powerOutFromConverter / efficiency_;
 			calcEfficiency(),
 			aCPowerIn_ = powerOutFromConverter / efficiency_;
@@ -2639,7 +2639,7 @@ namespace EnergyPlus {
 				ancillACuseRate_   = 0.0;
 				ancillACuseEnergy_ = 0.0;
 			}
-		
+
 		} else { // not available
 			aCPowerIn_ = 0.0;
 			dCPowerOut_ = 0.0;
@@ -2730,7 +2730,7 @@ namespace EnergyPlus {
 		int numNums; // Number of elements in the numeric array
 		int iOStat; // IO Status when calling get input subroutine
 		bool errorsFound = false;
-		// if/when add object class name to input object this can be simplified. for now search all possible types 
+		// if/when add object class name to input object this can be simplified. for now search all possible types
 		bool foundStorage = false;
 		int testStorageIndex = 0;
 		int storageIDFObjectNum = 0;
@@ -2785,7 +2785,7 @@ namespace EnergyPlus {
 
 			switch ( storageModelMode_ )
 			{
-			
+
 			case StorageModelType::simpleBucketStorage: {
 				energeticEfficCharge_    = DataIPShortCuts::rNumericArgs( 2 );
 				energeticEfficDischarge_ = DataIPShortCuts::rNumericArgs( 3 );
@@ -2796,7 +2796,7 @@ namespace EnergyPlus {
 				SetupOutputVariable( "Electric Storage Simple Charge State", OutputProcessor::Unit::J, electEnergyinStorage_, "System", "Average", name_ ); // issue #4921
 				break;
 			}
-			
+
 			case StorageModelType::kiBaMBattery: {
 				chargeCurveNum_ = CurveManager::GetCurveIndex( DataIPShortCuts::cAlphaArgs( 4 ) ); //voltage calculation for charging
 				if ( chargeCurveNum_ == 0 && ! DataIPShortCuts::lAlphaFieldBlanks( 4 ) ) {
@@ -2860,7 +2860,7 @@ namespace EnergyPlus {
 					cycleBinNum_ = DataIPShortCuts::rNumericArgs( 14 );
 
 					if ( ! errorsFound ) { // life cycle calculation for this battery, allocate arrays for degradation calculation
-					//std::vector is zero base instead of 1, so first index is now 0. 
+					//std::vector is zero base instead of 1, so first index is now 0.
 						b10_.resize( maxRainflowArrayBounds_ + 1, 0.0 );
 						x0_.resize( maxRainflowArrayBounds_ + 1, 0 );
 						nmb0_.resize( cycleBinNum_ , 0.0 );
@@ -2938,7 +2938,7 @@ namespace EnergyPlus {
 			errorsFound = true;
 		}
 		if ( errorsFound ) {
-			ShowFatalError( routineName + "Preceding errors terminate program." );
+			ShowFatalError( routineName + "Preceding errors terminate program." );  // LCOV_EXCL_LINE
 		}
 	}
 
@@ -3099,7 +3099,7 @@ namespace EnergyPlus {
 		Real64 const controlSOCMinFracLimit
 	)
 	{
-		// pass thru to constrain function depending on storage model type 
+		// pass thru to constrain function depending on storage model type
 		if ( ScheduleManager::GetCurrentScheduleValue( availSchedPtr_ ) == 0.0 ) { // storage not available
 			discharging = false;
 			powerDischarge = 0.0;
@@ -3261,7 +3261,7 @@ namespace EnergyPlus {
 			Real64 Inew = 0.0;
 			if ( Volt != 0.0 ) {
 				Inew = Pw / Volt;
-			} 
+			}
 			Real64 Tnew = 0.0;
 			if ( Inew != 0.0 ) {
 				Tnew = qmaxf / std::abs( Inew );
@@ -3285,7 +3285,7 @@ namespace EnergyPlus {
 			Real64 Imax = dividend / divisor;
 			// Below: This is the limit of charging current from Charge Rate Limit (input)
 			Imax = max( Imax, - ( qmax - q0 ) * maxChargeRate_ );
-				
+
 			if ( std::abs( I0 ) <= std::abs( Imax ) ) {
 				I0 = Pw / Volt;
 				Pactual = I0 * Volt;
@@ -3300,7 +3300,7 @@ namespace EnergyPlus {
 					qmaxf = RHS;
 				}
 			}
-		} 
+		}
 
 		if ( discharging ) {
 			//**********************************************
@@ -3326,8 +3326,8 @@ namespace EnergyPlus {
 
 			bool const ok = determineCurrentForBatteryDischarge( I0, T0, Volt, Pw, q0, dischargeCurveNum_, k, c, qmax, E0c, internalR_ );
 			if ( !ok ) {
-				ShowFatalError( "ElectricLoadCenter:Storage:Battery named=\"" + name_ + "\". Battery discharge current could not be estimated due to iteration limit reached. " );
-				//issue #5301, need more diagnostics for this. 
+				ShowFatalError( "ElectricLoadCenter:Storage:Battery named=\"" + name_ + "\". Battery discharge current could not be estimated due to iteration limit reached. " );  // LCOV_EXCL_LINE
+				//issue #5301, need more diagnostics for this.
 			}
 
 			Real64 dividend = k * lastTimeStepAvailable_ * std::exp( -k * DataHVACGlobals::TimeStepSys ) + q0 * k * c * ( 1.0 - std::exp( -k * DataHVACGlobals::TimeStepSys ) );
@@ -3413,7 +3413,7 @@ namespace EnergyPlus {
 		powerDischarge = drawnPower_;
 
 	}
-	
+
 	Real64
 	ElectricStorage::drawnPower() const
 	{
@@ -3437,14 +3437,14 @@ namespace EnergyPlus {
 	{
 		return storedEnergy_;
 	}
-	
+
 	bool
 	ElectricStorage::determineCurrentForBatteryDischarge(
 		Real64 & curI0,
 		Real64 & curT0,
 		Real64 & curVolt,
-		Real64 const Pw, // Power withdraw from each module, 
-		Real64 const q0, // available charge last timestep, sum of available and bound 
+		Real64 const Pw, // Power withdraw from each module,
+		Real64 const q0, // available charge last timestep, sum of available and bound
 		int const CurveNum,
 		Real64 const k,
 		Real64 const c,
@@ -3472,9 +3472,9 @@ namespace EnergyPlus {
 		//add div by zero protection #5301
 			if ( qmaxf != 0.0 ) {
 				Xf = ( qmax - q0 ) / qmaxf;
-			} else { 
+			} else {
 				Xf = 1.0;
-			} 
+			}
 
 			Ef = E0c + CurveManager::CurveValue( CurveNum, Xf ); //E0c+Ad*Xf+Cd*X/(Dd-Xf)
 			curVolt = Ef - curI0 * InternalR;
@@ -3832,7 +3832,7 @@ namespace EnergyPlus {
 			if ( usageMode_ == TransformerUse::powerInFromGrid ) { // power losses metered as an end use exterior equipment
 				SetupOutputVariable( "Transformer Distribution Electric Loss Energy", OutputProcessor::Unit::J, elecUseMeteredUtilityLosses_, "System", "Sum", name_, _, "Electricity", "ExteriorEquipment", "Transformer", "System" );
 			}
-			if ( usageMode_ == TransformerUse::powerOutFromBldgToGrid ) { 
+			if ( usageMode_ == TransformerUse::powerOutFromBldgToGrid ) {
 				SetupOutputVariable( "Transformer Cogeneration Electric Loss Energy", OutputProcessor::Unit::J, powerConversionMeteredLosses_, "System", "Sum", name_, _, "ElectricityProduced", "POWERCONVERSION", _, "System" );
 			}
 			if ( usageMode_ == TransformerUse::powerBetweenLoadCenterAndBldg ) {
@@ -3849,12 +3849,12 @@ namespace EnergyPlus {
 		}
 
 		if ( errorsFound ) {
-			ShowFatalError( routineName + "Preceding errors terminate program." );
+			ShowFatalError( routineName + "Preceding errors terminate program." );  // LCOV_EXCL_LINE
 		}
 	}
 
 	Real64
-	ElectricTransformer::getLossRateForOutputPower( Real64 const powerOutOfTransformer ) 
+	ElectricTransformer::getLossRateForOutputPower( Real64 const powerOutOfTransformer )
 	{
 		manageTransformers( powerOutOfTransformer );
 		return totalLossRate_;
@@ -3922,7 +3922,7 @@ namespace EnergyPlus {
 		}
 		case TransformerUse::powerOutFromBldgToGrid : {
 			powerIn_ = surplusPowerOutFromLoadCenters;
-			elecLoad = surplusPowerOutFromLoadCenters; // TODO this is input but should be output with the losses, but we don't have them yet. 
+			elecLoad = surplusPowerOutFromLoadCenters; // TODO this is input but should be output with the losses, but we don't have them yet.
 			break;
 		}
 		case TransformerUse::powerBetweenLoadCenterAndBldg : {
@@ -4002,7 +4002,7 @@ namespace EnergyPlus {
 			break;
 		}
 
-		case TransformerUse::powerOutFromBldgToGrid: 
+		case TransformerUse::powerOutFromBldgToGrid:
 		case TransformerUse::powerBetweenLoadCenterAndBldg : {
 			powerOut_ = elecLoad - totalLossRate_;
 
@@ -4057,7 +4057,7 @@ namespace EnergyPlus {
 				// Electricity such as ElectricityPurchased and ElectricityProduced.
 				//It is not proper to have this check in GetInput routine because the meter index may have not been defined
 				if ( ! has( GetMeterResourceType( wiredMeterPtrs_[ meterNum ] ), "Electricity" ) ) {
-					EnergyPlus::ShowFatalError( "Non-electricity meter used for " + name_ );
+					EnergyPlus::ShowFatalError( "Non-electricity meter used for " + name_ );  // LCOV_EXCL_LINE
 				}
 			}
 		}

--- a/src/EnergyPlus/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/EnergyPlusPgm.cc
@@ -478,7 +478,7 @@ EnergyPlusPgm( std::string const & filepath )
 				fileUnitNumber = GetNewUnitNumber();
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( fileUnitNumber, RVIfile, flags ); iostatus = flags.ios(); }
 				if ( iostatus != 0 ) {
-					ShowFatalError( "EnergyPlus: Could not open file \"" + RVIfile + "\" for output (write)." );
+					ShowFatalError( "EnergyPlus: Could not open file \"" + RVIfile + "\" for output (write)." );  // LCOV_EXCL_LINE
 				}
 				gio::write( fileUnitNumber, readvarsFmt ) << outputEsoFileName;
 				gio::write( fileUnitNumber, readvarsFmt ) << outputCsvFileName;
@@ -490,7 +490,7 @@ EnergyPlusPgm( std::string const & filepath )
 				fileUnitNumber = GetNewUnitNumber();
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( fileUnitNumber, MVIfile, flags ); iostatus = flags.ios(); }
 				if ( iostatus != 0 ) {
-					ShowFatalError( "EnergyPlus: Could not open file \"" + MVIfile + "\" for output (write)." );
+					ShowFatalError( "EnergyPlus: Could not open file \"" + MVIfile + "\" for output (write)." );  // LCOV_EXCL_LINE
 				}
 				gio::write( fileUnitNumber, readvarsFmt ) << outputMtrFileName;
 				gio::write( fileUnitNumber, readvarsFmt ) << outputMtrCsvFileName;

--- a/src/EnergyPlus/EvaporativeCoolers.cc
+++ b/src/EnergyPlus/EvaporativeCoolers.cc
@@ -235,17 +235,17 @@ namespace EvaporativeCoolers {
 		if ( CompIndex == 0 ) {
 			EvapCoolNum = FindItemInList( CompName, EvapCond, &EvapConditions::EvapCoolerName );
 			if ( EvapCoolNum == 0 ) {
-				ShowFatalError( "SimEvapCooler: Unit not found=" + CompName );
+				ShowFatalError( "SimEvapCooler: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = EvapCoolNum;
 		} else {
 			EvapCoolNum = CompIndex;
 			if ( EvapCoolNum > NumEvapCool || EvapCoolNum < 1 ) {
-				ShowFatalError( "SimEvapCooler:  Invalid CompIndex passed=" + TrimSigDigits( EvapCoolNum ) + ", Number of Units=" + TrimSigDigits( NumEvapCool ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimEvapCooler:  Invalid CompIndex passed=" + TrimSigDigits( EvapCoolNum ) + ", Number of Units=" + TrimSigDigits( NumEvapCool ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( EvapCoolNum ) ) {
 				if ( CompName != EvapCond( EvapCoolNum ).EvapCoolerName ) {
-					ShowFatalError( "SimEvapCooler: Invalid CompIndex passed=" + TrimSigDigits( EvapCoolNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + EvapCond( EvapCoolNum ).EvapCoolerName );
+					ShowFatalError( "SimEvapCooler: Invalid CompIndex passed=" + TrimSigDigits( EvapCoolNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + EvapCond( EvapCoolNum ).EvapCoolerName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( EvapCoolNum ) = false;
 			}
@@ -741,7 +741,7 @@ namespace EvaporativeCoolers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for evaporative coolers" );
+			ShowFatalError( "Errors found in processing input for evaporative coolers" );  // LCOV_EXCL_LINE
 		}
 
 		for ( EvapCoolNum = 1; EvapCoolNum <= NumEvapCool; ++EvapCoolNum ) {
@@ -1521,7 +1521,7 @@ namespace EvaporativeCoolers {
 				ShowContinueError( "Check size of Pad Area and/or Pad Depth in input" );
 				ShowContinueError( "Cooler Effectiveness calculated as: " + RoundSigDigits( SatEff, 2 ) );
 				ShowContinueError( "Air velocity (m/s) through pads calculated as: " + RoundSigDigits( AirVel, 2 ) );
-				ShowFatalError( "Program Terminates due to previous error condition" );
+				ShowFatalError( "Program Terminates due to previous error condition" );  // LCOV_EXCL_LINE
 
 			}
 			EvapCond( EvapCoolNum ).SatEff = SatEff;
@@ -1802,19 +1802,19 @@ namespace EvaporativeCoolers {
 			if ( StageEff >= 1.0 ) StageEff = 1.0;
 			// This is a rough approximation of the Total Indirect Stage Efficiency.  I think that
 			//   this would mainly be used for evap sizing purposes.
-			
+
 			//If there is a fault of fouling (zrp_Jan2017)
 			if( EvapCond( EvapCoolNum ).FaultyEvapCoolerFoulingFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 				int FaultIndex = EvapCond( EvapCoolNum ).FaultyEvapCoolerFoulingIndex;
 				Real64 StageEff_ff = StageEff;
-			
+
 				//calculate the Faulty Evaporative Cooler Fouling Factor using fault information
 				EvapCond( EvapCoolNum ).FaultyEvapCoolerFoulingFactor = FaultsEvapCoolerFouling( FaultIndex ).CalFoulingFactor();
-				
+
 				//update the StageEff at faulty cases
 				StageEff = StageEff_ff * EvapCond( EvapCoolNum ).FaultyEvapCoolerFoulingFactor;
 			}
- 
+
 			EvapCond( EvapCoolNum ).StageEff = StageEff;
 			//***************************************************************************
 			//   TEMP LEAVING DRY BULB IS CALCULATED FROM A SIMPLE WET BULB APPROACH
@@ -3356,17 +3356,17 @@ namespace EvaporativeCoolers {
 		if ( CompIndex == 0 ) {
 			CompNum = FindItemInList( CompName, ZoneEvapUnit );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimZoneEvaporativeCoolerUnit: Zone evaporative cooler unit not found." );
+				ShowFatalError( "SimZoneEvaporativeCoolerUnit: Zone evaporative cooler unit not found." );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CompNum;
 		} else {
 			CompNum = CompIndex;
 			if ( CompNum < 1 || CompNum > NumZoneEvapUnits ) {
-				ShowFatalError( "SimZoneEvaporativeCoolerUnit: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumZoneEvapUnits ) + ", Entered Unit name = " + CompName );
+				ShowFatalError( "SimZoneEvaporativeCoolerUnit: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumZoneEvapUnits ) + ", Entered Unit name = " + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckZoneEvapUnitName( CompNum ) ) {
 				if ( CompName != ZoneEvapUnit( CompNum ).Name ) {
-					ShowFatalError( "SimZoneEvaporativeCoolerUnit: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored unit name for that index=" + ZoneEvapUnit( CompNum ).Name );
+					ShowFatalError( "SimZoneEvaporativeCoolerUnit: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored unit name for that index=" + ZoneEvapUnit( CompNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckZoneEvapUnitName( CompNum ) = false;
 			}
@@ -3714,7 +3714,7 @@ namespace EvaporativeCoolers {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input." );
+			ShowFatalError( RoutineName + "Errors found in getting input." );  // LCOV_EXCL_LINE
 			ShowContinueError( "... Preceding condition causes termination." );
 		}
 
@@ -4150,7 +4150,7 @@ namespace EvaporativeCoolers {
 					Node( ZoneEvapUnit( UnitNum ).FanOutletNodeNum ).MassFlowRate = Node( ZoneEvapUnit( UnitNum ).OAInletNodeNum ).MassFlowRate;
 					Node( ZoneEvapUnit( UnitNum ).FanOutletNodeNum ).MassFlowRateMaxAvail = Node( ZoneEvapUnit( UnitNum ).OAInletNodeNum ).MassFlowRate;
 					if ( ZoneEvapUnit( UnitNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) {
-						Fans::SimulateFanComponents( ZoneEvapUnit( UnitNum ).FanName, false, ZoneEvapUnit( UnitNum ).FanIndex, ZoneEvapUnit( UnitNum ).DesignFanSpeedRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff ); 
+						Fans::SimulateFanComponents( ZoneEvapUnit( UnitNum ).FanName, false, ZoneEvapUnit( UnitNum ).FanIndex, ZoneEvapUnit( UnitNum ).DesignFanSpeedRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
 					} else {
 						HVACFan::fanObjs[ ZoneEvapUnit( UnitNum ).FanIndex ]->simulate( _ , ZoneCompTurnFansOn, ZoneCompTurnFansOff,_ );
 					}

--- a/src/EnergyPlus/EvaporativeFluidCoolers.cc
+++ b/src/EnergyPlus/EvaporativeFluidCoolers.cc
@@ -99,7 +99,7 @@ namespace EvaporativeFluidCoolers {
 
 	// METHODOLOGY EMPLOYED:
 	// Based on cooling tower by Shirey, Raustad: Dec 2000; Shirey, Sept 2002
-	
+
 	// Using/Aliasing
 	using namespace DataPrecisionGlobals;
 	using DataGlobals::KelvinConv;
@@ -254,17 +254,17 @@ namespace EvaporativeFluidCoolers {
 		if ( CompIndex == 0 ) {
 			EvapFluidCoolerNum = FindItemInList( EvapFluidCoolerName, SimpleEvapFluidCooler );
 			if ( EvapFluidCoolerNum == 0 ) {
-				ShowFatalError( "SimEvapFluidCoolers: Unit not found = " + EvapFluidCoolerName );
+				ShowFatalError( "SimEvapFluidCoolers: Unit not found = " + EvapFluidCoolerName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = EvapFluidCoolerNum;
 		} else {
 			EvapFluidCoolerNum = CompIndex;
 			if ( EvapFluidCoolerNum > NumSimpleEvapFluidCoolers || EvapFluidCoolerNum < 1 ) {
-				ShowFatalError( "SimEvapFluidCoolers:  Invalid CompIndex passed = " + TrimSigDigits( EvapFluidCoolerNum ) + ", Number of Units = " + TrimSigDigits( NumSimpleEvapFluidCoolers ) + ", Entered Unit name = " + EvapFluidCoolerName );
+				ShowFatalError( "SimEvapFluidCoolers:  Invalid CompIndex passed = " + TrimSigDigits( EvapFluidCoolerNum ) + ", Number of Units = " + TrimSigDigits( NumSimpleEvapFluidCoolers ) + ", Entered Unit name = " + EvapFluidCoolerName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( EvapFluidCoolerNum ) ) {
 				if ( EvapFluidCoolerName != SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name ) {
-					ShowFatalError( "SimEvapFluidCoolers: Invalid CompIndex passed = " + TrimSigDigits( EvapFluidCoolerNum ) + ", Unit name = " + EvapFluidCoolerName + ", stored Unit Name for that index = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
+					ShowFatalError( "SimEvapFluidCoolers: Invalid CompIndex passed = " + TrimSigDigits( EvapFluidCoolerNum ) + ", Unit name = " + EvapFluidCoolerName + ", stored Unit Name for that index = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( EvapFluidCoolerNum ) = false;
 			}
@@ -315,7 +315,7 @@ namespace EvaporativeFluidCoolers {
 			ReportEvapFluidCooler( RunFlag, EvapFluidCoolerNum );
 
 		} else {
-			ShowFatalError( "SimEvapFluidCoolers: Invalid evaporative fluid cooler Type Requested = " + EvapFluidCoolerType );
+			ShowFatalError( "SimEvapFluidCoolers: Invalid evaporative fluid cooler Type Requested = " + EvapFluidCoolerType );  // LCOV_EXCL_LINE
 
 		}} // TypeOfEquip
 
@@ -406,7 +406,7 @@ namespace EvaporativeFluidCoolers {
 		NumTwoSpeedEvapFluidCoolers = GetNumObjectsFound( cEvapFluidCooler_TwoSpeed );
 		NumSimpleEvapFluidCoolers = NumSingleSpeedEvapFluidCoolers + NumTwoSpeedEvapFluidCoolers;
 
-		if ( NumSimpleEvapFluidCoolers <= 0 ) ShowFatalError( "No evaporative fluid cooler objects found in input, however, a branch object has specified an evaporative fluid cooler. Search the input for evaporative fluid cooler to determine the cause for this error." );
+		if ( NumSimpleEvapFluidCoolers <= 0 ) ShowFatalError( "No evaporative fluid cooler objects found in input, however, a branch object has specified an evaporative fluid cooler. Search the input for evaporative fluid cooler to determine the cause for this error." );  // LCOV_EXCL_LINE
 
 		// See if load distribution manager has already gotten the input
 		if ( allocated( SimpleEvapFluidCooler ) ) return;
@@ -919,7 +919,7 @@ namespace EvaporativeFluidCoolers {
 		} // End Two-Speed Evaporative Fluid Cooler Loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting evaporative fluid cooler input." );
+			ShowFatalError( "Errors found in getting evaporative fluid cooler input." );  // LCOV_EXCL_LINE
 		}
 
 		// Set up output variables
@@ -1121,7 +1121,7 @@ namespace EvaporativeFluidCoolers {
 			ScanPlantLoopsForObject( SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name, TypeOf_Num, SimpleEvapFluidCooler( EvapFluidCoolerNum ).LoopNum, SimpleEvapFluidCooler( EvapFluidCoolerNum ).LoopSideNum, SimpleEvapFluidCooler( EvapFluidCoolerNum ).BranchNum, SimpleEvapFluidCooler( EvapFluidCoolerNum ).CompNum, _, _, _, _, _, ErrorsFound );
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "InitEvapFluidCooler: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitEvapFluidCooler: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( SimpleEvapFluidCooler( EvapFluidCoolerNum ).EvapFluidCoolerType_Num == EvapFluidCooler_TwoSpeed ) {
@@ -1138,7 +1138,7 @@ namespace EvaporativeFluidCoolers {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "InitEvapFluidCooler: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitEvapFluidCooler: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			OneTimeFlagForEachEvapFluidCooler( EvapFluidCoolerNum ) = false;
@@ -1285,7 +1285,7 @@ namespace EvaporativeFluidCoolers {
 			} else {
 				if ( PlantFirstSizesOkayToFinalize ) {
 					ShowSevereError( "Autosizing error for evaporative fluid cooler object = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
-					ShowFatalError( "Autosizing of evaporative fluid cooler condenser flow rate requires a loop Sizing:Plant object." );
+					ShowFatalError( "Autosizing of evaporative fluid cooler condenser flow rate requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 				}
 			}
 			// Check when the user specified Condenser/Evaporative Fluid Cooler water design setpoint
@@ -1300,7 +1300,7 @@ namespace EvaporativeFluidCoolers {
 				ShowContinueError( "Design Loop Exit Temperature (" + RoundSigDigits( PlantSizData( PltSizCondNum ).ExitTemp, 2 ) + " C) must be greater than design entering air wet-bulb temperature (" + RoundSigDigits( DesignEnteringAirWetBulb, 2 ) + " C) when autosizing the Evaporative Fluid Cooler UA." );
 				ShowContinueError( "It is recommended that the Design Loop Exit Temperature = Design Entering Air Wet-bulb Temp plus the Evaporative Fluid Cooler design approach temperature (e.g., 4 C)." );
 				ShowContinueError( "If using HVACTemplate:Plant:ChilledWaterLoop, then check that input field Condenser Water Design Setpoint must be > Design Entering Air Wet-bulb Temp if autosizing the Evaporative Fluid Cooler." );
-				ShowFatalError( "Review and revise design input values as appropriate." );
+				ShowFatalError( "Review and revise design input values as appropriate." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -1371,7 +1371,7 @@ namespace EvaporativeFluidCoolers {
 				} else {
 					if ( PlantFirstSizesOkayToFinalize ) {
 						ShowSevereError( "Autosizing of evaporative fluid cooler fan power requires a loop Sizing:Plant object." );
-						ShowFatalError( " Occurs in evaporative fluid cooler object= " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
+						ShowFatalError( " Occurs in evaporative fluid cooler object= " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -1438,7 +1438,7 @@ namespace EvaporativeFluidCoolers {
 						ShowContinueError( "The Design Loop Exit Temperature specified in Sizing:Plant object = " + PlantSizData( PltSizCondNum ).PlantLoopName );
 						ShowContinueError( "It is recommended that the Design Loop Exit Temperature = 25.6 C plus the Evaporative Fluid Cooler design approach temperature (e.g., 4 C)." );
 						ShowContinueError( "If using HVACTemplate:Plant:ChilledWaterLoop, then check that input field Condenser Water Design Setpoint must be > 25.6 C if autosizing the Evaporative Fluid Cooler." );
-						ShowFatalError( "Review and revise design input values as appropriate." );
+						ShowFatalError( "Review and revise design input values as appropriate." );  // LCOV_EXCL_LINE
 					}
 					rho = GetDensityGlycol( PlantLoop( SimpleEvapFluidCooler( EvapFluidCoolerNum ).LoopNum ).FluidName, DataGlobals::InitConvTemp, PlantLoop( SimpleEvapFluidCooler( EvapFluidCoolerNum ).LoopNum ).FluidIndex, CalledFrom );
 					Cp = GetSpecificHeatGlycol( PlantLoop( SimpleEvapFluidCooler( EvapFluidCoolerNum ).LoopNum ).FluidName, PlantSizData( PltSizCondNum ).ExitTemp, PlantLoop( SimpleEvapFluidCooler( EvapFluidCoolerNum ).LoopNum ).FluidIndex, CalledFrom );
@@ -1486,7 +1486,7 @@ namespace EvaporativeFluidCoolers {
 						ShowContinueError( "Design Evaporative Fluid Cooler Water Inlet Temp [C]          = " + RoundSigDigits( SimpleEvapFluidCoolerInlet( EvapFluidCoolerNum ).WaterTemp, 2 ) );
 						ShowContinueError( "Calculated water outlet temperature at low UA [C](UA = " + RoundSigDigits( UA0, 2 ) + " W/C)  = " + RoundSigDigits( OutWaterTempAtUA0, 2 ) );
 						ShowContinueError( "Calculated water outlet temperature at high UA [C](UA = " + RoundSigDigits( UA1, 2 ) + " W/C)  = " + RoundSigDigits( OutWaterTempAtUA1, 2 ) );
-						ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
+						ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 					}
 					tmpHighSpeedEvapFluidCoolerUA = UA;
 					if ( PlantFirstSizesOkayToFinalize ) SimpleEvapFluidCooler( EvapFluidCoolerNum ).HighSpeedEvapFluidCoolerUA = tmpHighSpeedEvapFluidCoolerUA;
@@ -1519,7 +1519,7 @@ namespace EvaporativeFluidCoolers {
 			} else {
 				if ( PlantFirstSizesOkayToFinalize ) {
 					ShowSevereError( "Autosizing error for evaporative fluid cooler object = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
-					ShowFatalError( "Autosizing of evaporative fluid cooler UA requires a loop Sizing:Plant object." );
+					ShowFatalError( "Autosizing of evaporative fluid cooler UA requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -1551,7 +1551,7 @@ namespace EvaporativeFluidCoolers {
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( CalledFrom + ": The combination of design input values did not allow the calculation of a " );
 					ShowContinueError( "reasonable UA value. Review and revise design input values as appropriate. " );
-					ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
+					ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				SimpleEvapFluidCooler( EvapFluidCoolerNum ).HighSpeedEvapFluidCoolerUA = UA;
 			} else {
@@ -1629,7 +1629,7 @@ namespace EvaporativeFluidCoolers {
 					ShowContinueError( "Design Evaporative Fluid Cooler Water Inlet Temp [C]          = " + RoundSigDigits( SimpleEvapFluidCoolerInlet( EvapFluidCoolerNum ).WaterTemp, 2 ) );
 					ShowContinueError( "Calculated water outlet temperature at low UA [C](UA = " + RoundSigDigits( UA0, 2 ) + " W/C)  = " + RoundSigDigits( OutWaterTempAtUA0, 2 ) );
 					ShowContinueError( "Calculated water outlet temperature at high UA [C](UA = " + RoundSigDigits( UA1, 2 ) + " W/C)  = " + RoundSigDigits( OutWaterTempAtUA1, 2 ) );
-					ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
+					ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				SimpleEvapFluidCooler( EvapFluidCoolerNum ).HighSpeedEvapFluidCoolerUA = UA;
 			} else {
@@ -1723,7 +1723,7 @@ namespace EvaporativeFluidCoolers {
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( CalledFrom + ": The combination of design input values did not allow the calculation of a " );
 					ShowContinueError( "reasonable low-speed UA value. Review and revise design input values as appropriate. " );
-					ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
+					ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				SimpleEvapFluidCooler( EvapFluidCoolerNum ).LowSpeedEvapFluidCoolerUA = UA;
 			} else {
@@ -1763,7 +1763,7 @@ namespace EvaporativeFluidCoolers {
 				SolveRoot( Acc, MaxIte, SolFla, UA, SimpleEvapFluidCoolerUAResidual, UA0, UA1, Par );
 				if ( SolFla == -1 ) {
 					ShowSevereError( "Iteration limit exceeded in calculating EvaporativeFluidCooler UA" );
-					ShowFatalError( "Autosizing of EvaporativeFluidCooler UA failed for EvaporativeFluidCooler " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
+					ShowFatalError( "Autosizing of EvaporativeFluidCooler UA failed for EvaporativeFluidCooler " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				} else if ( SolFla == -2 ) {
 					SimSimpleEvapFluidCooler( int( Par( 2 ) ), Par( 3 ), Par( 4 ), UA0, OutWaterTempAtUA0 );
 					SimSimpleEvapFluidCooler( int( Par( 2 ) ), Par( 3 ), Par( 4 ), UA1, OutWaterTempAtUA1 );
@@ -1785,7 +1785,7 @@ namespace EvaporativeFluidCoolers {
 					ShowContinueError( "Design Evaporative Fluid Cooler Water Inlet Temp [C]    = " + RoundSigDigits( SimpleEvapFluidCoolerInlet( EvapFluidCoolerNum ).WaterTemp, 2 ) );
 					ShowContinueError( "Calculated water outlet temperature at low UA(" + RoundSigDigits( UA0, 2 ) + ")  = " + RoundSigDigits( OutWaterTempAtUA0, 2 ) );
 					ShowContinueError( "Calculated water outlet temperature at high UA(" + RoundSigDigits( UA1, 2 ) + ")  = " + RoundSigDigits( OutWaterTempAtUA1, 2 ) );
-					ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );
+					ShowFatalError( "Autosizing of Evaporative Fluid Cooler UA failed for Evaporative Fluid Cooler = " + SimpleEvapFluidCooler( EvapFluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				SimpleEvapFluidCooler( EvapFluidCoolerNum ).LowSpeedEvapFluidCoolerUA = UA;
 			} else {

--- a/src/EnergyPlus/ExteriorEnergyUse.cc
+++ b/src/EnergyPlus/ExteriorEnergyUse.cc
@@ -455,7 +455,7 @@ namespace ExteriorEnergyUse {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -552,7 +552,7 @@ namespace ExteriorEnergyUse {
 			FuelTypeString = "DistrictHeating";
 		} else {
 			ShowSevereError( RoutineName + CurrentModuleObject + "=\"" + CurrentName + "\"." );
-			ShowFatalError( "Heating source/fuel type not recognized. Check input field " + CurrentField + "=\"" + FuelTypeAlpha );
+			ShowFatalError( "Heating source/fuel type not recognized. Check input field " + CurrentField + "=\"" + FuelTypeAlpha );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/ExternalInterface.cc
+++ b/src/EnergyPlus/ExternalInterface.cc
@@ -337,7 +337,7 @@ namespace ExternalInterface {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetExternalInterfaceInput: preceding conditions cause termination." );
+			ShowFatalError( "GetExternalInterfaceInput: preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		StopExternalInterfaceIfError();
@@ -374,12 +374,12 @@ namespace ExternalInterface {
 						retVal = sendclientmessage( &socketFD, &flag2 );
 					}
 				}
-				ShowFatalError( "Error in ExternalInterface: Check EnergyPlus *.err file." );
+				ShowFatalError( "Error in ExternalInterface: Check EnergyPlus *.err file." );  // LCOV_EXCL_LINE
 			}
 		}
 		if ( NumExternalInterfacesFMUImport != 0 ) {
 			if ( ErrorsFound ) {
-				ShowFatalError( "ExternalInterface/StopExternalInterfaceIfError: Error in ExternalInterface: Check EnergyPlus *.err file." );
+				ShowFatalError( "ExternalInterface/StopExternalInterfaceIfError: Error in ExternalInterface: Check EnergyPlus *.err file." );  // LCOV_EXCL_LINE
 			}
 		}
 	}

--- a/src/EnergyPlus/FanCoilUnits.cc
+++ b/src/EnergyPlus/FanCoilUnits.cc
@@ -177,7 +177,7 @@ namespace FanCoilUnits {
 
 	// DERIVED TYPE DEFINITIONS
 
-	// MODULE VARIABLE DECLARATIONS:	
+	// MODULE VARIABLE DECLARATIONS:
 	namespace {
 		bool InitFanCoilUnitsOneTimeFlag( true );
 		bool InitFanCoilUnitsCheckInZoneEquipmentListFlag( false ); // True after the Zone Equipment List has been checked for items
@@ -278,17 +278,17 @@ namespace FanCoilUnits {
 		if ( CompIndex == 0 ) {
 			FanCoilNum = FindItemInList( CompName, FanCoil );
 			if ( FanCoilNum == 0 ) {
-				ShowFatalError( "SimFanCoil: Unit not found=" + CompName );
+				ShowFatalError( "SimFanCoil: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = FanCoilNum;
 		} else {
 			FanCoilNum = CompIndex;
 			if ( FanCoilNum > NumFanCoils || FanCoilNum < 1 ) {
-				ShowFatalError( "SimFanCoil:  Invalid CompIndex passed=" + TrimSigDigits( FanCoilNum ) + ", Number of Units=" + TrimSigDigits( NumFanCoils ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimFanCoil:  Invalid CompIndex passed=" + TrimSigDigits( FanCoilNum ) + ", Number of Units=" + TrimSigDigits( NumFanCoils ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( FanCoilNum ) ) {
 				if ( CompName != FanCoil( FanCoilNum ).Name ) {
-					ShowFatalError( "SimFanCoil: Invalid CompIndex passed=" + TrimSigDigits( FanCoilNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + FanCoil( FanCoilNum ).Name );
+					ShowFatalError( "SimFanCoil: Invalid CompIndex passed=" + TrimSigDigits( FanCoilNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + FanCoil( FanCoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( FanCoilNum ) = false;
 			}
@@ -898,7 +898,7 @@ namespace FanCoilUnits {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input. Preceding condition(s) cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		for ( FanCoilNum = 1; FanCoilNum <= NumFanCoils; ++FanCoilNum ) {
@@ -1010,7 +1010,7 @@ namespace FanCoilUnits {
 
 				if ( errFlag ) {
 					ShowContinueError( "Reference Unit=\"" + FanCoil( FanCoilNum ).Name + "\", type=" + FanCoil( FanCoilNum ).UnitType );
-					ShowFatalError( "InitFanCoilUnits: Program terminated for previous conditions." );
+					ShowFatalError( "InitFanCoilUnits: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 
 				FanCoil( FanCoilNum ).HotPlantOutletNode = PlantLoop( FanCoil( FanCoilNum ).HWLoopNum ).LoopSide( FanCoil( FanCoilNum ).HWLoopSide ).Branch( FanCoil( FanCoilNum ).HWBranchNum ).Comp( FanCoil( FanCoilNum ).HWCompNum ).NodeNumOut;
@@ -1018,18 +1018,18 @@ namespace FanCoilUnits {
 			} else if ( FanCoil( FanCoilNum ).HCoilType_Num == HCoil_Electric ) {
 				// do nothing, valid type
 			} else {
-				ShowFatalError( "InitFanCoilUnits: FanCoil=" + FanCoil( FanCoilNum ).Name + ", invalid heating coil type. Program terminated." );
+				ShowFatalError( "InitFanCoilUnits: FanCoil=" + FanCoil( FanCoilNum ).Name + ", invalid heating coil type. Program terminated." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ( FanCoil( FanCoilNum ).CCoilPlantTypeOfNum == TypeOf_CoilWaterCooling ) || ( FanCoil( FanCoilNum ).CCoilPlantTypeOfNum == TypeOf_CoilWaterDetailedFlatCooling ) ) {
 				ScanPlantLoopsForObject( FanCoil( FanCoilNum ).CCoilPlantName, FanCoil( FanCoilNum ).CCoilPlantTypeOfNum, FanCoil( FanCoilNum ).CWLoopNum, FanCoil( FanCoilNum ).CWLoopSide, FanCoil( FanCoilNum ).CWBranchNum, FanCoil( FanCoilNum ).CWCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
 					ShowContinueError( "Reference Unit=\"" + FanCoil( FanCoilNum ).Name + "\", type=" + FanCoil( FanCoilNum ).UnitType );
-					ShowFatalError( "InitFanCoilUnits: Program terminated for previous conditions." );
+					ShowFatalError( "InitFanCoilUnits: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				FanCoil( FanCoilNum ).ColdPlantOutletNode = PlantLoop( FanCoil( FanCoilNum ).CWLoopNum ).LoopSide( FanCoil( FanCoilNum ).CWLoopSide ).Branch( FanCoil( FanCoilNum ).CWBranchNum ).Comp( FanCoil( FanCoilNum ).CWCompNum ).NodeNumOut;
 			} else {
-				ShowFatalError( "InitFanCoilUnits: FanCoil=" + FanCoil( FanCoilNum ).Name + ", invalid cooling coil type. Program terminated." );
+				ShowFatalError( "InitFanCoilUnits: FanCoil=" + FanCoil( FanCoilNum ).Name + ", invalid cooling coil type. Program terminated." );  // LCOV_EXCL_LINE
 			}
 
 			MyPlantScanFlag( FanCoilNum ) = false;
@@ -1397,7 +1397,7 @@ namespace FanCoilUnits {
 
 				//     If fan is autosized, get fan volumetric flow rate
 				if ( FanCoil( FanCoilNum ).FanAirVolFlow == AutoSize ) {
-					if ( FanCoil( FanCoilNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) { 
+					if ( FanCoil( FanCoilNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) {
 						Fans::SimulateFanComponents( FanCoil( FanCoilNum ).FanName, true, FanCoil( FanCoilNum ).FanIndex );
 						FanCoil( FanCoilNum ).FanAirVolFlow = GetFanDesignVolumeFlowRate( cFanTypes( FanCoil( FanCoilNum ).FanType_Num ), FanCoil( FanCoilNum ).FanName, ErrorsFound );
 					} else {
@@ -1434,7 +1434,7 @@ namespace FanCoilUnits {
 				}
 			}
 		} else if ( FanCoil( FanCoilNum ).FanAirVolFlow == AutoSize ) {
-			if ( FanCoil( FanCoilNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) { 
+			if ( FanCoil( FanCoilNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) {
 				Fans::SimulateFanComponents( FanCoil( FanCoilNum ).FanName, true, FanCoil( FanCoilNum ).FanIndex );
 				FanCoil( FanCoilNum ).FanAirVolFlow = GetFanDesignVolumeFlowRate( cFanTypes( FanCoil( FanCoilNum ).FanType_Num ), FanCoil( FanCoilNum ).FanName, ErrorsFound );
 			} else {
@@ -1831,7 +1831,7 @@ namespace FanCoilUnits {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2089,9 +2089,9 @@ namespace FanCoilUnits {
 					Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut ); // get QUnitOut
 				}
 				else {
-					// flow lock on 
+					// flow lock on
 					if ( MdotLockC > CWFlow ) { // if mdot > CWFlow, bypass extra flow
-						Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut ); // get QUnitOut with CWFlow; rest will be bypassed 
+						Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut ); // get QUnitOut with CWFlow; rest will be bypassed
 						Node( FanCoil( FanCoilNum ).ColdControlNode ).MassFlowRate = MdotLockC; // reset flow to locked value. Since lock is on, must do this by hand
 						Node( FanCoil( FanCoilNum ).ColdPlantOutletNode ).MassFlowRate = MdotLockC;
 						// Keep soln flow rate but reset outlet water temperature - i.e. bypass extra water
@@ -2213,9 +2213,9 @@ namespace FanCoilUnits {
 							FanCoil( FanCoilNum ).HWLoopSide, FanCoil( FanCoilNum ).HWBranchNum, FanCoil( FanCoilNum ).HWCompNum );
 						Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut ); // get QUnitOut
 					} else {
-						// flow lock on 
+						// flow lock on
 						if ( MdotLockH > HWFlow ) { // if mdot > HWFlow, bypass extra flow
-							Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut ); // get QUnitOut with HWFlow; rest will be bypassed 
+							Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut ); // get QUnitOut with HWFlow; rest will be bypassed
 							Node( FanCoil( FanCoilNum ).HotControlNode ).MassFlowRate = MdotLockH; // reset flow to locked value. Since lock is on, must do this by hand
 							Node( FanCoil( FanCoilNum ).HotPlantOutletNode ).MassFlowRate = MdotLockH;
 							// Keep soln flow rate but reset outlet water temperature - i.e. bypass extra water
@@ -2253,7 +2253,7 @@ namespace FanCoilUnits {
 			} else {
 				FanCoil( FanCoilNum ).ElecPower = HVACFan::fanObjs[ FanCoil( FanCoilNum ).FanIndex ]->fanPower();
 			}
-			
+
 			PowerMet = QUnitOut;
 			LatOutputProvided = LatentOutput;
 
@@ -2286,7 +2286,7 @@ namespace FanCoilUnits {
 			// speed fan selection only for multispeed cycling fan
 			if ( UnitOn && ( FanCoil( FanCoilNum ).CapCtrlMeth_Num == CCM_CycFan ) ) {
 				QZnReq = ZoneSysEnergyDemand( ZoneNum ).RemainingOutputRequired;
- 
+
 				// set water side mass flow rate
 				if ( QCoilCoolSP < 0 ) {
 					Node( FanCoil( FanCoilNum ).ColdControlNode ).MassFlowRate = FanCoil( FanCoilNum ).MaxColdWaterFlow;
@@ -3244,7 +3244,7 @@ namespace FanCoilUnits {
 		} else {
 			MinWaterFlow = mdot;
 		}
-	
+
 	}
 
 	void
@@ -3337,7 +3337,7 @@ namespace FanCoilUnits {
 		} else {
 			PLRMin = PLR;
 		}
-	
+
 	}
 
 	void
@@ -4201,7 +4201,7 @@ namespace FanCoilUnits {
 						if ( Iter > 70 && SRatio == 0.0 && DelPLR < 0.0 ) Error = 0.0;
 					}
 				}
-				//FanElecPower = FanElecPowerHS * SRatio + FanElecPowerLS * ( 1.0 - SRatio ); // why set the ugly global here? 
+				//FanElecPower = FanElecPowerHS * SRatio + FanElecPowerLS * ( 1.0 - SRatio ); // why set the ugly global here?
 				FanCoil( FanCoilNum ).ElecPower = FanElecPowerHS * SRatio + FanElecPowerLS * ( 1.0 - SRatio );
 			}
 		}
@@ -4717,7 +4717,7 @@ namespace FanCoilUnits {
 		ControlledZoneNum = int( Par( 3 ) );
 		QZnReq = Par( 4 );
 		WaterControlNode = int( Par( 5 ) );
-		
+
 		if ( WaterControlNode == FanCoil( FanCoilNum ).ColdControlNode ) {
 			Node( WaterControlNode ).MassFlowRate = PLR * FanCoil( FanCoilNum ).MaxColdWaterFlow;
 			Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, PLR ); // needs PLR=0 for electric heating coil, otherwise will run a full capacity
@@ -4759,7 +4759,7 @@ namespace FanCoilUnits {
 
 		// REFERENCES:
 		// na
-		
+
 		// USE STATEMENTS:
 		// na
 
@@ -4805,7 +4805,7 @@ namespace FanCoilUnits {
 		QZnReq = Par( 4 );
 
 		Node( FanCoil( FanCoilNum ).HotControlNode ).MassFlowRate = HWFlow;
-		Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 1.0 ); 
+		Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 1.0 );
 
 		// Calculate residual based on output magnitude
 		if ( std::abs( QZnReq ) <= 100.0 ) {
@@ -4885,7 +4885,7 @@ namespace FanCoilUnits {
 		QZnReq = Par( 4 );
 
 		Node( FanCoil( FanCoilNum ).ColdControlNode ).MassFlowRate = CWFlow;
-		Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 1.0 ); 
+		Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 1.0 );
 
 		// Calculate residual based on output magnitude
 		if ( std::abs( QZnReq ) <= 100.0 ) {
@@ -4903,49 +4903,49 @@ namespace FanCoilUnits {
 		Array1< Real64 > const & Par // Function parameters
 	)
 	{
-		
+
 				// FUNCTION INFORMATION:
 				//       AUTHOR         Richard Raustad, FSEC
 				//       DATE WRITTEN   December 2015
 				//       MODIFIED       na
 				//       RE-ENGINEERED  na
-			
+
 				// PURPOSE OF THIS SUBROUTINE:
 				// To calculate the part-load ratio for the FCU with varying water flow rate
-			
+
 				// METHODOLOGY EMPLOYED:
 				// Use SolveRoot to CALL this Function to converge on a solution
-			
+
 				// REFERENCES:
 				// na
-			
+
 				// USE STATEMENTS:
 				// na
-			
+
 				// Return value
 		Real64 Residuum; // Result (forces solution to be within tolerance)
 
 				// Argument array dimensioning
-			
+
 				// Locals
 				// SUBROUTINE ARGUMENT DEFINITIONS:
-			
+
 				//   Parameter description example:
 				//       Par(1)  = REAL(FanCoilNum,r64) ! Index to fan coil unit
 				//       Par(2)  = 0.0                  ! FirstHVACIteration FLAG, IF 1.0 then TRUE, if 0.0 then FALSE
 				//       Par(3)  = REAL(ControlledZoneNum,r64)     ! zone index
 				//       Par(4)  = QZnReq               ! zone load [W]
 				//       Par(5)  = WaterControlNode     ! CW or HW control node number
-			
+
 				// SUBROUTINE PARAMETER DEFINITIONS:
 				// na
-			
+
 				// INTERFACE BLOCK SPECIFICATIONS
 				// na
-			
+
 				// DERIVED TYPE DEFINITIONS
 				// na
-			
+
 				// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		int FanCoilNum; // Index to this fan coil unit
 		bool FirstHVACIteration; // FirstHVACIteration flag
@@ -4955,7 +4955,7 @@ namespace FanCoilUnits {
 		Real64 QUnitOut; // delivered capacity [W]
 		Real64 QZnReq;
 		Real64 FCOutletTempOn; // FCU outlet temperature
-		
+
 		// Convert parameters to usable variables
 		FanCoilNum = int( Par( 1 ) );
 		if ( Par( 2 ) == 1.0 ) {
@@ -4967,70 +4967,70 @@ namespace FanCoilUnits {
 		OutletTemp = Par( 4 );
 		QZnReq = Par( 5 );
 		WaterControlNode = int( Par( 6 ) );
-		
+
 		if ( WaterControlNode == FanCoil( FanCoilNum ).ColdControlNode || ( WaterControlNode == FanCoil( FanCoilNum ).HotControlNode && FanCoil( FanCoilNum ).HCoilType_Num != HCoil_Electric ) ) {
 			Node( WaterControlNode ).MassFlowRate = WaterFlow;
 			Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 0.0 ); // needs PLR=0 for electric heating coil, otherwise will run a full capacity
 		} else {
 			Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 1.0 ); // needs PLR=1 for electric heating coil
 		}
-		
+
 		FCOutletTempOn = Node( FanCoil( FanCoilNum ).AirOutNode ).Temp;
 		// Calculate residual based on output magnitude
 		Residuum = ( FCOutletTempOn - OutletTemp );
-		
+
 		return Residuum;
 	}
-	
+
 	Real64
 	CalcFanCoilWaterFlowResidual(
 		Real64 const WaterFlow, // water mass flow rate [kg/s]
 		Array1< Real64 > const & Par // Function parameters
 	)
 	{
-		
+
 				// FUNCTION INFORMATION:
 				//       AUTHOR         Richard Raustad, FSEC
 				//       DATE WRITTEN   December 2015
 				//       MODIFIED       na
 				//       RE-ENGINEERED  na
-			
+
 				// PURPOSE OF THIS SUBROUTINE:
 				// To calculate the part-load ratio for the FCU with varying water flow rate
-			
+
 				// METHODOLOGY EMPLOYED:
 				// Use SolveRoot to CALL this Function to converge on a solution
-			
+
 				// REFERENCES:
 				// na
-			
+
 				// USE STATEMENTS:
 				// na
-			
+
 				// Return value
 		Real64 Residuum; // Result (forces solution to be within tolerance)
 
 				// Argument array dimensioning
-			
+
 				// Locals
 				// SUBROUTINE ARGUMENT DEFINITIONS:
-			
+
 				//   Parameter description example:
 				//       Par(1)  = REAL(FanCoilNum,r64) ! Index to fan coil unit
 				//       Par(2)  = 0.0                  ! FirstHVACIteration FLAG, IF 1.0 then TRUE, if 0.0 then FALSE
 				//       Par(3)  = REAL(ControlledZoneNum,r64)     ! zone index
 				//       Par(4)  = QZnReq               ! zone load [W]
 				//       Par(5)  = WaterControlNode     ! CW or HW control node number
-			
+
 				// SUBROUTINE PARAMETER DEFINITIONS:
 				// na
-			
+
 				// INTERFACE BLOCK SPECIFICATIONS
 				// na
-			
+
 				// DERIVED TYPE DEFINITIONS
 				// na
-			
+
 				// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		int FanCoilNum; // Index to this fan coil unit
 		bool FirstHVACIteration; // FirstHVACIteration flag
@@ -5038,7 +5038,7 @@ namespace FanCoilUnits {
 		int WaterControlNode; // water node to control
 		Real64 QZnReq; // Sensible load to be met [W]
 		Real64 QUnitOut; // delivered capacity [W]
-		
+
 		// Convert parameters to usable variables
 		FanCoilNum = int( Par( 1 ) );
 		if ( Par( 2 ) == 1.0 ) {
@@ -5049,21 +5049,21 @@ namespace FanCoilUnits {
 		ControlledZoneNum = int( Par( 3 ) );
 		QZnReq = Par( 4 );
 		WaterControlNode = int( Par( 5 ) );
-		
+
 		if ( WaterControlNode == FanCoil( FanCoilNum ).ColdControlNode || ( WaterControlNode == FanCoil( FanCoilNum ).HotControlNode && FanCoil( FanCoilNum ).HCoilType_Num != HCoil_Electric ) ) {
 			Node( WaterControlNode ).MassFlowRate = WaterFlow;
 			Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 0.0 ); // needs PLR=0 for electric heating coil, otherwise will run a full capacity
 		} else {
 			Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 1.0 ); // needs PLR=1 for electric heating coil
 		}
-		
+
 		// Calculate residual based on output magnitude
 		if ( std::abs( QZnReq ) <= 100.0 ) {
 			Residuum = ( QUnitOut - QZnReq ) / 100.0;
 		} else {
 			Residuum = ( QUnitOut - QZnReq ) / QZnReq;
 		}
-		
+
 		return Residuum;
 	}
 
@@ -5146,7 +5146,7 @@ namespace FanCoilUnits {
 			Node( WaterControlNode ).MassFlowRate = MinWaterFlow + ( PLR * ( FanCoil( FanCoilNum ).MaxHotWaterFlow - MinWaterFlow ) );
 		} else {
 			// developer error
-			ShowFatalError( "Developer Error - CalcFanCoilAirAndWaterFlowResidual: Water control node not found for " + FanCoil( FanCoilNum ).Name );
+			ShowFatalError( "Developer Error - CalcFanCoilAirAndWaterFlowResidual: Water control node not found for " + FanCoil( FanCoilNum ).Name );  // LCOV_EXCL_LINE
 		}
 		Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 1.0 ); // needs PLR=0 for electric heating coil, otherwise will run a full capacity
 
@@ -5248,7 +5248,7 @@ namespace FanCoilUnits {
 			Calc4PipeFanCoil( FanCoilNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, 1.0 );
 		} else {
 			// developer error
-			ShowFatalError( "Developer Error - CalcFanCoilAirAndWaterFlowResidual: Water control node not found for " + FanCoil( FanCoilNum ).Name );
+			ShowFatalError( "Developer Error - CalcFanCoilAirAndWaterFlowResidual: Water control node not found for " + FanCoil( FanCoilNum ).Name );  // LCOV_EXCL_LINE
 		}
 
 		// Calculate residual based on output magnitude

--- a/src/EnergyPlus/Fans.cc
+++ b/src/EnergyPlus/Fans.cc
@@ -247,17 +247,17 @@ namespace Fans {
 		if ( CompIndex == 0 ) {
 			FanNum = FindItemInList( CompName, Fan, &FanEquipConditions::FanName );
 			if ( FanNum == 0 ) {
-				ShowFatalError( "SimulateFanComponents: Fan not found=" + CompName );
+				ShowFatalError( "SimulateFanComponents: Fan not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = FanNum;
 		} else {
 			FanNum = CompIndex;
 			if ( FanNum > NumFans || FanNum < 1 ) {
-				ShowFatalError( "SimulateFanComponents: Invalid CompIndex passed=" + TrimSigDigits( FanNum ) + ", Number of Fans=" + TrimSigDigits( NumFans ) + ", Fan name=" + CompName );
+				ShowFatalError( "SimulateFanComponents: Invalid CompIndex passed=" + TrimSigDigits( FanNum ) + ", Number of Fans=" + TrimSigDigits( NumFans ) + ", Fan name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( FanNum ) ) {
 				if ( ! CompName.empty() && CompName != Fan( FanNum ).FanName ) {
-					ShowFatalError( "SimulateFanComponents: Invalid CompIndex passed=" + TrimSigDigits( FanNum ) + ", Fan name=" + CompName + ", stored Fan Name for that index=" + Fan( FanNum ).FanName );
+					ShowFatalError( "SimulateFanComponents: Invalid CompIndex passed=" + TrimSigDigits( FanNum ) + ", Fan name=" + CompName + ", stored Fan Name for that index=" + Fan( FanNum ).FanName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( FanNum ) = false;
 			}
@@ -912,7 +912,7 @@ namespace Fans {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		for ( FanNum = 1; FanNum <= NumFans; ++FanNum ) {

--- a/src/EnergyPlus/FaultsManager.cc
+++ b/src/EnergyPlus/FaultsManager.cc
@@ -79,7 +79,7 @@ namespace FaultsManager {
 	//       MODIFIED       Sep. 2013, Xiufeng Pang (XP), LBNL. Added Fouling Coil fault
 	//                      Feb. 2015, Rongpeng Zhang, LBNL. Added Thermostat/Humidistat Offset faults
 	//                      Apr. 2015, Rongpeng Zhang, LBNL. Added Fouling Air Filter fault
-	//                      May. 2016, Rongpeng Zhang, LBNL. Added Chiller/Condenser Supply Water Temperature Sensor fault 
+	//                      May. 2016, Rongpeng Zhang, LBNL. Added Chiller/Condenser Supply Water Temperature Sensor fault
 	//                      Jun. 2016, Rongpeng Zhang, LBNL. Added Tower Scaling fault
 	//                      Jul. 2016, Rongpeng Zhang, LBNL. Added Coil Supply Air Temperature Sensor fault
 	//                      Oct. 2016, Rongpeng Zhang, LBNL. Added Fouling Boiler fault
@@ -106,18 +106,18 @@ namespace FaultsManager {
 	// DERIVED TYPE DEFINITIONS:
 
 	// MODULE VARIABLE TYPE DECLARATIONS:
-	
+
 	namespace {
 	// These were static variables within different functions. They were pulled out into the namespace
 	// to facilitate easier unit testing of those functions.
 	// These are purposefully not in the header file as an extern variable. No one outside of this module should
 	// use these. They are cleared by clear_state() for use by unit tests, but normal simulations should be unaffected.
 	// This is purposefully in an anonymous namespace so nothing outside this implementation file can use it.
-		
+
 		bool RunFaultMgrOnceFlag( false ); // True if CheckAndReadFaults is already done
 		bool ErrorsFound( false ); // True if errors detected in input
 	}
-	
+
 	// ControllerTypeEnum
 	int const iController_AirEconomizer( 1001 );
 
@@ -168,15 +168,15 @@ namespace FaultsManager {
 	//  Pressure sensor offset
 	//  more
 
-	Array1D_string const cFaults( NumFaultTypes, 
-	{ "FaultModel:TemperatureSensorOffset:OutdoorAir", 
-	"FaultModel:HumiditySensorOffset:OutdoorAir", 
-	"FaultModel:EnthalpySensorOffset:OutdoorAir", 
-	"FaultModel:TemperatureSensorOffset:ReturnAir", 
-	"FaultModel:EnthalpySensorOffset:ReturnAir", 
-	"FaultModel:Fouling:Coil", 
-	"FaultModel:ThermostatOffset", 
-	"FaultModel:HumidistatOffset", 
+	Array1D_string const cFaults( NumFaultTypes,
+	{ "FaultModel:TemperatureSensorOffset:OutdoorAir",
+	"FaultModel:HumiditySensorOffset:OutdoorAir",
+	"FaultModel:EnthalpySensorOffset:OutdoorAir",
+	"FaultModel:TemperatureSensorOffset:ReturnAir",
+	"FaultModel:EnthalpySensorOffset:ReturnAir",
+	"FaultModel:Fouling:Coil",
+	"FaultModel:ThermostatOffset",
+	"FaultModel:HumidistatOffset",
 	"FaultModel:Fouling:AirFilter",
 	"FaultModel:TemperatureSensorOffset:ChillerSupplyWater",
 	"FaultModel:TemperatureSensorOffset:CondenserSupplyWater",
@@ -195,15 +195,15 @@ namespace FaultsManager {
 	//      'FaultModel:DamperLeakage:ReturnAir           ', &
 	//      'FaultModel:DamperLeakage:OutdoorAir          ' /)
 
-	Array1D_int const iFaultTypeEnums( NumFaultTypes, 
-	{ iFault_TemperatureSensorOffset_OutdoorAir, 
-	iFault_HumiditySensorOffset_OutdoorAir, 
-	iFault_EnthalpySensorOffset_OutdoorAir, 
-	iFault_TemperatureSensorOffset_ReturnAir, 
-	iFault_EnthalpySensorOffset_ReturnAir, 
-	iFault_Fouling_Coil, 
-	iFault_ThermostatOffset, 
-	iFault_HumidistatOffset, 
+	Array1D_int const iFaultTypeEnums( NumFaultTypes,
+	{ iFault_TemperatureSensorOffset_OutdoorAir,
+	iFault_HumiditySensorOffset_OutdoorAir,
+	iFault_EnthalpySensorOffset_OutdoorAir,
+	iFault_TemperatureSensorOffset_ReturnAir,
+	iFault_EnthalpySensorOffset_ReturnAir,
+	iFault_Fouling_Coil,
+	iFault_ThermostatOffset,
+	iFault_HumidistatOffset,
 	iFault_Fouling_AirFilter,
 	iFault_TemperatureSensorOffset_ChillerSupplyWater,
 	iFault_TemperatureSensorOffset_CondenserSupplyWater,
@@ -216,7 +216,7 @@ namespace FaultsManager {
 
 	bool AnyFaultsInModel( false ); // True if there are operational faults in the model
 	int NumFaults( 0 ); // Number of faults (include multiple faults of same type) in the model
-	
+
 	int NumFaultyEconomizer( 0 ); // Total number of faults related with the economizer
 	int NumFouledCoil( 0 ); // Total number of fouled coils
 	int NumFaultyThermostat( 0 ); // Total number of faulty thermostat with offset
@@ -229,7 +229,7 @@ namespace FaultsManager {
 	int NumFaultyBoilerFouling( 0 );  // Total number of faulty Boilers with Fouling
 	int NumFaultyChillerFouling( 0 );  // Total number of faulty Chillers with Fouling
 	int NumFaultyEvapCoolerFouling( 0 );  // Total number of faulty Evaporative Coolers with Fouling
-	
+
 	// SUBROUTINE SPECIFICATIONS:
 
 	// Object Data
@@ -258,7 +258,7 @@ namespace FaultsManager {
 		//       MODIFIED       Sep. 2013, Xiufeng Pang (XP), LBNL. Added Fouling Coil fault
 		//                      Feb. 2015, Rongpeng Zhang, LBNL. Added Thermostat/Humidistat Offset faults
 		//                      Apr. 2015, Rongpeng Zhang, LBNL. Added Fouling Air Filter fault
-		//                      May. 2016, Rongpeng Zhang, LBNL. Added Chiller/Condenser Supply Water Temperature Sensor fault 
+		//                      May. 2016, Rongpeng Zhang, LBNL. Added Chiller/Condenser Supply Water Temperature Sensor fault
 		//                      Jun. 2016, Rongpeng Zhang, LBNL. Added Tower Scaling fault
 		//                      Jul. 2016, Rongpeng Zhang, LBNL. Added Coil Supply Air Temperature Sensor fault
 		//                      Oct. 2016, Rongpeng Zhang, LBNL. Added Fouling Boiler fault
@@ -316,46 +316,46 @@ namespace FaultsManager {
 		for ( int NumFaultsTemp = 0, i = 1; i <= NumFaultTypes; ++i ){
 			NumFaultsTemp = GetNumObjectsFound( cFaults( i ) );
 			NumFaults += NumFaultsTemp;
-			
+
 			if( i <= 5 ){
 				// 1st-5th fault: economizer sensor offset
 				NumFaultyEconomizer += NumFaultsTemp;
 			} else if( i == 6 ) {
-				// 6th fault: Coil fouling 
+				// 6th fault: Coil fouling
 				NumFouledCoil = NumFaultsTemp;
 			} else if( i == 7 ) {
 				// 7th fault: Faulty thermostat
 				NumFaultyThermostat = NumFaultsTemp;
 			} else if( i == 8 ) {
-				// 8th fault: Faulty humidistat 
+				// 8th fault: Faulty humidistat
 				NumFaultyHumidistat = NumFaultsTemp;
 			} else if( i == 9 ) {
 				// 9th fault: Fouled air filter
 				NumFaultyAirFilter = NumFaultsTemp;
 			} else if( i == 10 ) {
-				// 10th fault: Faulty Chillers Supply Water Temperature Sensor 
+				// 10th fault: Faulty Chillers Supply Water Temperature Sensor
 				NumFaultyChillerSWTSensor = NumFaultsTemp;
 			} else if( i == 11 ) {
 				// 11th fault: Faulty Condenser Supply Water Temperature Sensor
-				NumFaultyCondenserSWTSensor = NumFaultsTemp; 
+				NumFaultyCondenserSWTSensor = NumFaultsTemp;
 			} else if( i == 12 ) {
 				// 12th fault: Faulty Towers with Scaling
 				NumFaultyTowerFouling = NumFaultsTemp;
 			} else if( i == 13 ) {
 				// 13th fault: Faulty Coil Supply Air Temperature Sensor
-				NumFaultyCoilSATSensor = NumFaultsTemp;  
+				NumFaultyCoilSATSensor = NumFaultsTemp;
 			} else if( i == 14 ) {
 				// 14th fault: Faulty Boiler with Fouling
-				NumFaultyBoilerFouling = NumFaultsTemp;  
+				NumFaultyBoilerFouling = NumFaultsTemp;
 			} else if( i == 15 ) {
 				// 15th fault: Faulty Chiller with Fouling
-				NumFaultyChillerFouling = NumFaultsTemp;  
+				NumFaultyChillerFouling = NumFaultsTemp;
 			} else if( i == 16 ) {
 				// 16th fault: Faulty Evaporative Cooler with Fouling
-				NumFaultyEvapCoolerFouling = NumFaultsTemp;  
+				NumFaultyEvapCoolerFouling = NumFaultsTemp;
 			}
 		}
-	
+
 		if ( NumFaults > 0 ) {
 			AnyFaultsInModel = true;
 		} else {
@@ -380,13 +380,13 @@ namespace FaultsManager {
 		if( NumFaultyBoilerFouling > 0 ) FaultsBoilerFouling.allocate( NumFaultyBoilerFouling );
 		if( NumFaultyChillerFouling > 0 ) FaultsChillerFouling.allocate( NumFaultyChillerFouling );
 		if( NumFaultyEvapCoolerFouling > 0 ) FaultsEvapCoolerFouling.allocate( NumFaultyEvapCoolerFouling );
-		
+
 		// read faults input of Fault_type 116: Evaporative Cooler Fouling
 		for ( int jFault_EvapCoolerFouling = 1; jFault_EvapCoolerFouling <= NumFaultyEvapCoolerFouling; ++jFault_EvapCoolerFouling ) {
 
 			cFaultCurrentObject = cFaults( 16 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_EvapCoolerFouling, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsEvapCoolerFouling( jFault_EvapCoolerFouling ).FaultType = cFaultCurrentObject;
 			FaultsEvapCoolerFouling( jFault_EvapCoolerFouling ).FaultTypeEnum = iFault_Fouling_EvapCooler;
 			FaultsEvapCoolerFouling( jFault_EvapCoolerFouling ).Name = cAlphaArgs( 1 );
@@ -417,7 +417,7 @@ namespace FaultsManager {
 
 			// CapReductionFactor - degree of fault
 			FaultsEvapCoolerFouling( jFault_EvapCoolerFouling ).FoulingFactor = rNumericArgs( 1 );
-			
+
 			// Evaporative cooler type
 			FaultsEvapCoolerFouling( jFault_EvapCoolerFouling ).EvapCoolerType = cAlphaArgs( 4 );
 			if ( lAlphaFieldBlanks( 4 ) ) {
@@ -434,16 +434,16 @@ namespace FaultsManager {
 
 			// Evaporative cooler check
 			{ auto const SELECT_CASE_VAR( FaultsEvapCoolerFouling( jFault_EvapCoolerFouling ).EvapCoolerType );
-			
-				int EvapCoolerNum; 
-				
+
+				int EvapCoolerNum;
+
 				if( SameString( SELECT_CASE_VAR, "EvaporativeCooler:Indirect:WetCoil" ) ) {
 					// Read in evaporative cooler is not done yet
 					if ( EvaporativeCoolers::GetInputEvapComponentsFlag ) {
 						EvaporativeCoolers::GetEvapInput();
 						EvaporativeCoolers::GetInputEvapComponentsFlag = false;
 					}
-					
+
 					// Check whether the evaporative cooler  name and type match each other;
 					EvapCoolerNum = FindItemInList( FaultsEvapCoolerFouling( jFault_EvapCoolerFouling ).EvapCoolerName, EvaporativeCoolers::EvapCond, &EvaporativeCoolers::EvapConditions::EvapCoolerName );
 					if ( EvapCoolerNum <= 0 ) {
@@ -457,13 +457,13 @@ namespace FaultsManager {
 				}
 			}
 		}
-		
+
 		// read faults input of Fault_type 115: Chiller Fouling
 		for ( int jFault_ChillerFouling = 1; jFault_ChillerFouling <= NumFaultyChillerFouling; ++jFault_ChillerFouling ) {
 
 			cFaultCurrentObject = cFaults( 15 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_ChillerFouling, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsChillerFouling( jFault_ChillerFouling ).FaultType = cFaultCurrentObject;
 			FaultsChillerFouling( jFault_ChillerFouling ).FaultTypeEnum = iFault_Fouling_Chiller;
 			FaultsChillerFouling( jFault_ChillerFouling ).Name = cAlphaArgs( 1 );
@@ -494,7 +494,7 @@ namespace FaultsManager {
 
 			// CapReductionFactor - degree of fault
 			FaultsChillerFouling( jFault_ChillerFouling ).FoulingFactor = rNumericArgs( 1 );
-			
+
 			// Chiller type
 			FaultsChillerFouling( jFault_ChillerFouling ).ChillerType = cAlphaArgs( 4 );
 			if ( lAlphaFieldBlanks( 4 ) ) {
@@ -511,16 +511,16 @@ namespace FaultsManager {
 
 			// Chiller check
 			{ auto const SELECT_CASE_VAR( FaultsChillerFouling( jFault_ChillerFouling ).ChillerType );
-			
-				int ChillerNum; 
-				
+
+				int ChillerNum;
+
 				if( SameString( SELECT_CASE_VAR, "Chiller:Electric" ) ) {
 					// Read in chiller if not done yet
 					if ( PlantChillers::GetElectricInput ) {
 						PlantChillers::GetElectricChillerInput();
 						PlantChillers::GetElectricInput = false;
 					}
-					
+
 					// Check whether the chiller name and chiller type match each other
 					ChillerNum = FindItemInList( FaultsChillerFouling( jFault_ChillerFouling ).ChillerName, PlantChillers::ElectricChiller.ma( &PlantChillers::ElectricChillerSpecs::Base ) );
 					if ( ChillerNum <= 0 ) {
@@ -531,21 +531,21 @@ namespace FaultsManager {
 						if( PlantChillers::ElectricChiller( ChillerNum ).Base.CondenserType != PlantChillers::WaterCooled ){
 						// The fault model is only applicable to the chillers with water based condensers
 							ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\". The specified chiller is not water cooled. The chiller fouling fault model will not be applied." );
-							
+
 						} else {
 						// Link the chiller with the fault model
 							PlantChillers::ElectricChiller( ChillerNum ).Base.FaultyChillerFoulingFlag = true;
 							PlantChillers::ElectricChiller( ChillerNum ).Base.FaultyChillerFoulingIndex = jFault_ChillerFouling;
 						}
   					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:Electric:EIR" ) ) {
 					// Read in chiller if not done yet
 					if ( ChillerElectricEIR::GetInputEIR ) {
 						ChillerElectricEIR::GetElectricEIRChillerInput();
 						ChillerElectricEIR::GetInputEIR = false;
   					}
-					
+
 					// Check whether the chiller name and chiller type match each other
 					ChillerNum = FindItemInList( FaultsChillerFouling( jFault_ChillerFouling ).ChillerName, ChillerElectricEIR::ElectricEIRChiller );
 					if ( ChillerNum <= 0 ) {
@@ -556,16 +556,16 @@ namespace FaultsManager {
 						if( ChillerElectricEIR::ElectricEIRChiller( ChillerNum ).CondenserType != ChillerElectricEIR::WaterCooled ){
 						// The fault model is only applicable to the chillers with water based condensers
 							ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\". The specified chiller is not water cooled. The chiller fouling fault model will not be applied." );
-							
+
 						} else {
 						// Link the chiller with the fault model
 							ChillerElectricEIR::ElectricEIRChiller( ChillerNum ).FaultyChillerFoulingFlag = true;
 							ChillerElectricEIR::ElectricEIRChiller( ChillerNum ).FaultyChillerFoulingIndex = jFault_ChillerFouling;
 						}
   					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:Electric:ReformulatedEIR" ) ) {
-				
+
 					// Read in chiller if not done yet
 					if ( ChillerReformulatedEIR::GetInputREIR ) {
 						ChillerReformulatedEIR::GetElecReformEIRChillerInput();
@@ -582,21 +582,21 @@ namespace FaultsManager {
 						if( ChillerReformulatedEIR::ElecReformEIRChiller( ChillerNum ).CondenserType != ChillerReformulatedEIR::WaterCooled ){
 						// The fault model is only applicable to the chillers with water based condensers
 							ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\". The specified chiller is not water cooled. The chiller fouling fault model will not be applied." );
-							
+
 						} else {
 						// Link the chiller with the fault model
 							ChillerReformulatedEIR::ElecReformEIRChiller( ChillerNum ).FaultyChillerFoulingFlag = true;
 							ChillerReformulatedEIR::ElecReformEIRChiller( ChillerNum ).FaultyChillerFoulingIndex = jFault_ChillerFouling;
 						}
 					}
-				
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:ConstantCOP" ) ) {
 					// Read in chiller if not done yet
 					if ( PlantChillers::GetConstCOPInput ) {
 						PlantChillers::GetConstCOPChillerInput();
 						PlantChillers::GetConstCOPInput = false;
 					}
-					
+
 					// Check whether the chiller name and chiller type match each other
 					ChillerNum = FindItemInList( FaultsChillerFouling( jFault_ChillerFouling ).ChillerName, PlantChillers::ConstCOPChiller.ma( &PlantChillers::ConstCOPChillerSpecs::Base ) );
 					if ( ChillerNum <= 0 ) {
@@ -607,21 +607,21 @@ namespace FaultsManager {
 						if( PlantChillers::ConstCOPChiller( ChillerNum ).Base.CondenserType != PlantChillers::WaterCooled ){
 						// The fault model is only applicable to the chillers with water based condensers
 							ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\". The specified chiller is not water cooled. The chiller fouling fault model will not be applied." );
-							
+
 						} else {
 						// Link the chiller with the fault model
 							PlantChillers::ConstCOPChiller( ChillerNum ).Base.FaultyChillerFoulingFlag = true;
 							PlantChillers::ConstCOPChiller( ChillerNum ).Base.FaultyChillerFoulingIndex = jFault_ChillerFouling;
 						}
 					}
- 
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:EngineDriven" ) ) {
 					// Read in chiller if not done yet
 					if ( PlantChillers::GetEngineDrivenInput ) {
 						PlantChillers::GetEngineDrivenChillerInput();
 						PlantChillers::GetEngineDrivenInput = false;
 					}
-					
+
 					// Check whether the chiller name and chiller type match each other
 					ChillerNum = FindItemInList( FaultsChillerFouling( jFault_ChillerFouling ).ChillerName, PlantChillers::EngineDrivenChiller.ma( &PlantChillers::EngineDrivenChillerSpecs::Base ) );
 					if ( ChillerNum <= 0 ) {
@@ -632,14 +632,14 @@ namespace FaultsManager {
 						if( PlantChillers::EngineDrivenChiller( ChillerNum ).Base.CondenserType != PlantChillers::WaterCooled ){
 						// The fault model is only applicable to the chillers with water based condensers
 							ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\". The specified chiller is not water cooled. The chiller fouling fault model will not be applied." );
-							
+
 						} else {
 						// Link the fault model with the water cooled chiller
 							PlantChillers::EngineDrivenChiller( ChillerNum ).Base.FaultyChillerFoulingFlag = true;
 							PlantChillers::EngineDrivenChiller( ChillerNum ).Base.FaultyChillerFoulingIndex = jFault_ChillerFouling;
 						}
 					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:CombustionTurbine" ) ) {
 					// Read in chiller if not done yet
 					if ( PlantChillers::GetGasTurbineInput ) {
@@ -656,24 +656,24 @@ namespace FaultsManager {
 						if( PlantChillers::GTChiller( ChillerNum ).Base.CondenserType != PlantChillers::WaterCooled ){
 						// The fault model is only applicable to the chillers with water based condensers
 							ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\". The specified chiller is not water cooled. The chiller fouling fault model will not be applied." );
-							
+
 						} else {
 						// Link the fault model with the water cooled chiller
 							PlantChillers::GTChiller( ChillerNum ).Base.FaultyChillerFoulingFlag = true;
 							PlantChillers::GTChiller( ChillerNum ).Base.FaultyChillerFoulingIndex = jFault_ChillerFouling;
 						}
-						
+
 					}
 				}
 			}
 		}
-				
+
 		// read faults input of Fault_type 114: Boiler Fouling
 		for ( int jFault_BoilerFouling = 1; jFault_BoilerFouling <= NumFaultyBoilerFouling; ++jFault_BoilerFouling ) {
 
 			cFaultCurrentObject = cFaults( 14 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_BoilerFouling, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsBoilerFouling( jFault_BoilerFouling ).FaultType = cFaultCurrentObject;
 			FaultsBoilerFouling( jFault_BoilerFouling ).FaultTypeEnum = iFault_Fouling_Boiler;
 			FaultsBoilerFouling( jFault_BoilerFouling ).Name = cAlphaArgs( 1 );
@@ -704,7 +704,7 @@ namespace FaultsManager {
 
 			// CapReductionFactor - degree of fault
 			FaultsBoilerFouling( jFault_BoilerFouling ).FoulingFactor = rNumericArgs( 1 );
-			
+
 			// Boiler type
 			FaultsBoilerFouling( jFault_BoilerFouling ).BoilerType = cAlphaArgs( 4 );
 			if ( lAlphaFieldBlanks( 4 ) ) {
@@ -733,13 +733,13 @@ namespace FaultsManager {
 				}
 			}
 		}
-		
+
 		// read faults input of Fault_type 113: Coil SAT Sensor Offset
 		for ( int jFault_CoilSAT = 1; jFault_CoilSAT <= NumFaultyCoilSATSensor; ++jFault_CoilSAT ) {
 
 			cFaultCurrentObject = cFaults( 13 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_CoilSAT, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsCoilSATSensor( jFault_CoilSAT ).FaultType = cFaultCurrentObject;
 			FaultsCoilSATSensor( jFault_CoilSAT ).FaultTypeEnum = iFault_TemperatureSensorOffset_CoilSupplyAir;
 			FaultsCoilSATSensor( jFault_CoilSAT ).Name = cAlphaArgs( 1 );
@@ -770,7 +770,7 @@ namespace FaultsManager {
 
 			// offset - degree of fault
 			FaultsCoilSATSensor( jFault_CoilSAT ).Offset = rNumericArgs( 1 );
-			
+
 			// Coil type
 			FaultsCoilSATSensor( jFault_CoilSAT ).CoilType = cAlphaArgs( 4 );
 			if ( lAlphaFieldBlanks( 4 ) ) {
@@ -787,7 +787,7 @@ namespace FaultsManager {
 
 			// Coil check and link
 			{ auto const SELECT_CASE_VAR( FaultsCoilSATSensor( jFault_CoilSAT ).CoilType );
-	   
+
 				if ( SameString( SELECT_CASE_VAR, "Coil:Heating:Electric" ) ||
 					SameString( SELECT_CASE_VAR, "Coil:Heating:Gas" ) ||
 					SameString( SELECT_CASE_VAR, "Coil:Heating:Desuperheater" )
@@ -807,9 +807,9 @@ namespace FaultsManager {
 						HeatingCoils::HeatingCoil( CoilNum ).FaultyCoilSATFlag = true;
 						HeatingCoils::HeatingCoil( CoilNum ).FaultyCoilSATIndex = jFault_CoilSAT;
 					}
-					
+
 				} else if ( SameString( SELECT_CASE_VAR, "Coil:Heating:Steam" ) ) {
-					
+
 					// Read in coil input if not done yet
 					if ( SteamCoils::GetSteamCoilsInputFlag ) {
 						SteamCoils::GetSteamCoilInput();
@@ -821,7 +821,7 @@ namespace FaultsManager {
 						ShowSevereError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\" not found." );
 						ErrorsFound = true;
 					} else {
-						
+
 						if( SteamCoils::SteamCoil( CoilNum ).TypeOfCoil != SteamCoils::TemperatureSetPointControl ){
 						// The fault model is only applicable to the coils controlled on leaving air temperature
 							ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\". The specified coil is not controlled on leaving air temperature. The coil SAT sensor fault model will not be applied." );
@@ -831,7 +831,7 @@ namespace FaultsManager {
 							SteamCoils::SteamCoil( CoilNum ).FaultyCoilSATIndex = jFault_CoilSAT;
 						}
 					}
-					
+
 				} else if ( SameString( SELECT_CASE_VAR, "Coil:Heating:Water" ) ||
 					SameString( SELECT_CASE_VAR, "Coil:Cooling:Water" ) ||
 					SameString( SELECT_CASE_VAR, "Coil:Cooling:Water:Detailedgeometry" )
@@ -846,8 +846,8 @@ namespace FaultsManager {
 					if( CoilNum <= 0 ) {
 						ShowSevereError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) + "\" not found." );
 						ErrorsFound = true;
-					} 
-					
+					}
+
 					// Read in Water Coil Controller Name
 					FaultsCoilSATSensor( jFault_CoilSAT ).WaterCoilControllerName = cAlphaArgs( 6 );
 					if( lAlphaFieldBlanks( 6 ) ) {
@@ -855,7 +855,7 @@ namespace FaultsManager {
 						ErrorsFound = true;
 					}
 					// Read in controller input if not done yet
-					if( HVACControllers::GetControllerInputFlag ) { 
+					if( HVACControllers::GetControllerInputFlag ) {
 						HVACControllers::GetControllerInput();
 						HVACControllers::GetControllerInputFlag = false;
 					}
@@ -868,7 +868,7 @@ namespace FaultsManager {
 					// Link the controller with the fault model
 						HVACControllers::ControllerProps( ControlNum ).FaultyCoilSATFlag = true;
 						HVACControllers::ControllerProps( ControlNum ).FaultyCoilSATIndex = jFault_CoilSAT;
-						
+
 						// Check whether the controller match the coil
 						if( HVACControllers::ControllerProps( ControlNum ).SensedNode != WaterCoils::WaterCoil( CoilNum ).AirOutletNodeNum ){
 							ShowSevereError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 6 ) + " = \"" + cAlphaArgs( 6 ) + "\" does not match " + cAlphaFieldNames( 5 ) + " = \"" + cAlphaArgs( 5 ) );
@@ -881,7 +881,7 @@ namespace FaultsManager {
 						HVACDXSystem::GetDXCoolingSystemInput();
 						HVACDXSystem::GetInputFlag = false;
 					}
-		
+
 					// Check the coil name and coil type
 					int CoilSysNum = FindItemInList( FaultsCoilSATSensor( jFault_CoilSAT ).CoilName, HVACDXSystem::DXCoolingSystem );
 					if( CoilSysNum <= 0 ) {
@@ -898,7 +898,7 @@ namespace FaultsManager {
 						HVACDXHeatPumpSystem::GetDXHeatPumpSystemInput();
 						HVACDXHeatPumpSystem::GetInputFlag = false;
 					}
-		
+
 					// Check the coil name and coil type
 					int CoilSysNum = FindItemInList( FaultsCoilSATSensor( jFault_CoilSAT ).CoilName, HVACDXHeatPumpSystem::DXHeatPumpSystem );
 					if( CoilSysNum <= 0 ) {
@@ -915,7 +915,7 @@ namespace FaultsManager {
 						HVACUnitarySystem::GetUnitarySystemInput();
 						HVACUnitarySystem::GetInputFlag = false;
 					}
-		
+
 					// Check the coil name and coil type
 					int UnitarySysNum = FindItemInList( FaultsCoilSATSensor( jFault_CoilSAT ).CoilName, HVACUnitarySystem::UnitarySystem );
 					if( UnitarySysNum <= 0 ) {
@@ -936,13 +936,13 @@ namespace FaultsManager {
 				}
 			}
 		} // End read faults input of Fault_type 113
-		
+
 		// read faults input of Fault_type 112: Cooling tower scaling
 		for ( int jFault_TowerFouling = 1; jFault_TowerFouling <= NumFaultyTowerFouling; ++jFault_TowerFouling ) {
 
 			cFaultCurrentObject = cFaults( 12 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_TowerFouling, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsTowerFouling( jFault_TowerFouling ).FaultType = cFaultCurrentObject;
 			FaultsTowerFouling( jFault_TowerFouling ).FaultTypeEnum = iFault_Fouling_Tower;
 			FaultsTowerFouling( jFault_TowerFouling ).Name = cAlphaArgs( 1 );
@@ -973,7 +973,7 @@ namespace FaultsManager {
 
 			// UAReductionFactor - degree of fault
 			FaultsTowerFouling( jFault_TowerFouling ).UAReductionFactor = rNumericArgs( 1 );
-			
+
 			// Cooling tower type
 			FaultsTowerFouling( jFault_TowerFouling ).TowerType = cAlphaArgs( 4 );
 			if ( lAlphaFieldBlanks( 4 ) ) {
@@ -1004,13 +1004,13 @@ namespace FaultsManager {
 				// Link the tower with the fault model
 					CondenserLoopTowers::SimpleTower( TowerNum ).FaultyTowerFoulingFlag = true;
 					CondenserLoopTowers::SimpleTower( TowerNum ).FaultyTowerFoulingIndex = jFault_TowerFouling;
-					
+
 					// Check the faulty tower type
 					if ( ! SameString( CondenserLoopTowers::SimpleTower( TowerNum ).TowerType, FaultsTowerFouling( jFault_TowerFouling ).TowerType )) {
 						ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 4 ) + " = \"" + cAlphaArgs( 4 ) + "\" not match the type of " + cAlphaFieldNames( 5 ) + ". Tower type in the fault model is updated. " );
 						FaultsTowerFouling( jFault_TowerFouling ).TowerType = CondenserLoopTowers::SimpleTower( TowerNum ).TowerType;
 					}
-					
+
 					// Check the tower model
 					// Performance Input Method should be UFactorTimesAreaAndDesignWaterFlowRate to apply the fault model
 					if ( CondenserLoopTowers::SimpleTower( TowerNum ).PerformanceInputMethod_Num != CondenserLoopTowers::PIM_UFactor ) {
@@ -1020,13 +1020,13 @@ namespace FaultsManager {
 				}
 			}
 		}
-		
+
 		// read faults input of Fault_type 111: Condenser SWT Sensor Offset
 		for ( int jFault_CondenserSWT = 1; jFault_CondenserSWT <= NumFaultyCondenserSWTSensor; ++jFault_CondenserSWT ) {
 
 			cFaultCurrentObject = cFaults( 11 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_CondenserSWT, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsCondenserSWTSensor( jFault_CondenserSWT ).FaultType = cFaultCurrentObject;
 			FaultsCondenserSWTSensor( jFault_CondenserSWT ).FaultTypeEnum = iFault_TemperatureSensorOffset_CondenserSupplyWater;
 			FaultsCondenserSWTSensor( jFault_CondenserSWT ).Name = cAlphaArgs( 1 );
@@ -1057,7 +1057,7 @@ namespace FaultsManager {
 
 			// offset - degree of fault
 			FaultsCondenserSWTSensor( jFault_CondenserSWT ).Offset = rNumericArgs( 1 );
-			
+
 			// Cooling tower type
 			FaultsCondenserSWTSensor( jFault_CondenserSWT ).TowerType = cAlphaArgs( 4 );
 			if ( lAlphaFieldBlanks( 4 ) ) {
@@ -1088,7 +1088,7 @@ namespace FaultsManager {
 				// Link the tower with the fault model
 					CondenserLoopTowers::SimpleTower( TowerNum ).FaultyCondenserSWTFlag = true;
 					CondenserLoopTowers::SimpleTower( TowerNum ).FaultyCondenserSWTIndex = jFault_CondenserSWT;
-					
+
 					// Check the faulty tower type
 					if ( ! SameString( CondenserLoopTowers::SimpleTower( TowerNum ).TowerType, FaultsCondenserSWTSensor( jFault_CondenserSWT ).TowerType )) {
 						ShowWarningError( cFaultCurrentObject + " = \"" + cAlphaArgs( 1 ) + "\" invalid " + cAlphaFieldNames( 4 ) + " = \"" + cAlphaArgs( 4 ) + "\" not match the type of " + cAlphaFieldNames( 5 ) + ". Tower type is updated. " );
@@ -1097,13 +1097,13 @@ namespace FaultsManager {
 				}
 			}
 		}
-		
+
 		// read faults input of Fault_type 110: Chiller SWT Sensor Offset
 		for ( int jFault_ChillerSWT = 1; jFault_ChillerSWT <= NumFaultyChillerSWTSensor; ++jFault_ChillerSWT ) {
 
 			cFaultCurrentObject = cFaults( 10 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_ChillerSWT, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsChillerSWTSensor( jFault_ChillerSWT ).FaultType = cFaultCurrentObject;
 			FaultsChillerSWTSensor( jFault_ChillerSWT ).FaultTypeEnum = iFault_TemperatureSensorOffset_ChillerSupplyWater;
 			FaultsChillerSWTSensor( jFault_ChillerSWT ).Name = cAlphaArgs( 1 );
@@ -1134,7 +1134,7 @@ namespace FaultsManager {
 
 			// offset - degree of fault
 			FaultsChillerSWTSensor( jFault_ChillerSWT ).Offset = rNumericArgs( 1 );
-			
+
 			// Chiller type
 			FaultsChillerSWTSensor( jFault_ChillerSWT ).ChillerType = cAlphaArgs( 4 );
 			if ( lAlphaFieldBlanks( 4 ) ) {
@@ -1151,9 +1151,9 @@ namespace FaultsManager {
 
 			// Chiller check
 			{ auto const SELECT_CASE_VAR( FaultsChillerSWTSensor( jFault_ChillerSWT ).ChillerType );
-				
-				int ChillerNum; 
-				
+
+				int ChillerNum;
+
 				if( SameString( SELECT_CASE_VAR, "Chiller:Electric" ) ) {
 					// Read in chiller if not done yet
 					if ( PlantChillers::GetElectricInput ) {
@@ -1170,7 +1170,7 @@ namespace FaultsManager {
 						PlantChillers::ElectricChiller( ChillerNum ).Base.FaultyChillerSWTFlag = true;
 						PlantChillers::ElectricChiller( ChillerNum ).Base.FaultyChillerSWTIndex = jFault_ChillerSWT;
 					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:Electric:EIR" ) ) {
 					// Read in chiller if not done yet
 					if ( ChillerElectricEIR::GetInputEIR ) {
@@ -1187,7 +1187,7 @@ namespace FaultsManager {
 						ChillerElectricEIR::ElectricEIRChiller( ChillerNum ).FaultyChillerSWTFlag = true;
 						ChillerElectricEIR::ElectricEIRChiller( ChillerNum ).FaultyChillerSWTIndex = jFault_ChillerSWT;
 					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:Electric:ReformulatedEIR" ) ) {
 					// Read in chiller if not done yet
 					if ( ChillerReformulatedEIR::GetInputREIR ) {
@@ -1204,7 +1204,7 @@ namespace FaultsManager {
 						ChillerReformulatedEIR::ElecReformEIRChiller( ChillerNum ).FaultyChillerSWTFlag = true;
 						ChillerReformulatedEIR::ElecReformEIRChiller( ChillerNum ).FaultyChillerSWTIndex = jFault_ChillerSWT;
 					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:EngineDriven" ) ) {
 					// Read in chiller if not done yet
 					if ( PlantChillers::GetEngineDrivenInput ) {
@@ -1221,7 +1221,7 @@ namespace FaultsManager {
 						PlantChillers::EngineDrivenChiller( ChillerNum ).Base.FaultyChillerSWTFlag = true;
 						PlantChillers::EngineDrivenChiller( ChillerNum ).Base.FaultyChillerSWTIndex = jFault_ChillerSWT;
 					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:CombustionTurbine" ) ) {
 					// Read in chiller if not done yet
 					if ( PlantChillers::GetGasTurbineInput ) {
@@ -1238,7 +1238,7 @@ namespace FaultsManager {
 						PlantChillers::GTChiller( ChillerNum ).Base.FaultyChillerSWTFlag = true;
 						PlantChillers::GTChiller( ChillerNum ).Base.FaultyChillerSWTIndex = jFault_ChillerSWT;
 					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:ConstantCOP" ) ) {
 					// Read in chiller if not done yet
 					if ( PlantChillers::GetConstCOPInput ) {
@@ -1255,7 +1255,7 @@ namespace FaultsManager {
 						PlantChillers::ConstCOPChiller( ChillerNum ).Base.FaultyChillerSWTFlag = true;
 						PlantChillers::ConstCOPChiller( ChillerNum ).Base.FaultyChillerSWTIndex = jFault_ChillerSWT;
 					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:Absorption" ) ) {
 					// Read in chiller if not done yet
 					if ( ChillerAbsorption::GetInput ) {
@@ -1272,7 +1272,7 @@ namespace FaultsManager {
 						ChillerAbsorption::BLASTAbsorber( ChillerNum ).FaultyChillerSWTFlag = true;
 						ChillerAbsorption::BLASTAbsorber( ChillerNum ).FaultyChillerSWTIndex = jFault_ChillerSWT;
 					}
-					
+
 				} else if( SameString( SELECT_CASE_VAR, "Chiller:Absorption:Indirect" ) ) {
 					// Read in chiller if not done yet
 					if ( ChillerIndirectAbsorption::GetInput ) {
@@ -1288,18 +1288,18 @@ namespace FaultsManager {
 						ChillerIndirectAbsorption::IndirectAbsorber( ChillerNum ).FaultyChillerSWTFlag = true;
 						ChillerIndirectAbsorption::IndirectAbsorber( ChillerNum ).FaultyChillerSWTIndex = jFault_ChillerSWT;
 					}
-					
+
 				}
 			}
-			
+
 		}
-		
+
 		// read faults input of Fault_type 109: Fouled Air Filters
 		for ( int jFault_AirFilter = 1; jFault_AirFilter <= NumFaultyAirFilter; ++jFault_AirFilter ) {
 
 			cFaultCurrentObject = cFaults( 9 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_AirFilter, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsFouledAirFilters( jFault_AirFilter ).FaultType = cFaultCurrentObject;
 			FaultsFouledAirFilters( jFault_AirFilter ).FaultTypeEnum = iFault_Fouling_AirFilter;
 			FaultsFouledAirFilters( jFault_AirFilter ).Name = cAlphaArgs( 1 );
@@ -1366,13 +1366,13 @@ namespace FaultsManager {
 
 			//In the fan object, calculate by each time-step: 1) pressure increase value; 2) air flow rate decrease value.
 		}
-		
+
 		// read faults input of Fault_type 108: HumidistatOffset
 		for ( int jFault_Humidistat = 1; jFault_Humidistat <= NumFaultyHumidistat; ++jFault_Humidistat ) {
 
 			cFaultCurrentObject = cFaults( 8 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_Humidistat, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsHumidistatOffset( jFault_Humidistat ).FaultType = cFaultCurrentObject;
 			FaultsHumidistatOffset( jFault_Humidistat ).FaultTypeEnum = iFault_HumidistatOffset;
 			FaultsHumidistatOffset( jFault_Humidistat ).Name = cAlphaArgs( 1 );
@@ -1433,7 +1433,7 @@ namespace FaultsManager {
 
 			cFaultCurrentObject = cFaults( 7 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_Thermostat, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FaultsThermostatOffset( jFault_Thermostat ).FaultType = cFaultCurrentObject;
 			FaultsThermostatOffset( jFault_Thermostat ).FaultTypeEnum = iFault_ThermostatOffset;
 			FaultsThermostatOffset( jFault_Thermostat ).Name = cAlphaArgs( 1 );
@@ -1477,7 +1477,7 @@ namespace FaultsManager {
 
 			cFaultCurrentObject = cFaults( 6 ); // fault object string
 			GetObjectItem( cFaultCurrentObject, jFault_FoulingCoil, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-			
+
 			FouledCoils( jFault_FoulingCoil ).FaultType = cFaultCurrentObject;
 			FouledCoils( jFault_FoulingCoil ).FaultTypeEnum = iFault_Fouling_Coil;
 			FouledCoils( jFault_FoulingCoil ).Name = cAlphaArgs( 1 );
@@ -1533,7 +1533,7 @@ namespace FaultsManager {
 
 			for ( int jj = 1; jj <= NumFaultsTemp; ++jj ) {
 				GetObjectItem( cFaultCurrentObject, jj, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-				
+
 				++j;
 				FaultsEconomizer( j ).FaultType = cFaultCurrentObject;
 				FaultsEconomizer( j ).FaultTypeEnum = iFaultTypeEnums( i );
@@ -1590,11 +1590,11 @@ namespace FaultsManager {
 				FaultsEconomizer( j ).Offset = rNumericArgs( 1 );
 			}
 		}
-		
+
 		RunFaultMgrOnceFlag = true;
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors getting FaultModel input data.  Preceding condition(s) cause termination." );
+			ShowFatalError( "Errors getting FaultModel input data.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1617,23 +1617,23 @@ namespace FaultsManager {
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		Real64 FaultFac( 0.0 ); // fault modification factor
 		Real64 OffsetAct( 0.0 ); // actual offset after applying the modification factor
-		
+
 		// Check fault availability schedules
 		if ( GetCurrentScheduleValue( this->AvaiSchedPtr ) > 0.0 ) {
-		
-			// Check fault severity schedules 
+
+			// Check fault severity schedules
 			if ( this->SeveritySchedPtr >= 0 ) {
 				FaultFac = GetCurrentScheduleValue( this->SeveritySchedPtr );
 			} else {
 				FaultFac = 1.0;
 			}
 		}
-		
+
 		OffsetAct = FaultFac * this->Offset;
 
 		return OffsetAct;
 	}
-	
+
 	Real64
 	FaultPropertiesFouling::CalFoulingFactor()
 	{
@@ -1655,18 +1655,18 @@ namespace FaultsManager {
 		Real64 FoulingFactor( 1.0 ); // Actual Nominal Fouling Factor, ratio between the nominal capacity or efficiency at fouling case and that at fault free case
 
 		// FLOW
-		
+
 		// Check fault availability schedules
 		if ( GetCurrentScheduleValue( this->AvaiSchedPtr ) > 0.0 ) {
-		
-			// Check fault severity schedules 
+
+			// Check fault severity schedules
 			if ( this->SeveritySchedPtr >= 0 ) {
 				FaultFac = GetCurrentScheduleValue( this->SeveritySchedPtr );
 			} else {
 				FaultFac = 1.0;
 			}
 		}
-		
+
 		// The more severe the fouling fault is (i.e., larger FaultFac), the less the FoulingFactor is
 		if( FaultFac > 0.0 ) FoulingFactor = min( this->FoulingFactor / FaultFac, 1.0 );
 
@@ -1694,18 +1694,18 @@ namespace FaultsManager {
 		Real64 UAReductionFactorAct( 1.0 ); // actual UA Reduction Factor, ratio between the UA value at fouling case and that at fault free case
 
 		// FLOW
-		
+
 		// Check fault availability schedules
 		if ( GetCurrentScheduleValue( this->AvaiSchedPtr ) > 0.0 ) {
-		
-			// Check fault severity schedules 
+
+			// Check fault severity schedules
 			if ( this->SeveritySchedPtr >= 0 ) {
 				FaultFac = GetCurrentScheduleValue( this->SeveritySchedPtr );
 			} else {
 				FaultFac = 1.0;
 			}
 		}
-		
+
 		// The more severe the fouling fault is (i.e., larger FaultFac), the less the UAReductionFactor is
 		if( FaultFac > 0.0 ) UAReductionFactorAct = min( this->UAReductionFactor / FaultFac, 1.0 );
 
@@ -1717,8 +1717,8 @@ namespace FaultsManager {
 		bool FlagVariableFlow, // True if chiller is variable flow and false if it is constant flow
 		Real64 FaultyChillerSWTOffset, // Faulty chiller SWT sensor offset
 		Real64 Cp, // Local fluid specific heat
-		Real64 EvapInletTemp, // Chiller evaporator inlet water temperature 
-		Real64 & EvapOutletTemp, // Chiller evaporator outlet water temperature 
+		Real64 EvapInletTemp, // Chiller evaporator inlet water temperature
+		Real64 & EvapOutletTemp, // Chiller evaporator outlet water temperature
 		Real64 & EvapMassFlowRate, // Chiller mass flow rate
 		Real64 & QEvaporator // Chiller evaporator heat transfer rate
 	)
@@ -1735,29 +1735,29 @@ namespace FaultsManager {
 		Real64 EvapOutletTemp_ff = EvapOutletTemp;   // Chiller supply water temperature, fault free [C]
 		Real64 EvapMassFlowRate_ff = EvapMassFlowRate; // Chiller mass flow rate, fault free [kg/s]
 		Real64 QEvaporator_ff = QEvaporator; // Chiller evaporator heat transfer rate, fault free [W]
-		
+
 		// Variables for faulty cases
 		Real64 EvapOutletTemp_f = EvapOutletTemp_ff;    // Chiller supply water temperature, faulty case [C]
 		Real64 EvapMassFlowRate_f = EvapMassFlowRate_ff;  // Chiller mass flow rate, faulty case [kg/s]
 		Real64 QEvaporator_f = QEvaporator_ff;  // Chiller evaporator heat transfer rate, faulty case [W]
-		
+
 		if( !FlagVariableFlow ){
 		// Chillers with ConstantFlow mode
-		
+
 			EvapOutletTemp_f = EvapOutletTemp_ff - FaultyChillerSWTOffset;
-			
+
 			if( ( EvapInletTemp > EvapOutletTemp_f ) && ( EvapMassFlowRate_ff > 0 )){
 				QEvaporator_f = EvapMassFlowRate_ff * Cp * ( EvapInletTemp - EvapOutletTemp_f );
 			} else {
 				EvapMassFlowRate_f = 0.0;
 				QEvaporator_f = 0.0;
 			}
-		
+
 		} else {
 		// Chillers with LeavingSetpointModulated mode
-		
+
 			EvapOutletTemp_f = EvapOutletTemp_ff - FaultyChillerSWTOffset;
-			
+
 			if( ( EvapInletTemp > EvapOutletTemp_f ) && ( Cp > 0 ) && ( EvapMassFlowRate_ff > 0 ) ){
 				EvapMassFlowRate_f = QEvaporator_ff / Cp / ( EvapInletTemp - EvapOutletTemp_ff );
 				QEvaporator_f =  EvapMassFlowRate_f * Cp * ( EvapInletTemp - EvapOutletTemp_f );
@@ -1766,7 +1766,7 @@ namespace FaultsManager {
 				QEvaporator_f = 0.0;
 			}
 		}
-		
+
 		// Return variables
 		EvapOutletTemp = EvapOutletTemp_f;
 		EvapMassFlowRate = EvapMassFlowRate_f;
@@ -1795,7 +1795,7 @@ namespace FaultsManager {
 		Real64 FanDeltaPress;     // Design Delta Pressure Across the Fan [Pa]
 		Real64 FanDeltaPressCal;  // Calculated Delta Pressure Across the Fan [Pa]
 		bool   FanFound;          // Whether the fan is found or not
-		
+
 		std::string const FanName = this->FaultyAirFilterFanName; // name of the fan
 		int const FanCurvePtr = this->FaultyAirFilterFanCurvePtr; // pointer of the fan curve
 
@@ -1820,7 +1820,7 @@ namespace FaultsManager {
 
 		return ( ( FanDeltaPressCal > 0.95 * FanDeltaPress ) && ( FanDeltaPressCal < 1.05 * FanDeltaPress ) );
 	}
-	
+
 	// Clears the global data in Fans.
 	// Needed for unit tests, should not be normally called.
 	void
@@ -1829,7 +1829,7 @@ namespace FaultsManager {
 		RunFaultMgrOnceFlag = false;
 		ErrorsFound = false;
 		AnyFaultsInModel = false;
-		
+
 		NumFaults = 0 ;
 		NumFaultyEconomizer = 0;
 		NumFouledCoil = 0;

--- a/src/EnergyPlus/FluidCoolers.cc
+++ b/src/EnergyPlus/FluidCoolers.cc
@@ -240,17 +240,17 @@ namespace FluidCoolers {
 		if ( CompIndex == 0 ) {
 			FluidCoolerNum = FindItemInList( FluidCoolerName, SimpleFluidCooler );
 			if ( FluidCoolerNum == 0 ) {
-				ShowFatalError( "SimFluidCoolers: Unit not found = " + FluidCoolerName );
+				ShowFatalError( "SimFluidCoolers: Unit not found = " + FluidCoolerName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = FluidCoolerNum;
 		} else {
 			FluidCoolerNum = CompIndex;
 			if ( FluidCoolerNum > NumSimpleFluidCoolers || FluidCoolerNum < 1 ) {
-				ShowFatalError( "SimFluidCoolers:  Invalid CompIndex passed = " + TrimSigDigits( FluidCoolerNum ) + ", Number of Units = " + TrimSigDigits( NumSimpleFluidCoolers ) + ", Entered Unit name = " + FluidCoolerName );
+				ShowFatalError( "SimFluidCoolers:  Invalid CompIndex passed = " + TrimSigDigits( FluidCoolerNum ) + ", Number of Units = " + TrimSigDigits( NumSimpleFluidCoolers ) + ", Entered Unit name = " + FluidCoolerName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( FluidCoolerNum ) ) {
 				if ( FluidCoolerName != SimpleFluidCooler( FluidCoolerNum ).Name ) {
-					ShowFatalError( "SimFluidCoolers: Invalid CompIndex passed = " + TrimSigDigits( FluidCoolerNum ) + ", Unit name = " + FluidCoolerName + ", stored Unit Name for that index = " + SimpleFluidCooler( FluidCoolerNum ).Name );
+					ShowFatalError( "SimFluidCoolers: Invalid CompIndex passed = " + TrimSigDigits( FluidCoolerNum ) + ", Unit name = " + FluidCoolerName + ", stored Unit Name for that index = " + SimpleFluidCooler( FluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( FluidCoolerNum ) = false;
 			}
@@ -290,7 +290,7 @@ namespace FluidCoolers {
 			ReportFluidCooler( RunFlag, FluidCoolerNum );
 
 		} else {
-			ShowFatalError( "SimFluidCoolers: Invalid Fluid Cooler Type Requested = " + FluidCoolerType );
+			ShowFatalError( "SimFluidCoolers: Invalid Fluid Cooler Type Requested = " + FluidCoolerType );  // LCOV_EXCL_LINE
 
 		}} // TypeOfEquip
 
@@ -372,7 +372,7 @@ namespace FluidCoolers {
 		NumTwoSpeedFluidCoolers = GetNumObjectsFound( "FluidCooler:TwoSpeed" );
 		NumSimpleFluidCoolers = NumSingleSpeedFluidCoolers + NumTwoSpeedFluidCoolers;
 
-		if ( NumSimpleFluidCoolers <= 0 ) ShowFatalError( "No fluid cooler objects found in input, however, a branch object has specified a fluid cooler. Search the input for fluid cooler to determine the cause for this error." );
+		if ( NumSimpleFluidCoolers <= 0 ) ShowFatalError( "No fluid cooler objects found in input, however, a branch object has specified a fluid cooler. Search the input for fluid cooler to determine the cause for this error." );  // LCOV_EXCL_LINE
 
 		// See if load distribution manager has already gotten the input
 		if ( allocated( SimpleFluidCooler ) ) return;
@@ -512,7 +512,7 @@ namespace FluidCoolers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting fluid cooler input." );
+			ShowFatalError( "Errors found in getting fluid cooler input." );  // LCOV_EXCL_LINE
 		}
 
 		// Set up output variables, CurrentModuleObject='FluidCooler:SingleSpeed'
@@ -938,7 +938,7 @@ namespace FluidCoolers {
 			ScanPlantLoopsForObject( SimpleFluidCooler( FluidCoolerNum ).Name, TypeOf_Num, SimpleFluidCooler( FluidCoolerNum ).LoopNum, SimpleFluidCooler( FluidCoolerNum ).LoopSideNum, SimpleFluidCooler( FluidCoolerNum ).BranchNum, SimpleFluidCooler( FluidCoolerNum ).CompNum, _, _, _, _, _, ErrorsFound );
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "InitFluidCooler: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitFluidCooler: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			OneTimeFlagForEachFluidCooler( FluidCoolerNum ) = false;
@@ -1081,7 +1081,7 @@ namespace FluidCoolers {
 			} else {
 				if ( PlantFirstSizesOkayToFinalize ) {
 					ShowSevereError( "Autosizing error for fluid cooler object = " + SimpleFluidCooler( FluidCoolerNum ).Name );
-					ShowFatalError( "Autosizing of fluid cooler condenser flow rate requires a loop Sizing:Plant object." );
+					ShowFatalError( "Autosizing of fluid cooler condenser flow rate requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 				}
 			}
 			// This conditional statement is to trap when the user specified Condenser/Fluid Cooler water design setpoint
@@ -1091,7 +1091,7 @@ namespace FluidCoolers {
 				ShowContinueError( "Design Loop Exit Temperature (" + RoundSigDigits( PlantSizData( PltSizCondNum ).ExitTemp, 2 ) + " C) must be greater than design entering air dry-bulb temperature (" + RoundSigDigits( SimpleFluidCooler( FluidCoolerNum ).DesignEnteringAirTemp, 2 ) + " C) when autosizing the fluid cooler UA." );
 				ShowContinueError( "It is recommended that the Design Loop Exit Temperature = design inlet air dry-bulb temp plus the Fluid Cooler design approach temperature (e.g., 4 C)." );
 				ShowContinueError( "If using HVACTemplate:Plant:ChilledWaterLoop, then check that input field Condenser Water Design Setpoint must be > design inlet air dry-bulb temp if autosizing the Fluid Cooler." );
-				ShowFatalError( "Review and revise design input values as appropriate." );
+				ShowFatalError( "Review and revise design input values as appropriate." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -1126,7 +1126,7 @@ namespace FluidCoolers {
 							ShowContinueError( "Design Loop Exit Temperature (" + RoundSigDigits( PlantSizData( PltSizCondNum ).ExitTemp, 2 ) + " C) must be greater than design entering air dry-bulb temperature (" + RoundSigDigits( SimpleFluidCooler( FluidCoolerNum ).DesignEnteringAirTemp, 2 ) + " C) when autosizing the fluid cooler UA." );
 							ShowContinueError( "It is recommended that the Design Loop Exit Temperature = design inlet air dry-bulb temp plus the Fluid Cooler design approach temperature (e.g., 4 C)." );
 							ShowContinueError( "If using HVACTemplate:Plant:ChilledWaterLoop, then check that input field Condenser Water Design Setpoint must be > design inlet air dry-bulb temp if autosizing the Fluid Cooler." );
-							ShowFatalError( "Review and revise design input values as appropriate." );
+							ShowFatalError( "Review and revise design input values as appropriate." );  // LCOV_EXCL_LINE
 						}
 						rho = GetDensityGlycol( PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidName, DataGlobals::InitConvTemp, PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidIndex, CalledFrom );
 						Cp = GetSpecificHeatGlycol( PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidName, PlantSizData( PltSizCondNum ).ExitTemp, PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidIndex, CalledFrom );
@@ -1140,7 +1140,7 @@ namespace FluidCoolers {
 				} else {
 					if ( PlantFirstSizesOkayToFinalize ) {
 						ShowSevereError( "Autosizing of fluid cooler fan power requires a loop Sizing:Plant object." );
-						ShowFatalError( " Occurs in fluid cooler object = " + SimpleFluidCooler( FluidCoolerNum ).Name );
+						ShowFatalError( " Occurs in fluid cooler object = " + SimpleFluidCooler( FluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -1186,7 +1186,7 @@ namespace FluidCoolers {
 							ShowContinueError( "Design Loop Exit Temperature (" + RoundSigDigits( PlantSizData( PltSizCondNum ).ExitTemp, 2 ) + " C) must be greater than design entering air dry-bulb temperature (" + RoundSigDigits( SimpleFluidCooler( FluidCoolerNum ).DesignEnteringAirTemp, 2 ) + " C) when autosizing the fluid cooler UA." );
 							ShowContinueError( "It is recommended that the Design Loop Exit Temperature = design inlet air dry-bulb temp plus the Fluid Cooler design approach temperature (e.g., 4 C)." );
 							ShowContinueError( "If using HVACTemplate:Plant:ChilledWaterLoop, then check that input field Condenser Water Design Setpoint must be > design inlet air dry-bulb temp if autosizing the Fluid Cooler." );
-							ShowFatalError( "Review and revise design input values as appropriate." );
+							ShowFatalError( "Review and revise design input values as appropriate." );  // LCOV_EXCL_LINE
 						}
 						rho = GetDensityGlycol( PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidName, DataGlobals::InitConvTemp, PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidIndex, CalledFrom );
 						Cp = GetSpecificHeatGlycol( PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidName, PlantSizData( PltSizCondNum ).ExitTemp, PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidIndex, CalledFrom );
@@ -1200,7 +1200,7 @@ namespace FluidCoolers {
 				} else {
 					if ( PlantFirstSizesOkayToFinalize ) {
 						ShowSevereError( "Autosizing of fluid cooler air flow rate requires a loop Sizing:Plant object" );
-						ShowFatalError( " Occurs in fluid cooler object = " + SimpleFluidCooler( FluidCoolerNum ).Name );
+						ShowFatalError( " Occurs in fluid cooler object = " + SimpleFluidCooler( FluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -1239,7 +1239,7 @@ namespace FluidCoolers {
 						ShowContinueError( "Design Loop Exit Temperature (" + RoundSigDigits( PlantSizData( PltSizCondNum ).ExitTemp, 2 ) + " C) must be greater than design entering air dry-bulb temperature (" + RoundSigDigits( SimpleFluidCooler( FluidCoolerNum ).DesignEnteringAirTemp, 2 ) + " C) when autosizing the fluid cooler UA." );
 						ShowContinueError( "It is recommended that the Design Loop Exit Temperature = design inlet air dry-bulb temp plus the Fluid Cooler design approach temperature (e.g., 4 C)." );
 						ShowContinueError( "If using HVACTemplate:Plant:ChilledWaterLoop, then check that input field Condenser Water Design Setpoint must be > design inlet air dry-bulb temp if autosizing the Fluid Cooler." );
-						ShowFatalError( "Review and revise design input values as appropriate." );
+						ShowFatalError( "Review and revise design input values as appropriate." );  // LCOV_EXCL_LINE
 					}
 					rho = GetDensityGlycol( PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidName, DataGlobals::InitConvTemp, PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidIndex, CalledFrom );
 					Cp = GetSpecificHeatGlycol( PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidName, PlantSizData( PltSizCondNum ).ExitTemp, PlantLoop( SimpleFluidCooler( FluidCoolerNum ).LoopNum ).FluidIndex, CalledFrom );
@@ -1287,7 +1287,7 @@ namespace FluidCoolers {
 						ShowContinueError( "Design Fluid Cooler Water Inlet Temp [C]           = " + RoundSigDigits( SimpleFluidCoolerInlet( FluidCoolerNum ).WaterTemp, 2 ) );
 						ShowContinueError( "Calculated water outlet temp at low UA [C] (UA = " + RoundSigDigits( UA0, 2 ) + " W/K) = " + RoundSigDigits( OutWaterTempAtUA0, 2 ) );
 						ShowContinueError( "Calculated water outlet temp at high UA [C](UA = " + RoundSigDigits( UA1, 2 ) + " W/K) = " + RoundSigDigits( OutWaterTempAtUA1, 2 ) );
-						ShowFatalError( "Autosizing of Fluid Cooler UA failed for fluid cooler = " + SimpleFluidCooler( FluidCoolerNum ).Name );
+						ShowFatalError( "Autosizing of Fluid Cooler UA failed for fluid cooler = " + SimpleFluidCooler( FluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 					}
 					tmpHighSpeedEvapFluidCoolerUA = UA;
 					if ( PlantFirstSizesOkayToFinalize ) SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUA = tmpHighSpeedEvapFluidCoolerUA;
@@ -1322,7 +1322,7 @@ namespace FluidCoolers {
 			} else {
 				if ( PlantFirstSizesOkayToFinalize ) {
 					ShowSevereError( "Autosizing error for fluid cooler object = " + SimpleFluidCooler( FluidCoolerNum ).Name );
-					ShowFatalError( "Autosizing of fluid cooler UA requires a loop Sizing:Plant object." );
+					ShowFatalError( "Autosizing of fluid cooler UA requires a loop Sizing:Plant object." );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -1375,7 +1375,7 @@ namespace FluidCoolers {
 					ShowContinueError( "Design Fluid Cooler Water Inlet Temp [C]           = " + RoundSigDigits( SimpleFluidCoolerInlet( FluidCoolerNum ).WaterTemp, 2 ) );
 					ShowContinueError( "Calculated water outlet temp at low UA [C] (UA = " + RoundSigDigits( UA0, 2 ) + " W/K) = " + RoundSigDigits( OutWaterTempAtUA0, 2 ) );
 					ShowContinueError( "Calculated water outlet temp at high UA [C] (UA = " + RoundSigDigits( UA1, 2 ) + " W/K) = " + RoundSigDigits( OutWaterTempAtUA1, 2 ) );
-					ShowFatalError( "Autosizing of Fluid Cooler UA failed for fluid cooler = " + SimpleFluidCooler( FluidCoolerNum ).Name );
+					ShowFatalError( "Autosizing of Fluid Cooler UA failed for fluid cooler = " + SimpleFluidCooler( FluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				if ( PlantFirstSizesOkayToFinalize ) SimpleFluidCooler( FluidCoolerNum ).HighSpeedFluidCoolerUA = UA;
 			} else {
@@ -1502,7 +1502,7 @@ namespace FluidCoolers {
 					ShowContinueError( "Design Fluid Cooler Water Inlet Temp [C]             = " + RoundSigDigits( SimpleFluidCoolerInlet( FluidCoolerNum ).WaterTemp, 2 ) );
 					ShowContinueError( "Calculated water outlet temp at low UA [C](UA = " + RoundSigDigits( UA0, 2 ) + " W/C) = " + RoundSigDigits( OutWaterTempAtUA0, 2 ) );
 					ShowContinueError( "Calculated water outlet temp at high UA [C](UA = " + RoundSigDigits( UA1, 2 ) + " W/C) = " + RoundSigDigits( OutWaterTempAtUA1, 2 ) );
-					ShowFatalError( "Autosizing of Fluid Cooler UA failed for fluid cooler = " + SimpleFluidCooler( FluidCoolerNum ).Name );
+					ShowFatalError( "Autosizing of Fluid Cooler UA failed for fluid cooler = " + SimpleFluidCooler( FluidCoolerNum ).Name );  // LCOV_EXCL_LINE
 				}
 				if ( PlantFirstSizesOkayToFinalize ) SimpleFluidCooler( FluidCoolerNum ).LowSpeedFluidCoolerUA = UA;
 			} else {
@@ -1543,7 +1543,7 @@ namespace FluidCoolers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "SizeFluidCooler: Program terminated due to previous condition(s)." );
+			ShowFatalError( "SizeFluidCooler: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/FluidProperties.cc
+++ b/src/EnergyPlus/FluidProperties.cc
@@ -535,7 +535,7 @@ namespace FluidProperties {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + " Previous errors in input cause program termination." );
+			ShowFatalError( RoutineName + " Previous errors in input cause program termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( NumOfRefrigerants + 1 > 0 ) {
@@ -1066,7 +1066,7 @@ namespace FluidProperties {
 			// Check: TEMPERATURES for saturated density (must all be the same)
 			//    IF (RefrigData(Loop)%NumCpPoints /= RefrigData(Loop)%NumCpPoints) THEN
 			//!!!  Error -- can never happen, does this mean NumCp vs. NumRho?
-			//      CALL ShowFatalError('GetFluidPropertiesData: Number of specific heat fluid and gas/fluid points are not the same')
+			//      CALL ShowFatalError('GetFluidPropertiesData: Number of specific heat fluid and gas/fluid points are not the same')  // LCOV_EXCL_LINE
 			//    ELSE
 			//      DO TempLoop = 1, RefrigData(Loop)%NumCpPoints
 			//!!! Error -- something else that can never happen
@@ -1923,7 +1923,7 @@ namespace FluidProperties {
 		lNumericFieldBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Previous errors in input cause program termination." );
+			ShowFatalError( RoutineName + "Previous errors in input cause program termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( GetNumSectionsFound( "REPORTGLYCOLS" ) > 0 ) DebugReportGlycols = true;
@@ -2445,7 +2445,7 @@ namespace FluidProperties {
 					}
 				}
 			} else { // user has input data for concentrations that are too close or repeated, this must be fixed
-				ShowFatalError( RoutineName + "concentration values too close or data repeated, check your fluid property input data" );
+				ShowFatalError( RoutineName + "concentration values too close or data repeated, check your fluid property input data" );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -2548,7 +2548,7 @@ namespace FluidProperties {
 					}
 				}
 			} else { // user has input data for concentrations that are too close or repeated, this must be fixed
-				ShowFatalError( RoutineName + "concentration values too close or data repeated, check your fluid property input data" );
+				ShowFatalError( RoutineName + "concentration values too close or data repeated, check your fluid property input data" );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -3710,7 +3710,7 @@ namespace FluidProperties {
 		if ( ( Quality < 0.0 ) || ( Quality > 1.0 ) ) {
 			ShowSevereError( RoutineName + ": Refrigerant \"" + Refrigerant + "\", invalid quality, called from " + CalledFrom );
 			ShowContinueError( "Saturated refrigerant quality must be between 0 and 1, entered value=[" + RoundSigDigits( Quality, 4 ) + "]." );
-			ShowFatalError( "Program terminates due to preceding condition." );
+			ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 		}
 
 		if ( RefrigIndex > 0 ) {
@@ -3804,7 +3804,7 @@ namespace FluidProperties {
 		if ( ( Quality < 0.0 ) || ( Quality > 1.0 ) ) {
 			ShowSevereError( RoutineName + "Refrigerant \"" + Refrigerant + "\", invalid quality, called from " + CalledFrom );
 			ShowContinueError( "Saturated density quality must be between 0 and 1, entered value=[" + RoundSigDigits( Quality, 4 ) + "]." );
-			ShowFatalError( "Program terminates due to preceding condition." );
+			ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 		}
 
 		// Find which refrigerant (index) is being requested and then determine
@@ -3938,7 +3938,7 @@ namespace FluidProperties {
 		if ( ( Quality < 0.0 ) || ( Quality > 1.0 ) ) {
 			ShowSevereError( RoutineName + "Refrigerant \"" + Refrigerant + "\", invalid quality, called from " + CalledFrom );
 			ShowContinueError( "Saturated density quality must be between 0 and 1, entered value=[" + RoundSigDigits( Quality, 4 ) + "]." );
-			ShowFatalError( "Program terminates due to preceding condition." );
+			ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 		}
 
 		// Find which refrigerant (index) is being requested and then determine
@@ -4491,7 +4491,7 @@ namespace FluidProperties {
 		//       RE-ENGINEERED  na
 
 		// PURPOSE OF THIS SUBROUTINE:
-		// Performs iterations to calculate the refrigerant temperature corresponding to the given 
+		// Performs iterations to calculate the refrigerant temperature corresponding to the given
 		// enthalpy and pressure.  Works only in superheated region.
 
 		// METHODOLOGY EMPLOYED:
@@ -4515,7 +4515,7 @@ namespace FluidProperties {
 		Real64 RefTHigh; // High Temperature Value for Ps (max in tables)
 		Real64 RefTSat; // Saturated temperature of the refrigerant. Used to check whether the refrigernat is in the superheat area
 		Real64 Temp; // Temperature of the superheated refrigerant at the given enthalpy and pressure
-		
+
 		if ( GetInput ) {
 			GetFluidPropertiesData();
 			GetInput = false;
@@ -4543,7 +4543,7 @@ namespace FluidProperties {
 		// check temperature data range and attempt to cap if necessary
 		RefTHigh = refrig.PsHighTempValue;
 		RefTSat = GetSatTemperatureRefrig( Refrigerant, Pressure, RefrigNum, RoutineNameNoSpace + CalledFrom );
-		
+
 		if ( TempLow < RefTSat ) {
 			ShowWarningMessage( RoutineName + "Refrigerant [" + RefrigErrorTracking( RefrigNum ).Name + "] temperature lower bound is out of range for superheated refrigerant: values capped **" );
 			ShowContinueError( " Called From:" + CalledFrom );
@@ -4563,7 +4563,7 @@ namespace FluidProperties {
 			TempLow = RefTSat;
 			TempUp = RefTHigh;
 		}
-		
+
 		// check enthalpy data range and attempt to cap if necessary
 		EnthalpyLow = GetSupHeatEnthalpyRefrig( Refrigerant, TempLow, Pressure, RefrigNum, RoutineNameNoSpace + CalledFrom );
 		EnthalpyHigh = GetSupHeatEnthalpyRefrig( Refrigerant, TempUp, Pressure, RefrigNum, RoutineNameNoSpace + CalledFrom );
@@ -4575,18 +4575,18 @@ namespace FluidProperties {
 			ReturnValue = TempUp;
 			return ReturnValue;
 		}
-		
+
 		//Perform iterations to obtain the temperature level
 		{
 			Array1D< Real64 > Par( 6 ); // Parameters passed to RegulaFalsi
 			Real64 const ErrorTol( 0.001 ); // tolerance for RegulaFalsi iterations
 			int const MaxIte( 500 ); // maximum number of iterations
 			int SolFla; // Flag of RegulaFalsi solver
-			
+
 			Par( 1 ) = RefrigNum;
 			Par( 2 ) = Enthalpy;
 			Par( 3 ) = Pressure;
-			
+
 			SolveRoot( ErrorTol, MaxIte, SolFla, Temp, GetSupHeatTempRefrigResidual, TempLow, TempUp, Par );
 			ReturnValue = Temp;
 		}
@@ -4594,11 +4594,11 @@ namespace FluidProperties {
 		return ReturnValue;
 
 	}
-	
+
 	Real64
 	GetSupHeatTempRefrigResidual(
 		Real64 const Temp, // temperature of the refrigerant
-		Array1< Real64 > const & Par 
+		Array1< Real64 > const & Par
 	)
 	{
 		// FUNCTION INFORMATION:
@@ -4609,7 +4609,7 @@ namespace FluidProperties {
 
 		// PURPOSE OF THIS FUNCTION:
 		//  Calculates residual function (( Enthalpy_Actual - Enthalpy_Req ) / Enthalpy_Req )
-		//  This method is designed to support , which calculates the refrigerant temperature corresponding to the given 
+		//  This method is designed to support , which calculates the refrigerant temperature corresponding to the given
 		//  enthalpy and pressure in superheated region.
 
 		// REFERENCES:
@@ -4642,23 +4642,23 @@ namespace FluidProperties {
 		static std::string const RoutineNameNoSpace( "GetSupHeatTempRefrigResidual" );
 		std::string Refrigerant; // carries in substance name
 		int RefrigNum; // index for refrigerant under consideration
-		Real64 Pressure; // pressure of the refrigerant 
+		Real64 Pressure; // pressure of the refrigerant
 		Real64 Enthalpy_Req; // enthalpy of the refrigerant to meet
 		Real64 Enthalpy_Act; // enthalpy of the refrigerant calculated
-		
+
 		RefrigNum = int( Par( 1 ) );
 		Enthalpy_Req = Par( 2 );
 		Pressure = Par( 3 );
 		Refrigerant = RefrigErrorTracking( RefrigNum ).Name;
 		if ( std::abs( Enthalpy_Req ) < 100.0 ) Enthalpy_Req = sign( 100.0, Enthalpy_Req );
-		
+
 		Enthalpy_Act = GetSupHeatEnthalpyRefrig( Refrigerant, Temp, Pressure, RefrigNum, RoutineNameNoSpace);
-		
+
 		TempResidual = ( Enthalpy_Act - Enthalpy_Req ) / Enthalpy_Req;
 
 		return TempResidual;
 	}
-	
+
 	//*****************************************************************************
 
 	Real64
@@ -5446,7 +5446,7 @@ namespace FluidProperties {
 	void
 	GetInterpValue_error()
 	{
-		ShowFatalError( "GetInterpValue: Temperatures for fluid property data too close together, division by zero" );
+		ShowFatalError( "GetInterpValue: Temperatures for fluid property data too close together, division by zero" );  // LCOV_EXCL_LINE
 	}
 
 	//*****************************************************************************
@@ -6185,7 +6185,7 @@ namespace FluidProperties {
 		}
 		if ( RefrigNo > 0 ) ShowContinueError( "Note: that fluid is listed as a Refrigerant from input." );
 
-		ShowFatalError( "Program terminates due to preceding condition." );
+		ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -6246,7 +6246,7 @@ namespace FluidProperties {
 		}
 		if ( GlycolNo > 0 ) ShowContinueError( "Note: that fluid is listed as a Glycol from input." );
 
-		ShowFatalError( "Program terminates due to preceding condition." );
+		ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 
 	}
 

--- a/src/EnergyPlus/FuelCellElectricGenerator.cc
+++ b/src/EnergyPlus/FuelCellElectricGenerator.cc
@@ -175,16 +175,16 @@ namespace FuelCellElectricGenerator {
 
 		if ( GeneratorIndex == 0 ) {
 			GenNum = FindItemInList( GeneratorName, FuelCell );
-			if ( GenNum == 0 ) ShowFatalError( "SimFuelCellGenerator: Specified Generator not one of Valid FuelCell Generators " + GeneratorName );
+			if ( GenNum == 0 ) ShowFatalError( "SimFuelCellGenerator: Specified Generator not one of Valid FuelCell Generators " + GeneratorName );  // LCOV_EXCL_LINE
 			GeneratorIndex = GenNum;
 		} else {
 			GenNum = GeneratorIndex;
 			if ( GenNum > NumFuelCellGenerators || GenNum < 1 ) {
-				ShowFatalError( "SimFuelCellGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Number of FuelCell Generators=" + TrimSigDigits( NumFuelCellGenerators ) + ", Generator name=" + GeneratorName );
+				ShowFatalError( "SimFuelCellGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Number of FuelCell Generators=" + TrimSigDigits( NumFuelCellGenerators ) + ", Generator name=" + GeneratorName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( GenNum ) ) {
 				if ( GeneratorName != FuelCell( GenNum ).Name ) {
-					ShowFatalError( "SimFuelCellGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + FuelCell( GenNum ).Name );
+					ShowFatalError( "SimFuelCellGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + FuelCell( GenNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( GenNum ) = false;
 			}
@@ -1033,7 +1033,7 @@ namespace FuelCellElectricGenerator {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Errors found in getting input for fuel cell model " );
+				ShowFatalError( "Errors found in getting input for fuel cell model " );  // LCOV_EXCL_LINE
 			}
 
 			for ( GeneratorNum = 1; GeneratorNum <= NumFuelCellGenerators; ++GeneratorNum ) {
@@ -3722,7 +3722,7 @@ namespace FuelCellElectricGenerator {
 				CompNum = FindItemInList( CompName, FuelCell, &FCDataStruct::NameStackCooler );
 			}
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimFuelCellPlantHeatRecovery: Fuel Cell Generator Unit not found=" + CompName );
+				ShowFatalError( "SimFuelCellPlantHeatRecovery: Fuel Cell Generator Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			MinCap = 0.0;
 			MaxCap = 0.0;
@@ -3822,7 +3822,7 @@ namespace FuelCellElectricGenerator {
 			errFlag = false;
 			ScanPlantLoopsForObject( FuelCell( FCnum ).NameExhaustHX, TypeOf_Generator_FCExhaust, FuelCell( FCnum ).CWLoopNum, FuelCell( FCnum ).CWLoopSideNum, FuelCell( FCnum ).CWBranchNum, FuelCell( FCnum ).CWCompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitFuelCellGenerators: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitFuelCellGenerators: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			MyPlantScanFlag( FCnum ) = false;
 		}

--- a/src/EnergyPlus/Furnaces.cc
+++ b/src/EnergyPlus/Furnaces.cc
@@ -380,17 +380,17 @@ namespace Furnaces {
 		if ( CompIndex == 0 ) {
 			FurnaceNum = FindItemInList( FurnaceName, Furnace );
 			if ( FurnaceNum == 0 ) {
-				ShowFatalError( "SimFurnace: Unit not found=" + FurnaceName );
+				ShowFatalError( "SimFurnace: Unit not found=" + FurnaceName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = FurnaceNum;
 		} else {
 			FurnaceNum = CompIndex;
 			if ( FurnaceNum > NumFurnaces || FurnaceNum < 1 ) {
-				ShowFatalError( "SimFurnace:  Invalid CompIndex passed=" + TrimSigDigits( FurnaceNum ) + ", Number of Units=" + TrimSigDigits( NumFurnaces ) + ", Entered Unit name=" + FurnaceName );
+				ShowFatalError( "SimFurnace:  Invalid CompIndex passed=" + TrimSigDigits( FurnaceNum ) + ", Number of Units=" + TrimSigDigits( NumFurnaces ) + ", Entered Unit name=" + FurnaceName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( FurnaceNum ) ) {
 				if ( FurnaceName != Furnace( FurnaceNum ).Name ) {
-					ShowFatalError( "SimFurnace: Invalid CompIndex passed=" + TrimSigDigits( FurnaceNum ) + ", Unit name=" + FurnaceName + ", stored Unit Name for that index=" + Furnace( FurnaceNum ).Name );
+					ShowFatalError( "SimFurnace: Invalid CompIndex passed=" + TrimSigDigits( FurnaceNum ) + ", Unit name=" + FurnaceName + ", stored Unit Name for that index=" + Furnace( FurnaceNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( FurnaceNum ) = false;
 			}
@@ -4269,7 +4269,7 @@ namespace Furnaces {
 		Numbers.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting Furnace or Unitary System input." );
+			ShowFatalError( "Errors found in getting Furnace or Unitary System input." );  // LCOV_EXCL_LINE
 		}
 
 		for ( HeatOnlyNum = 1; HeatOnlyNum <= NumHeatOnly; ++HeatOnlyNum ) {
@@ -4592,7 +4592,7 @@ namespace Furnaces {
 					errFlag = false;
 					ScanPlantLoopsForObject( Furnace( FurnaceNum ).HeatingCoilName, TypeOf_CoilWaterSimpleHeating, Furnace( FurnaceNum ).LoopNum, Furnace( FurnaceNum ).LoopSide, Furnace( FurnaceNum ).BranchNum, Furnace( FurnaceNum ).CompNum, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitFurnace: Program terminated for previous conditions." );
+						ShowFatalError( "InitFurnace: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 					Furnace( FurnaceNum ).MaxHeatCoilFluidFlow = GetCoilMaxWaterFlowRate( "Coil:Heating:Water", Furnace( FurnaceNum ).HeatingCoilName, ErrorsFound );
 					if ( Furnace( FurnaceNum ).MaxHeatCoilFluidFlow > 0.0 ) {
@@ -4604,7 +4604,7 @@ namespace Furnaces {
 					errFlag = false;
 					ScanPlantLoopsForObject( Furnace( FurnaceNum ).HeatingCoilName, TypeOf_CoilSteamAirHeating, Furnace( FurnaceNum ).LoopNum, Furnace( FurnaceNum ).LoopSide, Furnace( FurnaceNum ).BranchNum, Furnace( FurnaceNum ).CompNum, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitFurnace: Program terminated for previous conditions." );
+						ShowFatalError( "InitFurnace: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 					Furnace( FurnaceNum ).MaxHeatCoilFluidFlow = GetCoilMaxSteamFlowRate( Furnace( FurnaceNum ).HeatingCoilIndex, ErrorsFound );
 					if ( Furnace( FurnaceNum ).MaxHeatCoilFluidFlow > 0.0 ) {
@@ -4632,7 +4632,7 @@ namespace Furnaces {
 					errFlag = false;
 					ScanPlantLoopsForObject( Furnace( FurnaceNum ).SuppHeatCoilName, TypeOf_CoilWaterSimpleHeating, Furnace( FurnaceNum ).LoopNumSupp, Furnace( FurnaceNum ).LoopSideSupp, Furnace( FurnaceNum ).BranchNumSupp, Furnace( FurnaceNum ).CompNumSupp, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitFurnace: Program terminated for previous conditions." );
+						ShowFatalError( "InitFurnace: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 					Furnace( FurnaceNum ).MaxSuppCoilFluidFlow = GetCoilMaxWaterFlowRate( "Coil:Heating:Water", Furnace( FurnaceNum ).SuppHeatCoilName, ErrorsFound );
 					if ( Furnace( FurnaceNum ).MaxSuppCoilFluidFlow > 0.0 ) {
@@ -4643,7 +4643,7 @@ namespace Furnaces {
 					errFlag = false;
 					ScanPlantLoopsForObject( Furnace( FurnaceNum ).SuppHeatCoilName, TypeOf_CoilSteamAirHeating, Furnace( FurnaceNum ).LoopNumSupp, Furnace( FurnaceNum ).LoopSideSupp, Furnace( FurnaceNum ).BranchNumSupp, Furnace( FurnaceNum ).CompNumSupp, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitFurnace: Program terminated for previous conditions." );
+						ShowFatalError( "InitFurnace: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 					Furnace( FurnaceNum ).MaxSuppCoilFluidFlow = GetCoilMaxSteamFlowRate( Furnace( FurnaceNum ).SuppHeatCoilIndex, ErrorsFound );
 					if ( Furnace( FurnaceNum ).MaxSuppCoilFluidFlow > 0.0 ) {
@@ -4798,7 +4798,7 @@ namespace Furnaces {
 			MyCheckFlag( FurnaceNum ) = false;
 			if ( Furnace( FurnaceNum ).ZoneInletNode == 0 ) {
 				ShowSevereError( cFurnaceTypes( Furnace( FurnaceNum ).FurnaceType_Num ) + " \"" + Furnace( FurnaceNum ).Name + "\": The zone inlet node in the controlled zone (" + Zone( Furnace( FurnaceNum ).ControlZoneNum ).Name + ") is not found." );
-				ShowFatalError( "Subroutine InitFurnace: Errors found in getting " + cFurnaceTypes( Furnace( FurnaceNum ).FurnaceType_Num ) + " input.  Preceding condition(s) causes termination." );
+				ShowFatalError( "Subroutine InitFurnace: Errors found in getting " + cFurnaceTypes( Furnace( FurnaceNum ).FurnaceType_Num ) + " input.  Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -8960,7 +8960,7 @@ namespace Furnaces {
 						}
 					}
 				} else if ( SolFla == -2 ) {
-					ShowFatalError( "VS WSHP unit cycling ratio calculation failed: cycling limits exceeded, for unit=" + Furnace( FurnaceNum ).Name );
+					ShowFatalError( "VS WSHP unit cycling ratio calculation failed: cycling limits exceeded, for unit=" + Furnace( FurnaceNum ).Name );  // LCOV_EXCL_LINE
 				}
 			} else {
 				// Check to see which speed to meet the load
@@ -9009,7 +9009,7 @@ namespace Furnaces {
 						}
 					}
 				} else if ( SolFla == -2 ) {
-					ShowFatalError( "VS WSHP unit compressor speed calculation failed: speed limits exceeded, for unit=" + Furnace( FurnaceNum ).Name );
+					ShowFatalError( "VS WSHP unit compressor speed calculation failed: speed limits exceeded, for unit=" + Furnace( FurnaceNum ).Name );  // LCOV_EXCL_LINE
 				}
 			}
 		}

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -2570,7 +2570,7 @@ namespace General {
 
 	}
 
-	// returns the Julian date for the first, second, etc. day of week for a given month 
+	// returns the Julian date for the first, second, etc. day of week for a given month
 	int
 	nthDayOfWeekOfMonth(
 		int const & dayOfWeek, // day of week (Sunday=1, Monday=2, ...)
@@ -2734,7 +2734,7 @@ namespace General {
 		Determinant = A( 1, 1 ) * A( 2, 2 ) * A( 3, 3 ) + A( 2, 1 ) * A( 3, 2 ) * A( 1, 3 ) + A( 3, 1 ) * A( 1, 2 ) * A( 2, 3 ) - A( 1, 1 ) * A( 2, 3 ) * A( 3, 2 ) - A( 1, 2 ) * A( 2, 1 ) * A( 3, 3 ) - A( 1, 3 ) * A( 2, 2 ) * A( 3, 1 );
 
 		if ( std::abs( Determinant ) < .1E-12 ) {
-			ShowFatalError( "Determinant = [Zero] in Invert3By3Matrix", OutputFileStandard );
+			ShowFatalError( "Determinant = [Zero] in Invert3By3Matrix", OutputFileStandard );  // LCOV_EXCL_LINE
 		}
 
 		// Compute Inverse

--- a/src/EnergyPlus/GeneralRoutines.cc
+++ b/src/EnergyPlus/GeneralRoutines.cc
@@ -308,7 +308,7 @@ ControlCompOutput(
 				ShowSevereError( "ControlCompOutput:" + CompType + ':' + CompName + ", Min Control Flow is > Max Control Flow" );
 				ShowContinueError( "Acuated Node=" + NodeID( ActuatedNode ) + " MinFlow=[" + TrimSigDigits( MinFlow, 3 ) + "], Max Flow=" + TrimSigDigits( MaxFlow, 3 ) );
 				ShowContinueErrorTimeStamp( "" );
-				ShowFatalError( "Program terminates due to preceding condition." );
+				ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 			}
 		} // End of FirstHVACIteration Conditional If
 		// The interface managers can reset the Max or Min to available values during the time step
@@ -479,7 +479,7 @@ ControlCompOutput(
 			} else if ( Action == iReverseAction ) {
 				Denom = -max( std::abs( QZnReq ), 100.0 );
 			} else {
-				ShowFatalError( "ControlCompOutput: Illegal Action argument =[" + TrimSigDigits( Action ) + ']' );
+				ShowFatalError( "ControlCompOutput: Illegal Action argument =[" + TrimSigDigits( Action ) + ']' );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -574,7 +574,7 @@ ControlCompOutput(
 			break;
 
 		default:
-			ShowFatalError( "ControlCompOutput: Illegal Component Number argument =[" + TrimSigDigits( SimCompNum ) + ']' );
+			ShowFatalError( "ControlCompOutput: Illegal Component Number argument =[" + TrimSigDigits( SimCompNum ) + ']' );  // LCOV_EXCL_LINE
 			break;
 
 		}
@@ -666,7 +666,7 @@ CheckSysSizing(
 		if ( ! DoSystemSizing ) {
 			ShowContinueError( "The \"SimulationControl\" object did not have the field \"Do System Sizing Calculation\" set to Yes." );
 		}
-		ShowFatalError( "Program terminates due to previously shown condition(s)." );
+		ShowFatalError( "Program terminates due to previously shown condition(s)." );  // LCOV_EXCL_LINE
 	}
 
 }
@@ -776,7 +776,7 @@ CheckZoneSizing(
 		if ( ! DoZoneSizing ) {
 			ShowContinueError( "The \"SimulationControl\" object did not have the field \"Do Zone Sizing Calculation\" set to Yes." );
 		}
-		ShowFatalError( "Program terminates due to previously shown condition(s)." );
+		ShowFatalError( "Program terminates due to previously shown condition(s)." );  // LCOV_EXCL_LINE
 	}
 
 }

--- a/src/EnergyPlus/GeneratorFuelSupply.cc
+++ b/src/EnergyPlus/GeneratorFuelSupply.cc
@@ -293,7 +293,7 @@ namespace GeneratorFuelSupply {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Problem found processing input for " + cCurrentModuleObject );
+				ShowFatalError( "Problem found processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 			}
 
 			MyOneTimeFlag = false;

--- a/src/EnergyPlus/GroundHeatExchangers.cc
+++ b/src/EnergyPlus/GroundHeatExchangers.cc
@@ -203,7 +203,7 @@ namespace GroundHeatExchangers {
 			}
 		}
 		// If we didn't find it, fatal
-		ShowFatalError( "Ground Heat Exchanger Factory: Error getting inputs for GHX named: " + objectName );
+		ShowFatalError( "Ground Heat Exchanger Factory: Error getting inputs for GHX named: " + objectName );  // LCOV_EXCL_LINE
 		// Shut up the compiler
 		return nullptr;
 	}
@@ -1414,7 +1414,7 @@ namespace GroundHeatExchangers {
 				}
 				//Check for Errors
 				if ( errorsFound ) {
-					ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+					ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -1564,7 +1564,7 @@ namespace GroundHeatExchangers {
 
 				//Check for Errors
 				if ( errorsFound ) {
-					ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+					ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -2007,7 +2007,7 @@ namespace GroundHeatExchangers {
 			errFlag = false;
 			ScanPlantLoopsForObject( Name, TypeOf_GrndHtExchgVertical, loopNum, loopSideNum, branchNum, compNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "initGLHESimVars: Program terminated due to previous condition(s)." );
+				ShowFatalError( "initGLHESimVars: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			myFlag = false;
 		}
@@ -2099,7 +2099,7 @@ namespace GroundHeatExchangers {
 			errFlag = false;
 			ScanPlantLoopsForObject( Name, TypeOf_GrndHtExchgSlinky, loopNum, loopSideNum, branchNum, compNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "initGLHESimVars: Program terminated due to previous condition(s)." );
+				ShowFatalError( "initGLHESimVars: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			myFlag = false;
 		}

--- a/src/EnergyPlus/GroundTemperatureModeling/FiniteDifferenceGroundTemperatureModel.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/FiniteDifferenceGroundTemperatureModel.cc
@@ -141,7 +141,7 @@ namespace EnergyPlus {
 			// Return the pointer
 			return thisModel;
 		} else {
-			ShowFatalError( "Site:GroundTemperature:Undisturbed:FiniteDifference--Errors getting input for ground temperature model" );
+			ShowFatalError( "Site:GroundTemperature:Undisturbed:FiniteDifference--Errors getting input for ground temperature model" );  // LCOV_EXCL_LINE
 			return nullptr;
 		}
 	}
@@ -225,7 +225,7 @@ namespace EnergyPlus {
 		if ( !WeatherFileExists ){
 			ShowContinueError( "Site:GroundTemperature:Undisturbed:FiniteDifference -- using this model requires specification of a weather file." );
 			ShowContinueError( "Either place in.epw in the working directory or specify a weather file on the command line using -w /path/to/weather.epw");
-			ShowFatalError( "Simulation halted due to input error in ground temperaure model." );
+			ShowFatalError( "Simulation halted due to input error in ground temperaure model." );  // LCOV_EXCL_LINE
 		}
 
 		++NumOfEnvrn;

--- a/src/EnergyPlus/GroundTemperatureModeling/GroundTemperatureModelManager.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/GroundTemperatureModelManager.cc
@@ -120,7 +120,7 @@ namespace GroundTemperatureManager {
 			objectType = objectType_XingGroundTemp;
 		} else {
 			// Error out if no ground temperature object types recognized
-			ShowFatalError( "GetGroundTempsModelAndInit: Ground temperature object " + objectType_str + " not recognized." );
+			ShowFatalError( "GetGroundTempsModelAndInit: Ground temperature object " + objectType_str + " not recognized." );  // LCOV_EXCL_LINE
 		}
 
 		int numGTMs = groundTempModels.size();

--- a/src/EnergyPlus/GroundTemperatureModeling/KusudaAchenbachGroundTemperatureModel.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/KusudaAchenbachGroundTemperatureModel.cc
@@ -165,7 +165,7 @@ namespace EnergyPlus {
 			groundTempModels.push_back( thisModel );
 			return thisModel;
 		} else {
-			ShowFatalError( "Site:GroundTemperature:Undisturbed:KusudaAchenbach--Errors getting input for ground temperature model");
+			ShowFatalError( "Site:GroundTemperature:Undisturbed:KusudaAchenbach--Errors getting input for ground temperature model");  // LCOV_EXCL_LINE
 			return nullptr;
 		}
 	}

--- a/src/EnergyPlus/GroundTemperatureModeling/SiteBuildingSurfaceGroundTemperatures.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/SiteBuildingSurfaceGroundTemperatures.cc
@@ -67,9 +67,9 @@ namespace EnergyPlus {
 	//******************************************************************************
 
 	// Site:GroundTemperature:BuildingSurface factory
-	std::shared_ptr< SiteBuildingSurfaceGroundTemps > 
-	SiteBuildingSurfaceGroundTemps::BuildingSurfaceGTMFactory( 
-		int objectType, 
+	std::shared_ptr< SiteBuildingSurfaceGroundTemps >
+	SiteBuildingSurfaceGroundTemps::BuildingSurfaceGTMFactory(
+		int objectType,
 		std::string objectName
 	)
 	{
@@ -84,7 +84,7 @@ namespace EnergyPlus {
 
 		// USE STATEMENTS:
 		using DataEnvironment::GroundTempObjInput;
-		using DataGlobals::OutputFileInits;		
+		using DataGlobals::OutputFileInits;
 		using namespace DataIPShortCuts;
 		using namespace GroundTemperatureManager;
 		using namespace ObjexxFCL::gio;

--- a/src/EnergyPlus/GroundTemperatureModeling/SiteDeepGroundTemperatures.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/SiteDeepGroundTemperatures.cc
@@ -67,9 +67,9 @@ namespace EnergyPlus {
 	//******************************************************************************
 
 	// Site:GroundTemperature:Deep factory
-	std::shared_ptr< SiteDeepGroundTemps > 
-	SiteDeepGroundTemps::DeepGTMFactory( 
-		int objectType, 
+	std::shared_ptr< SiteDeepGroundTemps >
+	SiteDeepGroundTemps::DeepGTMFactory(
+		int objectType,
 		std::string objectName
 	)
 	{
@@ -147,7 +147,7 @@ namespace EnergyPlus {
 			ShowContinueError( "Site:GroundTemperature:Deep--Errors getting input for ground temperature model");
 			return nullptr;
 		}
-	}	
+	}
 
 	//******************************************************************************
 

--- a/src/EnergyPlus/GroundTemperatureModeling/SiteFCFactorMethodGroundTemperatures.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/SiteFCFactorMethodGroundTemperatures.cc
@@ -67,9 +67,9 @@ namespace EnergyPlus {
 	//******************************************************************************
 
 	// Site:GroundTemperature:FCFactorMethod factory
-	std::shared_ptr< SiteFCFactorMethodGroundTemps > 
-	SiteFCFactorMethodGroundTemps::FCFactorGTMFactory( 
-		int objectType, 
+	std::shared_ptr< SiteFCFactorMethodGroundTemps >
+	SiteFCFactorMethodGroundTemps::FCFactorGTMFactory(
+		int objectType,
 		std::string objectName
 	)
 	{
@@ -130,7 +130,7 @@ namespace EnergyPlus {
 			thisModel->errorsFound = true;
 
 		} else if ( wthFCGroundTemps ) {
-			
+
 			for ( int i = 1; i <= 12; ++i ) {
 				thisModel->fcFactorGroundTemps( i ) = GroundTempsFCFromEPWHeader( i );
 			}

--- a/src/EnergyPlus/GroundTemperatureModeling/SiteShallowGroundTemperatures.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/SiteShallowGroundTemperatures.cc
@@ -67,9 +67,9 @@ namespace EnergyPlus {
 	//******************************************************************************
 
 	// Site:GroundTemperature:Shallow factory
-	std::shared_ptr< SiteShallowGroundTemps > 
-	SiteShallowGroundTemps::ShallowGTMFactory( 
-		int objectType, 
+	std::shared_ptr< SiteShallowGroundTemps >
+	SiteShallowGroundTemps::ShallowGTMFactory(
+		int objectType,
 		std::string objectName
 	)
 	{

--- a/src/EnergyPlus/GroundTemperatureModeling/XingGroundTemperatureModel.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/XingGroundTemperatureModel.cc
@@ -118,7 +118,7 @@ namespace EnergyPlus {
 			groundTempModels.push_back( thisModel );
 			return thisModel;
 		} else {
-			ShowFatalError( "Site:GroundTemperature:Undisturbed:Xing--Errors getting input for ground temperature model");
+			ShowFatalError( "Site:GroundTemperature:Undisturbed:Xing--Errors getting input for ground temperature model");  // LCOV_EXCL_LINE
 			return nullptr;
 		}
 	}

--- a/src/EnergyPlus/HVACControllers.cc
+++ b/src/EnergyPlus/HVACControllers.cc
@@ -360,17 +360,17 @@ namespace HVACControllers {
 		if ( ControllerIndex == 0 ) {
 			ControlNum = FindItemInList( ControllerName, ControllerProps, &ControllerPropsType::ControllerName );
 			if ( ControlNum == 0 ) {
-				ShowFatalError( "ManageControllers: Invalid controller=" + ControllerName + ". The only valid controller type for an AirLoopHVAC is Controller:WaterCoil." );
+				ShowFatalError( "ManageControllers: Invalid controller=" + ControllerName + ". The only valid controller type for an AirLoopHVAC is Controller:WaterCoil." );  // LCOV_EXCL_LINE
 			}
 			ControllerIndex = ControlNum;
 		} else {
 			ControlNum = ControllerIndex;
 			if ( ControlNum > NumControllers || ControlNum < 1 ) {
-				ShowFatalError( "ManageControllers: Invalid ControllerIndex passed=" + TrimSigDigits( ControlNum ) + ", Number of controllers=" + TrimSigDigits( NumControllers ) + ", Controller name=" + ControllerName );
+				ShowFatalError( "ManageControllers: Invalid ControllerIndex passed=" + TrimSigDigits( ControlNum ) + ", Number of controllers=" + TrimSigDigits( NumControllers ) + ", Controller name=" + ControllerName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( ControlNum ) ) {
 				if ( ControllerName != ControllerProps( ControlNum ).ControllerName ) {
-					ShowFatalError( "ManageControllers: Invalid ControllerIndex passed=" + TrimSigDigits( ControlNum ) + ", Controller name=" + ControllerName + ", stored Controller Name for that index=" + ControllerProps( ControlNum ).ControllerName );
+					ShowFatalError( "ManageControllers: Invalid ControllerIndex passed=" + TrimSigDigits( ControlNum ) + ", Controller name=" + ControllerName + ", stored Controller Name for that index=" + ControllerProps( ControlNum ).ControllerName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( ControlNum ) = false;
 			}
@@ -449,7 +449,7 @@ namespace HVACControllers {
 			if ( SELECT_CASE_var1 == ControllerSimple_Type ) { // 'Controller:WaterCoil'
 				CalcSimpleController( ControlNum, FirstHVACIteration, IsConvergedFlag, IsUpToDateFlag, ControllerName );
 			} else {
-				ShowFatalError( "Invalid controller type in ManageControllers=" + ControllerProps( ControlNum ).ControllerType );
+				ShowFatalError( "Invalid controller type in ManageControllers=" + ControllerProps( ControlNum ).ControllerType );  // LCOV_EXCL_LINE
 			}}
 
 			// Update the current Controller to the outlet nodes
@@ -471,14 +471,14 @@ namespace HVACControllers {
 				CheckSimpleController( ControlNum, IsConvergedFlag );
 				SaveSimpleController( ControlNum, FirstHVACIteration, IsConvergedFlag );
 			} else {
-				ShowFatalError( "Invalid controller type in ManageControllers=" + ControllerProps( ControlNum ).ControllerType );
+				ShowFatalError( "Invalid controller type in ManageControllers=" + ControllerProps( ControlNum ).ControllerType );  // LCOV_EXCL_LINE
 			}}
 
 			// Report the current Controller
 			ReportController( ControlNum );
 
 		} else {
-			ShowFatalError( "ManageControllers: Invalid Operation passed=" + TrimSigDigits( Operation ) + ", Controller name=" + ControllerName );
+			ShowFatalError( "ManageControllers: Invalid Operation passed=" + TrimSigDigits( Operation ) + ", Controller name=" + ControllerName );  // LCOV_EXCL_LINE
 		}}
 
 		// Write detailed diagnostic for individual controller
@@ -802,7 +802,7 @@ namespace HVACControllers {
 		CheckControllerListOrder();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1145,7 +1145,7 @@ namespace HVACControllers {
 			if ( ControllerProps( ControlNum ).MaxVolFlowActuated == 0.0 ) {
 				ControllerProps( ControlNum ).MinVolFlowActuated = 0.0;
 			} else if ( ControllerProps( ControlNum ).MinVolFlowActuated >= ControllerProps( ControlNum ).MaxVolFlowActuated ) {
-				ShowFatalError( "Controller:WaterCoil, Minimum control flow is > or = Maximum control flow; " + ControllerProps( ControlNum ).ControllerName );
+				ShowFatalError( "Controller:WaterCoil, Minimum control flow is > or = Maximum control flow; " + ControllerProps( ControlNum ).ControllerName );  // LCOV_EXCL_LINE
 			}
 
 			// Setup root finder after sizing calculation
@@ -1156,7 +1156,7 @@ namespace HVACControllers {
 			} else if ( SELECT_CASE_var == iReverseAction ) {
 				SetupRootFinder( RootFinders( ControlNum ), iSlopeDecreasing, iMethodBrent, constant_zero, 1.0e-6, ControllerProps( ControlNum ).Offset ); // Slope type | Method type | TolX: no relative tolerance for X variables | ATolX: absolute tolerance for X variables | ATolY: absolute tolerance for Y variables
 			} else {
-				ShowFatalError( "InitController: Invalid controller action. Valid choices are \"Normal\" or \"Reverse\"" );
+				ShowFatalError( "InitController: Invalid controller action. Valid choices are \"Normal\" or \"Reverse\"" );  // LCOV_EXCL_LINE
 			}}
 
 			MySizeFlag( ControlNum ) = false;
@@ -1285,7 +1285,7 @@ namespace HVACControllers {
 			}
 
 		} else {
-			ShowFatalError( "Invalid Controller Variable Type=" + ControlVariableTypes( ControllerProps( ControlNum ).ControlVar ) );
+			ShowFatalError( "Invalid Controller Variable Type=" + ControlVariableTypes( ControllerProps( ControlNum ).ControlVar ) );  // LCOV_EXCL_LINE
 		}}
 
 		{ auto const SELECT_CASE_var( ControllerProps( ControlNum ).ActuatorVar );
@@ -1306,7 +1306,7 @@ namespace HVACControllers {
 			}
 
 		} else {
-			ShowFatalError( "Invalid Actuator Variable Type=" + ControlVariableTypes( ControllerProps( ControlNum ).ActuatorVar ) );
+			ShowFatalError( "Invalid Actuator Variable Type=" + ControlVariableTypes( ControllerProps( ControlNum ).ActuatorVar ) );  // LCOV_EXCL_LINE
 		}}
 
 		// Compute residual for control function using desired setpoint value and current sensed value
@@ -1529,7 +1529,7 @@ namespace HVACControllers {
 					ShowSevereError( "CalcSimpleController: HVAC controller failed at " + CreateHVACStepFullString() );
 					ShowContinueError( " Controller name=" + ControllerProps( ControlNum ).ControllerName );
 					ShowContinueError( " Unrecognized control variable type=" + TrimSigDigits( ControllerProps( ControlNum ).ControlVar ) );
-					ShowFatalError( "Preceding error causes program termination." );
+					ShowFatalError( "Preceding error causes program termination." );  // LCOV_EXCL_LINE
 				}}
 
 			}
@@ -1546,7 +1546,7 @@ namespace HVACControllers {
 				ShowSevereError( "CalcSimpleController: Root finder failed at " + CreateHVACStepFullString() );
 				ShowContinueError( " Controller name=\"" + ControllerName + "\"" );
 				ShowContinueError( " Setpoint is not available/defined." );
-				ShowFatalError( "Preceding error causes program termination." );
+				ShowFatalError( "Preceding error causes program termination." );  // LCOV_EXCL_LINE
 			}
 			// Monitor invariants across successive controller iterations
 			// - min bound
@@ -1557,7 +1557,7 @@ namespace HVACControllers {
 				ShowContinueError( " Minimum bound must remain invariant during successive iterations." );
 				ShowContinueError( " Minimum root finder point=" + TrimSigDigits( RootFinders( ControlNum ).MinPoint.X, NumSigDigits ) );
 				ShowContinueError( " Minimum avail actuated=" + TrimSigDigits( ControllerProps( ControlNum ).MinAvailActuated, NumSigDigits ) );
-				ShowFatalError( "Preceding error causes program termination." );
+				ShowFatalError( "Preceding error causes program termination." );  // LCOV_EXCL_LINE
 			}
 			if ( RootFinders( ControlNum ).MaxPoint.X != ControllerProps( ControlNum ).MaxAvailActuated ) {
 				ShowSevereError( "CalcSimpleController: Root finder failed at " + CreateHVACStepFullString() );
@@ -1565,7 +1565,7 @@ namespace HVACControllers {
 				ShowContinueError( " Maximum bound must remain invariant during successive iterations." );
 				ShowContinueError( " Maximum root finder point=" + TrimSigDigits( RootFinders( ControlNum ).MaxPoint.X, NumSigDigits ) );
 				ShowContinueError( " Maximum avail actuated=" + TrimSigDigits( ControllerProps( ControlNum ).MaxAvailActuated, NumSigDigits ) );
-				ShowFatalError( "Preceding error causes program termination." );
+				ShowFatalError( "Preceding error causes program termination." );  // LCOV_EXCL_LINE
 			}
 
 			// Updates root finder with current iterate and computes next one if needed
@@ -1707,7 +1707,7 @@ namespace HVACControllers {
 			ShowContinueError( " Root candidate x=" + TrimSigDigits( ControllerProps( ControlNum ).ActuatedValue, NumSigDigits ) + " does not lie within the min/max bounds." );
 			ShowContinueError( " Min bound is x=" + TrimSigDigits( RootFinders( ControlNum ).MinPoint.X, NumSigDigits ) );
 			ShowContinueError( " Max bound is x=" + TrimSigDigits( RootFinders( ControlNum ).MaxPoint.X, NumSigDigits ) );
-			ShowFatalError( "Preceding error causes program termination." );
+			ShowFatalError( "Preceding error causes program termination." );  // LCOV_EXCL_LINE
 
 			// Abnormal case: should never happen
 		} else if ( SELECT_CASE_var == iStatusErrorBracket ) {
@@ -1721,7 +1721,7 @@ namespace HVACControllers {
 			if ( RootFinders( ControlNum ).UpperPoint.DefinedFlag ) {
 				ShowContinueError( " Upper bracket is x=" + TrimSigDigits( RootFinders( ControlNum ).UpperPoint.X, NumSigDigits ) );
 			}
-			ShowFatalError( "Preceding error causes program termination." );
+			ShowFatalError( "Preceding error causes program termination." );  // LCOV_EXCL_LINE
 
 			// Detected control function with wrong action between the min and max points.
 			// Should never happen: probably indicative of some serious problems in IDFs
@@ -1759,7 +1759,7 @@ namespace HVACControllers {
 			//    'x='//TRIM(TrimSigDigits(RootFinders(ControlNum)%MaxPoint%X,NumSigDigits))//','// &
 			//    'y='//TRIM(TrimSigDigits(RootFinders(ControlNum)%MaxPoint%Y,NumSigDigits)) &
 			//  )
-			//  CALL ShowFatalError('FindRootSimpleController: Preceding error causes program termination.')
+			//  CALL ShowFatalError('FindRootSimpleController: Preceding error causes program termination.')  // LCOV_EXCL_LINE
 			if ( ! WarmupFlag && ControllerProps( ControlNum ).BadActionErrCount == 0 ) {
 				++ControllerProps( ControlNum ).BadActionErrCount;
 				ShowSevereError( "FindRootSimpleController: Controller error for controller = \"" + ControllerName + "\"" );
@@ -1811,7 +1811,7 @@ namespace HVACControllers {
 			ShowSevereError( "FindRootSimpleController: Root finder failed at " + CreateHVACStepFullString() );
 			ShowContinueError( " Controller name=" + ControllerName );
 			ShowContinueError( " Unrecognized root finder status flag=" + TrimSigDigits( RootFinders( ControlNum ).StatusFlag ) );
-			ShowFatalError( "Preceding error causes program termination." );
+			ShowFatalError( "Preceding error causes program termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -2030,7 +2030,7 @@ namespace HVACControllers {
 			ShowSevereError( "CheckMinActiveController: Invalid controller action during " + CreateHVACStepFullString() + '.' );
 			ShowContinueError( "CheckMinActiveController: Controller name=" + ControllerProps( ControlNum ).ControllerName );
 			ShowContinueError( "CheckMinActiveController: Valid choices are \"NORMAL\" or \"REVERSE\"" );
-			ShowFatalError( "CheckMinActiveController: Preceding error causes program termination." );
+			ShowFatalError( "CheckMinActiveController: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -2104,7 +2104,7 @@ namespace HVACControllers {
 			ShowSevereError( "CheckMaxActiveController: Invalid controller action during " + CreateHVACStepFullString() + '.' );
 			ShowContinueError( "CheckMaxActiveController: Controller name=" + ControllerProps( ControlNum ).ControllerName );
 			ShowContinueError( "CheckMaxActiveController: Valid choices are \"NORMAL\" or \"REVERSE\"" );
-			ShowFatalError( "CheckMaxActiveController: Preceding error causes program termination." );
+			ShowFatalError( "CheckMaxActiveController: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -2267,7 +2267,7 @@ namespace HVACControllers {
 			//     Node(ActuatedNode)%MassFlowRate = ControllerProps(ControlNum)%NextActuatedValue
 
 		} else {
-			ShowFatalError( "UpdateController: Invalid Actuator Variable Type=" + ControlVariableTypes( ControllerProps( ControlNum ).ActuatorVar ) );
+			ShowFatalError( "UpdateController: Invalid Actuator Variable Type=" + ControlVariableTypes( ControllerProps( ControlNum ).ActuatorVar ) );  // LCOV_EXCL_LINE
 		}}
 
 	}
@@ -2614,7 +2614,7 @@ namespace HVACControllers {
 		return;
 
 Label100: ;
-		ShowFatalError( "DumpAirLoopStatistics: Failed to open statistics file \"" + StatisticsFileName + "\" for output (write)." );
+		ShowFatalError( "DumpAirLoopStatistics: Failed to open statistics file \"" + StatisticsFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -2856,7 +2856,7 @@ Label100: ;
 		return;
 
 Label100: ;
-		ShowFatalError( "SetupAirLoopControllersTracer: Failed to open air loop trace file \"" + TraceFileName + "\" for output (write)." );
+		ShowFatalError( "SetupAirLoopControllersTracer: Failed to open air loop trace file \"" + TraceFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -3089,7 +3089,7 @@ Label100: ;
 		TraceFileUnit = GetNewUnitNumber();
 
 		if ( TraceFileUnit <= 0 ) {
-			ShowFatalError( "SetupIndividualControllerTracer: Invalid unit (<=0) for setting up controller trace file" );
+			ShowFatalError( "SetupIndividualControllerTracer: Invalid unit (<=0) for setting up controller trace file" );  // LCOV_EXCL_LINE
 			return;
 		}
 
@@ -3115,7 +3115,7 @@ Label100: ;
 		return;
 
 Label100: ;
-		ShowFatalError( "SetupIndividualControllerTracer: Failed to open controller trace file \"" + TraceFileName + "\" for output (write)." );
+		ShowFatalError( "SetupIndividualControllerTracer: Failed to open controller trace file \"" + TraceFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -3237,7 +3237,7 @@ Label100: ;
 
 		} else {
 			// Should never happen
-			ShowFatalError( "TraceIndividualController: Invalid Operation passed=" + TrimSigDigits( Operation ) + ", Controller name=" + ControllerProps( ControlNum ).ControllerName );
+			ShowFatalError( "TraceIndividualController: Invalid Operation passed=" + TrimSigDigits( Operation ) + ", Controller name=" + ControllerProps( ControlNum ).ControllerName );  // LCOV_EXCL_LINE
 
 		}}
 

--- a/src/EnergyPlus/HVACCooledBeam.cc
+++ b/src/EnergyPlus/HVACCooledBeam.cc
@@ -207,23 +207,23 @@ namespace HVACCooledBeam {
 		if ( CompIndex == 0 ) {
 			CBNum = FindItemInList( CompName, CoolBeam );
 			if ( CBNum == 0 ) {
-				ShowFatalError( "SimCoolBeam: Cool Beam Unit not found=" + CompName );
+				ShowFatalError( "SimCoolBeam: Cool Beam Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CBNum;
 		} else {
 			CBNum = CompIndex;
 			if ( CBNum > NumCB || CBNum < 1 ) {
-				ShowFatalError( "SimCoolBeam: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of Cool Beam Units=" + TrimSigDigits( NumCB ) + ", System name=" + CompName );
+				ShowFatalError( "SimCoolBeam: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of Cool Beam Units=" + TrimSigDigits( NumCB ) + ", System name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( CBNum ) ) {
 				if ( CompName != CoolBeam( CBNum ).Name ) {
-					ShowFatalError( "SimCoolBeam: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Cool Beam Unit name=" + CompName + ", stored Cool Beam Unit for that index=" + CoolBeam( CBNum ).Name );
+					ShowFatalError( "SimCoolBeam: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Cool Beam Unit name=" + CompName + ", stored Cool Beam Unit for that index=" + CoolBeam( CBNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( CBNum ) = false;
 			}
 		}
 		if ( CBNum == 0 ) {
-			ShowFatalError( "Cool Beam Unit not found = " + CompName );
+			ShowFatalError( "Cool Beam Unit not found = " + CompName );  // LCOV_EXCL_LINE
 		}
 
 		DataSizing::CurTermUnitSizingNum = DataDefineEquip::AirDistUnit( CoolBeam( CBNum ).ADUNum ).TermUnitSizingNum;
@@ -447,7 +447,7 @@ namespace HVACCooledBeam {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input. Preceding conditions cause termination." );
+			ShowFatalError( RoutineName + "Errors found in getting input. Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -520,7 +520,7 @@ namespace HVACCooledBeam {
 			errFlag = false;
 			ScanPlantLoopsForObject( CoolBeam( CBNum ).Name, TypeOf_CooledBeamAirTerminal, CoolBeam( CBNum ).CWLoopNum, CoolBeam( CBNum ).CWLoopSideNum, CoolBeam( CBNum ).CWBranchNum, CoolBeam( CBNum ).CWCompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitCoolBeam: Program terminated for previous conditions." );
+				ShowFatalError( "InitCoolBeam: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 			}
 			PlantLoopScanFlag( CBNum ) = false;
 
@@ -809,7 +809,7 @@ namespace HVACCooledBeam {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding cooled beam sizing errors cause program termination" );
+			ShowFatalError( "Preceding cooled beam sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/HVACDXHeatPumpSystem.cc
+++ b/src/EnergyPlus/HVACDXHeatPumpSystem.cc
@@ -224,17 +224,17 @@ namespace HVACDXHeatPumpSystem {
 		if ( CompIndex == 0 ) {
 			DXSystemNum = FindItemInList( DXHeatPumpSystemName, DXHeatPumpSystem );
 			if ( DXSystemNum == 0 ) {
-				ShowFatalError( "SimDXHeatPumpSystem: DXUnit not found=" + DXHeatPumpSystemName );
+				ShowFatalError( "SimDXHeatPumpSystem: DXUnit not found=" + DXHeatPumpSystemName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DXSystemNum;
 		} else {
 			DXSystemNum = CompIndex;
 			if ( DXSystemNum > NumDXHeatPumpSystems || DXSystemNum < 1 ) {
-				ShowFatalError( "SimDXHeatPumpSystem:  Invalid CompIndex passed=" + TrimSigDigits( DXSystemNum ) + ", Number of DX Units=" + TrimSigDigits( NumDXHeatPumpSystems ) + ", DX Unit name=" + DXHeatPumpSystemName );
+				ShowFatalError( "SimDXHeatPumpSystem:  Invalid CompIndex passed=" + TrimSigDigits( DXSystemNum ) + ", Number of DX Units=" + TrimSigDigits( NumDXHeatPumpSystems ) + ", DX Unit name=" + DXHeatPumpSystemName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( DXSystemNum ) ) {
 				if ( DXHeatPumpSystemName != DXHeatPumpSystem( DXSystemNum ).Name ) {
-					ShowFatalError( "SimDXHeatPumpSystem: Invalid CompIndex passed=" + TrimSigDigits( DXSystemNum ) + ", DX Unit name=" + DXHeatPumpSystemName + ", stored DX Unit Name for that index=" + DXHeatPumpSystem( DXSystemNum ).Name );
+					ShowFatalError( "SimDXHeatPumpSystem: Invalid CompIndex passed=" + TrimSigDigits( DXSystemNum ) + ", DX Unit name=" + DXHeatPumpSystemName + ", stored DX Unit Name for that index=" + DXHeatPumpSystem( DXSystemNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( DXSystemNum ) = false;
 			}
@@ -263,7 +263,7 @@ namespace HVACDXHeatPumpSystem {
 			SimVariableSpeedCoils( CompName, DXHeatPumpSystem( DXSystemNum ).HeatPumpCoilIndex, DXHeatPumpSystem( DXSystemNum ).FanOpMode, MaxONOFFCyclesperHour, HPTimeConstant, FanDelayTime, On, DXHeatPumpSystem( DXSystemNum ).PartLoadFrac, DXHeatPumpSystem( DXSystemNum ).SpeedNum, DXHeatPumpSystem( DXSystemNum ).SpeedRatio, QZnReq, QLatReq, OnOffAirFlowRatio );
 
 		} else {
-			ShowFatalError( "SimDXCoolingSystem: Invalid DX Heating System/Coil=" + DXHeatPumpSystem( DXSystemNum ).HeatPumpCoilType );
+			ShowFatalError( "SimDXCoolingSystem: Invalid DX Heating System/Coil=" + DXHeatPumpSystem( DXSystemNum ).HeatPumpCoilType );  // LCOV_EXCL_LINE
 
 		}}
 		// set econo lockout flag
@@ -445,7 +445,7 @@ namespace HVACDXHeatPumpSystem {
 		} //End of the DX System Loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		for ( DXHeatSysNum = 1; DXHeatSysNum <= NumDXHeatPumpSystems; ++DXHeatSysNum ) {
@@ -583,7 +583,7 @@ namespace HVACDXHeatPumpSystem {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Brent Griffith (derived from ControlDXSystem by Richard Liesen)
 		//       DATE WRITTEN   Jan 2012
-		//       MODIFIED       Nov. 2003, R. Raustad, FSEC 
+		//       MODIFIED       Nov. 2003, R. Raustad, FSEC
 		//                      Feb. 2005, M. J. Witte, GARD. Add dehumidification controls and support for multimode DX coil
 		//                      Jan. 2008, R. Raustad, FSEC. Added coolreheat to all coil types
 		//                      Feb. 2013, B. Shen, ORNL. Add Coil:Heating:DX:VariableSpeed
@@ -696,7 +696,7 @@ namespace HVACDXHeatPumpSystem {
 			//update the DesOutTemp
 			DesOutTemp -= DXHeatPumpSystem( DXSystemNum ).FaultyCoilSATOffset;
 		}
-		
+
 		// If DXHeatingSystem is scheduled on and there is flow
 		if ( ( GetCurrentScheduleValue( DXHeatPumpSystem( DXSystemNum ).SchedPtr ) > 0.0 ) && ( Node( InletNode ).MassFlowRate > MinAirMassFlow ) ) {
 
@@ -926,7 +926,7 @@ namespace HVACDXHeatPumpSystem {
 					}
 
 				} else {
-					ShowFatalError( "ControlDXHeatingSystem: Invalid DXHeatPumpSystem coil type = " + DXHeatPumpSystem( DXSystemNum ).HeatPumpCoilType );
+					ShowFatalError( "ControlDXHeatingSystem: Invalid DXHeatPumpSystem coil type = " + DXHeatPumpSystem( DXSystemNum ).HeatPumpCoilType );  // LCOV_EXCL_LINE
 
 				}}
 			} // End of cooling load type (sensible or latent) if block

--- a/src/EnergyPlus/HVACDXSystem.cc
+++ b/src/EnergyPlus/HVACDXSystem.cc
@@ -257,17 +257,17 @@ namespace HVACDXSystem {
 		if ( CompIndex == 0 ) {
 			DXSystemNum = FindItemInList( DXCoolingSystemName, DXCoolingSystem );
 			if ( DXSystemNum == 0 ) {
-				ShowFatalError( "SimDXCoolingSystem: DXUnit not found=" + DXCoolingSystemName );
+				ShowFatalError( "SimDXCoolingSystem: DXUnit not found=" + DXCoolingSystemName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DXSystemNum;
 		} else {
 			DXSystemNum = CompIndex;
 			if ( DXSystemNum > NumDXSystem || DXSystemNum < 1 ) {
-				ShowFatalError( "SimulateDXCoolingSystem:  Invalid CompIndex passed=" + TrimSigDigits( DXSystemNum ) + ", Number of DX Units=" + TrimSigDigits( NumDXSystem ) + ", DX Unit name=" + DXCoolingSystemName );
+				ShowFatalError( "SimulateDXCoolingSystem:  Invalid CompIndex passed=" + TrimSigDigits( DXSystemNum ) + ", Number of DX Units=" + TrimSigDigits( NumDXSystem ) + ", DX Unit name=" + DXCoolingSystemName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( DXSystemNum ) ) {
 				if ( DXCoolingSystemName != DXCoolingSystem( DXSystemNum ).Name ) {
-					ShowFatalError( "SimulateDXCoolingSystem: Invalid CompIndex passed=" + TrimSigDigits( DXSystemNum ) + ", DX Unit name=" + DXCoolingSystemName + ", stored DX Unit Name for that index=" + DXCoolingSystem( DXSystemNum ).Name );
+					ShowFatalError( "SimulateDXCoolingSystem: Invalid CompIndex passed=" + TrimSigDigits( DXSystemNum ) + ", DX Unit name=" + DXCoolingSystemName + ", stored DX Unit Name for that index=" + DXCoolingSystem( DXSystemNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( DXSystemNum ) = false;
 			}
@@ -311,7 +311,7 @@ namespace HVACDXSystem {
 			SimTESCoil( CompName, DXCoolingSystem( DXSystemNum ).CoolingCoilIndex, DXCoolingSystem( DXSystemNum ).FanOpMode, DXCoolingSystem( DXSystemNum ).TESOpMode, DXCoolingSystem( DXSystemNum ).PartLoadFrac );
 
 		} else {
-			ShowFatalError( "SimDXCoolingSystem: Invalid DX Cooling System/Coil=" + DXCoolingSystem( DXSystemNum ).CoolingCoilType );
+			ShowFatalError( "SimDXCoolingSystem: Invalid DX Cooling System/Coil=" + DXCoolingSystem( DXSystemNum ).CoolingCoilType );  // LCOV_EXCL_LINE
 
 		}}
 		// set econo lockout flag
@@ -633,7 +633,7 @@ namespace HVACDXSystem {
 		} //End of the DX System Loop
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		for ( DXSystemNum = 1; DXSystemNum <= NumDXSystem; ++DXSystemNum ) {
@@ -846,7 +846,7 @@ namespace HVACDXSystem {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Richard Liesen
 		//       DATE WRITTEN   Feb. 2001
-		//       MODIFIED       Nov. 2003, R. Raustad, FSEC 
+		//       MODIFIED       Nov. 2003, R. Raustad, FSEC
 		//                      Feb. 2005, M. J. Witte, GARD. Add dehumidification controls and support for multimode DX coil
 		//                      Jan. 2008, R. Raustad, FSEC. Added coolreheat to all coil types
 		//                      Feb. 2013, B. Shen, ORNL. Add Coil:Cooling:DX:VariableSpeed, capable of both sensible and latent cooling
@@ -985,7 +985,7 @@ namespace HVACDXSystem {
 			//update the DesOutTemp
 			DesOutTemp -= DXCoolingSystem( DXSystemNum ).FaultyCoilSATOffset;
 		}
-		
+
 		// If DXCoolingSystem is scheduled on and there is flow
 		if ( ( GetCurrentScheduleValue( DXCoolingSystem( DXSystemNum ).SchedPtr ) > 0.0 ) && ( Node( InletNode ).MassFlowRate > MinAirMassFlow ) ) {
 
@@ -1448,7 +1448,7 @@ namespace HVACDXSystem {
 									ShowRecurringWarningErrorAtEnd( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " \"" + DXCoolingSystem( DXSystemNum ).Name + "\" - Iteration limit exceeded calculating sensible speed ratio error continues. Sensible speed ratio statistics follow.", DXCoolingSystem( DXSystemNum ).MSpdSensPLRIterIndex, SpeedRatio, SpeedRatio );
 								}
 							} else if ( SolFla == -2 ) {
-								if ( ! WarmupFlag ) ShowFatalError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " - compressor speed calculation failed: speed limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );
+								if ( ! WarmupFlag ) ShowFatalError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " - compressor speed calculation failed: speed limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );  // LCOV_EXCL_LINE
 							}
 						} else {
 							SpeedRatio = 1.0;
@@ -1469,7 +1469,7 @@ namespace HVACDXSystem {
 								ShowRecurringWarningErrorAtEnd( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " \"" + DXCoolingSystem( DXSystemNum ).Name + "\" - Iteration limit exceeded calculating sensible cycling ratio error continues. Sensible cycling ratio statistics follow.", DXCoolingSystem( DXSystemNum ).MSpdCycSensPLRIterIndex, CycRatio, CycRatio );
 							}
 						} else if ( SolFla == -2 ) { // should never get here, if it does logic above to protect from this
-							if ( ! WarmupFlag ) ShowFatalError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " - cycling ratio calculation failed: cycling limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );
+							if ( ! WarmupFlag ) ShowFatalError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " - cycling ratio calculation failed: cycling limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );  // LCOV_EXCL_LINE
 						}
 					} else {
 						PartLoadFrac = 0.0;
@@ -1514,7 +1514,7 @@ namespace HVACDXSystem {
 											ShowRecurringWarningErrorAtEnd( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " \"" + DXCoolingSystem( DXSystemNum ).Name + "\" - Iteration limit exceeded calculating latent speed ratio error continues. Latent speed ratio statistics follow.", DXCoolingSystem( DXSystemNum ).MSpdLatPLRIterIndex, SpeedRatio, SpeedRatio );
 										}
 									} else if ( SolFla == -2 ) {
-										if ( ! WarmupFlag ) ShowFatalError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " - compressor speed calculation failed:speed limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );
+										if ( ! WarmupFlag ) ShowFatalError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " - compressor speed calculation failed:speed limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );  // LCOV_EXCL_LINE
 									}
 								} else {
 									SpeedRatio = 1.0;
@@ -1535,7 +1535,7 @@ namespace HVACDXSystem {
 										ShowRecurringWarningErrorAtEnd( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " \"" + DXCoolingSystem( DXSystemNum ).Name + "\" - Iteration limit exceeded calculating latent cycling ratio error continues. Latent cycling ratio statistics follow.", DXCoolingSystem( DXSystemNum ).MSpdCycLatPLRIterIndex, CycRatio, CycRatio );
 									}
 								} else if ( SolFla == -2 ) { // should never get here, if it does logic above to protect from this
-									if ( ! WarmupFlag ) ShowFatalError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " - cycling ratio calculation failed: cycling limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );
+									if ( ! WarmupFlag ) ShowFatalError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " - cycling ratio calculation failed: cycling limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );  // LCOV_EXCL_LINE
 								}
 							}
 
@@ -1594,7 +1594,7 @@ namespace HVACDXSystem {
 							} else if ( SolFla == -2 ) {
 								if ( ! WarmupFlag ) {
 									ShowSevereError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " : part-load ratio calculation failed: part-load ratio limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );
-									ShowFatalError( "Program terminates due to previous condition." );
+									ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 								}
 							}
 						}
@@ -1658,7 +1658,7 @@ namespace HVACDXSystem {
 								} else if ( SolFla == -2 ) {
 									if ( ! WarmupFlag ) {
 										ShowSevereError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " : part-load ratio calculation failed: part-load ratio limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );
-										ShowFatalError( "Program terminates due to previous condition." );
+										ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 									}
 								}
 
@@ -1684,7 +1684,7 @@ namespace HVACDXSystem {
 								} else if ( SolFla == -2 ) {
 									if ( ! WarmupFlag ) {
 										ShowSevereError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " : part-load ratio calculation failed: part-load ratio limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );
-										ShowFatalError( "Program terminates due to previous condition." );
+										ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 									}
 								}
 							}
@@ -1735,7 +1735,7 @@ namespace HVACDXSystem {
 							} else if ( SolFla == -2 ) {
 								if ( ! WarmupFlag ) {
 									ShowSevereError( DXCoolingSystem( DXSystemNum ).DXCoolingSystemType + " : part-load ratio calculation failed: part-load ratio limits exceeded, for unit=" + DXCoolingSystem( DXSystemNum ).Name );
-									ShowFatalError( "Program terminates due to previous condition." );
+									ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 								}
 							}
 						}
@@ -2017,12 +2017,12 @@ namespace HVACDXSystem {
 						DXCoolingSystem( DXSystemNum ).DXCoilLatPLRFail, DXCoolingSystem( DXSystemNum ).DXCoilLatPLRFailIndex );
 
 				} else {
-					ShowFatalError( "ControlDXSystem: Invalid DXCoolingSystem coil type = " + DXCoolingSystem( DXSystemNum ).CoolingCoilType );
+					ShowFatalError( "ControlDXSystem: Invalid DXCoolingSystem coil type = " + DXCoolingSystem( DXSystemNum ).CoolingCoilType );  // LCOV_EXCL_LINE
 
 				}}
 			} // End of cooling load type (sensible or latent) if block
 		} // End of If DXCoolingSystem is scheduled on and there is flow
-		
+
 		//Set the final results
 		DXCoolingSystem( DXSystemNum ).PartLoadFrac = PartLoadFrac;
 		DXCoolingSystem( DXSystemNum ).SpeedRatio = SpeedRatio;

--- a/src/EnergyPlus/HVACDuct.cc
+++ b/src/EnergyPlus/HVACDuct.cc
@@ -167,17 +167,17 @@ namespace HVACDuct {
 		if ( CompIndex == 0 ) {
 			DuctNum = FindItemInList( CompName, Duct );
 			if ( DuctNum == 0 ) {
-				ShowFatalError( "SimDuct: Component not found=" + CompName );
+				ShowFatalError( "SimDuct: Component not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DuctNum;
 		} else {
 			DuctNum = CompIndex;
 			if ( DuctNum > NumDucts || DuctNum < 1 ) {
-				ShowFatalError( "SimDuct:  Invalid CompIndex passed=" + TrimSigDigits( DuctNum ) + ", Number of Components=" + TrimSigDigits( NumDucts ) + ", Entered Component name=" + CompName );
+				ShowFatalError( "SimDuct:  Invalid CompIndex passed=" + TrimSigDigits( DuctNum ) + ", Number of Components=" + TrimSigDigits( NumDucts ) + ", Entered Component name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( DuctNum ) ) {
 				if ( CompName != Duct( DuctNum ).Name ) {
-					ShowFatalError( "SimDuct: Invalid CompIndex passed=" + TrimSigDigits( DuctNum ) + ", Component name=" + CompName + ", stored Component Name for that index=" + Duct( DuctNum ).Name );
+					ShowFatalError( "SimDuct: Invalid CompIndex passed=" + TrimSigDigits( DuctNum ) + ", Component name=" + CompName + ", stored Component Name for that index=" + Duct( DuctNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( DuctNum ) = false;
 			}
@@ -266,7 +266,7 @@ namespace HVACDuct {
 		// No output variables
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + " Errors found in input" );
+			ShowFatalError( RoutineName + " Errors found in input" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/HVACFan.cc
+++ b/src/EnergyPlus/HVACFan.cc
@@ -98,7 +98,7 @@ namespace HVACFan {
 					index = loop;
 					found = true;
 				} else { // found duplicate
-					//TODO throw warning?  
+					//TODO throw warning?
 					index = -1;
 					ShowSevereError( "getFanObjectVectorIndex: Found duplicate Fan:SystemModel inputs of name =" + objectName + ". Check inputs" );
 				}
@@ -114,14 +114,14 @@ namespace HVACFan {
 	checkIfFanNameIsAFanSystem( // look up to see if input contains a Fan:SystemModel with the name (for use before object construction
 		std::string const & objectName
 	) {
-	
+
 		int testNum = InputProcessor::GetObjectItemNum("Fan:SystemModel", objectName );
 		if ( testNum > 0 ) {
 			return true;
 		} else {
 			return false;
 		}
-	
+
 	}
 
 	void
@@ -184,7 +184,7 @@ namespace HVACFan {
 
 	void
 	FanSystem::init()
-	{ 
+	{
 		if ( ! DataGlobals::SysSizingCalc && m_objSizingFlag ) {
 			set_size();
 			m_objSizingFlag = false;
@@ -234,7 +234,7 @@ namespace HVACFan {
 	FanSystem::set_size()
 	{
 		std::string static const routineName = "FanSystem::set_size ";
-	
+
 		Real64 tempFlow = designAirVolFlowRate;
 		bool bPRINT = true;
 		DataSizing::DataAutosizable = true;
@@ -251,7 +251,7 @@ namespace HVACFan {
 
 			switch ( m_powerSizingMethod )
 			{
-		
+
 			case PowerSizingMethod::powerPerFlow: {
 				designElecPower = designAirVolFlowRate * m_elecPowerPerFlowRate;
 				break;
@@ -268,12 +268,12 @@ namespace HVACFan {
 				// do nothing
 				break;
 			}
-		
+
 			} // end switch
 
 			//report design power
 			ReportSizingManager::ReportSizingOutput( m_fanType, name, "Design Electric Power Consumption [W]", designElecPower );
-		
+
 		} // end if power was autosized
 
 		m_rhoAirStdInit = DataEnvironment::StdRhoAir;
@@ -293,7 +293,7 @@ namespace HVACFan {
 					m_totEfficAtSpeed[ loop ] = m_flowFractionAtSpeed[ loop ] * designAirVolFlowRate * deltaPress / ( designElecPower * CurveManager::CurveValue( powerModFuncFlowFractionCurveIndex, m_flowFractionAtSpeed[ loop ] ) );
 					m_powerFractionAtSpeed[ loop ] = CurveManager::CurveValue( powerModFuncFlowFractionCurveIndex, m_flowFractionAtSpeed[ loop ] );
 				}
-				
+
 			}
 		}
 
@@ -319,7 +319,7 @@ namespace HVACFan {
 		inletNodeNum( 0 ),
 		outletNodeNum( 0 ),
 		designAirVolFlowRate( 0.0 ),
-		speedControl( SpeedControlMethod::NotSet ), 
+		speedControl( SpeedControlMethod::NotSet ),
 		deltaPress( 0.0 ),
 		designElecPower( 0.0 ),
 		powerModFuncFlowFractionCurveIndex( 0 ),
@@ -371,7 +371,7 @@ namespace HVACFan {
 		m_massFlowRateMaxAvail( 0.0 ),
 		m_massFlowRateMinAvail( 0.0 ),
 		m_rhoAirStdInit( 0.0 )
-		//oneTimePowerCurveCheck_( true ) 
+		//oneTimePowerCurveCheck_( true )
 	{
 
 		std::string const static routineName = "HVACFan constructor ";
@@ -506,7 +506,7 @@ namespace HVACFan {
 		} else {
 			m_endUseSubcategoryName = "General";
 		}
-		
+
 		if ( ! isNumericFieldBlank( 13 ) ){
 			m_numSpeeds =  numericArgs( 13 );
 		} else {
@@ -514,7 +514,7 @@ namespace HVACFan {
 		}
 		m_fanRunTimeFractionAtSpeed.resize( m_numSpeeds, 0.0 );
 		if ( speedControl == SpeedControlMethod::Discrete && m_numSpeeds > 1 ) {
-			//should have field sets 
+			//should have field sets
 			m_flowFractionAtSpeed.resize( m_numSpeeds, 0.0 );
 			m_powerFractionAtSpeed.resize( m_numSpeeds, 0.0 );
 			m_powerFractionInputAtSpeed.resize( m_numSpeeds, false );
@@ -548,7 +548,7 @@ namespace HVACFan {
 			}
 		}
 
-		// check if power curve present when any speeds have no power fraction 
+		// check if power curve present when any speeds have no power fraction
 		if ( speedControl == SpeedControlMethod::Discrete && m_numSpeeds > 1 && powerModFuncFlowFractionCurveIndex == 0 ) {
 			bool foundMissingPowerFraction = false;
 			for ( auto loop = 0 ; loop< m_numSpeeds; ++loop ) {
@@ -565,7 +565,7 @@ namespace HVACFan {
 		}
 
 		if ( errorsFound ) {
-			ShowFatalError( routineName + "Errors found in input for fan name = " + name + ".  Program terminates." );
+			ShowFatalError( routineName + "Errors found in input for fan name = " + name + ".  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		SetupOutputVariable( "Fan Electric Power", OutputProcessor::Unit::W, m_fanPower, "System", "Average", name );
@@ -636,7 +636,7 @@ namespace HVACFan {
 
 		if ( DataHVACGlobals::NightVentOn ) {
 		// assume if non-zero inputs for night data then this fan is to be used with that data
-			if ( m_nightVentPressureDelta > 0.0 ) { 
+			if ( m_nightVentPressureDelta > 0.0 ) {
 				localPressureRise[ 0 ] = m_nightVentPressureDelta;
 				localPressureRise[ 1 ] = m_nightVentPressureDelta;
 			}
@@ -742,7 +742,7 @@ namespace HVACFan {
 				if ( localAirMassFlow[ mode ] == 0.0 ) continue;
 
 				switch ( speedControl ) {
-			
+
 				case SpeedControlMethod::Discrete: {
 					//
 					if ( DataHVACGlobals::OnOffFanPartLoadFraction <= 0.0 ) {
@@ -936,7 +936,7 @@ namespace HVACFan {
 				m_massFlowRateMaxAvail = 0.0;
 				m_massFlowRateMinAvail = 0.0;
 			}
-			
+
 		}
 
 		if ( m_heatLossesDestination == ThermalLossDestination::zoneGains ) {
@@ -1017,7 +1017,7 @@ namespace HVACFan {
 		}
 	}
 
-	Real64 
+	Real64
 	FanSystem::getFanDesignHeatGain(
 		Real64 const FanVolFlow // fan volume flow rate [m3/s]
 	)
@@ -1036,7 +1036,7 @@ namespace HVACFan {
 	}
 
 	//void
-	//FanSystem::fanIsSecondaryDriver() 
+	//FanSystem::fanIsSecondaryDriver()
 	//{
 	//	// this concept is used when the fan may be operating in a situation where there is airflow without it running at all
 	//	// call this when some other fan is feeding the device containing this fan, making it a secondary fan.

--- a/src/EnergyPlus/HVACFourPipeBeam.cc
+++ b/src/EnergyPlus/HVACFourPipeBeam.cc
@@ -349,7 +349,7 @@ namespace FourPipeBeam {
 			FourPipeBeams.push_back( thisBeam );
 			return thisBeam;
 		} else {
-			ShowFatalError( routineName + "Errors found in getting input. Preceding conditions cause termination." );
+			ShowFatalError( routineName + "Errors found in getting input. Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 			return nullptr;
 		}
 
@@ -412,7 +412,7 @@ namespace FourPipeBeam {
 					this->cWLocation.loopSideNum, this->cWLocation.branchNum, this->cWLocation.compNum, _, _, _,
 					this->cWInNodeNum, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( routineName + " Program terminated for previous conditions." );
+					ShowFatalError( routineName + " Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( this->beamHeatingPresent ){
@@ -420,7 +420,7 @@ namespace FourPipeBeam {
 					this->hWLocation.loopSideNum, this->hWLocation.branchNum, this->hWLocation.compNum, _, _, _,
 					this->hWInNodeNum, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( routineName + " Program terminated for previous conditions." );
+					ShowFatalError( routineName + " Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 			}
 			this->plantLoopScanFlag = false;
@@ -794,7 +794,7 @@ namespace FourPipeBeam {
 					( this->vDotDesignPrimAir - originalTermUnitSizeMaxVDot ) );
 			} else {
 				ShowSevereError( "Four pipe beam requires system sizing. Turn on system sizing." );
-				ShowFatalError( "Program terminating due to previous errors" );
+				ShowFatalError( "Program terminating due to previous errors" );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -850,7 +850,7 @@ namespace FourPipeBeam {
 			RegisterPlantCompDesignFlow( this->hWInNodeNum, this->vDotDesignHW );
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding four pipe beam sizing errors cause program termination" );
+			ShowFatalError( "Preceding four pipe beam sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	} //set_size

--- a/src/EnergyPlus/HVACHXAssistedCoolingCoil.cc
+++ b/src/EnergyPlus/HVACHXAssistedCoolingCoil.cc
@@ -216,17 +216,17 @@ namespace HVACHXAssistedCoolingCoil {
 		if ( CompIndex == 0 ) {
 			HXAssistedCoilNum = FindItemInList( HXAssistedCoilName, HXAssistedCoil );
 			if ( HXAssistedCoilNum == 0 ) {
-				ShowFatalError( "HX Assisted Coil not found=" + HXAssistedCoilName );
+				ShowFatalError( "HX Assisted Coil not found=" + HXAssistedCoilName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = HXAssistedCoilNum;
 		} else {
 			HXAssistedCoilNum = CompIndex;
 			if ( HXAssistedCoilNum > TotalNumHXAssistedCoils || HXAssistedCoilNum < 1 ) {
-				ShowFatalError( "SimHXAssistedCoolingCoil: Invalid CompIndex passed=" + TrimSigDigits( HXAssistedCoilNum ) + ", Number of HX Assisted Cooling Coils=" + TrimSigDigits( TotalNumHXAssistedCoils ) + ", Coil name=" + HXAssistedCoilName );
+				ShowFatalError( "SimHXAssistedCoolingCoil: Invalid CompIndex passed=" + TrimSigDigits( HXAssistedCoilNum ) + ", Number of HX Assisted Cooling Coils=" + TrimSigDigits( TotalNumHXAssistedCoils ) + ", Coil name=" + HXAssistedCoilName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( HXAssistedCoilNum ) ) {
 				if ( ! HXAssistedCoilName.empty() && HXAssistedCoilName != HXAssistedCoil( HXAssistedCoilNum ).Name ) {
-					ShowFatalError( "SimHXAssistedCoolingCoil: Invalid CompIndex passed=" + TrimSigDigits( HXAssistedCoilNum ) + ", Coil name=" + HXAssistedCoilName + ", stored Coil Name for that index=" + HXAssistedCoil( HXAssistedCoilNum ).Name );
+					ShowFatalError( "SimHXAssistedCoolingCoil: Invalid CompIndex passed=" + TrimSigDigits( HXAssistedCoilNum ) + ", Coil name=" + HXAssistedCoilName + ", stored Coil Name for that index=" + HXAssistedCoil( HXAssistedCoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( HXAssistedCoilNum ) = false;
 			}
@@ -664,7 +664,7 @@ namespace HVACHXAssistedCoolingCoil {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Previous error condition causes termination." );
+			ShowFatalError( RoutineName + "Previous error condition causes termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -719,8 +719,8 @@ namespace HVACHXAssistedCoolingCoil {
 			DXCoilFullLoadOutAirTemp( HXAssistedCoil( HXAssistedCoilNum ).CoolingCoilIndex ) = 0.0;
 			DXCoilFullLoadOutAirHumRat( HXAssistedCoil( HXAssistedCoilNum ).CoolingCoilIndex ) = 0.0;
 		} else if ( HXAssistedCoil( HXAssistedCoilNum ).CoolingCoilType_Num == DataHVACGlobals::Coil_CoolingAirToAirVariableSpeed ) {
-			// 
-		
+			//
+
 		}
 
 	}
@@ -982,17 +982,17 @@ namespace HVACHXAssistedCoolingCoil {
 			}
 
 			if ( HXAssistedCoilNum == 0 ) {
-				ShowFatalError( "CheckHXAssistedCoolingCoilSchedule: HX Assisted Coil not found=" + CompName );
+				ShowFatalError( "CheckHXAssistedCoolingCoilSchedule: HX Assisted Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = HXAssistedCoilNum;
 			Value = 1.0; // not scheduled?
 		} else {
 			HXAssistedCoilNum = CompIndex;
 			if ( HXAssistedCoilNum > TotalNumHXAssistedCoils || HXAssistedCoilNum < 1 ) {
-				ShowFatalError( "CheckHXAssistedCoolingCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( HXAssistedCoilNum ) + ", Number of Heating Coils=" + TrimSigDigits( TotalNumHXAssistedCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "CheckHXAssistedCoolingCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( HXAssistedCoilNum ) + ", Number of Heating Coils=" + TrimSigDigits( TotalNumHXAssistedCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CompName != HXAssistedCoil( HXAssistedCoilNum ).Name ) {
-				ShowFatalError( "CheckHXAssistedCoolingCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( HXAssistedCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + HXAssistedCoil( HXAssistedCoilNum ).Name );
+				ShowFatalError( "CheckHXAssistedCoolingCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( HXAssistedCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + HXAssistedCoil( HXAssistedCoilNum ).Name );  // LCOV_EXCL_LINE
 			}
 
 			Value = 1.0; // not scheduled?

--- a/src/EnergyPlus/HVACInterfaceManager.cc
+++ b/src/EnergyPlus/HVACInterfaceManager.cc
@@ -706,7 +706,7 @@ namespace HVACInterfaceManager {
 		//update heat trasport and heat storage rates
 		PlantLoop( LoopNum ).LoopSide( TankOutletLoopSide ).LoopSideInlet_MdotCpDeltaT = ( TankInletTemp - TankFinalTemp ) * Cp * MassFlowRate;
 		PlantLoop( LoopNum ).LoopSide( TankOutletLoopSide ).LoopSideInlet_McpDTdt = ( ThisTankMass * Cp * ( TankFinalTemp - LastTankOutletTemp ))/ TimeStepSeconds;
-		
+
 		//Determine excessive storage
 		if (PlantLoop( LoopNum ).LoopSide( TankOutletLoopSide ).LoopSideInlet_MdotCpDeltaT < PlantLoop( LoopNum ).LoopSide( TankOutletLoopSide ).LoopSideInlet_McpDTdt) {
 			PlantLoop( LoopNum ).LoopSide( TankOutletLoopSide ).LoopSideInlet_CapExcessStorageTimeReport = TimeStepSys;
@@ -1287,7 +1287,7 @@ namespace HVACInterfaceManager {
 			}
 
 		} else {
-			//???      CALL ShowFatalError('ManageTwoWayCommonPipe: Calling Case Fall Through')
+			//???      CALL ShowFatalError('ManageTwoWayCommonPipe: Calling Case Fall Through')  // LCOV_EXCL_LINE
 
 		}}
 

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -1485,7 +1485,7 @@ namespace HVACManager {
 			}
 		}
 		if ( SetPointErrorFlag ) {
-			ShowFatalError( "Previous severe set point errors cause program termination" );
+			ShowFatalError( "Previous severe set point errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1799,7 +1799,7 @@ namespace HVACManager {
 						}
 						if ( ( Node( SupplyNode ).MassFlowRateSetPoint - Node( SupplyNode ).MassFlowRate ) < -HVACFlowRateToler * 0.01 ) {
 							if ( Node( SupplyNode ).MassFlowRateSetPoint == 0.0 ) {
-								//               CALL ShowFatalError('ResolveAirLoopFlowLimits: Node MassFlowRateSetPoint = 0.0, Node='//  &
+								//               CALL ShowFatalError('ResolveAirLoopFlowLimits: Node MassFlowRateSetPoint = 0.0, Node='//  &  // LCOV_EXCL_LINE
 								//                                   TRIM(NodeID(SupplyNode))//  &
 								//                                   ', check for Node Connection Errors in the following messages.')
 								for ( ZonesCooledIndex = 1; ZonesCooledIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesCooled; ++ZonesCooledIndex ) {
@@ -1835,7 +1835,7 @@ namespace HVACManager {
 						}
 						if ( ( Node( SupplyNode ).MassFlowRateSetPoint - Node( SupplyNode ).MassFlowRate ) < -HVACFlowRateToler * 0.01 ) {
 							if ( Node( SupplyNode ).MassFlowRateSetPoint == 0.0 ) {
-								// CALL ShowFatalError('ResolveAirLoopFlowLimits: Node MassFlowRateSetPoint = 0.0, Node='//  &
+								// CALL ShowFatalError('ResolveAirLoopFlowLimits: Node MassFlowRateSetPoint = 0.0, Node='//  &  // LCOV_EXCL_LINE
 								// TRIM(NodeID(SupplyNode))//  &
 								// ', check for Node Connection Errors in the following messages.')
 								for ( ZonesHeatedIndex = 1; ZonesHeatedIndex <= AirToZoneNodeInfo( AirLoopIndex ).NumZonesHeated; ++ZonesHeatedIndex ) {

--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
@@ -275,17 +275,17 @@ namespace HVACMultiSpeedHeatPump {
 		if ( CompIndex == 0 ) {
 			MSHeatPumpNum = FindItemInList( CompName, MSHeatPump );
 			if ( MSHeatPumpNum == 0 ) {
-				ShowFatalError( "MultiSpeed Heat Pump is not found=" + CompName );
+				ShowFatalError( "MultiSpeed Heat Pump is not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = MSHeatPumpNum;
 		} else {
 			MSHeatPumpNum = CompIndex;
 			if ( MSHeatPumpNum > NumMSHeatPumps || MSHeatPumpNum < 1 ) {
-				ShowFatalError( "SimMSHeatPump: Invalid CompIndex passed=" + TrimSigDigits( MSHeatPumpNum ) + ", Number of MultiSpeed Heat Pumps=" + TrimSigDigits( NumMSHeatPumps ) + ", Heat Pump name=" + CompName );
+				ShowFatalError( "SimMSHeatPump: Invalid CompIndex passed=" + TrimSigDigits( MSHeatPumpNum ) + ", Number of MultiSpeed Heat Pumps=" + TrimSigDigits( NumMSHeatPumps ) + ", Heat Pump name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( MSHeatPumpNum ) ) {
 				if ( CompName != MSHeatPump( MSHeatPumpNum ).Name ) {
-					ShowFatalError( "SimMSHeatPump: Invalid CompIndex passed=" + TrimSigDigits( MSHeatPumpNum ) + ", Heat Pump name=" + CompName + MSHeatPump( MSHeatPumpNum ).Name );
+					ShowFatalError( "SimMSHeatPump: Invalid CompIndex passed=" + TrimSigDigits( MSHeatPumpNum ) + ", Heat Pump name=" + CompName + MSHeatPump( MSHeatPumpNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( MSHeatPumpNum ) = false;
 			}
@@ -821,7 +821,7 @@ namespace HVACMultiSpeedHeatPump {
 					ShowSevereError( "Configuration error in " + CurrentModuleObject + " \"" + Alphas( 1 ) + "\"" );
 					ShowContinueError( cAlphaFields( 11 ) + " \"" + Alphas( 11 ) + "\" not found." );
 					ShowContinueError( cAlphaFields( 10 ) + " must be Coil:Heating:DX:MultiSpeed " );
-					ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+					ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 					ErrorsFound = true;
 				}
 				LocalError = false;
@@ -856,7 +856,7 @@ namespace HVACMultiSpeedHeatPump {
 						ShowSevereError( "Configuration error in " + CurrentModuleObject + " \"" + Alphas( 1 ) + "\"" );
 						ShowContinueError( cAlphaFields( 11 ) + " \"" + Alphas( 11 ) + "\" not found." );
 						ShowContinueError( cAlphaFields( 10 ) + " must be Coil:Heating:Electric:MultiStage " );
-						ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+						ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 						ErrorsFound = true;
 					}
 				} else {
@@ -866,7 +866,7 @@ namespace HVACMultiSpeedHeatPump {
 						ShowSevereError( "Configuration error in " + CurrentModuleObject + " \"" + Alphas( 1 ) + "\"" );
 						ShowContinueError( cAlphaFields( 11 ) + " \"" + Alphas( 11 ) + "\" not found." );
 						ShowContinueError( cAlphaFields( 10 ) + " must be Coil:Heating:Gas:MultiStage " );
-						ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+						ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 						ErrorsFound = true;
 					}
 				}
@@ -1014,7 +1014,7 @@ namespace HVACMultiSpeedHeatPump {
 					ShowSevereError( "Configuration error in " + CurrentModuleObject + " \"" + Alphas( 1 ) + "\"" );
 					ShowContinueError( cAlphaFields( 13 ) + " \"" + Alphas( 13 ) + "\" not found." );
 					ShowContinueError( cAlphaFields( 12 ) + " must be Coil:Cooling:DX:MultiSpeed " );
-					ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );
+					ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 					ErrorsFound = true;
 				}
 				LocalError = false;
@@ -1487,7 +1487,7 @@ namespace HVACMultiSpeedHeatPump {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 		// End of multispeed heat pump
 
@@ -1670,7 +1670,7 @@ namespace HVACMultiSpeedHeatPump {
 				errFlag = false;
 				ScanPlantLoopsForObject( MSHeatPump( MSHeatPumpNum ).Name, TypeOf_MultiSpeedHeatPumpRecovery, MSHeatPump( MSHeatPumpNum ).HRLoopNum, MSHeatPump( MSHeatPumpNum ).HRLoopSideNum, MSHeatPump( MSHeatPumpNum ).HRBranchNum, MSHeatPump( MSHeatPumpNum ).HRCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );
+					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 
 				MyPlantScantFlag( MSHeatPumpNum ) = false;
@@ -1681,7 +1681,7 @@ namespace HVACMultiSpeedHeatPump {
 				errFlag = false;
 				ScanPlantLoopsForObject( MSHeatPump( MSHeatPumpNum ).HeatCoilName, TypeOf_CoilWaterSimpleHeating, MSHeatPump( MSHeatPumpNum ).LoopNum, MSHeatPump( MSHeatPumpNum ).LoopSide, MSHeatPump( MSHeatPumpNum ).BranchNum, MSHeatPump( MSHeatPumpNum ).CompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );
+					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				MSHeatPump( MSHeatPumpNum ).MaxCoilFluidFlow = GetCoilMaxWaterFlowRate( "Coil:Heating:Water", MSHeatPump( MSHeatPumpNum ).HeatCoilName, ErrorsFound );
 
@@ -1697,7 +1697,7 @@ namespace HVACMultiSpeedHeatPump {
 				errFlag = false;
 				ScanPlantLoopsForObject( MSHeatPump( MSHeatPumpNum ).HeatCoilName, TypeOf_CoilSteamAirHeating, MSHeatPump( MSHeatPumpNum ).LoopNum, MSHeatPump( MSHeatPumpNum ).LoopSide, MSHeatPump( MSHeatPumpNum ).BranchNum, MSHeatPump( MSHeatPumpNum ).CompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );
+					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				MSHeatPump( MSHeatPumpNum ).MaxCoilFluidFlow = GetCoilMaxSteamFlowRate( MSHeatPump( MSHeatPumpNum ).HeatCoilNum, ErrorsFound );
 				if ( MSHeatPump( MSHeatPumpNum ).MaxCoilFluidFlow > 0.0 ) {
@@ -1715,7 +1715,7 @@ namespace HVACMultiSpeedHeatPump {
 				errFlag = false;
 				ScanPlantLoopsForObject( MSHeatPump( MSHeatPumpNum ).SuppHeatCoilName, TypeOf_CoilWaterSimpleHeating, MSHeatPump( MSHeatPumpNum ).SuppLoopNum, MSHeatPump( MSHeatPumpNum ).SuppLoopSide, MSHeatPump( MSHeatPumpNum ).SuppBranchNum, MSHeatPump( MSHeatPumpNum ).SuppCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );
+					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				MSHeatPump( MSHeatPumpNum ).MaxSuppCoilFluidFlow = GetCoilMaxWaterFlowRate( "Coil:Heating:Water", MSHeatPump( MSHeatPumpNum ).SuppHeatCoilName, ErrorsFound );
 
@@ -1731,7 +1731,7 @@ namespace HVACMultiSpeedHeatPump {
 				errFlag = false;
 				ScanPlantLoopsForObject( MSHeatPump( MSHeatPumpNum ).SuppHeatCoilName, TypeOf_CoilSteamAirHeating, MSHeatPump( MSHeatPumpNum ).SuppLoopNum, MSHeatPump( MSHeatPumpNum ).SuppLoopSide, MSHeatPump( MSHeatPumpNum ).SuppBranchNum, MSHeatPump( MSHeatPumpNum ).SuppCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );
+					ShowFatalError( "InitMSHeatPump: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				MSHeatPump( MSHeatPumpNum ).MaxSuppCoilFluidFlow = GetCoilMaxSteamFlowRate( MSHeatPump( MSHeatPumpNum ).SuppHeatCoilNum, ErrorsFound );
 				if ( MSHeatPump( MSHeatPumpNum ).MaxSuppCoilFluidFlow > 0.0 ) {
@@ -1796,7 +1796,7 @@ namespace HVACMultiSpeedHeatPump {
 			MyCheckFlag( MSHeatPumpNum ) = false;
 			if ( MSHeatPump( MSHeatPumpNum ).ZoneInletNode == 0 ) {
 				ShowSevereError( "AirLoopHVAC:UnitaryHeatPump:AirToAir:MultiSpeed, \"" + MSHeatPump( MSHeatPumpNum ).Name + "\", The zone inlet node in the controlled zone (" + MSHeatPump( MSHeatPumpNum ).ControlZoneName + ") is not found." );
-				ShowFatalError( "Subroutine InitMSHeatPump: Errors found in getting AirLoopHVAC:UnitaryHeatPump:AirToAir:MultiSpeed input.  Preceding condition(s) causes termination." );
+				ShowFatalError( "Subroutine InitMSHeatPump: Errors found in getting AirLoopHVAC:UnitaryHeatPump:AirToAir:MultiSpeed input.  Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -2114,7 +2114,7 @@ namespace HVACMultiSpeedHeatPump {
 			if ( MSHeatPump( MSHeatPumpNum ).HeatCoolMode == CoolingMode ) {
 				CoilAvailSchPtr = GetDXCoilAvailSchPtr( "Coil:Cooling:DX:MultiSpeed", MSHeatPump( MSHeatPumpNum ).DXCoolCoilName, ErrorsFound, MSHeatPump( MSHeatPumpNum ).DXCoolCoilIndex );
 				if ( ErrorsFound ) {
-					ShowFatalError( "InitMSHeatPump, The previous error causes termination." );
+					ShowFatalError( "InitMSHeatPump, The previous error causes termination." );  // LCOV_EXCL_LINE
 				}
 				if ( GetCurrentScheduleValue( CoilAvailSchPtr ) == 0.0 ) {
 					if ( MSHeatPump( MSHeatPumpNum ).CoolCountAvail == 0 ) {
@@ -2130,7 +2130,7 @@ namespace HVACMultiSpeedHeatPump {
 			if ( MSHeatPump( MSHeatPumpNum ).HeatCoolMode == HeatingMode && MSHeatPump( MSHeatPumpNum ).HeatCoilType == MultiSpeedHeatingCoil ) {
 				CoilAvailSchPtr = GetDXCoilAvailSchPtr( "Coil:Heating:DX:MultiSpeed", MSHeatPump( MSHeatPumpNum ).DXHeatCoilName, ErrorsFound, MSHeatPump( MSHeatPumpNum ).DXHeatCoilIndex );
 				if ( ErrorsFound ) {
-					ShowFatalError( "InitMSHeatPump, The previous error causes termination." );
+					ShowFatalError( "InitMSHeatPump, The previous error causes termination." );  // LCOV_EXCL_LINE
 				}
 				if ( GetCurrentScheduleValue( CoilAvailSchPtr ) == 0.0 ) {
 					if ( MSHeatPump( MSHeatPumpNum ).HeatCountAvail == 0 ) {
@@ -2569,7 +2569,7 @@ namespace HVACMultiSpeedHeatPump {
 						}
 					}
 				} else if ( SolFla == -2 ) {
-					ShowFatalError( "DX unit cycling ratio calculation failed: cycling limits exceeded, for unit=" + MSHeatPump( MSHeatPumpNum ).DXCoolCoilName );
+					ShowFatalError( "DX unit cycling ratio calculation failed: cycling limits exceeded, for unit=" + MSHeatPump( MSHeatPumpNum ).DXCoolCoilName );  // LCOV_EXCL_LINE
 				}
 			} else {
 				// Check to see which speed to meet the load
@@ -2606,7 +2606,7 @@ namespace HVACMultiSpeedHeatPump {
 						}
 					}
 				} else if ( SolFla == -2 ) {
-					ShowFatalError( "DX unit compressor speed calculation failed: speed limits exceeded, for unit=" + MSHeatPump( MSHeatPumpNum ).DXCoolCoilName );
+					ShowFatalError( "DX unit compressor speed calculation failed: speed limits exceeded, for unit=" + MSHeatPump( MSHeatPumpNum ).DXCoolCoilName );  // LCOV_EXCL_LINE
 				}
 			}
 		} else {
@@ -2643,7 +2643,7 @@ namespace HVACMultiSpeedHeatPump {
 								}
 							}
 						} else if ( SolFla == -2 ) {
-							ShowFatalError( "DX unit cycling ratio calculation failed: cycling limits exceeded, for unit=" + MSHeatPump( MSHeatPumpNum ).DXCoolCoilName );
+							ShowFatalError( "DX unit cycling ratio calculation failed: cycling limits exceeded, for unit=" + MSHeatPump( MSHeatPumpNum ).DXCoolCoilName );  // LCOV_EXCL_LINE
 						}
 					} else {
 						FullOutput = LowOutput;
@@ -2673,7 +2673,7 @@ namespace HVACMultiSpeedHeatPump {
 									}
 								}
 							} else if ( SolFla == -2 ) {
-								ShowFatalError( "DX unit compressor speed calculation failed: speed limits exceeded, for unit=" + MSHeatPump( MSHeatPumpNum ).DXCoolCoilName );
+								ShowFatalError( "DX unit compressor speed calculation failed: speed limits exceeded, for unit=" + MSHeatPump( MSHeatPumpNum ).DXCoolCoilName );  // LCOV_EXCL_LINE
 							}
 						} else {
 							SpeedRatio = 1.0;

--- a/src/EnergyPlus/HVACSingleDuctInduc.cc
+++ b/src/EnergyPlus/HVACSingleDuctInduc.cc
@@ -225,17 +225,17 @@ namespace HVACSingleDuctInduc {
 		if ( CompIndex == 0 ) {
 			IUNum = FindItemInList( CompName, IndUnit );
 			if ( IUNum == 0 ) {
-				ShowFatalError( "SimIndUnit: Induction Unit not found=" + CompName );
+				ShowFatalError( "SimIndUnit: Induction Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = IUNum;
 		} else {
 			IUNum = CompIndex;
 			if ( IUNum > NumIndUnits || IUNum < 1 ) {
-				ShowFatalError( "SimIndUnit: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of Induction Units=" + TrimSigDigits( NumIndUnits ) + ", System name=" + CompName );
+				ShowFatalError( "SimIndUnit: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of Induction Units=" + TrimSigDigits( NumIndUnits ) + ", System name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( IUNum ) ) {
 				if ( CompName != IndUnit( IUNum ).Name ) {
-					ShowFatalError( "SimIndUnit: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Induction Unit name=" + CompName + ", stored Induction Unit for that index=" + IndUnit( IUNum ).Name );
+					ShowFatalError( "SimIndUnit: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Induction Unit name=" + CompName + ", stored Induction Unit for that index=" + IndUnit( IUNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( IUNum ) = false;
 			}
@@ -257,7 +257,7 @@ namespace HVACSingleDuctInduc {
 		} else {
 			ShowSevereError( "Illegal Induction Unit Type used=" + IndUnit( IUNum ).UnitType );
 			ShowContinueError( "Occurs in Induction Unit=" + IndUnit( IUNum ).Name );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -511,7 +511,7 @@ namespace HVACSingleDuctInduc {
 		lAlphaBlanks.deallocate();
 		lNumericBlanks.deallocate();
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input. Preceding conditions cause termination." );
+			ShowFatalError( RoutineName + "Errors found in getting input. Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -597,7 +597,7 @@ namespace HVACSingleDuctInduc {
 			}
 			if ( errFlag ) {
 				ShowContinueError( "Reference Unit=\"" + IndUnit( IUNum ).Name + "\", type=" + IndUnit( IUNum ).UnitType );
-				ShowFatalError( "InitIndUnit: Program terminated for previous conditions." );
+				ShowFatalError( "InitIndUnit: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 			}
 			MyPlantScanFlag( IUNum ) = false;
 		} else if ( MyPlantScanFlag( IUNum ) && ! AnyPlantInModel ) {

--- a/src/EnergyPlus/HVACSizingSimulationManager.cc
+++ b/src/EnergyPlus/HVACSizingSimulationManager.cc
@@ -396,7 +396,7 @@ namespace EnergyPlus {
 
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Error condition occurred.  Previous Severe Errors cause termination." );
+				ShowFatalError( "Error condition occurred.  Previous Severe Errors cause termination." );  // LCOV_EXCL_LINE
 			}
 
 

--- a/src/EnergyPlus/HVACStandAloneERV.cc
+++ b/src/EnergyPlus/HVACStandAloneERV.cc
@@ -230,17 +230,17 @@ namespace HVACStandAloneERV {
 		if ( CompIndex == 0 ) {
 			StandAloneERVNum = FindItem( CompName, StandAloneERV );
 			if ( StandAloneERVNum == 0 ) {
-				ShowFatalError( "SimStandAloneERV: Unit not found=" + CompName );
+				ShowFatalError( "SimStandAloneERV: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = StandAloneERVNum;
 		} else {
 			StandAloneERVNum = CompIndex;
 			if ( StandAloneERVNum > NumStandAloneERVs || StandAloneERVNum < 1 ) {
-				ShowFatalError( "SimStandAloneERV:  Invalid CompIndex passed=" + TrimSigDigits( StandAloneERVNum ) + ", Number of Units=" + TrimSigDigits( NumStandAloneERVs ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimStandAloneERV:  Invalid CompIndex passed=" + TrimSigDigits( StandAloneERVNum ) + ", Number of Units=" + TrimSigDigits( NumStandAloneERVs ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( StandAloneERVNum ) ) {
 				if ( CompName != StandAloneERV( StandAloneERVNum ).Name ) {
-					ShowFatalError( "SimStandAloneERV: Invalid CompIndex passed=" + TrimSigDigits( StandAloneERVNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + StandAloneERV( StandAloneERVNum ).Name );
+					ShowFatalError( "SimStandAloneERV: Invalid CompIndex passed=" + TrimSigDigits( StandAloneERVNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + StandAloneERV( StandAloneERVNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( StandAloneERVNum ) = false;
 			}
@@ -1017,7 +1017,7 @@ namespace HVACStandAloneERV {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting ZoneHVAC:EnergyRecoveryVentilator input." );
+			ShowFatalError( "Errors found in getting ZoneHVAC:EnergyRecoveryVentilator input." );  // LCOV_EXCL_LINE
 		}
 
 		// Setup report variables for the stand alone ERVs

--- a/src/EnergyPlus/HVACUnitaryBypassVAV.cc
+++ b/src/EnergyPlus/HVACUnitaryBypassVAV.cc
@@ -268,17 +268,17 @@ namespace HVACUnitaryBypassVAV {
 		if ( CompIndex == 0 ) {
 			CBVAVNum = FindItemInList( CompName, CBVAV );
 			if ( CBVAVNum == 0 ) {
-				ShowFatalError( "SimUnitaryBypassVAV: Unit not found=" + CompName );
+				ShowFatalError( "SimUnitaryBypassVAV: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CBVAVNum;
 		} else {
 			CBVAVNum = CompIndex;
 			if ( CBVAVNum > NumCBVAV || CBVAVNum < 1 ) {
-				ShowFatalError( "SimUnitaryBypassVAV:  Invalid CompIndex passed=" + TrimSigDigits( CBVAVNum ) + ", Number of Units=" + TrimSigDigits( NumCBVAV ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimUnitaryBypassVAV:  Invalid CompIndex passed=" + TrimSigDigits( CBVAVNum ) + ", Number of Units=" + TrimSigDigits( NumCBVAV ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( CBVAVNum ) ) {
 				if ( CompName != CBVAV( CBVAVNum ).Name ) {
-					ShowFatalError( "SimUnitaryBypassVAV: Invalid CompIndex passed=" + TrimSigDigits( CBVAVNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + CBVAV( CBVAVNum ).Name );
+					ShowFatalError( "SimUnitaryBypassVAV: Invalid CompIndex passed=" + TrimSigDigits( CBVAVNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + CBVAV( CBVAVNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( CBVAVNum ) = false;
 			}
@@ -1214,7 +1214,7 @@ namespace HVACUnitaryBypassVAV {
 		} // CBVAVIndex = 1,NumCBVAV
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetCBVAV: Errors found in getting " + CurrentModuleObject + " input." );
+			ShowFatalError( "GetCBVAV: Errors found in getting " + CurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 			ShowContinueError( "... Preceding condition causes termination." );
 		}
 
@@ -1345,7 +1345,7 @@ namespace HVACUnitaryBypassVAV {
 					ErrorFlag = false;
 					ScanPlantLoopsForObject( CBVAV( CBVAVNum ).HeatCoilName, TypeOf_CoilWaterSimpleHeating, CBVAV( CBVAVNum ).LoopNum, CBVAV( CBVAVNum ).LoopSide, CBVAV( CBVAVNum ).BranchNum, CBVAV( CBVAVNum ).CompNum, _, _, _, _, _, ErrorFlag );
 					if ( ErrorFlag ) {
-						ShowFatalError( "InitCBVAV: Program terminated for previous conditions." );
+						ShowFatalError( "InitCBVAV: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 
 					CBVAV( CBVAVNum ).MaxHeatCoilFluidFlow = GetCoilMaxWaterFlowRate( "Coil:Heating:Water", CBVAV( CBVAVNum ).HeatCoilName, ErrorsFound );
@@ -1361,7 +1361,7 @@ namespace HVACUnitaryBypassVAV {
 					ScanPlantLoopsForObject( CBVAV( CBVAVNum ).HeatCoilName, TypeOf_CoilSteamAirHeating, CBVAV( CBVAVNum ).LoopNum, CBVAV( CBVAVNum ).LoopSide, CBVAV( CBVAVNum ).BranchNum, CBVAV( CBVAVNum ).CompNum, _, _, _, _, _, ErrorFlag );
 
 					if ( ErrorFlag ) {
-						ShowFatalError( "InitCBVAV: Program terminated for previous conditions." );
+						ShowFatalError( "InitCBVAV: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 
 					CBVAV( CBVAVNum ).MaxHeatCoilFluidFlow = GetCoilMaxSteamFlowRate( CBVAV( CBVAVNum ).HeatCoilIndex, ErrorsFound );
@@ -2160,7 +2160,7 @@ namespace HVACUnitaryBypassVAV {
 
 					Real64 FullOutput = Node( CBVAV( CBVAVNum ).DXCoilInletNode ).MassFlowRate * ( PsyHFnTdbW( Node( CBVAV( CBVAVNum ).DXCoilOutletNode ).Temp, Node( CBVAV( CBVAVNum ).DXCoilOutletNode ).HumRat ) - PsyHFnTdbW( Node( CBVAV( CBVAVNum ).DXCoilInletNode ).Temp, Node( CBVAV( CBVAVNum ).DXCoilOutletNode ).HumRat ) );
 					Real64 ReqOutput = Node( CBVAV( CBVAVNum ).DXCoilInletNode ).MassFlowRate * ( PsyHFnTdbW( DesOutTemp, Node( CBVAV( CBVAVNum ).DXCoilOutletNode ).HumRat ) - PsyHFnTdbW( Node( CBVAV( CBVAVNum ).DXCoilInletNode ).Temp, Node( CBVAV( CBVAVNum ).DXCoilOutletNode ).HumRat ) );
-			
+
 					Real64 loadAccuracy( 0.001 ); // Watts, power
 					Real64 tempAccuracy( 0.001 ); // delta C, temperature
 					if ( ( NoOutput - ReqOutput ) < loadAccuracy ) { //         IF NoOutput is lower than (more cooling than required) or very near the ReqOutput, do not run the compressor
@@ -2170,7 +2170,7 @@ namespace HVACUnitaryBypassVAV {
 						QZnReq = 0.0;
 						// Get no load result
 						VariableSpeedCoils::SimVariableSpeedCoils( CBVAV( CBVAVNum ).DXCoolCoilName, CBVAV( CBVAVNum ).CoolCoilCompIndex, DataHVACGlobals::ContFanCycCoil, MaxONOFFCyclesperHour, HPTimeConstant, FanDelayTime, Off, PartLoadFrac, SpeedNum, SpeedRatio, QZnReq, QLatReq );
-					
+
 					} else if ( ( FullOutput - ReqOutput ) > loadAccuracy ) {	//         If the FullOutput is greater than (insufficient cooling) or very near the ReqOutput,
 						//         run the compressor at PartLoadFrac = 1.
 						PartLoadFrac = 1.0;
@@ -2242,7 +2242,7 @@ namespace HVACUnitaryBypassVAV {
 									}
 									SpeedRatio = TempSpeedReqst / TempSpeedOut;
 								}
-							} else { 
+							} else {
 								// cycling compressor at lowest speed number, find part load fraction
 								Par( 1 ) = double( CBVAV( CBVAVNum ).CoolCoilCompIndex );
 								Par( 2 ) = DesOutTemp;
@@ -2260,7 +2260,7 @@ namespace HVACUnitaryBypassVAV {
 										ShowRecurringWarningErrorAtEnd( CBVAV( CBVAVNum ).DXCoolCoilType + " \"" + CBVAV( CBVAVNum ).DXCoolCoilName + "\" - Iteration limit exceeded calculating low speed cycling ratio error continues. Sensible PLR statistics follow.", CBVAV( CBVAVNum ).DXCyclingIterationExceededIndex, PartLoadFrac, PartLoadFrac );
 									}
 								} else if ( SolFla == -2 ) {
-									
+
 									if ( ! WarmupFlag ) {
 										if ( CBVAV( CBVAVNum ).DXCyclingIterationFailed < 4 ) {
 											++CBVAV( CBVAVNum ).DXCyclingIterationFailed;
@@ -2283,7 +2283,7 @@ namespace HVACUnitaryBypassVAV {
 					}
 					SaveCompressorPLR = VariableSpeedCoils::getVarSpeedPartLoadRatio( CBVAV( CBVAVNum ).CoolCoilCompIndex );
 					//variable-speed air-to-air cooling coil, end -------------------------
-				
+
 				} else if ( SELECT_CASE_var == DataHVACGlobals::CoilDX_CoolingTwoStageWHumControl ) { // Coil:Cooling:DX:TwoStageWithHumidityControlMode
 					// formerly (v3 and beyond) Coil:DX:MultiMode:CoolingEmpirical
 
@@ -2438,7 +2438,7 @@ namespace HVACUnitaryBypassVAV {
 					SaveCompressorPLR = DXCoilPartLoadRatio( CBVAV( CBVAVNum ).DXCoolCoilIndexNum );
 
 				} else {
-					ShowFatalError( "SimCBVAV System: Invalid DX Cooling Coil=" + CBVAV( CBVAVNum ).DXCoolCoilType );
+					ShowFatalError( "SimCBVAV System: Invalid DX Cooling Coil=" + CBVAV( CBVAVNum ).DXCoolCoilType );  // LCOV_EXCL_LINE
 
 				}}
 			} else { // IF(OutdoorDryBulbTemp .GE. CBVAV(CBVAVNum)%MinOATCompressor)THEN
@@ -2482,7 +2482,7 @@ namespace HVACUnitaryBypassVAV {
 				Real64 PartLoadFrac( 0.0 );
 				Real64 SpeedRatio( 0.0 );
 				int SpeedNum( 1 );
-				// run model with no load 
+				// run model with no load
 				VariableSpeedCoils::SimVariableSpeedCoils( CBVAV( CBVAVNum ).DXCoolCoilName, CBVAV( CBVAVNum ).CoolCoilCompIndex, DataHVACGlobals::ContFanCycCoil, MaxONOFFCyclesperHour, HPTimeConstant, FanDelayTime, Off, PartLoadFrac, SpeedNum, SpeedRatio, QZnReq, QLatReq );
 
 			} else if ( CBVAV( CBVAVNum ).DXCoolCoilType_Num == DataHVACGlobals::CoilDX_CoolingTwoStageWHumControl ) {
@@ -2557,7 +2557,7 @@ namespace HVACUnitaryBypassVAV {
 					//Real64 FullLoadHumRatOut = VariableSpeedCoils::VarSpeedCoil( CBVAV( CBVAVNum ).CoolCoilCompIndex ).OutletAirHumRat;
 					Real64 FullOutput = Node( CBVAV( CBVAVNum ).HeatingCoilInletNode ).MassFlowRate * ( PsyHFnTdbW( Node( CBVAV( CBVAVNum ).HeatingCoilOutletNode ).Temp, Node( CBVAV( CBVAVNum ).HeatingCoilOutletNode ).HumRat ) - PsyHFnTdbW( Node( CBVAV( CBVAVNum ).HeatingCoilInletNode ).Temp, Node( CBVAV( CBVAVNum ).HeatingCoilOutletNode ).HumRat ) );
 					Real64 ReqOutput = Node( CBVAV( CBVAVNum ).HeatingCoilInletNode ).MassFlowRate * ( PsyHFnTdbW( DesOutTemp, Node( CBVAV( CBVAVNum ).HeatingCoilOutletNode ).HumRat ) - PsyHFnTdbW( Node( CBVAV( CBVAVNum ).HeatingCoilInletNode ).Temp, Node( CBVAV( CBVAVNum ).HeatingCoilOutletNode ).HumRat ) );
-					
+
 					Real64 loadAccuracy( 0.001 ); // Watts, power
 					Real64 tempAccuracy( 0.001 ); // delta C, temperature
 					if ( ( NoOutput - ReqOutput ) > - loadAccuracy ) { //         IF NoOutput is higher than (more heating than required) or very near the ReqOutput, do not run the compressor
@@ -2567,12 +2567,12 @@ namespace HVACUnitaryBypassVAV {
 						QZnReq = 0.0;
 						// call again with coil off
 						VariableSpeedCoils::SimVariableSpeedCoils( CBVAV( CBVAVNum ).HeatCoilName, CBVAV( CBVAVNum ).DXHeatCoilIndexNum, ContFanCycCoil, MaxONOFFCyclesperHour, HPTimeConstant, FanDelayTime, Off, PartLoadFrac, SpeedNum, SpeedRatio, QZnReq, QLatReq );
-					
+
 					} else if ( ( FullOutput - ReqOutput ) < loadAccuracy ) {	//         If the FullOutput is less than (insufficient cooling) or very near the ReqOutput,
 						//         run the compressor at PartLoadFrac = 1.
 						// which we just did so nothing to be done
 
-						
+
 					} else { //  Else find how the coil is modulating (speed level and speed ratio or part load between off and speed 1) to meet the load
 						//           OutletTempDXCoil is the full capacity outlet temperature at PartLoadFrac = 1 from the CALL above. If this temp is
 						//           greater than the desired outlet temp, then run the compressor at PartLoadFrac = 1, otherwise find the operating PLR.
@@ -2638,7 +2638,7 @@ if ( CBVAV( CBVAVNum ).DXHeatIterationExceeded < 4 ) {
 									SpeedRatio = 0.5;
 								}
 								VariableSpeedCoils::SimVariableSpeedCoils( CBVAV( CBVAVNum ).HeatCoilName, CBVAV( CBVAVNum ).DXHeatCoilIndexNum, DataHVACGlobals::ContFanCycCoil, MaxONOFFCyclesperHour, HPTimeConstant, FanDelayTime, On, PartLoadFrac, SpeedNum, SpeedRatio, QZnReq, QLatReq, OnOffAirFlowRatio );
-							} else { 
+							} else {
 								// cycling compressor at lowest speed number, find part load fraction
 								Par( 1 ) = double( CBVAV( CBVAVNum ).DXHeatCoilIndexNum );
 								Par( 2 ) = DesOutTemp;
@@ -2656,18 +2656,18 @@ if ( CBVAV( CBVAVNum ).DXHeatIterationExceeded < 4 ) {
 										ShowRecurringWarningErrorAtEnd( CBVAV( CBVAVNum ).HeatCoilType + " \"" + CBVAV( CBVAVNum ).HeatCoilName + "\" - Iteration limit exceeded calculating low speed cycling ratio error continues. Sensible PLR statistics follow.", CBVAV( CBVAVNum ).DXHeatCyclingIterationExceededIndex, PartLoadFrac, PartLoadFrac );
 									}
 								} else if ( SolFla == -2 ) {
-									
+
 									if ( ! WarmupFlag ) {
 										if ( CBVAV( CBVAVNum ).DXHeatCyclingIterationFailed < 4 ) {
 											++CBVAV( CBVAVNum ).DXHeatCyclingIterationFailed;
 											ShowWarningError( CBVAV( CBVAVNum ).HeatCoilType + " - DX unit low speed cycling ratio calculation failed: limits exceeded, for unit = " + CBVAV( CBVAVNum ).Name );
-											ShowContinueError( "Estimated low speed cycling ratio = " + RoundSigDigits( ( DesOutTemp - TempNoOutput) / ( 
+											ShowContinueError( "Estimated low speed cycling ratio = " + RoundSigDigits( ( DesOutTemp - TempNoOutput) / (
 										TempSpeedOutSpeed1 - TempNoOutput ), 3 ) );
 											ShowContinueErrorTimeStamp( "The estimated low speed cycling ratio will be used and the simulation continues. Occurrence info:" );
 										}
 										ShowRecurringWarningErrorAtEnd( CBVAV( CBVAVNum ).HeatCoilType + " \"" + CBVAV( CBVAVNum ).HeatCoilName + "\" - DX unit low speed cycling ratio calculation failed error continues. cycling ratio statistics follow.", CBVAV( CBVAVNum ).DXHeatCyclingIterationFailedIndex, PartLoadFrac, PartLoadFrac );
 									}
-									PartLoadFrac = ( DesOutTemp - TempNoOutput) / ( 
+									PartLoadFrac = ( DesOutTemp - TempNoOutput) / (
 										TempSpeedOutSpeed1 - TempNoOutput );
 								}
 								VariableSpeedCoils::SimVariableSpeedCoils( CBVAV( CBVAVNum ).HeatCoilName, CBVAV( CBVAVNum ).DXHeatCoilIndexNum, DataHVACGlobals::ContFanCycCoil, MaxONOFFCyclesperHour, HPTimeConstant, FanDelayTime, On, PartLoadFrac, SpeedNum, SpeedRatio, QZnReq, QLatReq, OnOffAirFlowRatio );
@@ -2693,7 +2693,7 @@ if ( CBVAV( CBVAVNum ).DXHeatIterationExceeded < 4 ) {
 			Node( CBVAV( CBVAVNum ).HeatingCoilOutletNode ).TempSetPoint = CBVAV( CBVAVNum ).CoilTempSetPoint;
 			CalcNonDXHeatingCoils( CBVAVNum, FirstHVACIteration, QHeater, CBVAV( CBVAVNum ).OpMode, QHeaterActual );
 		} else {
-			ShowFatalError( "SimCBVAV System: Invalid Heating Coil=" + CBVAV( CBVAVNum ).HeatCoilType );
+			ShowFatalError( "SimCBVAV System: Invalid Heating Coil=" + CBVAV( CBVAVNum ).HeatCoilType );  // LCOV_EXCL_LINE
 
 		}}
 

--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -376,17 +376,17 @@ namespace HVACUnitarySystem {
 		if ( CompIndex == 0 ) {
 			UnitarySysNum = FindItemInList( UnitarySystemName, UnitarySystem );
 			if ( UnitarySysNum == 0 ) {
-				ShowFatalError( "SimUnitarySystem: Unitary System not found=" + UnitarySystemName );
+				ShowFatalError( "SimUnitarySystem: Unitary System not found=" + UnitarySystemName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = UnitarySysNum;
 		} else {
 			UnitarySysNum = CompIndex;
 			if ( UnitarySysNum > NumUnitarySystem || UnitarySysNum < 1 ) {
-				ShowFatalError( "SimUnitarySystem:  Invalid CompIndex passed=" + TrimSigDigits( UnitarySysNum ) + ", Number of Unit Systems=" + TrimSigDigits( NumUnitarySystem ) + ", Unitary System name=" + UnitarySystemName );
+				ShowFatalError( "SimUnitarySystem:  Invalid CompIndex passed=" + TrimSigDigits( UnitarySysNum ) + ", Number of Unit Systems=" + TrimSigDigits( NumUnitarySystem ) + ", Unitary System name=" + UnitarySystemName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( UnitarySysNum ) ) {
 				if ( UnitarySystemName != UnitarySystem( UnitarySysNum ).Name ) {
-					ShowFatalError( "SimUnitarySystem: Invalid CompIndex passed=" + TrimSigDigits( UnitarySysNum ) + ", Unitary System name=" + UnitarySystemName + ", stored Unit Name for that index=" + UnitarySystem( UnitarySysNum ).Name );
+					ShowFatalError( "SimUnitarySystem: Invalid CompIndex passed=" + TrimSigDigits( UnitarySysNum ) + ", Unitary System name=" + UnitarySystemName + ", stored Unit Name for that index=" + UnitarySystem( UnitarySysNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( UnitarySysNum ) = false;
 			}
@@ -586,7 +586,7 @@ namespace HVACUnitarySystem {
 				if( UnitarySystem( UnitarySysNum ).ControlType == CCM_ASHRAE ) {
 					ShowSevereError( UnitarySystem( UnitarySysNum ).UnitarySystemType + ": " + UnitarySystem( UnitarySysNum ).Name );
 					ShowContinueError( "  Invalid application of Control Type = SingleZoneVAV in outdoor air system." );
-					ShowFatalError( "InitUnitarySystems: Program terminated for previous conditions." );
+					ShowFatalError( "InitUnitarySystems: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -602,7 +602,7 @@ namespace HVACUnitarySystem {
 				InitUnitarySystemsErrFlag = false;
 				ScanPlantLoopsForObject( UnitarySystem( UnitarySysNum ).Name, TypeOf_UnitarySystemRecovery, UnitarySystem( UnitarySysNum ).HRLoopNum, UnitarySystem( UnitarySysNum ).HRLoopSideNum, UnitarySystem( UnitarySysNum ).HRBranchNum, UnitarySystem( UnitarySysNum ).HRCompNum, _, _, _, _, _, InitUnitarySystemsErrFlag );
 				if ( InitUnitarySystemsErrFlag ) {
-					ShowFatalError( "InitUnitarySystems: Program terminated for previous conditions." );
+					ShowFatalError( "InitUnitarySystems: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( UnitarySystem( UnitarySysNum ).CoolingCoilType_Num == Coil_CoolingWater || UnitarySystem( UnitarySysNum ).CoolingCoilType_Num == Coil_CoolingWaterDetailed || UnitarySystem( UnitarySysNum ).CoolingCoilType_Num == CoilWater_CoolingHXAssisted ) {
@@ -628,7 +628,7 @@ namespace HVACUnitarySystem {
 				InitUnitarySystemsErrFlag = false;
 				ScanPlantLoopsForObject( CoolingCoilName, TypeOfCoilWaterCooling, UnitarySystem( UnitarySysNum ).CoolCoilLoopNum, UnitarySystem( UnitarySysNum ).CoolCoilLoopSide, UnitarySystem( UnitarySysNum ).CoolCoilBranchNum, UnitarySystem( UnitarySysNum ).CoolCoilCompNum, _, _, _, _, _, InitUnitarySystemsErrFlag );
 				if ( InitUnitarySystemsErrFlag ) {
-					ShowFatalError( "InitUnitarySystem: Program terminated for previous conditions." );
+					ShowFatalError( "InitUnitarySystem: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				UnitarySystem( UnitarySysNum ).MaxCoolCoilFluidFlow = GetCoilMaxWaterFlowRate( CoolingCoilType, CoolingCoilName, InitUnitarySystemsErrorsFound );
 
@@ -652,7 +652,7 @@ namespace HVACUnitarySystem {
 				InitUnitarySystemsErrFlag = false;
 				ScanPlantLoopsForObject( UnitarySystem( UnitarySysNum ).HeatingCoilName, TypeOfCoilWaterHeating, UnitarySystem( UnitarySysNum ).HeatCoilLoopNum, UnitarySystem( UnitarySysNum ).HeatCoilLoopSide, UnitarySystem( UnitarySysNum ).HeatCoilBranchNum, UnitarySystem( UnitarySysNum ).HeatCoilCompNum, _, _, _, _, _, InitUnitarySystemsErrFlag );
 				if ( InitUnitarySystemsErrFlag ) {
-					ShowFatalError( "InitUnitarySystem: Program terminated for previous conditions." );
+					ShowFatalError( "InitUnitarySystem: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				if ( UnitarySystem( UnitarySysNum ).HeatingCoilType_Num == Coil_HeatingWater ) {
 					UnitarySystem( UnitarySysNum ).MaxHeatCoilFluidFlow = GetCoilMaxWaterFlowRate( HeatingCoilType, UnitarySystem( UnitarySysNum ).HeatingCoilName, InitUnitarySystemsErrorsFound );
@@ -687,7 +687,7 @@ namespace HVACUnitarySystem {
 				SetCoilDesFlow( cAllCoilTypes( UnitarySystem( UnitarySysNum ).SuppHeatCoilType_Num ), UnitarySystem( UnitarySysNum ).SuppHeatCoilName, UnitarySystem( UnitarySysNum ).MaxHeatAirVolFlow, InitUnitarySystemsErrorsFound );
 
 				if ( InitUnitarySystemsErrFlag ) {
-					ShowFatalError( "InitUnitarySystems: Program terminated for previous conditions." );
+					ShowFatalError( "InitUnitarySystems: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				UnitarySystem( UnitarySysNum ).MaxSuppCoilFluidFlow = GetCoilMaxWaterFlowRate( "Coil:Heating:Water", UnitarySystem( UnitarySysNum ).SuppHeatCoilName, InitUnitarySystemsErrorsFound );
 
@@ -702,7 +702,7 @@ namespace HVACUnitarySystem {
 				InitUnitarySystemsErrFlag = false;
 				ScanPlantLoopsForObject( UnitarySystem( UnitarySysNum ).SuppHeatCoilName, TypeOf_CoilSteamAirHeating, UnitarySystem( UnitarySysNum ).SuppCoilLoopNum, UnitarySystem( UnitarySysNum ).SuppCoilLoopSide, UnitarySystem( UnitarySysNum ).SuppCoilBranchNum, UnitarySystem( UnitarySysNum ).SuppCoilCompNum, _, _, _, _, _, InitUnitarySystemsErrFlag );
 				if ( InitUnitarySystemsErrFlag ) {
-					ShowFatalError( "InitUnitarySystems: Program terminated for previous conditions." );
+					ShowFatalError( "InitUnitarySystems: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				UnitarySystem( UnitarySysNum ).MaxSuppCoilFluidFlow = GetCoilMaxSteamFlowRate( UnitarySystem( UnitarySysNum ).SuppHeatCoilIndex, InitUnitarySystemsErrorsFound );
 				if ( UnitarySystem( UnitarySysNum ).MaxSuppCoilFluidFlow > 0.0 ) {
@@ -1085,7 +1085,7 @@ namespace HVACUnitarySystem {
 		if ( SELECT_CASE_var == LoadBased || SELECT_CASE_var == CCM_ASHRAE ) {
 			if ( AirLoopNum == -1 ) { // This IF-THEN routine is just for ZoneHVAC:OutdoorAirUnit
 				ShowWarningError( UnitarySystem( UnitarySysNum ).UnitarySystemType + " \"" + UnitarySystem( UnitarySysNum ).Name + "\"" );
-				ShowFatalError( "...Load based control is not allowed when used with ZoneHVAC:OutdoorAirUnit" );
+				ShowFatalError( "...Load based control is not allowed when used with ZoneHVAC:OutdoorAirUnit" );  // LCOV_EXCL_LINE
 			}
 
 			// here we need to deal with sequenced zone equip
@@ -1414,7 +1414,7 @@ namespace HVACUnitarySystem {
 			MyCheckFlag( UnitarySysNum ) = false;
 			if ( UnitarySystem( UnitarySysNum ).ZoneInletNode == 0 ) {
 				ShowSevereError( UnitarySystem( UnitarySysNum ).UnitarySystemType + " \"" + UnitarySystem( UnitarySysNum ).Name + "\": The zone inlet node in the controlled zone (" + Zone( UnitarySystem( UnitarySysNum ).ControlZoneNum ).Name + ") is not found." );
-				ShowFatalError( "Subroutine InitLoadBasedControl: Errors found in getting " + UnitarySystem( UnitarySysNum ).UnitarySystemType + " input.  Preceding condition(s) causes termination." );
+				ShowFatalError( "Subroutine InitLoadBasedControl: Errors found in getting " + UnitarySystem( UnitarySysNum ).UnitarySystemType + " input.  Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -2710,7 +2710,7 @@ namespace HVACUnitarySystem {
 		}
 
 		if( ErrorFlag ) {
-			ShowFatalError( RoutineName + "Errors found in getting AirLoopHVAC:UnitarySystem input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting AirLoopHVAC:UnitarySystem input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -5272,7 +5272,7 @@ namespace HVACUnitarySystem {
 							//++TotalZonesOnAirLoop;
 							TotalFloorAreaOnAirLoop = Zone( ZoneEquipConfig( ControlledZoneNum ).ActualZoneNum ).FloorArea;
 							UnitarySystem( UnitarySysNum ).AirLoopEquipment = false;
-							UnitarySystem( UnitarySysNum ).ZoneInletNode = UnitarySystem( UnitarySysNum ).ATMixerOutNode;							
+							UnitarySystem( UnitarySysNum ).ZoneInletNode = UnitarySystem( UnitarySysNum ).ATMixerOutNode;
 							if ( ZoneEquipConfig( ControlledZoneNum ).EquipListIndex > 0 ) {
 								for ( EquipNum = 1; EquipNum <= ZoneEquipList( ZoneEquipConfig( ControlledZoneNum ).EquipListIndex ).NumOfEquipTypes; ++EquipNum ) {
 									if ( ( ZoneEquipList( ZoneEquipConfig( ControlledZoneNum ).EquipListIndex ).EquipType_Num( EquipNum ) != ZoneUnitarySystem_Num ) || ZoneEquipList( ZoneEquipConfig( ControlledZoneNum ).EquipListIndex ).EquipName( EquipNum ) != UnitarySystem( UnitarySysNum ).Name ) continue;
@@ -5317,7 +5317,7 @@ namespace HVACUnitarySystem {
 				}
 			}
 
-			if ( !ZoneEquipmentFound ) { 
+			if ( !ZoneEquipmentFound ) {
 				// check if the UnitarySystem is connected to an air loop
 				for ( AirLoopNum = 1; AirLoopNum <= NumPrimaryAirSys; ++AirLoopNum ) {
 					for ( BranchNum = 1; BranchNum <= PrimaryAirSystem( AirLoopNum ).NumBranches; ++BranchNum ) {
@@ -5365,7 +5365,7 @@ namespace HVACUnitarySystem {
 						}
 					}
 				}
-			}			 
+			}
 
 			if ( !AirLoopFound && !ZoneEquipmentFound && !OASysFound && !DataHVACGlobals::GetAirPathDataDone ) {
 				// Unsucessful attempt
@@ -6336,7 +6336,7 @@ namespace HVACUnitarySystem {
 					UnitarySystem( UnitarySysNum ).validASHRAECoolCoil = false;
 				}
 				// only allow for water, fuel, or electric at this time
-				if( UnitarySystem( UnitarySysNum ).HeatCoilExists && UnitarySystem( UnitarySysNum ).HeatingCoilType_Num != Coil_HeatingWater 
+				if( UnitarySystem( UnitarySysNum ).HeatCoilExists && UnitarySystem( UnitarySysNum ).HeatingCoilType_Num != Coil_HeatingWater
 																	&& UnitarySystem( UnitarySysNum ).HeatingCoilType_Num != Coil_HeatingGasOrOtherFuel
 																	&& UnitarySystem( UnitarySysNum ).HeatingCoilType_Num != Coil_HeatingElectric
 																	&& UnitarySystem( UnitarySysNum ).HeatingCoilType_Num != CoilDX_HeatingEmpirical) {
@@ -6379,7 +6379,7 @@ namespace HVACUnitarySystem {
 				SetupOutputVariable( "Unitary System Latent Heating Rate", OutputProcessor::Unit::W, UnitarySystem( UnitarySysNum ).LatHeatEnergyRate, "System", "Average", UnitarySystem( UnitarySysNum ).Name );
 				SetupOutputVariable( "Unitary System Ancillary Electric Power", OutputProcessor::Unit::W, UnitarySystem( UnitarySysNum ).TotalAuxElecPower, "System", "Average", UnitarySystem( UnitarySysNum ).Name );
 
-				// report predicted load as determined by Unitary System for load control only 
+				// report predicted load as determined by Unitary System for load control only
 				if ( UnitarySystem( UnitarySysNum ).ControlType != SetPointBased ) {
 					SetupOutputVariable( "Unitary System Predicted Sensible Load to Setpoint Heat Transfer Rate", OutputProcessor::Unit::W, UnitarySystem( UnitarySysNum ).SensibleLoadPredicted, "System", "Average", UnitarySystem( UnitarySysNum ).Name );
 					SetupOutputVariable( "Unitary System Predicted Moisture Load to Setpoint Heat Transfer Rate", OutputProcessor::Unit::W, UnitarySystem( UnitarySysNum ).MoistureLoadPredicted, "System", "Average", UnitarySystem( UnitarySysNum ).Name );
@@ -6513,7 +6513,7 @@ namespace HVACUnitarySystem {
 		//CALL the series of components that simulate a Unitary System
 		if ( UnitarySystem( UnitarySysNum ).FanExists && UnitarySystem( UnitarySysNum ).FanPlace == BlowThru ) {
 			if ( UnitarySystem( UnitarySysNum ).FanType_Num == DataHVACGlobals::FanType_SystemModelObject ) {
-				
+
 				HVACFan::fanObjs[ UnitarySystem( UnitarySysNum ).FanIndex ]->simulate( _,_,_,_, m_massFlow1, m_runTimeFraction1, m_massFlow2, m_runTimeFraction2, _ );
 			} else {
 				Fans::SimulateFanComponents( BlankString, FirstHVACIteration, UnitarySystem( UnitarySysNum ).FanIndex, FanSpeedRatio );
@@ -7041,7 +7041,7 @@ namespace HVACUnitarySystem {
 							UnitarySystem( UnitarySysNum ).CoolingSpeedRatio = 0.0;
 							if ( UnitarySystem( UnitarySysNum ).SingleMode == 1 ) {
 								CoolPLR = 1.0;
-							} 
+							}
 						}
 
 						CalcUnitarySystemToLoad( UnitarySysNum, AirLoopNum, FirstHVACIteration, CoolPLR, HeatPLR, OnOffAirFlowRatio, SensOutputOff, LatOutputOff, HXUnitOn, _, _, CompressorONFlag );
@@ -7180,7 +7180,7 @@ namespace HVACUnitarySystem {
 			Par( 6 ) = OnOffAirFlowRatio;
 			Par( 7 ) = double( AirLoopNum );
 			Par( 8 ) = double( coilFluidInletNode );
-			// initialize other RegulaFalsi variables to most common state 
+			// initialize other RegulaFalsi variables to most common state
 			Par( 9 ) = 0.0; // minCoilFluidFlow - low fan speed water flow rate
 //			Par( 10 ) = maxCoilFluidFlow; // max water flow rate used by RegulaFalsi
 			Par( 11 ) = lowSpeedFanRatio; // ratio of low speed fan flow to max flow
@@ -7527,7 +7527,7 @@ namespace HVACUnitarySystem {
 
 				}
 
-			} 
+			}
 
 			if( coilLoopNum > 0 ) SetComponentFlowRate( Node( coilFluidInletNode ).MassFlowRate, coilFluidInletNode, coilFluidOutletNode, coilLoopNum, coilLoopSide, coilBranchNum, coilCompNum );
 
@@ -7853,23 +7853,23 @@ namespace HVACUnitarySystem {
 		Array1< Real64 > const & Par // Function parameters
 	)
 	{
-		
+
 				// FUNCTION INFORMATION:
 				//       AUTHOR         Richard Raustad, FSEC
 				//       DATE WRITTEN   January 2017
 				//       MODIFIED       na
 				//       RE-ENGINEERED  na
-			
+
 				// PURPOSE OF THIS SUBROUTINE:
 				// To calculate the part-load ratio for the UnitarySystem coil with varying part load ratio
-			
+
 				// METHODOLOGY EMPLOYED:
 				// Use SolveRoot to CALL this Function to converge on a solution
-			
+
 				// USE STATEMENTS:
 		using Psychrometrics::PsyHFnTdbW;
 		using General::SolveRoot;
-			
+
 				// Return value
 		Real64 Residuum; // Result (forces solution to be within tolerance)
 
@@ -7891,7 +7891,7 @@ namespace HVACUnitarySystem {
 				//       Par(14) = systemMaxAirFlowRate     ! UnitarySystem maximum air flow rate [kg/s]
 				//       Par(15) = LoadType                 ! 1.0 for CoolingLoad otherwise don't care
 				//       Par(16) = iteration method         ! 1 = iteration on coil capacity, 2 = iterate on air flow rate at constant coil capacity
-			
+
 				// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		bool FirstHVACIteration; // FirstHVACIteration flag
 		bool HXUnitOn; // flag for HX operation
@@ -7917,7 +7917,7 @@ namespace HVACUnitarySystem {
 		Real64 SATempTarget; // coil outelt air target temperature [C]
 		Real64 coolingPLR; // part-load ratio passed to cooling coil
 		Real64 heatingPLR; // part-load ratio passed to heating coil
-		
+
 
 		// Convert parameters to usable variables
 		UnitarySysNum = int( Par( 1 ) );
@@ -8009,7 +8009,7 @@ namespace HVACUnitarySystem {
 			OutletNode = UnitarySystem( UnitarySysNum ).UnitarySystemOutletNodeNum;
 			Residuum = ( Node( OutletNode ).Temp - SATempTarget ) * 10.0;
 		}
-		
+
 		return Residuum;
 	}
 
@@ -8454,7 +8454,7 @@ namespace HVACUnitarySystem {
 		int const UnitarySysNum,
 		Real64 & SensOutput,
 		Real64 & LatOutput
-	) 
+	)
 	{
 
 		// Using/Aliasing
@@ -8856,7 +8856,7 @@ namespace HVACUnitarySystem {
 			UnitarySystem( UnitarySysNum ).HeatCompPartLoadRatio = PartLoadRatio * double( CompOn );
 
 		} else {
-			ShowFatalError( "CalcUnitaryHeatingSystem: Invalid Unitary System coil type = " + cAllCoilTypes( UnitarySystem( UnitarySysNum ).HeatingCoilType_Num ) );
+			ShowFatalError( "CalcUnitaryHeatingSystem: Invalid Unitary System coil type = " + cAllCoilTypes( UnitarySystem( UnitarySysNum ).HeatingCoilType_Num ) );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -9597,7 +9597,7 @@ namespace HVACUnitarySystem {
 
 						} else {
 							ShowMessage( " For :" + UnitarySystem( UnitarySysNum ).UnitarySystemType + "=\"" + UnitarySystem( UnitarySysNum ).Name + "\"" );
-							ShowFatalError( "ControlCoolingSystemToSP: Invalid cooling coil type = " + cAllCoilTypes( CoilType_Num ) );
+							ShowFatalError( "ControlCoolingSystemToSP: Invalid cooling coil type = " + cAllCoilTypes( CoilType_Num ) );  // LCOV_EXCL_LINE
 
 						}
 
@@ -9863,7 +9863,7 @@ namespace HVACUnitarySystem {
 						} else if ( CoilType_Num == CoilDX_MultiSpeedCooling )  {
 
 							SimDXCoilMultiSpeed( CompName, SpeedRatio, CycRatio, UnitarySystem( UnitarySysNum ).CoolingCoilIndex );
-							OutletHumRatDXCoil = DXCoilOutletHumRat( UnitarySystem( UnitarySysNum ).CoolingCoilIndex ); 
+							OutletHumRatDXCoil = DXCoilOutletHumRat( UnitarySystem( UnitarySysNum ).CoolingCoilIndex );
 
 							// IF humidity setpoint is not satisfied and humidity control type is CoolReheat,
 							// then overcool to meet moisture load
@@ -9898,13 +9898,13 @@ namespace HVACUnitarySystem {
 							}
 						} else if ( ( CoilType_Num == Coil_CoolingAirToAirVariableSpeed ) || ( CoilType_Num == Coil_CoolingWaterToAirHPVSEquationFit ) ) {
 							SimVariableSpeedCoils( CompName, UnitarySystem( UnitarySysNum ).CoolingCoilIndex, UnitarySystem( UnitarySysNum ).FanOpMode, UnitarySystem( UnitarySysNum ).MaxONOFFCyclesperHour, UnitarySystem( UnitarySysNum ).HPTimeConstant, UnitarySystem( UnitarySysNum ).FanDelayTime, 1, CycRatio, SpeedNum, SpeedRatio, ReqOutput, dummy, OnOffAirFlowRatio );
-							OutletHumRatLS = DataLoopNode::Node( UnitarySystem( UnitarySysNum ).CoolCoilOutletNodeNum ).HumRat; 
+							OutletHumRatLS = DataLoopNode::Node( UnitarySystem( UnitarySysNum ).CoolCoilOutletNodeNum ).HumRat;
 
 								if ( OutletHumRatLS > DesOutHumRat ) {
 									CycRatio = 1.0;
 
 									SimVariableSpeedCoils( CompName, UnitarySystem( UnitarySysNum ).CoolingCoilIndex, UnitarySystem( UnitarySysNum ).FanOpMode, UnitarySystem( UnitarySysNum ).MaxONOFFCyclesperHour, UnitarySystem( UnitarySysNum ).HPTimeConstant, UnitarySystem( UnitarySysNum ).FanDelayTime, 1, 1.0, SpeedNum, 1.0, ReqOutput, dummy, OnOffAirFlowRatio );
-									
+
 									OutletHumRatHS = DataLoopNode::Node( UnitarySystem( UnitarySysNum ).CoolCoilOutletNodeNum ).HumRat;
 
 									if ( OutletHumRatHS < DesOutHumRat ) {
@@ -10515,7 +10515,7 @@ namespace HVACUnitarySystem {
 
 						} else {
 							ShowMessage( " For :" + UnitarySystem( UnitarySysNum ).UnitarySystemType + "=\"" + UnitarySystem( UnitarySysNum ).Name + "\"" );
-							ShowFatalError( "ControlHeatingSystemToSP: Invalid heating coil type = " + cAllCoilTypes( UnitarySystem( UnitarySysNum ).HeatingCoilType_Num ) );
+							ShowFatalError( "ControlHeatingSystemToSP: Invalid heating coil type = " + cAllCoilTypes( UnitarySystem( UnitarySysNum ).HeatingCoilType_Num ) );  // LCOV_EXCL_LINE
 
 						}}
 					}
@@ -11757,7 +11757,7 @@ namespace HVACUnitarySystem {
 				UnitarySystem( UnitarySysNum ).SensHeatEnergyRate = std::abs( max( 0.0, QSensUnitOut ) );
 				UnitarySystem( UnitarySysNum ).LatHeatEnergyRate = std::abs( max( 0.0, ( QTotUnitOut - QSensUnitOut ) ) );
 			}
-		} 
+		}
 
 		if ( UnitarySystem( UnitarySysNum ).FanExists ) {
 			if ( CompOnMassFlow > 0.0 ) {

--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
@@ -177,12 +177,12 @@ namespace HVACVariableRefrigerantFlow {
 	// Flag for hex operation
 	int const FlagCondMode( 0 ); // Flag for the hex running as condenser [-]
 	int const FlagEvapMode( 1 ); // Flag for the hex running as evaporator [-]
-	
+
 	// Flag for VRF operational mode
 	int const ModeCoolingOnly( 1 ); // Flag for Cooling Only Mode [-]
 	int const ModeHeatingOnly( 2 ); // Flag for Heating Only Mode [-]
 	int const ModeCoolingAndHeating( 3 ); // Flag for Simultaneous Cooling and Heating Only Mode [-]
-	
+
 	// Fuel Types
 	int const FuelTypeElectric( 1 ); // Fuel type for electricity
 	int const FuelTypeNaturalGas( 2 ); // Fuel type for natural gas
@@ -338,18 +338,18 @@ namespace HVACVariableRefrigerantFlow {
 		if ( CompIndex == 0 ) {
 			VRFTUNum = FindItemInList( CompName, VRFTU );
 			if ( VRFTUNum == 0 ) {
-				ShowFatalError( "SimulateVRF: VRF Terminal Unit not found=" + CompName );
+				ShowFatalError( "SimulateVRF: VRF Terminal Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = VRFTUNum;
 
 		} else {
 			VRFTUNum = CompIndex;
 			if ( VRFTUNum > NumVRFTU || VRFTUNum < 1 ) {
-				ShowFatalError( "SimulateVRF: Invalid CompIndex passed=" + TrimSigDigits( VRFTUNum ) + ", Number of VRF Terminal Units = " + TrimSigDigits( NumVRFTU ) + ", VRF Terminal Unit name = " + CompName );
+				ShowFatalError( "SimulateVRF: Invalid CompIndex passed=" + TrimSigDigits( VRFTUNum ) + ", Number of VRF Terminal Units = " + TrimSigDigits( NumVRFTU ) + ", VRF Terminal Unit name = " + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( VRFTUNum ) ) {
 				if ( ! CompName.empty() && CompName != VRFTU( VRFTUNum ).Name ) {
-					ShowFatalError( "SimulateVRF: Invalid CompIndex passed=" + TrimSigDigits( VRFTUNum ) + ", VRF Terminal Unit name=" + CompName + ", stored VRF TU Name for that index=" + VRFTU( VRFTUNum ).Name );
+					ShowFatalError( "SimulateVRF: Invalid CompIndex passed=" + TrimSigDigits( VRFTUNum ) + ", VRF Terminal Unit name=" + CompName + ", stored VRF TU Name for that index=" + VRFTU( VRFTUNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( VRFTUNum ) = false;
 			}
@@ -478,7 +478,7 @@ namespace HVACVariableRefrigerantFlow {
 					MaxCap = max( VRF( VRFNum ).CoolingCapacity, VRF( VRFNum ).HeatingCapacity ); // greater of cooling and heating capacity
 					OptCap = max( VRF( VRFNum ).CoolingCapacity, VRF( VRFNum ).HeatingCapacity ); // connects to single loop, need to switch between cooling/heating capacity?
 				} else {
-					ShowFatalError( "SimVRFCondenserPlant: Module called with incorrect VRFType=" + VRFType );
+					ShowFatalError( "SimVRFCondenserPlant: Module called with incorrect VRFType=" + VRFType );  // LCOV_EXCL_LINE
 				}}
 				SizeVRFCondenser( VRFNum );
 				return;
@@ -493,13 +493,13 @@ namespace HVACVariableRefrigerantFlow {
 					UpdateChillerComponentCondenserSide( VRF( VRFNum ).SourceLoopNum, VRF( VRFNum ).SourceLoopSideNum, TypeOf_HeatPumpVRF, VRF( VRFNum ).CondenserNodeNum, VRF( VRFNum ).CondenserOutletNodeNum, VRF( VRFNum ).QCondenser, VRF( VRFNum ).CondenserInletTemp, VRF( VRFNum ).CondenserSideOutletTemp, VRF( VRFNum ).WaterCondenserMassFlow, FirstHVACIteration );
 
 				} else {
-					ShowFatalError( "SimVRFCondenserPlant:: Invalid loop connection " + cVRFTypes( VRF_HeatPump ) + ", Requested Unit=" + VRFName );
+					ShowFatalError( "SimVRFCondenserPlant:: Invalid loop connection " + cVRFTypes( VRF_HeatPump ) + ", Requested Unit=" + VRFName );  // LCOV_EXCL_LINE
 				}
 			} else {
-				ShowFatalError( "SimVRFCondenserPlant:: Invalid " + cVRFTypes( VRF_HeatPump ) + ", Requested Unit=" + VRFName );
+				ShowFatalError( "SimVRFCondenserPlant:: Invalid " + cVRFTypes( VRF_HeatPump ) + ", Requested Unit=" + VRFName );  // LCOV_EXCL_LINE
 			}
 		} else {
-			ShowFatalError( "SimVRFCondenserPlant: Module called with incorrect VRFType=" + VRFType );
+			ShowFatalError( "SimVRFCondenserPlant: Module called with incorrect VRFType=" + VRFType );  // LCOV_EXCL_LINE
 		}}
 
 	}
@@ -1270,7 +1270,7 @@ namespace HVACVariableRefrigerantFlow {
 		GetVRFInputData( ErrorsFound );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting AirConditioner:VariableRefrigerantFlow system input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting AirConditioner:VariableRefrigerantFlow system input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1435,9 +1435,9 @@ namespace HVACVariableRefrigerantFlow {
 			MaxAlphas = max( MaxAlphas, NumAlphas );
 			MaxNumbers = max( MaxNumbers, NumNums );
 		}
-		
+
 		NumVRFCond = NumVRFCond_SysCurve + NumVRFCond_FluidTCtrl_HP + NumVRFCond_FluidTCtrl_HR;
-		
+
 		NumVRFTULists = GetNumObjectsFound( "ZoneTerminalUnitList" );
 		if ( NumVRFTULists > 0 ) {
 			GetObjectDefMaxArgs( "ZoneTerminalUnitList", NumParams, NumAlphas, NumNums );
@@ -2670,13 +2670,13 @@ namespace HVACVariableRefrigerantFlow {
 				if ( IsBlank ) cAlphaArgs( 1 ) = "xxxxx";
 			}
 			VRF( VRFNum ).Name = cAlphaArgs( 1 );
-			
+
 			VRF( VRFNum ).ThermostatPriority = LoadPriority;
 			VRF( VRFNum ).HeatRecoveryUsed = true;
 			VRF( VRFNum ).VRFSystemTypeNum = VRF_HeatPump;
 			VRF( VRFNum ).VRFAlgorithmTypeNum = AlgorithmTypeFluidTCtrl;
 			VRF( VRFNum ).FuelType = FuelTypeElectric;
-			
+
 			if ( lAlphaFieldBlanks( 2 ) ) {
 				VRF( VRFNum ).SchedPtr = ScheduleAlwaysOn;
 			} else {
@@ -2694,7 +2694,7 @@ namespace HVACVariableRefrigerantFlow {
 				ShowContinueError( cAlphaFieldNames( 3 ) + " = " + cAlphaArgs( 3 ) + " not found." );
 				ErrorsFound = true;
 			}
-			
+
 			//Refrigerant type
 			VRF( VRFNum ).RefrigerantName = cAlphaArgs( 4 );
 			if ( EnergyPlus::FluidProperties::GetInput ) {
@@ -2706,17 +2706,17 @@ namespace HVACVariableRefrigerantFlow {
 				ShowContinueError( "Illegal " + cAlphaFieldNames( 4 ) + " = " + cAlphaArgs( 4 ) );
 				ErrorsFound = true;
 			}
-			
+
 			VRF( VRFNum ).RatedEvapCapacity = rNumericArgs( 1 );
 			VRF( VRFNum ).RatedCompPowerPerCapcity = rNumericArgs( 2 );
 			VRF( VRFNum ).RatedCompPower = VRF( VRFNum ).RatedCompPowerPerCapcity * VRF( VRFNum ).RatedEvapCapacity;
 			VRF( VRFNum ).CoolingCapacity = VRF( VRFNum ).RatedEvapCapacity;
 			VRF( VRFNum ).HeatingCapacity = VRF( VRFNum ).RatedEvapCapacity * ( 1 + VRF( VRFNum ).RatedCompPowerPerCapcity );
-			
+
 			//Reference system COP
 			VRF( VRFNum ).CoolingCOP = 1 / VRF( VRFNum ).RatedCompPowerPerCapcity;
 			VRF( VRFNum ).HeatingCOP = 1 / VRF( VRFNum ).RatedCompPowerPerCapcity + 1;
-			
+
 			//OA temperature range for VRF-HP operations
 			VRF( VRFNum ).MinOATCooling = rNumericArgs( 3 );
 			VRF( VRFNum ).MaxOATCooling = rNumericArgs( 4 );
@@ -2757,7 +2757,7 @@ namespace HVACVariableRefrigerantFlow {
 				VRF( VRFNum ).MaxOATHeatRecovery = max( VRF( VRFNum ).MaxOATCooling, VRF( VRFNum ).MaxOATHeating );
 				ShowContinueError( "... adjusted " + cNumericFieldNames( 8 ) + " = " + TrimSigDigits( VRF( VRFNum ).MaxOATHeatRecovery, 2 ) + " C" );
 			}
-			
+
 			// IU Control Type
 			if( SameString( cAlphaArgs( 5 ), "VariableTemp" ) ) {
 				VRF(VRFNum).AlgorithmIUCtrl = 1;
@@ -2766,11 +2766,11 @@ namespace HVACVariableRefrigerantFlow {
 			} else {
 				VRF(VRFNum).AlgorithmIUCtrl = 1;
 			}
-			
+
 			//Reference IU Te/Tc for IU Control Algorithm: ConstantTemp
 			VRF( VRFNum ).EvapTempFixed  = rNumericArgs( 9 );
 			VRF( VRFNum ).CondTempFixed  = rNumericArgs( 10 );
-			
+
 			//Bounds of Te/Tc for IU Control Algorithm: VariableTemp
 			VRF( VRFNum ).IUEvapTempLow = rNumericArgs( 11 );
 			VRF( VRFNum ).IUEvapTempHigh = rNumericArgs( 12 );
@@ -2786,7 +2786,7 @@ namespace HVACVariableRefrigerantFlow {
 				ShowContinueError( "... " + cNumericFieldNames( 13 ) + " (" + TrimSigDigits( VRF( VRFNum ).IUCondTempLow, 3 ) + ") must be less than maximum (" + TrimSigDigits( VRF( VRFNum ).IUCondTempHigh, 3 ) + ")." );
 				ErrorsFound = true;
 			}
-			
+
 			//Reference OU SH/SC
 			VRF( VRFNum ).SH = rNumericArgs( 15 );
 			VRF( VRFNum ).SC = rNumericArgs( 16 );
@@ -2798,23 +2798,23 @@ namespace HVACVariableRefrigerantFlow {
 				ShowWarningError( cCurrentModuleObject + ", \"" + VRF( VRFNum ).Name + "\", \" " + cNumericFieldNames( 15 ) );
 				ShowContinueError( "...is higher than 20C, which is usually the maximum of normal range." );
 			}
-			
+
 			// OU Heat Exchanger Rated Bypass Factor
 			VRF( VRFNum ).RateBFOUEvap = rNumericArgs( 17 );
 			VRF( VRFNum ).RateBFOUCond = rNumericArgs( 18 );
-			
+
 			// Difference between Outdoor Unit Te and OAT during Simultaneous Heating and Cooling operations
 			VRF( VRFNum ).DiffOUTeTo = rNumericArgs( 19 );
 
 			// HR OU Heat Exchanger Capacity Ratio
 			VRF( VRFNum ).HROUHexRatio = rNumericArgs( 20 );
-			
+
 			//Get OU fan data
 			VRF( VRFNum ).RatedOUFanPowerPerCapcity = rNumericArgs( 21 );
 			VRF( VRFNum ).OUAirFlowRatePerCapcity = rNumericArgs( 22 );
 			VRF( VRFNum ).RatedOUFanPower = VRF( VRFNum ).RatedOUFanPowerPerCapcity * VRF( VRFNum ).RatedEvapCapacity;
 			VRF( VRFNum ).OUAirFlowRate = VRF( VRFNum ).OUAirFlowRatePerCapcity * VRF( VRFNum ).RatedEvapCapacity;
-			
+
 			// OUEvapTempCurve
 			int indexOUEvapTempCurve = GetCurveIndex( cAlphaArgs( 6 ) ); // convert curve name to index number
 			// Verify curve name and type
@@ -2842,7 +2842,7 @@ namespace HVACVariableRefrigerantFlow {
 					}
 				}
 			}
-			
+
 			// OUCondTempCurve
 			int indexOUCondTempCurve = GetCurveIndex( cAlphaArgs( 7 ) ); // convert curve name to index number
 			// Verify curve name and type
@@ -2870,7 +2870,7 @@ namespace HVACVariableRefrigerantFlow {
 					}
 				}
 			}
-			
+
 			// Pipe parameters
 			VRF( VRFNum ).RefPipDiaSuc   = rNumericArgs( 23 );
 			VRF( VRFNum ).RefPipDiaDis   = rNumericArgs( 24 );
@@ -2879,7 +2879,7 @@ namespace HVACVariableRefrigerantFlow {
 			VRF( VRFNum ).RefPipHei      = rNumericArgs( 27 );
 			VRF( VRFNum ).RefPipInsThi   = rNumericArgs( 28 );
 			VRF( VRFNum ).RefPipInsCon   = rNumericArgs( 29 );
-			
+
 			// Check the RefPipEquLen
 			if ( lNumericFieldBlanks( 26 ) && !lNumericFieldBlanks( 25 ) ) {
 				VRF( VRFNum ).RefPipEquLen = 1.2 * VRF( VRFNum ).RefPipLen;
@@ -2892,13 +2892,13 @@ namespace HVACVariableRefrigerantFlow {
 				ShowContinueError( "...Equivalent length of main pipe should be greater than or equal to the actual length." );
 				ShowContinueError( "...The value is recalculated based on the provided \"" + cNumericFieldNames( 25 ) + "\" value." );
 			}
-			
+
 			// Crank case
 			VRF( VRFNum ).CCHeaterPower = rNumericArgs( 30 );
 			VRF( VRFNum ).NumCompressors = rNumericArgs( 31 );
 			VRF( VRFNum ).CompressorSizeRatio = rNumericArgs( 32 );
 			VRF( VRFNum ).MaxOATCCHeater = rNumericArgs( 33 );
-			
+
 			//Defrost
 			if ( ! lAlphaFieldBlanks( 8 ) ) {
 				if ( SameString( cAlphaArgs( 8 ), "ReverseCycle" ) ) VRF( VRFNum ).DefrostStrategy = ReverseCycle;
@@ -2945,14 +2945,14 @@ namespace HVACVariableRefrigerantFlow {
 					ErrorsFound = true;
 				}
 			}
-			
+
 			VRF( VRFNum ).DefrostFraction = rNumericArgs( 34 );
 			VRF( VRFNum ).DefrostCapacity = rNumericArgs( 35 );
 			VRF( VRFNum ).MaxOATDefrost = rNumericArgs( 36 );
 			if ( VRF( VRFNum ).DefrostCapacity == 0.0 && VRF( VRFNum ).DefrostStrategy == Resistive ) {
 				ShowWarningError( cCurrentModuleObject + ", \"" + VRF( VRFNum ).Name + "\" " + cNumericFieldNames( 35 ) + " = 0.0 for defrost strategy = RESISTIVE." );
 			}
-			
+
 			//HR mode transition
 			VRF( VRFNum ).HRInitialCoolCapFrac = rNumericArgs( 37 );
 			VRF( VRFNum ).HRCoolCapTC = rNumericArgs( 38 );
@@ -2962,16 +2962,16 @@ namespace HVACVariableRefrigerantFlow {
 			VRF( VRFNum ).HRHeatCapTC = rNumericArgs( 42 );
 			VRF( VRFNum ).HRInitialHeatEIRFrac = rNumericArgs( 43 );
 			VRF( VRFNum ).HRHeatEIRTC = rNumericArgs( 44 );
-			
+
 			// Compressor configuration
 			VRF( VRFNum ).CompMaxDeltaP  = rNumericArgs( 45 );
 			VRF( VRFNum ).EffCompInverter = rNumericArgs( 46 );
 			VRF( VRFNum ).CoffEvapCap = rNumericArgs( 47 );
-			
+
 			// The new VRF model is Air cooled
 			VRF( VRFNum ).CondenserType = AirCooled;
 			VRF( VRFNum ).CondenserNodeNum = 0;
-			
+
 			// Evaporative Capacity & Compressor Power Curves corresponding to each Loading Index / compressor speed
 			NumOfCompSpd = rNumericArgs( 48 );
 			VRF( VRFNum ).CompressorSpeed.dimension( NumOfCompSpd );
@@ -2984,7 +2984,7 @@ namespace HVACVariableRefrigerantFlow {
 
 				// Evaporating Capacity Curve
 				if ( ! lAlphaFieldBlanks( Count2Index + 2 * NumCompSpd ) ) {
-					int indexOUEvapCapCurve = GetCurveIndex( cAlphaArgs( Count2Index + 2 * NumCompSpd ) ); // convert curve name to index number	
+					int indexOUEvapCapCurve = GetCurveIndex( cAlphaArgs( Count2Index + 2 * NumCompSpd ) ); // convert curve name to index number
 					if ( indexOUEvapCapCurve == 0 ) {// Verify curve name and type
 						if ( lAlphaFieldBlanks( Count2Index + 2 * NumCompSpd ) ) {
 							ShowSevereError( RoutineName + cCurrentModuleObject + "=\"" + VRF( VRFNum ).Name + "\", missing" );
@@ -2996,7 +2996,7 @@ namespace HVACVariableRefrigerantFlow {
 						ErrorsFound = true;
 					} else {
 						{ auto const SELECT_CASE_var( GetCurveType( indexOUEvapCapCurve ) );
-					
+
 							if ( SELECT_CASE_var == "BIQUADRATIC" ) {
 								VRF( VRFNum ).OUCoolingCAPFT( NumCompSpd ) = indexOUEvapCapCurve;
 							} else {
@@ -3008,10 +3008,10 @@ namespace HVACVariableRefrigerantFlow {
 						}
 					}
 				}
-				
+
 				// Compressor Power Curve
 				if ( ! lAlphaFieldBlanks( Count2Index + 2 * NumCompSpd + 1 ) ) {
-					int indexOUCompPwrCurve = GetCurveIndex( cAlphaArgs( Count2Index + 2 * NumCompSpd + 1 ) ); // convert curve name to index number	
+					int indexOUCompPwrCurve = GetCurveIndex( cAlphaArgs( Count2Index + 2 * NumCompSpd + 1 ) ); // convert curve name to index number
 					if ( indexOUCompPwrCurve == 0 ) {// Verify curve name and type
 						if ( lAlphaFieldBlanks( Count2Index + 2 * NumCompSpd + 1 ) ) {
 							ShowSevereError( RoutineName + cCurrentModuleObject + "=\"" + VRF( VRFNum ).Name + "\", missing" );
@@ -3023,7 +3023,7 @@ namespace HVACVariableRefrigerantFlow {
 						ErrorsFound = true;
 					} else {
 						{ auto const SELECT_CASE_var( GetCurveType( indexOUCompPwrCurve ) );
-					
+
 							if ( SELECT_CASE_var == "BIQUADRATIC" ) {
 								VRF( VRFNum ).OUCoolingPWRFT( NumCompSpd ) = indexOUCompPwrCurve;
 							} else {
@@ -3035,11 +3035,11 @@ namespace HVACVariableRefrigerantFlow {
 						}
 					}
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		cCurrentModuleObject = "ZoneHVAC:TerminalUnit:VariableRefrigerantFlow";
 		for ( VRFNum = 1; VRFNum <= NumVRFTU; ++VRFNum ) {
 			VRFTUNum = VRFNum;
@@ -3919,7 +3919,7 @@ namespace HVACVariableRefrigerantFlow {
 				SetupOutputVariable( "VRF Heat Pump Indoor Unit Piping Correction for Heating", OutputProcessor::Unit::None, VRF( NumCond ).PipingCorrectionHeating, "System", "Average", VRF( NumCond ).Name );
 				SetupOutputVariable( "VRF Heat Pump Outdoor Unit Evaporator Heat Extract Rate", OutputProcessor::Unit::W, VRF( NumCond ).OUEvapHeatRate, "System", "Average", VRF( NumCond ).Name );
 				SetupOutputVariable( "VRF Heat Pump Outdoor Unit Condenser Heat Release Rate", OutputProcessor::Unit::W, VRF( NumCond ).OUCondHeatRate, "System", "Average", VRF( NumCond ).Name );
-				
+
 			} else {
 			// For VRF_SysCurve Model
 				SetupOutputVariable( "VRF Heat Pump Maximum Capacity Cooling Rate", OutputProcessor::Unit::W, MaxCoolingCapacity( NumCond ), "System", "Average", VRF( NumCond ).Name );
@@ -4319,7 +4319,7 @@ namespace HVACVariableRefrigerantFlow {
 					} else {
 						GetFanVolFlow( VRFTU( VRFTUNum ).FanIndex, VRFTU( VRFTUNum ).ActualFanVolFlowRate );
 					}
-					
+
 				}
 			}
 		} // IF(MyVRFFlag(VRFTUNum))THEN
@@ -4523,7 +4523,7 @@ namespace HVACVariableRefrigerantFlow {
 			if ( VRFTU( VRFTUNum ).ATMixerType == ATMixer_InletSide ) { // if there is an inlet side air terminal mixer
 				// set the primary air inlet mass flow rate
 				Node( VRFTU( VRFTUNum ).ATMixerPriNode ).MassFlowRate = min( Node( VRFTU( VRFTUNum ).ATMixerPriNode ).MassFlowRateMaxAvail, Node( VRFTU( VRFTUNum ).VRFTUInletNodeNum ).MassFlowRate );
-				// now calculate the the mixer outlet air conditions (and the secondary air inlet flow rate). The mixer outlet flow rate has already been set above 
+				// now calculate the the mixer outlet air conditions (and the secondary air inlet flow rate). The mixer outlet flow rate has already been set above
 				// (it is the "inlet" node flow rate)
 				SimATMixer( VRFTU( VRFTUNum ).ATMixerName, FirstHVACIteration, VRFTU( VRFTUNum ).ATMixerIndex );
 			}
@@ -5162,7 +5162,7 @@ namespace HVACVariableRefrigerantFlow {
 		DataZoneNumber = VRFTU( VRFTUNum ).ZoneNum;
 		if ( CurZoneEqNum > 0 ) {
 			if ( VRFTU( VRFTUNum ).HVACSizingIndex > 0 ) {
-				zoneHVACIndex = VRFTU( VRFTUNum ).HVACSizingIndex;				
+				zoneHVACIndex = VRFTU( VRFTUNum ).HVACSizingIndex;
 
 				SizingMethod = CoolingAirflowSizing;
 				FieldNum = 1; // N1, \field Supply Air Flow Rate During Cooling Operation
@@ -5568,7 +5568,7 @@ namespace HVACVariableRefrigerantFlow {
 
 			if ( FoundAll && ( VRF( VRFCond ).VRFAlgorithmTypeNum == AlgorithmTypeSysCurve )) {
 			// Size VRF rated cooling/heating capacity (VRF-SysCurve Model)
-			
+
 				// Size VRF( VRFCond ).CoolingCapacity
 				IsAutoSize = false;
 				if ( VRF( VRFCond ).CoolingCapacity == AutoSize ) {
@@ -5669,40 +5669,40 @@ namespace HVACVariableRefrigerantFlow {
 					HeatCombinationRatio( VRFCond ) = 1.0;
 				}
 			}
-			
+
 			if ( FoundAll && ( VRF( VRFCond ).VRFAlgorithmTypeNum == AlgorithmTypeFluidTCtrl )) {
 			// Size VRF rated evaporative capacity (VRF-FluidTCtrl Model)
-			
+
 				// Size VRF( VRFCond ).RatedEvapCapacity
 				IsAutoSize = false;
 				if ( VRF( VRFCond ).RatedEvapCapacity == AutoSize ) {
 					IsAutoSize = true;
 				}
-				
+
 				CoolingCapacityDes = TUCoolingCapacity;
 				HeatingCapacityDes = TUHeatingCapacity;
-				
+
 				if ( IsAutoSize ) {
 					//RatedEvapCapacity
 					VRF( VRFCond ).RatedEvapCapacity = max( CoolingCapacityDes, HeatingCapacityDes / ( 1 + VRF( VRFCond ).RatedCompPowerPerCapcity ) );
-					
+
 					//Other parameters dependent on RatedEvapCapacity
 					VRF( VRFCond ).RatedCompPower = VRF( VRFCond ).RatedCompPowerPerCapcity * VRF( VRFCond ).RatedEvapCapacity;
 					VRF( VRFCond ).RatedOUFanPower = VRF( VRFCond ).RatedOUFanPowerPerCapcity * VRF( VRFCond ).RatedEvapCapacity;
 					VRF( VRFCond ).OUAirFlowRate = VRF( VRFCond ).OUAirFlowRatePerCapcity * VRF( VRFCond ).RatedEvapCapacity;
-			
+
 					VRF( VRFCond ).CoolingCapacity = VRF( VRFCond ).RatedEvapCapacity;
 					VRF( VRFCond ).HeatingCapacity = VRF( VRFCond ).RatedEvapCapacity * ( 1 + VRF( VRFCond ).RatedCompPowerPerCapcity );
-					
+
 					ReportSizingOutput( cVRFTypes( VRF( VRFCond ).VRFSystemTypeNum ), VRF( VRFCond ).Name, "Design Size Rated Total Heating Capacity [W]", VRF( VRFCond ).HeatingCapacity );
 					ReportSizingOutput( cVRFTypes( VRF( VRFCond ).VRFSystemTypeNum ), VRF( VRFCond ).Name, "Design Size Rated Total Cooling Capacity (gross) [W]", VRF( VRFCond ).CoolingCapacity );
 				} else {
 					CoolingCapacityUser = VRF( VRFCond ).CoolingCapacity;
 					HeatingCapacityUser = VRF( VRFCond ).HeatingCapacity;
-					
+
 					ReportSizingOutput( cVRFTypes( VRF( VRFCond ).VRFSystemTypeNum ), VRF( VRFCond ).Name, "Design Size Rated Total Cooling Capacity (gross) [W]", CoolingCapacityDes, "User-Specified Rated Total Cooling Capacity (gross) [W]", CoolingCapacityUser );
 					ReportSizingOutput( cVRFTypes( VRF( VRFCond ).VRFSystemTypeNum ), VRF( VRFCond ).Name, "Design Size Rated Total Heating Capacity [W]", HeatingCapacityDes, "User-Specified Rated Total Heating Capacity [W]", HeatingCapacityUser );
-					
+
 					if ( DisplayExtraWarnings ) {
 						if ( ( std::abs( CoolingCapacityDes - CoolingCapacityUser ) / CoolingCapacityUser ) > AutoVsHardSizingThreshold ) {
 							ShowMessage( "SizeVRF: Potential issue with equipment sizing for " + cVRFTypes( VRF( VRFCond ).VRFSystemTypeNum ) + ' ' + VRFTU( VRFCond ).Name );
@@ -5711,7 +5711,7 @@ namespace HVACVariableRefrigerantFlow {
 							ShowContinueError( "This may, or may not, indicate mismatched component sizes." );
 							ShowContinueError( "Verify that the value entered is intended and is consistent with other components." );
 						}
-						
+
 						if ( ( std::abs( HeatingCapacityDes - HeatingCapacityUser ) / HeatingCapacityUser ) > AutoVsHardSizingThreshold ) {
 								ShowMessage( "SizeVRF: Potential issue with equipment sizing for " + cVRFTypes( VRF( VRFCond ).VRFSystemTypeNum ) + ' ' + VRFTU( VRFCond ).Name );
 								ShowContinueError( "User-Specified Rated Total Heating Capacity of " + RoundSigDigits( HeatingCapacityUser, 2 ) + " [W]" );
@@ -5722,7 +5722,7 @@ namespace HVACVariableRefrigerantFlow {
 					}
 				}
 			}
-			
+
 			if ( FoundAll ) {
 				// autosize resistive defrost heater capacity
 				IsAutoSize = false;
@@ -5898,7 +5898,7 @@ namespace HVACVariableRefrigerantFlow {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Preceding sizing errors cause program termination" );
+				ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 			}
 
 			RegisterPlantCompDesignFlow( VRF( VRFCond ).CondenserNodeNum, VRF( VRFCond ).WaterCondVolFlowRate );
@@ -6340,7 +6340,7 @@ namespace HVACVariableRefrigerantFlow {
 			if ( VRFTU( VRFTUNum ).ATMixerType == ATMixer_InletSide ) { // if there is an inlet side air terminal mixer
 				// set the primary air inlet mass flow rate
 				Node( VRFTU( VRFTUNum ).ATMixerPriNode ).MassFlowRate = min( Node( VRFTU( VRFTUNum ).ATMixerPriNode ).MassFlowRateMaxAvail, Node( VRFTUInletNodeNum ).MassFlowRate );
-				// now calculate the the mixer outlet air conditions (and the secondary air inlet flow rate). The mixer outlet flow rate has already been set above 
+				// now calculate the the mixer outlet air conditions (and the secondary air inlet flow rate). The mixer outlet flow rate has already been set above
 				// (it is the "inlet" node flow rate)
 				SimATMixer( VRFTU( VRFTUNum ).ATMixerName, FirstHVACIteration, VRFTU( VRFTUNum ).ATMixerIndex );
 			}
@@ -6393,7 +6393,7 @@ namespace HVACVariableRefrigerantFlow {
 				} else {
 					HVACFan::fanObjs[ VRFTU( VRFTUNum ).FanIndex ]->simulate( 1.0, ZoneCompTurnFansOn, ZoneCompTurnFansOff,_);
 				}
-				
+
 			} else {
 				Fans::SimulateFanComponents( "", FirstHVACIteration, VRFTU( VRFTUNum ).FanIndex, FanSpeedRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
 			}
@@ -6413,7 +6413,7 @@ namespace HVACVariableRefrigerantFlow {
 			}
 		}
 		// calculate sensible load met
-		if ( VRFTU( VRFTUNum ).ATMixerExists ) {			
+		if ( VRFTU( VRFTUNum ).ATMixerExists ) {
 			if ( VRFTU( VRFTUNum ).ATMixerType == ATMixer_SupplySide ) {
 				// Air terminal supply side mixer
 				MinHumRat = min( Node( ZoneNode ).HumRat, Node( ATMixOutNode ).HumRat );
@@ -8297,7 +8297,7 @@ namespace HVACVariableRefrigerantFlow {
 			}
 
 			// Update h_IU_evap_in in iterations Label12
-			h_IU_evap_in_new  = GetSatEnthalpyRefrig( this->RefrigerantName, this->CondensingTemp - this->SC, 0.0, RefrigerantIndex, RoutineName ); 		
+			h_IU_evap_in_new  = GetSatEnthalpyRefrig( this->RefrigerantName, this->CondensingTemp - this->SC, 0.0, RefrigerantIndex, RoutineName );
 			if( ( abs( h_IU_evap_in - h_IU_evap_in_new ) > Tolerance * h_IU_evap_in ) && ( h_IU_evap_in < h_IU_evap_in_up ) && ( h_IU_evap_in > h_IU_evap_in_low ) ) {
 				h_IU_evap_in = h_IU_evap_in_new;
 				NumIteHIUIn = NumIteHIUIn + 1;
@@ -8378,7 +8378,7 @@ namespace HVACVariableRefrigerantFlow {
 					if( TerminalUnitList( TUListNum ).TotalHeatLoad( NumTU ) > 0 ) {
 						TUIndex = TerminalUnitList( TUListNum ).ZoneTUPtr( NumTU );
 						HeatCoilIndex = VRFTU( TUIndex ).HeatCoilIndex;
-						h_IU_cond_out_i = GetSatEnthalpyRefrig( this->RefrigerantName, GetSatTemperatureRefrig( this->RefrigerantName, max( min( Pcond, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName ) - DXCoil( HeatCoilIndex ).ActualSC, 0.0, RefrigerantIndex, RoutineName ); //Quality=0 		
+						h_IU_cond_out_i = GetSatEnthalpyRefrig( this->RefrigerantName, GetSatTemperatureRefrig( this->RefrigerantName, max( min( Pcond, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName ) - DXCoil( HeatCoilIndex ).ActualSC, 0.0, RefrigerantIndex, RoutineName ); //Quality=0
 						m_ref_IU_cond_i = ( TerminalUnitList( TUListNum ).TotalHeatLoad( NumTU ) <= 0.0 ) ? 0.0 : ( TerminalUnitList( TUListNum ).TotalHeatLoad( NumTU ) / ( h_IU_cond_in - h_IU_cond_out_i ) );
 						m_ref_IU_cond = m_ref_IU_cond + m_ref_IU_cond_i;
 						h_IU_cond_out_ave = h_IU_cond_out_ave + m_ref_IU_cond_i * h_IU_cond_out_i;
@@ -8575,7 +8575,7 @@ namespace HVACVariableRefrigerantFlow {
 
 					RefTSat = GetSatTemperatureRefrig( this->RefrigerantName, max( min( Pevap, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 					h_IU_evap_out_i = GetSupHeatEnthalpyRefrig( this->RefrigerantName, max( RefTSat, this->IUEvaporatingTemp + DXCoil( CoolCoilIndex ).ActualSH ), max( min( Pevap, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
-				
+
 					if( h_IU_evap_out_i > h_IU_evap_in  ) {
 						m_ref_IU_evap_i = ( TerminalUnitList( TUListNum ).TotalCoolLoad( NumTU ) <= 0.0 ) ? 0.0 : ( TerminalUnitList( TUListNum ).TotalCoolLoad( NumTU ) / ( h_IU_evap_out_i - h_IU_evap_in ) ); //Ref Flow Rate in the IU( kg/s )
 						m_ref_IU_evap  = m_ref_IU_evap + m_ref_IU_evap_i;
@@ -8802,7 +8802,7 @@ namespace HVACVariableRefrigerantFlow {
 
 					HRInitialEIRFrac = this->HRInitialCoolEIRFrac; // Fractional cooling degradation at the start of heat recovery from cooling mode
 					HREIRTC = this->HRCoolEIRTC; // Time constant used to recover from initial degradation in cooling heat recovery
-					
+
 				} else if ( HeatingLoad( VRFCond ) ) {
 					if ( ! this->HRHeatingActive && this->HRCoolingActive ) {
 						this->HRModeChange = true;
@@ -8815,7 +8815,7 @@ namespace HVACVariableRefrigerantFlow {
 
 					HRInitialEIRFrac = this->HRInitialHeatEIRFrac; // Fractional heating degradation at the start of heat recovery from heating mode
 					HREIRTC = this->HRHeatEIRTC; // Time constant used to recover from initial degradation in heating heat recovery
-					
+
 							} else {
 					//   zone thermostats satisfied, condenser is off. Set values anyway
 					// HRCAPFTConst = 1.0;
@@ -8893,7 +8893,7 @@ namespace HVACVariableRefrigerantFlow {
 					HeatingPLR = 0.0;
 				}
 			}
-			
+
 			this->VRFCondPLR = max( CoolingPLR, HeatingPLR );
 		}
 		}
@@ -8915,21 +8915,21 @@ namespace HVACVariableRefrigerantFlow {
 
 			this->ElecCoolingPower = VRF(VRFCond).Ncomp + this->OUFanPower;
 			this->ElecHeatingPower = 0;
-			
+
 		} else if ( this->OperatingMode == ModeHeatingOnly ) {
 			PartLoadFraction = 1.0;
 			VRFRTF = min( 1.0, ( CyclingRatio / PartLoadFraction ) );
 
 			this->ElecCoolingPower = 0;
 			this->ElecHeatingPower = this->Ncomp + this->OUFanPower;
-			
+
 		} else if ( this->OperatingMode == ModeCoolingAndHeating ) {
 			PartLoadFraction = 1.0;
 			VRFRTF = min( 1.0, ( CyclingRatio / PartLoadFraction ) );
 
 			this->ElecCoolingPower = ( this->Ncomp + this->OUFanPower ) * this->IUEvapHeatRate / ( this->IUCondHeatRate + this->IUEvapHeatRate );
 			this->ElecHeatingPower = ( this->Ncomp + this->OUFanPower ) * this->IUCondHeatRate / ( this->IUCondHeatRate + this->IUEvapHeatRate );
-			
+
 		} else {
 			this->ElecCoolingPower = 0;
 			this->ElecHeatingPower = 0;
@@ -9321,7 +9321,7 @@ namespace HVACVariableRefrigerantFlow {
 			if ( this->ATMixerType == ATMixer_InletSide ) { // if there is an inlet side air terminal mixer
 				// set the primary air inlet mass flow rate
 				Node( this->ATMixerPriNode ).MassFlowRate = min( Node( this->ATMixerPriNode ).MassFlowRateMaxAvail, Node( VRFTUInletNodeNum ).MassFlowRate );
-				// now calculate the the mixer outlet air conditions (and the secondary air inlet flow rate). The mixer outlet flow rate has already been set above 
+				// now calculate the the mixer outlet air conditions (and the secondary air inlet flow rate). The mixer outlet flow rate has already been set above
 				// (it is the "inlet" node flow rate)
 				SimATMixer( this->ATMixerName, FirstHVACIteration, this->ATMixerIndex );
 			}
@@ -9495,7 +9495,7 @@ namespace HVACVariableRefrigerantFlow {
 			// The difference is usually 2-3C according to the engineering experience. 2 is used here for a slightly bigger fan flow rate.
 			if( VRF( VRFCond ).HeatRecoveryUsed )
 				TeTc = min( TeTc, OutDryBulbTemp - 2 );
-			
+
 		} else if ( ( ! VRF( VRFCond ).HeatRecoveryUsed && HeatingLoad( VRFCond ) ) || ( VRF( VRFCond ).HeatRecoveryUsed && TerminalUnitList( TUListIndex ).HRHeatRequest( IndexToTUInTUList ) ) ) {
 			// VRF terminal unit is on heating mode
 			DXCoilNum = this->HeatCoilIndex;
@@ -9703,13 +9703,13 @@ namespace HVACVariableRefrigerantFlow {
 		// METHODOLOGY EMPLOYED:
 		// 		Call VRFOU_CompCap to calculate the total evaporative capacity Q_c_tot, at the given compressor speed and operational
 		// 		conditions, and then call VRFOU_TeTc to obtain Tsuction_new based on OU evaporator air-side calculations
-		
+
 
 		// REFERENCES:
 		// na
 
 		// Using/Aliasing
-		
+
 		using DataEnvironment::OutDryBulbTemp;
 		using DataEnvironment::OutHumRat;
 		using DataEnvironment::OutBaroPress;
@@ -9752,18 +9752,18 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 Tfs; // OU evaporator coil surface temperature [C]
 
 		// FLOW
-		
+
 		// calculate the total evaporative capacity Q_c_tot, at the given compressor speed and operational conditions
 		VRF( VRFCond ).VRFOU_CompCap( CompSpdActual, Te, Tdischarge, h_IU_evap_in, h_comp_in, Q_c_tot_temp, Ncomp_temp );
 		Q_c_OU_temp = Q_c_tot_temp - Q_c_TU_PL;
-		
+
 		// Tsuction_new calculated based on OU evaporator air-side calculations (Tsuction_new < To)
 		VRF( VRFCond ).VRFOU_TeTc( FlagEvapMode, Q_c_OU_temp, VRF( VRFCond ).SH, m_air_evap_rated, OutDryBulbTemp, OutHumRat, OutBaroPress, Tfs, Te_new );
-		
+
 		TeResidual = Te_new - Te;
 
 		return TeResidual;
-		
+
 	}
 
 	Real64
@@ -9818,7 +9818,7 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 & TeTc // VRF Tc at cooling mode, or Te at heating mode [C]
 	)
 	{
-	
+
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rongpeng Zhang, LBNL
 		//       DATE WRITTEN   Jan 2016
@@ -9839,7 +9839,7 @@ namespace HVACVariableRefrigerantFlow {
 		//
 		// USE STATEMENTS:
 		using General::TrimSigDigits;
-	
+
 		Real64 BF; // VRF OU bypass  [-]
 		Real64 deltaT;     // Difference between Te/Tc and air temperature at coil surface [C]
 		Real64 h_coil_in; // Enthalpy of air at OU coil inlet [C]
@@ -9847,57 +9847,57 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 T_coil_out; // Air temperature at coil outlet [C]
 		Real64 T_coil_surf_sat; // Saturated air temperature at coil surface [C]
 		Real64 W_coil_surf_sat; // Humidity ratio of saturated air at coil surface [kg/kg]
-		
+
 		if( OperationMode == FlagCondMode ) {
 		//IU Cooling: OperationMode 0
-		
+
 			if( m_air <= 0 ) {
 				TeTc = this->CondensingTemp;
 				ShowSevereMessage( " Unreasonable outdoor unit airflow rate (" + TrimSigDigits( m_air, 3 ) + " ) for \"" + this->Name + "\":" );
 				ShowContinueError( " This cannot be used to calculate outdoor unit refrigerant temperature." );
 				ShowContinueError( " Default condensing temperature is used: " + TrimSigDigits( TeTc, 3 ) );
 			}
-			
+
 			BF = this->RateBFOUCond; //0.219;
 			T_coil_out = T_coil_in + Q_coil / 1005.0 / m_air;
 			T_coil_surf = T_coil_in + ( T_coil_out - T_coil_in ) / ( 1 - BF );
-			
+
 			deltaT = this->C3Tc * pow_2( SHSC ) + this->C2Tc * SHSC + this->C1Tc;
-			
+
 			TeTc = T_coil_surf + deltaT;
-		
+
 		} else if( OperationMode == FlagEvapMode ) {
 		//IU Heating: OperationMode 1
-	
+
 			if( m_air <= 0 ) {
 				TeTc = this->EvaporatingTemp;
 				ShowSevereMessage( " Unreasonable outdoor unit airflow rate (" + TrimSigDigits( m_air, 3 ) + " ) for \"" + this->Name + "\":" );
 				ShowContinueError( " This cannot be used to calculate outdoor unit refrigerant temperature." );
 				ShowContinueError( " Default condensing temperature is used: " + TrimSigDigits( TeTc, 3 ) );
 			}
-			
+
 			BF = this->RateBFOUEvap; //0.45581;
 			h_coil_in = PsyHFnTdbW( T_coil_in, W_coil_in );
 			h_coil_out = h_coil_in - Q_coil / m_air / ( 1 - BF );
 			h_coil_out = max( 0.01, h_coil_out );
-			
+
 			T_coil_surf_sat = PsyTsatFnHPb( h_coil_out, OutdoorPressure, "VRFOU_TeTc" );
 			W_coil_surf_sat = PsyWFnTdbH( T_coil_surf_sat, h_coil_out, "VRFOU_TeTc" );
-			
+
 			if( W_coil_surf_sat < W_coil_in )
 			// There is dehumidification
 				T_coil_surf = T_coil_surf_sat;
 			else
 			// No dehumidification
 				T_coil_surf = PsyTdbFnHW( h_coil_out, W_coil_in );
-				
+
 			deltaT = this->C3Te * pow_2( SHSC ) + this->C2Te * SHSC + this->C1Te;
-			
+
 			TeTc = T_coil_surf - deltaT;
-		
+
 		}
 	}
-	
+
 	Real64
 	VRFCondenserEquipment::VRFOU_Cap(
 		int const OperationMode, // Mode 0 for running as condenser, 1 for evaporator
@@ -9908,7 +9908,7 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 const W_coil_in // Humidity ratio of air at OU coil inlet [kg/kg]
 	)
 	{
-	
+
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rongpeng Zhang, LBNL
 		//       DATE WRITTEN   Jan 2016
@@ -9929,7 +9929,7 @@ namespace HVACVariableRefrigerantFlow {
 		// USE STATEMENTS:
 		using General::TrimSigDigits;
 		using DataEnvironment::OutBaroPress;
-	
+
 		Real64 BF; // VRF OU bypass [-]
 		Real64 deltaT; // Difference between Te/Tc and air temperature at coil surface [C]
 		Real64 h_coil_in; // Enthalpy of air at OU coil inlet [C]
@@ -9938,36 +9938,36 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 T_coil_out; // Air temperature at coil outlet [C]
 		Real64 T_coil_surf; // Air temperature at coil surface [C]
 		Real64 W_coil_surf_sat; // Humidity ratio of saturated air at coil surface [kg/kg]
-		
+
 		Q_coil = 0.0;
-		
+
 		if( OperationMode == FlagCondMode ) {
 		//IU Cooling: OperationMode 0
 			if( m_air <= 0 ) {
 				ShowSevereMessage( " Unreasonable outdoor unit airflow rate (" + TrimSigDigits( m_air, 3 ) + " ) for \"" + this->Name + "\":" );
 				ShowContinueError( " This cannot be used to calculate outdoor unit capacity." );
 			}
-			
+
 			BF = this->RateBFOUCond; //0.219;
 			deltaT = this->C3Tc * pow_2( SHSC ) + this->C2Tc * SHSC + this->C1Tc;
 			T_coil_surf = TeTc - deltaT;
 			T_coil_out = T_coil_in + ( T_coil_surf - T_coil_in ) * ( 1 - BF );
 			Q_coil = ( T_coil_out - T_coil_in ) * 1005.0 * m_air;
-		
+
 		} else if( OperationMode == FlagEvapMode ) {
 		//IU Heating: OperationMode 1
 			if( m_air <= 0 ) {
 				ShowSevereMessage( " Unreasonable outdoor unit airflow rate (" + TrimSigDigits( m_air, 3 ) + " ) for \"" + this->Name + "\":" );
 				ShowContinueError( " This cannot be used to calculate outdoor unit capacity." );
 			}
-			
+
 			BF = this->RateBFOUEvap; //0.45581;
 			deltaT = this->C3Te * pow_2( SHSC ) + this->C2Te * SHSC + this->C1Te;
 			T_coil_surf = TeTc + deltaT;
-			
+
 			// saturated humidity ratio corresponding to T_coil_surf
 			W_coil_surf_sat = PsyWFnTdpPb( T_coil_surf, OutBaroPress );
-			
+
 			if( W_coil_surf_sat < W_coil_in ) {
 			// There is dehumidification, W_coil_out = W_coil_surf_sat
 				h_coil_out = PsyHFnTdbW( T_coil_surf, W_coil_surf_sat );
@@ -9978,16 +9978,16 @@ namespace HVACVariableRefrigerantFlow {
 			h_coil_out = max( 0.01, h_coil_out );
 			h_coil_in = PsyHFnTdbW( T_coil_in, W_coil_in );
 			Q_coil = ( h_coil_in - h_coil_out ) * m_air * ( 1 - BF ); // bypass airflow should not be included here
-			
+
 		} else {
 		//Should not come here
 			ShowSevereMessage( " Unreasonable outdoor unit operational mode for \"" + this->Name + "\":" );
 			ShowContinueError( " The operational mode is not correctly set in the function VRFOU_Cap." );
 		}
-		
+
 		return Q_coil;
 	}
-	
+
 	Real64
 	VRFCondenserEquipment::VRFOU_FlowRate(
 		int const OperationMode, // Mode 0 for running as condenser, 1 for evaporator
@@ -9998,7 +9998,7 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 const W_coil_in // Humidity ratio of air at OU coil inlet [kg/kg]
 	)
 	{
-	
+
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rongpeng Zhang, LBNL
 		//       DATE WRITTEN   Mar 2016
@@ -10019,7 +10019,7 @@ namespace HVACVariableRefrigerantFlow {
 		// USE STATEMENTS:
 		using General::TrimSigDigits;
 		using DataEnvironment::OutBaroPress;
-	
+
 		Real64 BF; // VRF OU bypass [-]
 		Real64 deltaT; // Difference between Te/Tc and air temperature at coil surface [C]
 		Real64 h_coil_in; // Enthalpy of air at OU coil inlet [C]
@@ -10028,28 +10028,28 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 T_coil_out; // Air temperature at coil outlet [C]
 		Real64 T_coil_surf; // Air temperature at coil surface [C]
 		Real64 W_coil_surf_sat; // Humidity ratio of saturated air at coil surface [kg/kg]
-		
+
 		m_air = 0.0;
-		
+
 		if( OperationMode == FlagCondMode ) {
 		//IU Cooling: OperationMode 0
-			
+
 			BF = this->RateBFOUCond; //0.219;
 			deltaT = this->C3Tc * pow_2( SHSC ) + this->C2Tc * SHSC + this->C1Tc;
 			T_coil_surf = TeTc - deltaT;
 			T_coil_out = T_coil_in + ( T_coil_surf - T_coil_in ) * ( 1 - BF );
 			m_air = Q_coil / ( T_coil_out - T_coil_in ) / 1005.0;
-		
+
 		} else if( OperationMode == FlagEvapMode ) {
 		//IU Heating: OperationMode 1
-			
+
 			BF = this->RateBFOUEvap; //0.45581;
 			deltaT = this->C3Te * pow_2( SHSC ) + this->C2Te * SHSC + this->C1Te;
 			T_coil_surf = TeTc + deltaT;
-			
+
 			// saturated humidity ratio corresponding to T_coil_surf
 			W_coil_surf_sat = PsyWFnTdpPb( T_coil_surf, OutBaroPress );
-			
+
 			if( W_coil_surf_sat < W_coil_in ) {
 			// There is dehumidification, W_coil_out = W_coil_surf_sat
 				h_coil_out = PsyHFnTdbW( T_coil_surf, W_coil_surf_sat );
@@ -10060,16 +10060,16 @@ namespace HVACVariableRefrigerantFlow {
 			h_coil_out = max( 0.01, h_coil_out );
 			h_coil_in = PsyHFnTdbW( T_coil_in, W_coil_in );
 			m_air = Q_coil / ( h_coil_in - h_coil_out ) / ( 1 - BF );
-			
+
 		} else {
 		//Should not come here
 			ShowSevereMessage( " Unreasonable outdoor unit operational mode for \"" + this->Name + "\":" );
 			ShowContinueError( " The operational mode is not correctly set in the function VRFOU_Cap." );
 		}
-		
+
 		return m_air;
 	}
-	
+
 	Real64
 	VRFCondenserEquipment::VRFOU_SCSH(
 		int const OperationMode, // Mode 0 for running as condenser, 1 for evaporator
@@ -10081,7 +10081,7 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 const OutdoorPressure // Outdoor air pressure [Pa]
 	)
 	{
-	
+
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rongpeng Zhang, LBNL
 		//       DATE WRITTEN   Jan 2016
@@ -10103,7 +10103,7 @@ namespace HVACVariableRefrigerantFlow {
 		// USE STATEMENTS:
 		using General::TrimSigDigits;
 		using DataEnvironment::OutBaroPress;
-	
+
 		Real64 BF; // VRF OU bypass [-]
 		Real64 deltaT; // Difference between Te/Tc and air temperature at coil surface [C]
 		Real64 h_coil_in; // Enthalpy of air at OU coil inlet [C]
@@ -10113,66 +10113,66 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 T_coil_surf; // Air temperature at coil surface [C]
 		Real64 T_coil_surf_sat; // Saturated air temperature at coil surface [C]
 		Real64 W_coil_surf_sat; // Humidity ratio of saturated air at coil surface [kg/kg]
-		
+
 		SHSC = 0.0;
-		
+
 		if( OperationMode == FlagCondMode ) {
 		//Cooling: OperationMode 0
 			if( m_air <= 0 ) {
 				ShowSevereMessage( " Unreasonable outdoor unit airflow rate (" + TrimSigDigits( m_air, 3 ) + " ) for \"" + this->Name + "\":" );
 				ShowContinueError( " This cannot be used to calculate outdoor unit subcooling." );
 			}
-			
+
 			BF = this->RateBFOUCond; //0.219;
 			T_coil_out = T_coil_in + Q_coil / 1005.0 / m_air;
 			T_coil_surf = T_coil_in + ( T_coil_out - T_coil_in ) / ( 1 - BF );
 			deltaT = TeTc - T_coil_surf;
-			
+
 			// SC_OU
 			if( this->C3Tc == 0 )
 				SHSC = -( this->C1Tc - deltaT ) / this->C2Tc;
 			else
 				SHSC = ( - this->C2Tc + std::pow( ( pow_2( this->C2Tc ) - 4 * ( this->C1Tc - deltaT ) * this->C3Tc) , 0.5 ) ) / ( 2 * this->C3Tc );
-		
+
 		} else if( OperationMode == FlagEvapMode ) {
 		//Heating: OperationMode 1
 			if( m_air <= 0 ) {
 				ShowSevereMessage( " Unreasonable outdoor unit airflow rate (" + TrimSigDigits( m_air, 3 ) + " ) for \"" + this->Name + "\":" );
 				ShowContinueError( " This cannot be used to calculate outdoor unit super heating." );
 			}
-			
+
 			BF = this->RateBFOUEvap; //0.45581;
 			h_coil_in = PsyHFnTdbW( T_coil_in, W_coil_in );
 			h_coil_out = h_coil_in - Q_coil / m_air / ( 1 - BF );
 			h_coil_out = max( 0.01, h_coil_out );
-			
+
 			T_coil_surf_sat = PsyTsatFnHPb( h_coil_out, OutdoorPressure, "VRFOU_TeTc" );
 			W_coil_surf_sat = PsyWFnTdbH( T_coil_surf_sat, h_coil_out, "VRFOU_TeTc" );
-			
+
 			if( W_coil_surf_sat < W_coil_in )
 			// There is dehumidification
 				T_coil_surf = T_coil_surf_sat;
 			else
 			// No dehumidification
 				T_coil_surf = PsyTdbFnHW( h_coil_out, W_coil_in );
-			
+
 			deltaT = T_coil_surf - TeTc;
-			
+
 			// SH_OU
 			if( this->C3Te == 0 )
 				SHSC = -( this->C1Te - deltaT ) / this->C2Te;
 			else
 				SHSC = ( - this->C2Te + std::pow( ( pow_2( this->C2Te ) - 4 * ( this->C1Te - deltaT ) * this->C3Te) , 0.5 ) ) / ( 2 * this->C3Te );
-			
+
 		} else {
 		//Should not come here
 			ShowSevereMessage( " Unreasonable outdoor unit operational mode for \"" + this->Name + "\":" );
 			ShowContinueError( " The operational mode is not correctly set in the function VRFOU_Cap." );
 		}
-		
+
 		return SHSC;
 	}
-	
+
 	Real64
 	VRFCondenserEquipment::VRFOU_CapModFactor(
 		Real64 const h_comp_in_real, // Enthalpy of refrigerant at the compressor inlet at real conditions [kJ/kg]
@@ -10221,20 +10221,20 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 h_evap_in_rate; // enthalpy of refrigerant at the evaporator inlet at rated conditions [kJ/kg]
 		Real64 density_rate; // density of refrigerant at rated conditions [kg/m3]
 		Real64 density_real; // density of refrigerant at rated conditions [kg/m3]
-		
+
 		// INTERFACE BLOCK SPECIFICATIONS
 		// na
-		
+
 		// DERIVED TYPE DEFINITIONS
 		// na
-		
+
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-		
+
 		static std::string const RoutineName( "VRFOU_CapModFactor" );
-		
+
 		// variable initializations
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
-		
+
 		//Saturated temperature at real evaporating pressure
 		RefTSat = GetSatTemperatureRefrig( this->RefrigerantName, P_evap_real, RefrigerantIndex, RoutineName );
 
@@ -10251,18 +10251,18 @@ namespace HVACVariableRefrigerantFlow {
 			C_cap_density = density_rate / density_real;
 		else
 			C_cap_density = 1.0;
-			
+
 		if( ( h_comp_in_real - h_evap_in_real ) > 0 )
 			C_cap_enthalpy = abs( h_evap_out_rate - h_evap_in_rate) / abs( h_comp_in_real - h_evap_in_real );
 		else
 			C_cap_enthalpy = 1.0;
 
 		C_cap_operation = C_cap_density * C_cap_enthalpy;
-		
+
 		return C_cap_operation;
 
 	}
-	
+
 	void
 	VRFCondenserEquipment::VRFOU_TeModification(
 		Real64 const Te_up, // Upper bound of Te during iteration, i.e., Te before reduction [C]
@@ -10325,29 +10325,29 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 Te_ItePreci; // Precision of iterations for Te [C]he superheat area [C]
 		Real64 Tfs; // Temperature of the air at the coil surface [C]]
 		Real64 Tsuction; // VRF compressor suction refrigerant temperature [Pa]
-		
+
 		// INTERFACE BLOCK SPECIFICATIONS
 		// na
-		
+
 		// DERIVED TYPE DEFINITIONS
 		// na
-		
+
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		static std::string const RoutineName( "VRFOU_TeModification" );
-		
+
 		// variable initializations
 		TUListNum = this->ZoneTUListPtr;
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
 		RefPLow = RefrigData( RefrigerantIndex ).PsLowPresValue;
 		RefPHigh = RefrigData( RefrigerantIndex ).PsHighPresValue;
 		NumTUInList = TerminalUnitList( TUListNum ).NumTUInList;
-		
+
 		//Initialization of Te iterations (Label11)
 		NumTeIte = 1;
 		Te_ItePreci = 0.1;
 		MaxNumTeIte = ( Te_up - Te_low ) / Te_ItePreci + 1; //upper bound and lower bound of Te iterations
 		Te_update = Te_up - Te_ItePreci;
-		
+
 		Label11: ;
 		Pipe_m_ref = 0; // Total Ref Flow Rate( kg/s )
 		Pipe_h_IU_out = 0;
@@ -10355,25 +10355,25 @@ namespace HVACVariableRefrigerantFlow {
 		Pipe_m_ref_i = 0;
 		Pipe_SH_merged = 0;
 		Pe_update = GetSatPressureRefrig( this->RefrigerantName, Te_update, RefrigerantIndex, RoutineName );
-		
+
 		// Re-calculate total refrigerant flow rate, with updated SH
 		for ( int NumTU = 1; NumTU <= NumTUInList; NumTU++ ){
 			if( TerminalUnitList( TUListNum ).TotalCoolLoad( NumTU ) > 0  ) {
 				TUIndex = TerminalUnitList( TUListNum ).ZoneTUPtr( NumTU );
 				CoolCoilIndex = VRFTU( TUIndex ).CoolCoilIndex;
-				
+
 				// The IU coil surface temperature should be the same.
 				Tfs = Te_up + ( this->C3Te * pow_2( DXCoil( CoolCoilIndex ).ActualSH ) + this->C2Te * DXCoil( CoolCoilIndex ).ActualSH + this->C1Te );
-				
+
 				// SH_IU_update is the updated SH for a specific IU
 				if( this->C3Te == 0 )
 					SH_IU_update = -( this->C1Te - Tfs + Te_update ) / this->C2Te;
 				else
 					SH_IU_update = ( - this->C2Te + std::pow( ( pow_2( this->C2Te ) - 4 * ( this->C1Te - Tfs + Te_update ) * this->C3Te) , 0.5 ) ) / ( 2 * this->C3Te );
-				
+
 				RefTSat = GetSatTemperatureRefrig( this->RefrigerantName, Pe_update, RefrigerantIndex, RoutineName );
 				Pipe_h_IU_out_i = GetSupHeatEnthalpyRefrig( this->RefrigerantName, max( RefTSat, Te_update + SH_IU_update ), Pe_update, RefrigerantIndex, RoutineName ); // hB_i for the IU
-			
+
 				if( Pipe_h_IU_out_i > Pipe_h_IU_in ) {
 					Pipe_m_ref_i = ( TerminalUnitList( TUListNum ).TotalCoolLoad( NumTU ) <= 0.0 ) ? 0.0 : ( TerminalUnitList( TUListNum ).TotalCoolLoad( NumTU ) / ( Pipe_h_IU_out_i - Pipe_h_IU_in ) );
 					Pipe_m_ref = Pipe_m_ref + Pipe_m_ref_i;
@@ -10388,12 +10388,12 @@ namespace HVACVariableRefrigerantFlow {
 		} else {
 			Pipe_SH_merged = this->SH;
 			RefTSat = GetSatTemperatureRefrig( this->RefrigerantName, Pe_update, RefrigerantIndex, RoutineName );
-			Pipe_h_IU_out = GetSupHeatEnthalpyRefrig( this->RefrigerantName, max( RefTSat, Te_update + Pipe_SH_merged ), Pe_update, RefrigerantIndex, RoutineName );	
+			Pipe_h_IU_out = GetSupHeatEnthalpyRefrig( this->RefrigerantName, max( RefTSat, Te_update + Pipe_SH_merged ), Pe_update, RefrigerantIndex, RoutineName );
 		}
 
 		// Re-calculate piping loss
 		this->VRFOU_PipeLossC( Pipe_m_ref, Pe_update, Pipe_h_IU_out, Pipe_SH_merged, OutdoorDryBulb, Pipe_Q, Pipe_DeltP, Pipe_h_comp_in );
-		
+
 		Tsuction = GetSatTemperatureRefrig( this->RefrigerantName, max( min( Pe_update - Pipe_DeltP, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 
 		if( ( abs( Tsuction - Te_low ) > 0.5 ) && ( Te_update < Te_up ) && ( Te_update > Te_low ) && ( NumTeIte < MaxNumTeIte ) ){
@@ -10401,7 +10401,7 @@ namespace HVACVariableRefrigerantFlow {
 			NumTeIte = NumTeIte + 1;
 			goto Label11;
 		}
-		
+
 		if( abs( Tsuction - Te_low ) > 0.5 ) {
 			NumTeIte = 999;
 			Tsuction = Te_low;
@@ -10410,7 +10410,7 @@ namespace HVACVariableRefrigerantFlow {
 		}
 
 	}
-	
+
 	void
 	VRFCondenserEquipment::VRFOU_CompSpd(
 		Real64 const Q_req, // Required capacity [W]
@@ -10466,33 +10466,33 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 T_comp_in; // Refrigerant temperature at compressor inlet (after piping loss) [C]
 		Array1D< Real64 > CompEvaporatingPWRSpd; // Array for the compressor power at certain speed [W]
 		Array1D< Real64 > CompEvaporatingCAPSpd; // Array for the evaporating capacity at certain speed [W]
-		
+
 		// INTERFACE BLOCK SPECIFICATIONS
 		// na
-		
+
 		// DERIVED TYPE DEFINITIONS
 		// na
-		
+
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		static std::string const RoutineName( "VRFOU_CompSpd" );
-		
+
 		// variable initializations: component index
 		TUListNum = this->ZoneTUListPtr;
 		NumTUInList = TerminalUnitList( TUListNum ).NumTUInList;
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
 		RefPLow = RefrigData( RefrigerantIndex ).PsLowPresValue;
 		RefPHigh = RefrigData( RefrigerantIndex ).PsHighPresValue;
-		
+
 		// variable initializations: compressor
 		NumOfCompSpdInput = this->CompressorSpeed.size();
 		CompEvaporatingPWRSpd.dimension( NumOfCompSpdInput );
 		CompEvaporatingCAPSpd.dimension( NumOfCompSpdInput );
-		
+
 		// variable initializations: system operational parameters
 		P_suction = GetSatPressureRefrig( this->RefrigerantName, T_suction, RefrigerantIndex, RoutineName );
 		T_comp_in = GetSupHeatTempRefrig( this->RefrigerantName, max( min( P_suction, RefPHigh ), RefPLow ), h_comp_in, T_suction + 3, T_suction + 30, RefrigerantIndex, RoutineName );
 		SH_Comp = T_comp_in - T_suction;
-		
+
 		//Calculate capacity modification factor
 		C_cap_operation = this->VRFOU_CapModFactor( h_comp_in, h_IU_evap_in, max( min( P_suction, RefPHigh ), RefPLow ), T_suction + SH_Comp, T_suction + 8, T_discharge - 5 );
 
@@ -10500,74 +10500,74 @@ namespace HVACVariableRefrigerantFlow {
 		// Capacity to meet is for evaporator
 
 			Q_evap_req = Q_req;
-		
+
 			for ( CounterCompSpdTemp = 1; CounterCompSpdTemp <= NumOfCompSpdInput; CounterCompSpdTemp++ ){
 			//Iteration to find the VRF speed that can meet the required load, Iteration DoName1
-				
+
 				CompEvaporatingPWRSpd( CounterCompSpdTemp ) = this->RatedCompPower * CurveValue( this->OUCoolingPWRFT( CounterCompSpdTemp ), T_discharge, T_suction );
 				CompEvaporatingCAPSpd( CounterCompSpdTemp ) = this->CoffEvapCap * this->RatedEvapCapacity * CurveValue( this->OUCoolingCAPFT( CounterCompSpdTemp ), T_discharge, T_suction );
-				
+
 				if( Q_evap_req * C_cap_operation <= CompEvaporatingCAPSpd( CounterCompSpdTemp ) ) {
 				// Compressor speed stage CounterCompSpdTemp need not to be increased, finish Iteration DoName1
-				
+
 					if( CounterCompSpdTemp > 1 ){
-					
+
 						CompSpdLB = CounterCompSpdTemp - 1;
 						CompSpdUB = CounterCompSpdTemp;
-						
+
 						CompSpdActual = this->CompressorSpeed( CompSpdLB ) + ( this->CompressorSpeed( CompSpdUB ) - this->CompressorSpeed( CompSpdLB ) )
 										/ ( CompEvaporatingCAPSpd( CompSpdUB ) - CompEvaporatingCAPSpd( CompSpdLB ) ) * ( Q_evap_req * C_cap_operation - CompEvaporatingCAPSpd( CompSpdLB ) );
-					
+
 					} else {
 						CompSpdActual = this->CompressorSpeed( 1 ) * ( Q_evap_req * C_cap_operation ) / CompEvaporatingCAPSpd( 1 );
 					}
-					
+
 					break; //EXIT DoName1
 				}
 			} // End: Iteration DoName1
-			
+
 			if( CounterCompSpdTemp > NumOfCompSpdInput ) {
 				CompSpdActual = this->CompressorSpeed( NumOfCompSpdInput );
 			}
-		
+
 		} else {
 		// Capacity to meet is for condenser
-		
+
 			Q_cond_req = Q_req;
 
 			for ( CounterCompSpdTemp = 1; CounterCompSpdTemp <= NumOfCompSpdInput; CounterCompSpdTemp++ ){
 			//Iteration to find the VRF speed that can meet the required load, Iteration DoName1
-				
+
 				CompEvaporatingPWRSpd( CounterCompSpdTemp ) = this->RatedCompPower * CurveValue( this->OUCoolingPWRFT( CounterCompSpdTemp ), T_discharge, T_suction );
 				CompEvaporatingCAPSpd( CounterCompSpdTemp ) = this->CoffEvapCap * this->RatedEvapCapacity * CurveValue( this->OUCoolingCAPFT( CounterCompSpdTemp ), T_discharge, T_suction );
-				
+
 				Q_evap_req = Q_cond_req - CompEvaporatingPWRSpd( CounterCompSpdTemp );
 
 				if( Q_evap_req * C_cap_operation <= CompEvaporatingCAPSpd( CounterCompSpdTemp ) ) {
 				// Compressor speed stage CounterCompSpdTemp need not to be increased, finish Iteration DoName1
-				
+
 					if( CounterCompSpdTemp > 1 ){
-					
+
 						CompSpdLB = CounterCompSpdTemp - 1;
 						CompSpdUB = CounterCompSpdTemp;
-						
+
 						CompSpdActual = this->CompressorSpeed( CompSpdLB ) + ( this->CompressorSpeed( CompSpdUB ) - this->CompressorSpeed( CompSpdLB ) )
 										/ ( CompEvaporatingCAPSpd( CompSpdUB ) - CompEvaporatingCAPSpd( CompSpdLB ) ) * ( Q_evap_req * C_cap_operation - CompEvaporatingCAPSpd( CompSpdLB ) );
-					
+
 					} else {
 						CompSpdActual = this->CompressorSpeed( 1 ) * ( Q_evap_req * C_cap_operation ) / CompEvaporatingCAPSpd( 1 );
 					}
-					
+
 					break; //EXIT DoName1
 				}
 			} // End: Iteration DoName1
-			
+
 			if( CounterCompSpdTemp > NumOfCompSpdInput ) {
 				CompSpdActual = this->CompressorSpeed( NumOfCompSpdInput );
 			}
-			
+
 		}
-		
+
 	}
 
 	void
@@ -10624,64 +10624,64 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 T_comp_in; // Refrigerant temperature at compressor inlet (after piping loss) [C]
 		Array1D< Real64 > CompEvaporatingPWRSpd; // Array for the compressor power at certain speed [W]
 		Array1D< Real64 > CompEvaporatingCAPSpd; // Array for the evaporating capacity at certain speed [W]
-		
+
 		// INTERFACE BLOCK SPECIFICATIONS
 		// na
-		
+
 		// DERIVED TYPE DEFINITIONS
 		// na
-		
+
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		static std::string const RoutineName( "VRFOU_CompCap" );
-		
+
 		// variable initializations: component index
 		TUListNum = this->ZoneTUListPtr;
 		NumTUInList = TerminalUnitList( TUListNum ).NumTUInList;
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
 		RefPLow = RefrigData( RefrigerantIndex ).PsLowPresValue;
 		RefPHigh = RefrigData( RefrigerantIndex ).PsHighPresValue;
-		
+
 		// variable initializations: compressor
 		NumOfCompSpdInput = this->CompressorSpeed.size();
 		CompEvaporatingPWRSpd.dimension( NumOfCompSpdInput );
 		CompEvaporatingCAPSpd.dimension( NumOfCompSpdInput );
 
 		for ( CounterCompSpdTemp = 1; CounterCompSpdTemp <= NumOfCompSpdInput; CounterCompSpdTemp++ ){
-			
+
 			CompEvaporatingPWRSpd( CounterCompSpdTemp ) = this->RatedCompPower * CurveValue( this->OUCoolingPWRFT( CounterCompSpdTemp ), T_discharge, T_suction );
 			CompEvaporatingCAPSpd( CounterCompSpdTemp ) = this->CoffEvapCap * this->RatedEvapCapacity * CurveValue( this->OUCoolingCAPFT( CounterCompSpdTemp ), T_discharge, T_suction );
-			
+
 			if( CompSpdActual <= this->CompressorSpeed( CounterCompSpdTemp ) ) {
 			// Compressor speed stage CounterCompSpdTemp need not to be increased, finish Iteration DoName1
-			
+
 				if( CounterCompSpdTemp > 1 ){
-				
+
 					CompSpdLB = CounterCompSpdTemp - 1;
 					CompSpdUB = CounterCompSpdTemp;
-					
+
 					Q_evap_sys = CompEvaporatingCAPSpd( CompSpdLB ) + ( CompEvaporatingCAPSpd( CompSpdUB ) - CompEvaporatingCAPSpd( CompSpdLB ) ) * ( CompSpdActual - this->CompressorSpeed( CompSpdLB )) / ( this->CompressorSpeed( CompSpdUB ) - this->CompressorSpeed( CompSpdLB ) );
 					Ncomp = CompEvaporatingPWRSpd( CompSpdLB ) + ( CompEvaporatingPWRSpd( CompSpdUB ) - CompEvaporatingPWRSpd( CompSpdLB ) ) * ( CompSpdActual - this->CompressorSpeed( CompSpdLB )) / ( this->CompressorSpeed( CompSpdUB ) - this->CompressorSpeed( CompSpdLB ) );
-				
-				
+
+
 				} else {
 					Q_evap_sys = CompEvaporatingCAPSpd( 1 ) * CompSpdActual / this->CompressorSpeed( 1 );
 					Ncomp = CompEvaporatingPWRSpd( 1 ) * CompSpdActual / this->CompressorSpeed( 1 );
 				}
-				
+
 				break;
 			}
 		}
-		
+
 		if( CounterCompSpdTemp > NumOfCompSpdInput ) {
 			Q_evap_sys = CompEvaporatingCAPSpd( NumOfCompSpdInput ) ;
 			Ncomp = CompEvaporatingPWRSpd( NumOfCompSpdInput );
 		}
-		
+
 		// variable initializations: system operational parameters
 		P_suction = GetSatPressureRefrig( this->RefrigerantName, T_suction, RefrigerantIndex, RoutineName );
 		T_comp_in = GetSupHeatTempRefrig( this->RefrigerantName, max( min( P_suction, RefPHigh ), RefPLow ), h_comp_in, T_suction + 3, T_suction + 30, RefrigerantIndex, RoutineName );
 		SH_Comp = T_comp_in - T_suction;
-		
+
 		//Calculate capacity modification factor
 		C_cap_operation = this->VRFOU_CapModFactor( h_comp_in, h_IU_evap_in, max( min( P_suction, RefPHigh ), RefPLow ), T_suction + SH_Comp, T_suction + 8, T_discharge - 5 );
 		C_cap_operation = min( 1.5, max( 0.5, C_cap_operation ));
@@ -10787,14 +10787,14 @@ namespace HVACVariableRefrigerantFlow {
 		Array1D< Real64 > CompEvaporatingPWRSpd; // Array for the compressor power at certain speed [W]
 		Array1D< Real64 > CompEvaporatingCAPSpd; // Array for the evaporating capacity at certain speed [W]
 		Array1D< Real64 > Par( 3 ); // Array for the parameters [-]
-		
-		
+
+
 		// INTERFACE BLOCK SPECIFICATIONS
 		// na
-		
+
 		// DERIVED TYPE DEFINITIONS
 		// na
-		
+
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		static std::string const RoutineName( "VRFOU_CalcCompC" );
 
@@ -10803,57 +10803,57 @@ namespace HVACVariableRefrigerantFlow {
 		CompEvaporatingPWRSpd.dimension( NumOfCompSpdInput );
 		CompEvaporatingCAPSpd.dimension( NumOfCompSpdInput );
 		Q_evap_req = TU_load + Pipe_Q;
-		
+
 		TUListNum = this->ZoneTUListPtr;
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
 		RefPLow = RefrigData( RefrigerantIndex ).PsLowPresValue;
 		RefPHigh = RefrigData( RefrigerantIndex ).PsHighPresValue;
 		NumTUInList = TerminalUnitList( TUListNum ).NumTUInList;
-		
+
 		Modifi_SH = Pipe_T_comp_in - T_suction;
-		
+
 		// set condenser entering air conditions (Outdoor air conditions)
 		Real64 OutdoorDryBulb = OutDryBulbTemp;
 		Real64 OutdoorHumRat = OutHumRat;
 		Real64 OutdoorPressure = OutBaroPress;
 		Real64 RhoAir = PsyRhoAirFnPbTdbW( OutdoorPressure, OutdoorDryBulb, OutdoorHumRat);
-		
+
 		//Calculate capacity modification factor
 		C_cap_operation = this->VRFOU_CapModFactor( Pipe_h_comp_in, Pipe_h_IU_in, max( min( P_suction, RefPHigh ), RefPLow ), T_suction + Modifi_SH, T_suction + 8, T_discharge - 5 );
 
 		for ( CounterCompSpdTemp = 1; CounterCompSpdTemp <= NumOfCompSpdInput; CounterCompSpdTemp++ ){
 		//Iteration to find the VRF speed that can meet the required load, Iteration DoName1
-			
+
 			CompEvaporatingPWRSpd( CounterCompSpdTemp ) = this->RatedCompPower * CurveValue( this->OUCoolingPWRFT( CounterCompSpdTemp ), T_discharge, T_suction );
 			CompEvaporatingCAPSpd( CounterCompSpdTemp ) = this->CoffEvapCap * this->RatedEvapCapacity * CurveValue( this->OUCoolingCAPFT( CounterCompSpdTemp ), T_discharge, T_suction );
-			
+
 			if( Q_evap_req * C_cap_operation <= CompEvaporatingCAPSpd( CounterCompSpdTemp ) ) {
 			// Compressor speed stage CounterCompSpdTemp need not to be increased, finish Iteration DoName1
-			
+
 				if( CounterCompSpdTemp > 1 ){// Since: if( CounterCompSpdTemp <= 1 )
 					//Compressor speed > min
-				
+
 					CompSpdLB = CounterCompSpdTemp - 1;
 					CompSpdUB = CounterCompSpdTemp;
-					
+
 					CompSpdActual = this->CompressorSpeed( CompSpdLB ) +( this->CompressorSpeed( CompSpdUB ) - this->CompressorSpeed( CompSpdLB ) )
 									/ ( CompEvaporatingCAPSpd( CompSpdUB ) - CompEvaporatingCAPSpd( CompSpdLB ) ) * ( Q_evap_req * C_cap_operation - CompEvaporatingCAPSpd( CompSpdLB ) );
-					
+
 					Ncomp = CompEvaporatingPWRSpd( CompSpdLB ) + ( CompEvaporatingPWRSpd( CompSpdUB ) - CompEvaporatingPWRSpd( CompSpdLB ) ) /
 								  ( this->CompressorSpeed( CompSpdUB ) - this->CompressorSpeed( CompSpdLB ) ) *
 								  ( CompSpdActual - this->CompressorSpeed( CompSpdLB ) );
 					break; //EXIT DoName1
-				
+
 				} else {
 				// Compressor runs at the min speed
 				// Low Load Modification Algorithm for cooling (IU side modification)
-				
+
 					//Initialization of NumIteCcap iterations (Label13)
 					Pipe_Q0 = Pipe_Q;
 					C_cap_operation0 = C_cap_operation;
 					T_discharge_new = T_discharge;
 					NumIteCcap = 1;
-					
+
 					//Update the C_cap_operation
 					Label13: ;
 					Q_evap_req = TU_load + Pipe_Q0; //Pipe_Q0 is updated during the iteration
@@ -10862,18 +10862,18 @@ namespace HVACVariableRefrigerantFlow {
 					Par( 1 ) = T_discharge_new;
 					Par( 2 ) = Q_evap_req * C_cap_operation0 / this->RatedEvapCapacity;  // 150130 To be confirmed
 					Par( 3 ) = this->OUCoolingCAPFT( CounterCompSpdTemp );
-					
+
 					// Update Te' (SmallLoadTe) to meet the required evaporator capacity
 					MinOutdoorUnitTe = 6;
 					P_discharge = GetSatPressureRefrig( this->RefrigerantName, T_discharge, RefrigerantIndex, RoutineName );
-					
+
 					MinRefriPe = GetSatPressureRefrig( this->RefrigerantName, -15, RefrigerantIndex, RoutineName );
 					MinOutdoorUnitPe = max( P_discharge - this->CompMaxDeltaP, MinRefriPe );
 					MinOutdoorUnitTe = GetSatTemperatureRefrig( this->RefrigerantName, max( min( MinOutdoorUnitPe, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
-					
+
 					SolveRoot( 1.0e-3, MaxIter, SolFla, SmallLoadTe, CompResidual_FluidTCtrl, MinOutdoorUnitTe, T_suction, Par ); // SmallLoadTe is the updated Te'
 					if( SolFla < 0 ) SmallLoadTe = 6; //MinOutdoorUnitTe; //SmallLoadTe( Te'_new ) is constant during iterations
-					
+
 					//Get an updated Te corresponding to the updated Te'
 					//VRFOU_TeModification( VRFCond, this->EvaporatingTemp, SmallLoadTe, Pipe_h_IU_in, OutdoorDryBulb, Pipe_Te_assumed, Pipe_Pe_assumed, Pipe_m_ref, Pipe_SH_merged );
 					{
@@ -10883,34 +10883,34 @@ namespace HVACVariableRefrigerantFlow {
 					NumIteTe = 1;
 					MaxNumIteTe = ( this->EvaporatingTemp - SmallLoadTe ) / 0.1 + 1; //upper bound and lower bound of Te iterations
 					Pipe_Te_assumed = this->EvaporatingTemp - 0.1;
-					
+
 					Label11: ;
 					Pipe_m_ref = 0; // Total Ref Flow Rate( kg/s )
-					
+
 					// Re-calculate Piping loss due to the Te and SH updates
 					Pipe_h_IU_out = 0;
 					Pipe_h_IU_out_i = 0;
 					Pipe_m_ref_i = 0;
 					Pipe_SH_merged = 0;
 					Pipe_Pe_assumed = GetSatPressureRefrig( this->RefrigerantName, Pipe_Te_assumed, RefrigerantIndex, RoutineName );
-					
+
 					// Re-calculate total refrigerant flow rate, with updated SH
 					for ( int NumTU = 1; NumTU <= NumTUInList; NumTU++ ){
 						if( TerminalUnitList( TUListNum ).TotalCoolLoad( NumTU ) > 0  ) {
 							TUIndex = TerminalUnitList( TUListNum ).ZoneTUPtr( NumTU );
 							CoolCoilIndex = VRFTU( TUIndex ).CoolCoilIndex;
-							
+
 							Tfs = this->EvaporatingTemp +( this->C3Te * pow_2( DXCoil( CoolCoilIndex ).ActualSH ) + this->C2Te * DXCoil( CoolCoilIndex ).ActualSH + this->C1Te );
-							
+
 							// Modifi_SH is the updated SH for a specific IU
 							if( this->C3Te == 0 )
 								Modifi_SHin = -( this->C1Te - Tfs + Pipe_Te_assumed ) /this->C2Te; //150130 Modifi_SH>Modifi_SHin
 							else
 								Modifi_SHin = ( -this->C2Te + std::pow( ( pow_2( this->C2Te ) - 4 * ( this->C1Te - Tfs + Pipe_Te_assumed ) * this->C3Te) , 0.5 ) ) / ( 2 * this->C3Te );
-							
+
 							RefTSat = GetSatTemperatureRefrig( this->RefrigerantName, max( min( Pipe_Pe_assumed, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 							Pipe_h_IU_out_i = GetSupHeatEnthalpyRefrig( this->RefrigerantName, max( RefTSat, Pipe_Te_assumed + Modifi_SHin ), max( min( Pipe_Pe_assumed, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
-						
+
 							if( Pipe_h_IU_out_i > Pipe_h_IU_in ) {
 								Pipe_m_ref_i = ( TerminalUnitList( TUListNum ).TotalCoolLoad( NumTU ) <= 0.0 ) ? 0.0 : ( TerminalUnitList( TUListNum ).TotalCoolLoad( NumTU ) / ( Pipe_h_IU_out_i - Pipe_h_IU_in ) );
 								Pipe_m_ref = Pipe_m_ref + Pipe_m_ref_i;
@@ -10930,7 +10930,7 @@ namespace HVACVariableRefrigerantFlow {
 
 					// Re-calculate piping loss
 					this->VRFOU_PipeLossC( Pipe_m_ref, max( min( Pipe_Pe_assumed, RefPHigh ), RefPLow ), Pipe_h_IU_out, Pipe_SH_merged, OutdoorDryBulb, Pipe_Q, Pipe_DeltP, Pipe_h_comp_in );
-					
+
 					T_suction = GetSatTemperatureRefrig( this->RefrigerantName, max( min( Pipe_Pe_assumed - Pipe_DeltP, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 
 					if( ( abs( T_suction - SmallLoadTe ) > 0.5 ) && ( Pipe_Te_assumed < this->EvaporatingTemp ) && ( Pipe_Te_assumed > SmallLoadTe ) && ( NumIteTe < MaxNumIteTe ) ){
@@ -10938,7 +10938,7 @@ namespace HVACVariableRefrigerantFlow {
 						NumIteTe = NumIteTe + 1;
 						goto Label11;
 					}
-					
+
 					if( abs( T_suction - SmallLoadTe ) > 0.5 ) {
 						NumIteTe = 999;
 						T_suction = SmallLoadTe;
@@ -10947,25 +10947,25 @@ namespace HVACVariableRefrigerantFlow {
 					}
 					//Iteration_Te End
 					}
-					
+
 					//Perform iteration to calculate Pipe_T_comp_in( Te'+SH' )
 					Pipe_T_comp_in = GetSupHeatTempRefrig( this->RefrigerantName, max( min( Pipe_Pe_assumed - Pipe_DeltP, RefPHigh ), RefPLow ), Pipe_h_comp_in, T_suction + 3, T_suction + 30,  RefrigerantIndex, RoutineName );
-					
+
 					Modifi_SH = Pipe_T_comp_in - T_suction;
 					P_suction = Pipe_Pe_assumed - Pipe_DeltP;
 					OUCondHeatRelease = TU_load + Pipe_Q + Ncomp; //Pipe_Q is changed when T_suction is changed -> Tc is also changed
-					
+
 					// *VRF OU Tc calculations
 					this->VRFOU_TeTc( FlagCondMode, OUCondHeatRelease, this->SC, this->OUAirFlowRate * RhoAir, OutdoorDryBulb, OutdoorHumRat, OutdoorPressure, Tfs, T_discharge );
 					T_discharge = min( MaxOutdoorUnitTc, T_discharge );
-					
+
 					// *Calculate capacity modification factor
 					C_cap_operation = this->VRFOU_CapModFactor( Pipe_h_comp_in, Pipe_h_IU_in, max( min( P_suction, RefPHigh ), RefPLow ), T_suction + Modifi_SH, T_suction + 8, T_discharge - 5 );
-					
+
 					Cap_Eva0 = ( TU_load + Pipe_Q ) * C_cap_operation; //New Pipe_Q & C_cap_operation
 					Cap_Eva1 = this->CoffEvapCap * this->RatedEvapCapacity * CurveValue( this->OUCoolingCAPFT( CounterCompSpdTemp ), T_discharge, T_suction );  //New Tc
 					CapDiff = abs( Cap_Eva1 - Cap_Eva0 );
-		
+
 					if( ( CapDiff > ( Tolerance * Cap_Eva0 ) ) && ( NumIteCcap < 30 ) ) {
 						Pipe_Q0 = Pipe_Q;
 						C_cap_operation0 = C_cap_operation;
@@ -10973,21 +10973,21 @@ namespace HVACVariableRefrigerantFlow {
 						NumIteCcap = NumIteCcap + 1;
 						goto Label13;
 					}
-						
+
 					if( CapDiff > ( Tolerance * Cap_Eva0 ) ) NumIteCcap = 999;
-					
+
 					Ncomp = this->RatedCompPower * CurveValue( this->OUCoolingPWRFT( CounterCompSpdTemp ), T_discharge, T_suction );
-					
+
 					this->CondensingTemp = T_discharge; // OU Tc' is updated due to OUCondHeatRelease updates, which is caused by IU Te' updates during low load conditions
-					
+
 					break; //EXIT DoName1
-	
+
 				} // End: if( CounterCompSpdTemp <= 1 ) Low load modification
-				
+
 			} // End: if( Q_evap_req <= CompEvaporatingCAPSpd( CounterCompSpdTemp ) )
-			
+
 		} // End: Iteration DoName1
-		
+
 		if( CounterCompSpdTemp > NumOfCompSpdInput ) {
 		// Required load is beyond the maximum system capacity
 			CompEvaporatingCAPSpd( NumOfCompSpdInput ) = this->CoffEvapCap * this->RatedEvapCapacity * CurveValue( this->OUCoolingCAPFT( NumOfCompSpdInput ), T_discharge, T_suction );
@@ -10995,7 +10995,7 @@ namespace HVACVariableRefrigerantFlow {
 			CompSpdActual = this->CompressorSpeed( NumOfCompSpdInput );
 			Ncomp = CompEvaporatingPWRSpd( NumOfCompSpdInput );
 		}
-		
+
 	}
 
 	void
@@ -11078,13 +11078,13 @@ namespace HVACVariableRefrigerantFlow {
 		Array1D< Real64 > CompEvaporatingPWRSpd; // Array for the compressor power at certain speed [W]
 		Array1D< Real64 > CompEvaporatingCAPSpd; // Array for the evaporating capacity at certain speed [W]
 		Array1D< Real64 > Par( 3 ); // Array for the parameters [-]
-		
+
 		// INTERFACE BLOCK SPECIFICATIONS
 		// na
-		
+
 		// DERIVED TYPE DEFINITIONS
 		// na
-		
+
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		static std::string const RoutineName( "VRFOU_CalcCompH" );
 
@@ -11093,22 +11093,22 @@ namespace HVACVariableRefrigerantFlow {
 		CompEvaporatingPWRSpd.dimension( NumOfCompSpdInput );
 		CompEvaporatingCAPSpd.dimension( NumOfCompSpdInput );
 		Q_evap_req = TU_load + Pipe_Q - Ncomp;
-		
+
 		TUListNum = this->ZoneTUListPtr;
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
 		RefPLow = RefrigData( RefrigerantIndex ).PsLowPresValue;
 		RefPHigh = RefrigData( RefrigerantIndex ).PsHighPresValue;
 		NumTUInList = TerminalUnitList( TUListNum ).NumTUInList;
-		
+
 		//Calculate capacity modification factor
 		MinOutdoorUnitPe = GetSatPressureRefrig( this->RefrigerantName, T_suction, RefrigerantIndex, RoutineName );
 		RefTSat = GetSatTemperatureRefrig( this->RefrigerantName, max( min( MinOutdoorUnitPe, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 		Pipe_h_comp_in = GetSupHeatEnthalpyRefrig( this->RefrigerantName, max( RefTSat, T_suction + this->SH ), max( min( MinOutdoorUnitPe, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 		C_cap_operation = this->VRFOU_CapModFactor( Pipe_h_comp_in, Pipe_h_out_ave, max( min( MinOutdoorUnitPe, RefPHigh ), RefPLow ), T_suction + this->SH, T_suction + 8, IUMaxCondTemp - 5 );
-		
+
 		// Perform iterations to find the compressor speed that can meet the required heating load, Iteration DoName2
 		for ( CounterCompSpdTemp = 1; CounterCompSpdTemp <= NumOfCompSpdInput; CounterCompSpdTemp++ ) {
-		
+
 			CompEvaporatingPWRSpd( CounterCompSpdTemp ) = this->RatedCompPower * CurveValue( this->OUCoolingPWRFT( CounterCompSpdTemp ), T_discharge, T_suction );
 			CompEvaporatingCAPSpd( CounterCompSpdTemp ) = this->CoffEvapCap * this->RatedEvapCapacity * CurveValue( this->OUCoolingCAPFT( CounterCompSpdTemp ), T_discharge, T_suction );
 
@@ -11126,17 +11126,17 @@ namespace HVACVariableRefrigerantFlow {
 					Ncomp = CompEvaporatingPWRSpd( CompSpdLB ) + ( CompEvaporatingPWRSpd( CompSpdUB ) - CompEvaporatingPWRSpd( CompSpdLB ) ) /
 								  ( this->CompressorSpeed( CompSpdUB ) - this->CompressorSpeed( CompSpdLB ) ) *
 								  ( CompSpdActual - this->CompressorSpeed( CompSpdLB ) );
-					
+
 					break; // EXIT DoName2
-					
+
 				} else {
 				//Compressor runs at the min speed
 				//Low Load Modifications
-				
+
 					NumIteCcap = 1;
 					Label19: ;
 					Q_evap_req = max( 0.0, TU_load + Pipe_Q - Ncomp );
-					
+
 					// Update Te'( SmallLoadTe ) to meet the required evaporator capacity
 					CompSpdActual = this->CompressorSpeed( 1 );
 					Par( 1 ) = T_discharge;
@@ -11145,9 +11145,9 @@ namespace HVACVariableRefrigerantFlow {
 
 					SolveRoot( 1.0e-3, MaxIter, SolFla, SmallLoadTe, CompResidual_FluidTCtrl, MinOutdoorUnitTe, T_suction, Par );
 					if( SolFla < 0 ) SmallLoadTe = MinOutdoorUnitTe;
-					
+
 					T_suction = SmallLoadTe;
-					
+
 					//Update SH and Pe to calculate Modification Factor, which is used to update rps to for N_comp calculations
 					if( this->C3Te == 0 )
 						Modifi_SH = -( this->C1Te - Tfs + T_suction ) / this->C2Te;
@@ -11155,7 +11155,7 @@ namespace HVACVariableRefrigerantFlow {
 						Modifi_SH = ( -this->C2Te + std::pow( ( pow_2( this->C2Te ) - 4 * ( this->C1Te - Tfs + T_suction ) * this->C3Te ), 0.5 ) ) / ( 2*this->C3Te );
 
 					Modifi_Pe = GetSatPressureRefrig( this->RefrigerantName, T_suction, RefrigerantIndex, RoutineName );
-					
+
 					//Calculate capacity modification factor
 					RefTSat = GetSatTemperatureRefrig( this->RefrigerantName, max( min( Modifi_Pe, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 					Pipe_h_comp_in = GetSupHeatEnthalpyRefrig( this->RefrigerantName, max( RefTSat, T_suction + Modifi_SH ), max( min( Modifi_Pe, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
@@ -11164,21 +11164,21 @@ namespace HVACVariableRefrigerantFlow {
 					Cap_Eva0 = Q_evap_req * C_cap_operation;
 					Cap_Eva1 = this->CoffEvapCap * this->RatedEvapCapacity * CurveValue( this->OUCoolingCAPFT( CounterCompSpdTemp ), T_discharge, T_suction );
 					CapDiff = abs( Cap_Eva1 - Cap_Eva0 );
-		
+
 					if( ( CapDiff > ( Tolerance * Cap_Eva0 ) ) && ( NumIteCcap < 30 ) ) {
 						NumIteCcap = NumIteCcap + 1;
 						goto Label19;
 					}
 					if( CapDiff >( Tolerance*Cap_Eva0 ) ) NumIteCcap = 999;
-					
+
 					Ncomp = this->RatedCompPower * CurveValue( this->OUCoolingPWRFT( CounterCompSpdTemp ), T_discharge, T_suction );
-							
+
 					break; // EXIT DoName2
-					
+
 				} // End: if( CounterCompSpdTemp <= 1 ) Low load modification
-				
+
 			} //End: if( Q_evap_req <= CompEvaporatingCAPSpd( CounterCompSpdTemp ) )
-		
+
 		} // End: Iteration DoName2
 
 		if( CounterCompSpdTemp > NumOfCompSpdInput ) {
@@ -11188,9 +11188,9 @@ namespace HVACVariableRefrigerantFlow {
 			CompSpdActual = this->CompressorSpeed( NumOfCompSpdInput );
 			Ncomp = CompEvaporatingPWRSpd( NumOfCompSpdInput );
 		}
-		
+
 	}
-	
+
 	void
 	VRFCondenserEquipment::VRFHR_OU_HR_Mode(
 		Real64 const h_IU_evap_in, // enthalpy of IU evaporator at inlet [kJ/kg]
@@ -11213,7 +11213,7 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 & Ncomp // compressor power [W]
 	)
 	{
-	
+
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rongpeng Zhang, LBNL
 		//       DATE WRITTEN   Jan 2016
@@ -11248,7 +11248,7 @@ namespace HVACVariableRefrigerantFlow {
 		using FluidProperties::RefrigData;
 		using General::SolveRoot;
 		using General::TrimSigDigits;
-		
+
 		Array1D< Real64 > Par( 7 ); // Parameters passed to RegulaFalsi
 		int const FlagCondMode( 0 ); // Flag for running as condenser [-]
 		int const FlagEvapMode( 1 ); // Flag for running as evaporator [-]
@@ -11276,20 +11276,20 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 Tfs; // temperature of the air at coil surface [C]
 		Real64 Tolerance( 0.05 ); // Tolerance for condensing temperature calculation [C}
 		Real64 Tsuction_new; // VRF compressor suction refrigerant temperature (new) [C]
-		
+
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		static std::string const RoutineName( "VRFHR_OU_Mode" );
-		
+
 		// Initialization: operational parameters
 		RhoAir = PsyRhoAirFnPbTdbW( OutBaroPress, OutDryBulbTemp, OutHumRat);
 		m_air_rated = this->OUAirFlowRate * RhoAir;
 		C_OU_HexRatio = this->HROUHexRatio;
-		
+
 		// Initializations: component index
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
 		RefPLow = RefrigData( RefrigerantIndex ).PsLowPresValue;
 		RefPHigh = RefrigData( RefrigerantIndex ).PsHighPresValue;
-		
+
 		// **Q_OU: HR mode determination
 		//	 HRMode-1. Cooling Only
 		//	 HRMode-2. Cooling Dominant w/o HR Loss
@@ -11299,11 +11299,11 @@ namespace HVACVariableRefrigerantFlow {
 		//	 HRMode-6. Heating Only
 		//	 HRMode-7. OU Hex not running
 		{
-			
+
 			bool FlagMode5; // true if compressor speed satisfying IU cooling load < that satisfying IU heating load
 			bool FlagToLower; // true if To-5 is lower than the Tsuction determined by IU part
 			Real64 temp_Tsuction;
-		
+
 			// Determine FlagToLower
 			if( OutDryBulbTemp - this->DiffOUTeTo < Tsuction ) {
 				temp_Tsuction = OutDryBulbTemp - this->DiffOUTeTo;
@@ -11312,18 +11312,18 @@ namespace HVACVariableRefrigerantFlow {
 				temp_Tsuction = Tsuction;
 				FlagToLower = false;
 			}
-			
+
 			// Calculate compressor speed satisfying IU loads: rps1_evap & rps2_cond
 			this->VRFOU_CompSpd( Q_c_TU_PL, FlagEvapMode, temp_Tsuction, Tdischarge, h_IU_evap_in, h_IU_PLc_out, rps1_evap );
 			this->VRFOU_CompSpd( Q_h_TU_PL, FlagCondMode, temp_Tsuction, Tdischarge, h_IU_evap_in, h_IU_PLc_out, rps2_cond );
-			
+
 			// Determine FlagMode5
 			if( rps1_evap <= rps2_cond ) {
 				FlagMode5 = true;
 			} else {
 				FlagMode5 = false;
 			}
-			
+
 			// Determine HR Mode
 			if( FlagMode5 ){
 				HRMode = 5;
@@ -11332,39 +11332,39 @@ namespace HVACVariableRefrigerantFlow {
 				else
 					HRMode_sub = 2;
 			} else {
-				
+
 				if( FlagToLower )
 					HRMode = 3; //Mode 3&4 share the same logics below
 				else
 					HRMode = 2;
 			}
-			
+
 			this->VRFOperationSimPath = HRMode * 10 + HRMode_sub;
 		}
-		
+
 		// **Simulate outdoor unit and compressor performance, including
 		// (1) compressor spd/power (2) OU hex capacity (3) OU fan flow rate and power
 		// Tsuction/Te may also need updates
 		if ( HRMode == 5 && HRMode_sub == 2 ){
-		
+
 				CompSpdActual = rps2_cond; //constant in this mode
 				// Tsuction = Te'_iu < OutDryBulbTemp – 5; constant in this mode
-				
+
 				//compressor: Ncomp & Q_c_tot
 				this->VRFOU_CompCap( CompSpdActual, Tsuction, Tdischarge, h_IU_evap_in, h_comp_in, Q_c_tot, Ncomp );
-				
+
 				//OU hex capacity
 				Q_c_OU = Q_c_tot - Q_c_TU_PL;
 				Q_h_OU = 0;
-				
+
 				//OU fan flow rate and power
 				m_air_evap = this->VRFOU_FlowRate( FlagEvapMode, Tsuction, this->SH, Q_c_OU, OutDryBulbTemp, OutHumRat );
 				m_air_evap_rated = m_air_rated;
 				N_fan_OU_evap = this->RatedOUFanPower * m_air_evap / m_air_evap_rated;
 				N_fan_OU_cond = 0;
-				
+
 		} else if ( HRMode == 5 && HRMode_sub == 1 ){
-			
+
 			//local parameters
 			int Counter_Iter_Ncomp;
 			bool Flag_Iter_Ncomp( true ); //Flag to perform iterations
@@ -11372,81 +11372,81 @@ namespace HVACVariableRefrigerantFlow {
 			Real64 Ncomp_new;
 			Real64 Q_c_tot_temp;
 			Real64 Q_c_OU_temp;
-			
+
 			//===**Ncomp Iterations
-			
+
 			//initialization: Ncomp_ini, CompSpdActual
 			Counter_Iter_Ncomp = 1;
 			CompSpdActual = rps2_cond;
 			Tsuction_new = OutDryBulbTemp - this->DiffOUTeTo;
 			Pipe_Q_c_new = Pipe_Q_c;
-			
+
 			this->VRFOU_CompCap( CompSpdActual, Tsuction_new, Tdischarge, h_IU_evap_in, h_comp_in, Q_c_tot, Ncomp_ini );
-			
+
 			while( Flag_Iter_Ncomp ){
-			
+
 				Q_c_tot_temp = Q_h_TU_PL - Ncomp_ini; //Q_h_OU = 0
 				Q_c_OU_temp = Q_c_tot_temp - Q_c_TU_PL;
-				
+
 				// Tsuction_new updated based on OU evaporator air-side calculations (Tsuction_new < To)
 				m_air_evap_rated = m_air_rated;
 				this->VRFOU_TeTc( FlagEvapMode, Q_c_OU_temp, this->SH, m_air_evap_rated, OutDryBulbTemp, OutHumRat, OutBaroPress, Tfs, Tsuction_new );
 				Tsuction_new = min( Tsuction_new, Tsuction ); // should be lower than Tsuction_IU
-				
+
 				// Calculate updated rps corresponding to updated Tsuction_new and Q_c_tot_temp
 				this->VRFOU_CompSpd( Q_c_tot_temp, FlagEvapMode, Tsuction_new, Tdischarge, h_IU_evap_in, h_comp_in, CompSpdActual );
-				
+
 				// Calculate Ncomp_new, using updated CompSpdActual and Tsuction_new
 				this->VRFOU_CompCap( CompSpdActual, Tsuction_new, Tdischarge, h_IU_evap_in, h_comp_in, Q_c_tot_temp, Ncomp_new );
-				
+
 				if( ( abs( Ncomp_new - Ncomp_ini ) > ( Tolerance * Ncomp_ini ) ) && ( Counter_Iter_Ncomp < 30 ) ) {
 					Ncomp_ini = 0.5 * Ncomp_ini + 0.5 * Ncomp_new;
 					Counter_Iter_Ncomp = Counter_Iter_Ncomp + 1;
 					continue;
 				}
-				
+
 				Flag_Iter_Ncomp = false;
-				
+
 			}
-			
+
 			// Ncomp Iterations Update
 			Ncomp = Ncomp_new;
 			Q_c_tot = Q_c_tot_temp;
-			
+
 			if ( Tsuction_new < Tsuction ) {
 				//Need to update the Tsuction, and thus update Te_update & Pipe_Q_c_new.
 				//Iteration continues.
-				
+
 				// temporary parameters
 				Real64 Pe_update;
 				Real64 Pipe_SH_merged;
 				Real64 Pipe_DeltP;
 				Real64 Pipe_h_IU_out;
-				
+
 				// Get an updated Te (Te_update) corresponding to the updated Te' (Tsuction_new). PL_c is re-performed.
 				this->VRFOU_TeModification( this->EvaporatingTemp, Tsuction_new, h_IU_evap_in, OutDryBulbTemp, Te_update, Pe_update, m_ref_IU_evap, Pipe_h_IU_out, Pipe_SH_merged );
-				
+
 				// Re-calculate piping loss, update Pipe_Q_c_new
 				this->VRFOU_PipeLossC( m_ref_IU_evap, Pe_update, Pipe_h_IU_out, Pipe_SH_merged, OutDryBulbTemp, Pipe_Q_c_new, Pipe_DeltP, h_IU_PLc_out );
-				
+
 				Tsuction = Tsuction_new;
 				Pipe_Q_c = Pipe_Q_c_new;
 			}
-			
+
 			//No need to update the Tsuction.
-		
+
 			//===**Ncomp Iteration Ends (Label200)
-			
+
 			//OU hex capacity
 			Q_c_OU = Q_c_tot - Q_c_TU_PL;
 			Q_h_OU = 0;
-			
+
 			//OU fan power
 			N_fan_OU_evap = this->RatedOUFanPower;
 			N_fan_OU_cond = 0;
-			
+
 		} else if ( HRMode == 3 ){ // Mode3 & Mode4 share the same algorithm
-			
+
 			//local parameters
 			Real64 Ncomp_new;
 			Real64 Q_c_tot_temp;
@@ -11454,12 +11454,12 @@ namespace HVACVariableRefrigerantFlow {
 			Real64 Tsuction_new;
 			Real64 Tsuction_LB = OutDryBulbTemp - this->DiffOUTeTo;
 			Real64 Tsuction_HB = Tsuction;
-			
+
 			//compressor speed is fixed in this mode
 			CompSpdActual = rps1_evap; //constant in this mode
 			m_air_evap_rated = m_air_rated * ( 1 - C_OU_HexRatio );
 			m_air_evap = m_air_evap_rated; // may be updated
-			
+
 			//perform iterations to calculate Te at the given compressor speed and operational conditions
 			{
 			Par( 1 ) = VRFTU( TerminalUnitList( this->ZoneTUListPtr ).ZoneTUPtr( 1 ) ).VRFSysNum; //VRFCond;
@@ -11476,73 +11476,73 @@ namespace HVACVariableRefrigerantFlow {
 			// Update Q_c_tot_temp using updated Tsuction_new
 			this->VRFOU_CompCap( CompSpdActual, Tsuction_new, Tdischarge, h_IU_evap_in, h_comp_in, Q_c_tot_temp, Ncomp_new );
 			Q_c_OU_temp = Q_c_tot_temp - Q_c_TU_PL;
-			
+
 			// Iterations_Te Update
 			Ncomp = Ncomp_new;
 			Tsuction = Tsuction_new;
 			Q_c_tot = Q_c_tot_temp;
 			Q_c_OU = Q_c_OU_temp;
 			}
-			
+
 			if( Tsuction >= Tsuction_HB ){
 			// modify m_air_evap to adjust OU evaporator capacity;
 			// update Ncomp, Q_c_OU, m_air_evap
-				
+
 				Tsuction = Tsuction_HB;
-				
+
 				// Q_c_tot
 				this->VRFOU_CompCap( CompSpdActual, Tsuction_new, Tdischarge, h_IU_evap_in, h_comp_in, Q_c_tot, Ncomp );
 				Q_c_OU = Q_c_tot - Q_c_TU_PL;
-			
+
 				//OU evaporator fan flow rate and power
 				m_air_evap = this->VRFOU_FlowRate( FlagEvapMode, Tsuction, this->SH, Q_c_OU_temp, OutDryBulbTemp, OutHumRat );
-				
+
 			} else {
 				//Need to update Te_update & Pipe_Q_c_new, corresponding to Tsuction update.
-				
+
 				// temporary parameters
 				Real64 Pe_update;
 				Real64 Pipe_SH_merged;
 				Real64 Pipe_DeltP;
 				Real64 Pipe_h_IU_out;
-				
+
 				// Get an updated Te (Te_update) corresponding to the updated Te' (Tsuction_new). PL_c is re-performed.
 				this->VRFOU_TeModification( this->EvaporatingTemp, Tsuction_new, h_IU_evap_in, OutDryBulbTemp, Te_update, Pe_update, m_ref_IU_evap, Pipe_h_IU_out, Pipe_SH_merged );
-				
+
 				// Re-calculate piping loss, update Pipe_Q_c_new
 				this->VRFOU_PipeLossC( m_ref_IU_evap, Pe_update, Pipe_h_IU_out, Pipe_SH_merged, OutDryBulbTemp, Pipe_Q_c_new, Pipe_DeltP, h_IU_PLc_out );
 				Pipe_Q_c = Pipe_Q_c_new;
 			}
-			
+
 			// Q_h_ou
 			Q_h_tot = Q_c_tot + Ncomp;
 			Q_h_OU = Q_h_tot - Q_h_TU_PL;
-			
+
 			//OU condenser fan flow rate and power
 			m_air_cond = this->VRFOU_FlowRate( FlagCondMode, Tdischarge, this->SC, Q_h_OU, OutDryBulbTemp, OutHumRat );
-			
+
 			// OU fan power
 			N_fan_OU_evap = this->RatedOUFanPower * m_air_evap / m_air_rated;
 			N_fan_OU_cond = this->RatedOUFanPower * m_air_cond / m_air_rated;
-			
+
 		} else if ( HRMode == 2 ){
-		
+
 				CompSpdActual = rps1_evap; //constant in this mode
 				// Tsuction = Te'_iu < OutDryBulbTemp – 5; constant in this mode
-				
+
 				//compressor: Ncomp & Q_c_tot
 				this->VRFOU_CompCap( CompSpdActual, Tsuction, Tdischarge, h_IU_evap_in, h_comp_in, Q_c_tot, Ncomp );
-				
+
 				//OU hex capacity
 				Q_h_tot = Q_c_tot + Ncomp;
 				Q_h_OU = Q_h_tot - Q_h_TU_PL;
 				Q_c_OU = 0;
-				
+
 				//OU fan flow rate and power
 				m_air_cond = this->VRFOU_FlowRate( FlagCondMode, Tdischarge, this->SC, Q_h_OU, OutDryBulbTemp, OutHumRat );
 				N_fan_OU_cond = this->RatedOUFanPower * m_air_cond / m_air_rated;
 				N_fan_OU_evap = 0;
-				
+
 		} else {
 				Ncomp = 0;
 				CompSpdActual = 0;
@@ -11552,37 +11552,37 @@ namespace HVACVariableRefrigerantFlow {
 				N_fan_OU_cond = 0;
 
 		}
-		
+
 		// OU fan power
 		N_fan_OU = N_fan_OU_evap + N_fan_OU_cond;
-		
+
 		// Calculate the m_ref_OU_evap & m_ref_OU_cond, with updated Tsuction
 		{
 			Real64 h_OU_evap_in;  // enthalpy of OU evaporator at inlet [kJ/kg]
 			Real64 h_OU_evap_out; // enthalpy of OU evaporator at outlet [kJ/kg]
 			Real64 h_OU_cond_in;  // enthalpy of OU condenser at inlet [kJ/kg]
 			Real64 h_OU_cond_out; // enthalpy of OU condenser at outlet [kJ/kg]
-			
+
 			Real64 Psuction = GetSatPressureRefrig( this->RefrigerantName, Tsuction, RefrigerantIndex, RoutineName );
-			
+
 			// enthalpy of OU evaporator/condenser inlets and outlets
 			h_OU_evap_in = h_IU_evap_in;
 			h_OU_cond_in = h_comp_out;
 			h_OU_evap_out = GetSupHeatEnthalpyRefrig( this->RefrigerantName, Tsuction + this->SH, max( min( Psuction, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
 			h_OU_cond_out = GetSatEnthalpyRefrig( this->RefrigerantName, Tdischarge - this->SC, 0.0, RefrigerantIndex, RoutineName );
-			
+
 			if (( Q_c_OU == 0 ) || ( h_OU_evap_out - h_OU_evap_in ) <= 0 ){
 				m_ref_OU_evap = 0;
 			} else {
 				m_ref_OU_evap = Q_c_OU / ( h_OU_evap_out - h_OU_evap_in );
 			}
-			
+
 			if (( Q_h_OU == 0 ) || ( h_OU_cond_in - h_OU_cond_out <= 0 )) {
 				m_ref_OU_cond = 0;
 			} else {
 				m_ref_OU_cond = Q_h_OU / ( h_OU_cond_in - h_OU_cond_out );
 			}
-			
+
 			// Calculate the parameters of refrigerant at compressor inlet, which is
 			// a combination of refrigerant from IU evaporators and OU evaporator
 			if (( m_ref_OU_evap + m_ref_IU_evap ) > 0 ){
@@ -11590,7 +11590,7 @@ namespace HVACVariableRefrigerantFlow {
 			}
 		}
 	}
-	
+
 	void
 	VRFCondenserEquipment::VRFOU_PipeLossC(
 		Real64 const Pipe_m_ref, // Refrigerant mass flow rate [kg/s]
@@ -11613,7 +11613,7 @@ namespace HVACVariableRefrigerantFlow {
 		// PURPOSE OF THIS SUBROUTINE:
 		// Determine the piping loss of the refrigerant, including both the heat loss and pressure drop.
 		// This happens at VRF cooling mode, within the Main Pipe connecting Outdoor Unit to Indoor Units.
-		
+
 		// METHODOLOGY EMPLOYED:
 		// Use a physics based piping loss model.
 
@@ -11632,14 +11632,14 @@ namespace HVACVariableRefrigerantFlow {
 		// SUBROUTINE ARGUMENT DEFINITIONS:
 
 		// SUBROUTINE PARAMETER DEFINITIONS:
-		
+
 		int TUListNum; // index to TU List
 		int TUIndex; // Index to terminal unit
 		int CoilIndex; // index to coil in terminal unit
 		int NumTUInList; // number of terminal units is list
 		int NumIUActivated; // number of the used indoor units [-]
 		int RefrigerantIndex; // Index of the refrigerant [-]
-		
+
 		Real64 Pipe_v_ref; // Piping Loss Algorithm Parameter: Refrigerant velocity [m/s]
 		Real64 Pipe_T_room; // Piping Loss Algorithm Parameter: Average Room Temperature [C]
 		Real64 Pipe_Num_Re; // Piping Loss Algorithm Parameter: refrigerant Re Number [-]
@@ -11656,33 +11656,33 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 Ref_Coe_v2; // Piping Loss Algorithm Parameter: coefficient to calculate Pipe_viscosity_ref [-]
 		Real64 Ref_Coe_v3; // Piping Loss Algorithm Parameter: coefficient to calculate Pipe_viscosity_ref [-]
 		Real64 RefPipInsH; // Heat transfer coefficient for calculating piping loss [W/m2K]
-		
+
 		// INTERFACE BLOCK SPECIFICATIONS
 		// na
 
 		// DERIVED TYPE DEFINITIONS
 		// na
-		
+
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-		
+
 		static std::string const RoutineName( "VRFOU_PipeLossC" );
-		
-		
+
+
 		// variable initializations
-		
+
 		TUListNum = this->ZoneTUListPtr;
 		NumTUInList = TerminalUnitList( TUListNum ).NumTUInList;
 		Pipe_conductivity_ref = this->RefPipInsCon;
-		
+
 		RefPipInsH = 9.3;
 		Pipe_cp_ref = 1.6;
-		
+
 		// Refrigerant data
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
 		Real64 RefPLow = RefrigData( RefrigerantIndex ).PsLowPresValue; // Low Pressure Value for Ps (>0.0)
 		Real64 RefPHigh = RefrigData( RefrigerantIndex ).PsHighPresValue; // High Pressure Value for Ps (max in tables)
-		
+
 		//Calculate Pipe_T_room
 		Pipe_T_room = 0;
 		NumIUActivated = 0;
@@ -11699,15 +11699,15 @@ namespace HVACVariableRefrigerantFlow {
 			Pipe_T_room = Pipe_T_room / NumIUActivated;
 		else
 			Pipe_T_room = 24;
-				
-				
+
+
 		if( Pipe_m_ref > 0 ) {
 			if( this->RefPipDiaSuc <= 0 ) this->RefPipDiaSuc = 0.025;
-			
+
 			Ref_Coe_v1 = Pevap/1000000/ 4.926;
 			Ref_Coe_v2 = Pipe_h_IU_out / 383.5510343;
 			Ref_Coe_v3 = ( this->EvaporatingTemp + Pipe_SH_merged + 273.15 ) / 344.39;
-			
+
 			Pipe_viscosity_ref = 4.302 * Ref_Coe_v1 + 0.81622 * pow_2( Ref_Coe_v1 ) - 120.98 * Ref_Coe_v2 + 139.17 * pow_2( Ref_Coe_v2 ) + 118.76 * Ref_Coe_v3 + 81.04 * pow_2( Ref_Coe_v3 ) + 5.7858 * Ref_Coe_v1 * Ref_Coe_v2 - 8.3817 * Ref_Coe_v1 * Ref_Coe_v3 - 218.48 * Ref_Coe_v2 * Ref_Coe_v3 + 21.58;
 			if( Pipe_viscosity_ref <= 0 ) Pipe_viscosity_ref = 16.26; // default superheated vapor viscosity data (MuPa*s) at T=353.15 K, P=2MPa
 
@@ -11716,9 +11716,9 @@ namespace HVACVariableRefrigerantFlow {
 			Pipe_Num_Pr = Pipe_viscosity_ref * Pipe_cp_ref * 0.001 / Pipe_conductivity_ref;
 			Pipe_Num_Nu = 0.023 * std::pow( Pipe_Num_Re, 0.8) * std::pow( Pipe_Num_Pr, 0.3 );
 			Pipe_Num_St = Pipe_Num_Nu / Pipe_Num_Re / Pipe_Num_Pr;
-		
+
 			Pipe_DeltP = max( 0.0, 8 * Pipe_Num_St * std::pow( Pipe_Num_Pr, 0.6667 ) * this->RefPipEquLen / this->RefPipDiaSuc * GetSupHeatDensityRefrig( this->RefrigerantName, this->EvaporatingTemp + Pipe_SH_merged, max( min( Pevap, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName ) * pow_2( Pipe_v_ref ) / 2 - this->RefPipHei * GetSupHeatDensityRefrig( this->RefrigerantName, this->EvaporatingTemp + Pipe_SH_merged, max( min( Pevap, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName ) *9.80665 );
-		
+
 			Pipe_Coe_k1 = Pipe_Num_Nu * Pipe_viscosity_ref;
 			Pipe_Coe_k3 = RefPipInsH *( this->RefPipDiaSuc + 2 * this->RefPipInsThi );
 			if(  this->RefPipInsThi >= 0.0 ){
@@ -11728,7 +11728,7 @@ namespace HVACVariableRefrigerantFlow {
 			}
 
 			Pipe_Q = max( 0.0, ( Pi * this->RefPipLen ) * ( OutdoorDryBulb / 2 + Pipe_T_room / 2 - this->EvaporatingTemp - Pipe_SH_merged ) / ( 1 / Pipe_Coe_k1 + 1 / Pipe_Coe_k2 + 1 / Pipe_Coe_k3 ) );
-		
+
 			Pipe_h_comp_in = Pipe_h_IU_out + Pipe_Q / Pipe_m_ref;
 
 		} else {
@@ -11736,9 +11736,9 @@ namespace HVACVariableRefrigerantFlow {
 			Pipe_Q = 0;
 			Pipe_h_comp_in = Pipe_h_IU_out;
 		}
-		
+
 	}
-	
+
 	void
 	VRFCondenserEquipment::VRFOU_PipeLossH(
 		Real64 const Pipe_m_ref, // Refrigerant mass flow rate [kg/s]
@@ -11782,14 +11782,14 @@ namespace HVACVariableRefrigerantFlow {
 		// SUBROUTINE ARGUMENT DEFINITIONS:
 
 		// SUBROUTINE PARAMETER DEFINITIONS:
-		
+
 		int TUListNum; // index to TU List
 		int TUIndex; // Index to terminal unit
 		int CoilIndex; // index to coil in terminal unit
 		int NumTUInList; // number of terminal units is list
 		int NumIUActivated; // number of the used indoor units [-]
 		int RefrigerantIndex; // Index of the refrigerant [-]
-		
+
 		Real64 Pipe_v_ref; // Piping Loss Algorithm Parameter: Refrigerant velocity [m/s]
 		Real64 Pipe_T_room; // Piping Loss Algorithm Parameter: Average Room Temperature [C]
 		Real64 Pipe_T_IU_in; // Piping Loss Algorithm Parameter: Average Refrigerant Temperature [C]
@@ -11807,38 +11807,38 @@ namespace HVACVariableRefrigerantFlow {
 		Real64 Ref_Coe_v2; // Piping Loss Algorithm Parameter: coefficient to calculate Pipe_viscosity_ref [-]
 		Real64 Ref_Coe_v3; // Piping Loss Algorithm Parameter: coefficient to calculate Pipe_viscosity_ref [-]
 		Real64 RefPipInsH; // Heat transfer coefficient for calculating piping loss [W/m2K]
-		
+
 		// INTERFACE BLOCK SPECIFICATIONS
 		// na
 
 		// DERIVED TYPE DEFINITIONS
 		// na
-		
+
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-		
+
 		static std::string const RoutineName( "VRFOU_PipeLossH" );
-		
+
 		// variable initializations
-		
+
 		TUListNum = this->ZoneTUListPtr;
 		NumTUInList = TerminalUnitList( TUListNum ).NumTUInList;
 		Pipe_conductivity_ref = this->RefPipInsCon;
-		
+
 		RefPipInsH = 9.3;
 		Pipe_cp_ref = 1.6;
-		
+
 		// Refrigerant data
 		RefrigerantIndex = FindRefrigerant( this->RefrigerantName );
 		Real64 RefTHigh = RefrigData( RefrigerantIndex ).PsHighTempValue; // High Temperature Value for Ps (max in tables)
 		Real64 RefPLow = RefrigData( RefrigerantIndex ).PsLowPresValue; // Low Pressure Value for Ps (>0.0)
 		Real64 RefPHigh = RefrigData( RefrigerantIndex ).PsHighPresValue; // High Pressure Value for Ps (max in tables)
 		Real64 RefTSat = GetSatTemperatureRefrig( this->RefrigerantName, max( min( Pcond, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName );
-		
+
 		//Perform iteration to calculate Pipe_T_IU_in, given P and h
 		Pipe_T_IU_in = GetSupHeatTempRefrig( this->RefrigerantName, max( min( Pcond, RefPHigh ), RefPLow ), Pipe_h_IU_in, max( this->IUCondensingTemp, RefTSat ), min( this->IUCondensingTemp + 50, RefTHigh ), RefrigerantIndex, RoutineName );
 		Pipe_T_IU_in = min( RefTHigh, Pipe_T_IU_in );
-		
+
 		// Calculate average room temperature
 		Pipe_T_room = 0;
 		NumIUActivated = 0;
@@ -11855,7 +11855,7 @@ namespace HVACVariableRefrigerantFlow {
 			Pipe_T_room = Pipe_T_room / NumIUActivated;
 		else
 			Pipe_T_room = 18;
-			
+
 		// Calculate piping loss
 		if( Pipe_m_ref > 0 ){
 			Ref_Coe_v1 = Pcond / 1000000 / 4.926;
@@ -11869,24 +11869,24 @@ namespace HVACVariableRefrigerantFlow {
 			Pipe_Num_Pr = Pipe_viscosity_ref * Pipe_cp_ref * 0.001 / Pipe_conductivity_ref;
 			Pipe_Num_Nu = 0.023 * std::pow( Pipe_Num_Re, 0.8) * std::pow( Pipe_Num_Pr, 0.4);
 			Pipe_Num_St = Pipe_Num_Nu / Pipe_Num_Re / Pipe_Num_Pr;
-	
+
 			Pipe_Coe_k1 = Pipe_Num_Nu * Pipe_viscosity_ref;
 			Pipe_Coe_k2 = this->RefPipInsCon * ( this->RefPipDiaDis + this->RefPipInsThi ) /this->RefPipInsThi;
 			Pipe_Coe_k3 = RefPipInsH * ( this->RefPipDiaDis + 2 * this->RefPipInsThi );
-		
+
 			Pipe_Q = max( 0.0, ( Pi * this->RefPipLen ) * ( Pipe_T_IU_in - OutdoorDryBulb / 2 - Pipe_T_room / 2 ) / ( 1 / Pipe_Coe_k1 + 1 / Pipe_Coe_k2 + 1 / Pipe_Coe_k3 ) ); // [W]
 			Pipe_DeltP = max( 0.0, 8 * Pipe_Num_St * std::pow( Pipe_Num_Pr, 0.6667 ) * this->RefPipEquLen / this->RefPipDiaDis * GetSupHeatDensityRefrig( this->RefrigerantName,
 					Pipe_T_IU_in, max( min( Pcond, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName ) * pow_2( Pipe_v_ref ) / 2 - this->RefPipHei * GetSupHeatDensityRefrig( this->RefrigerantName, Pipe_T_IU_in, max( min( Pcond, RefPHigh ), RefPLow ), RefrigerantIndex, RoutineName ) * 9.80665 );
-		
+
 			Pipe_h_comp_out = Pipe_h_IU_in + Pipe_Q / Pipe_m_ref;
-			
+
 		} else {
 			Pipe_DeltP = 0;
 			Pipe_Q = 0;
 			Pipe_h_comp_out = Pipe_h_IU_in;
 		}
 	}
-	
+
 	// Clears the global data in HVACVariableRefrigerantFlow.
 	// Needed for unit tests, should not be normally called.
 	void

--- a/src/EnergyPlus/HWBaseboardRadiator.cc
+++ b/src/EnergyPlus/HWBaseboardRadiator.cc
@@ -217,17 +217,17 @@ namespace HWBaseboardRadiator {
 		if ( CompIndex == 0 ) {
 			BaseboardNum = FindItemInList( EquipName, HWBaseboard, &HWBaseboardParams::EquipID );
 			if ( BaseboardNum == 0 ) {
-				ShowFatalError( "SimHWBaseboard: Unit not found=" + EquipName );
+				ShowFatalError( "SimHWBaseboard: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BaseboardNum;
 		} else {
 			BaseboardNum = CompIndex;
 			if ( BaseboardNum > NumHWBaseboards || BaseboardNum < 1 ) {
-				ShowFatalError( "SimHWBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumHWBaseboards ) + ", Entered Unit name=" + EquipName );
+				ShowFatalError( "SimHWBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumHWBaseboards ) + ", Entered Unit name=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( BaseboardNum ) ) {
 				if ( EquipName != HWBaseboard( BaseboardNum ).EquipID ) {
-					ShowFatalError( "SimHWBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + HWBaseboard( BaseboardNum ).EquipID );
+					ShowFatalError( "SimHWBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + HWBaseboard( BaseboardNum ).EquipID );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( BaseboardNum ) = false;
 			}
@@ -256,7 +256,7 @@ namespace HWBaseboardRadiator {
 			} else {
 				ShowSevereError( "SimBaseboard: Errors in Baseboard=" + HWBaseboard( BaseboardNum ).EquipID );
 				ShowContinueError( "Invalid or unimplemented equipment type=" + TrimSigDigits( HWBaseboard( BaseboardNum ).EquipType ) );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			}}
 
@@ -267,7 +267,7 @@ namespace HWBaseboardRadiator {
 			ReportHWBaseboard( BaseboardNum );
 
 		} else {
-			ShowFatalError( "SimHWBaseboard: Unit not found=" + EquipName );
+			ShowFatalError( "SimHWBaseboard: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -608,7 +608,7 @@ namespace HWBaseboardRadiator {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + cCMO_BBRadiator_Water + "Errors found getting input. Program terminates." );
+			ShowFatalError( RoutineName + cCMO_BBRadiator_Water + "Errors found getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		// Setup Report variables for the Coils
@@ -740,7 +740,7 @@ namespace HWBaseboardRadiator {
 				errFlag = false;
 				ScanPlantLoopsForObject( HWBaseboard( BaseboardNum ).EquipID, HWBaseboard( BaseboardNum ).EquipType, HWBaseboard( BaseboardNum ).LoopNum, HWBaseboard( BaseboardNum ).LoopSideNum, HWBaseboard( BaseboardNum ).BranchNum, HWBaseboard( BaseboardNum ).CompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitHWBaseboard: Program terminated for previous conditions." );
+					ShowFatalError( "InitHWBaseboard: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				SetLoopIndexFlag( BaseboardNum ) = false;
 			}
@@ -1093,7 +1093,7 @@ namespace HWBaseboardRadiator {
 		RegisterPlantCompDesignFlow( HWBaseboard( BaseboardNum ).WaterInletNode, HWBaseboard( BaseboardNum ).WaterVolFlowRateMax );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1478,7 +1478,7 @@ namespace HWBaseboardRadiator {
 						ShowContinueError( "Occurs in " + cCMO_BBRadiator_Water + " = " + HWBaseboard( BaseboardNum ).EquipID );
 						ShowContinueError( "Radiation intensity = " + RoundSigDigits( ThisSurfIntensity, 2 ) + " [W/m2]" );
 						ShowContinueError( "Assign a larger surface area or more surfaces in " + cCMO_BBRadiator_Water );
-						ShowFatalError( "DistributeBBRadGains:  excessive thermal radiation heat flux intensity detected" );
+						ShowFatalError( "DistributeBBRadGains:  excessive thermal radiation heat flux intensity detected" );  // LCOV_EXCL_LINE
 					}
 				} else {
 					ShowSevereError( "DistributeBBRadGains:  surface not large enough to receive thermal radiation heat flux" );
@@ -1486,7 +1486,7 @@ namespace HWBaseboardRadiator {
 					ShowContinueError( "Surface area = " + RoundSigDigits( Surface( SurfNum ).Area, 3 ) + " [m2]" );
 					ShowContinueError( "Occurs in " + cCMO_BBRadiator_Water + " = " + HWBaseboard( BaseboardNum ).EquipID );
 					ShowContinueError( "Assign a larger surface area or more surfaces in " + cCMO_BBRadiator_Water );
-					ShowFatalError( "DistributeBBRadGains:  surface not large enough to receive thermal radiation heat flux" );
+					ShowFatalError( "DistributeBBRadGains:  surface not large enough to receive thermal radiation heat flux" );  // LCOV_EXCL_LINE
 
 				}
 			}
@@ -1666,20 +1666,20 @@ namespace HWBaseboardRadiator {
 		if ( CompIndex == 0 ) {
 			BaseboardNum = FindItemInList( BaseboardName, HWBaseboard, &HWBaseboardParams::EquipID );
 			if ( BaseboardNum == 0 ) {
-				ShowFatalError( "UpdateHWBaseboardPlantConnection: Specified baseboard not valid =" + BaseboardName );
+				ShowFatalError( "UpdateHWBaseboardPlantConnection: Specified baseboard not valid =" + BaseboardName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BaseboardNum;
 		} else {
 			BaseboardNum = CompIndex;
 			if ( BaseboardNum > NumHWBaseboards || BaseboardNum < 1 ) {
-				ShowFatalError( "UpdateHWBaseboardPlantConnection:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of baseboards=" + TrimSigDigits( NumHWBaseboards ) + ", Entered baseboard name=" + BaseboardName );
+				ShowFatalError( "UpdateHWBaseboardPlantConnection:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of baseboards=" + TrimSigDigits( NumHWBaseboards ) + ", Entered baseboard name=" + BaseboardName );  // LCOV_EXCL_LINE
 			}
 			if ( KickOffSimulation ) {
 				if ( BaseboardName != HWBaseboard( BaseboardNum ).EquipID ) {
-					ShowFatalError( "UpdateHWBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + HWBaseboard( BaseboardNum ).EquipID );
+					ShowFatalError( "UpdateHWBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + HWBaseboard( BaseboardNum ).EquipID );  // LCOV_EXCL_LINE
 				}
 				if ( BaseboardTypeNum != TypeOf_Baseboard_Rad_Conv_Water ) {
-					ShowFatalError( "UpdateHWBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + ccSimPlantEquipTypes( BaseboardTypeNum ) );
+					ShowFatalError( "UpdateHWBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + ccSimPlantEquipTypes( BaseboardTypeNum ) );  // LCOV_EXCL_LINE
 				}
 			}
 		}

--- a/src/EnergyPlus/HeatBalFiniteDiffManager.cc
+++ b/src/EnergyPlus/HeatBalFiniteDiffManager.cc
@@ -466,7 +466,7 @@ namespace HeatBalFiniteDiffManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetCondFDInput: Errors found getting ConductionFiniteDifference properties. Program terminates." );
+			ShowFatalError( "GetCondFDInput: Errors found getting ConductionFiniteDifference properties. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		InitialInitHeatBalFiniteDiff();
@@ -776,7 +776,7 @@ namespace HeatBalFiniteDiffManager {
 								ShowContinueError( "Material may be too thin to be modeled well, thickness = " + RoundSigDigits( Material( CurrentLayer ).Thickness, 5 ) + " [m]" );
 								ShowContinueError( "Material with this thermal diffusivity should have thickness > " + RoundSigDigits( ThinMaterialLayerThreshold, 5 ) + " [m]" );
 							}
-							ShowFatalError( "Preceding conditions cause termination." );
+							ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 						}
 					}
 

--- a/src/EnergyPlus/HeatBalanceAirManager.cc
+++ b/src/EnergyPlus/HeatBalanceAirManager.cc
@@ -262,7 +262,7 @@ namespace HeatBalanceAirManager {
 		GetRoomAirModelParameters( ErrorsFound );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetAirHeatBalanceInput: Errors found in getting Air inputs" );
+			ShowFatalError( "GetAirHeatBalanceInput: Errors found in getting Air inputs" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/HeatBalanceHAMTManager.cc
+++ b/src/EnergyPlus/HeatBalanceHAMTManager.cc
@@ -650,7 +650,7 @@ namespace HeatBalanceHAMTManager {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetHeatBalHAMTInput: Errors found getting input.  Program terminates." );
+			ShowFatalError( "GetHeatBalHAMTInput: Errors found getting input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -808,7 +808,7 @@ namespace HeatBalanceHAMTManager {
 		}
 
 		if ( errorCount > 0 ) {
-			ShowFatalError( "CombinedHeatAndMoistureFiniteElement: Incomplete data to start solution, program terminates." );
+			ShowFatalError( "CombinedHeatAndMoistureFiniteElement: Incomplete data to start solution, program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		// Make the cells and initialize
@@ -1331,7 +1331,7 @@ namespace HeatBalanceHAMTManager {
 				if ( ! WarmupFlag ) {
 					ShowSevereError( "HAMT: HAMT: Temperature (high) out of bounds ( " + RoundSigDigits( tempmax, 2 ) + ") for surface=" + Surface( sid ).Name );
 					ShowContinueErrorTimeStamp( "" );
-					ShowFatalError( "Program terminates due to preceding condition." );
+					ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( tempmin < MinSurfaceTempLimit ) {
@@ -1347,7 +1347,7 @@ namespace HeatBalanceHAMTManager {
 				if ( ! WarmupFlag ) {
 					ShowSevereError( "HAMT: HAMT: Temperature (low) out of bounds ( " + RoundSigDigits( tempmin, 2 ) + ") for surface=" + Surface( sid ).Name );
 					ShowContinueErrorTimeStamp( "" );
-					ShowFatalError( "Program terminates due to preceding condition." );
+					ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -1416,7 +1416,7 @@ namespace HeatBalanceHAMTManager {
 				} else {
 					ShowSevereError( "CalcHeatBalHAMT: demoninator in calculating RH is zero.  Check material properties for accuracy." );
 					ShowContinueError( "...Problem occurs in Material=\"" + Material( cells( cid ).matid ).Name + "\"." );
-					ShowFatalError( "Program terminates due to preceding condition." );
+					ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 				}
 
 				if ( cells( cid ).rhp1 > rhmax ) {

--- a/src/EnergyPlus/HeatBalanceIntRadExchange.cc
+++ b/src/EnergyPlus/HeatBalanceIntRadExchange.cc
@@ -454,12 +454,12 @@ namespace HeatBalanceIntRadExchange {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rick Strand
 		//       DATE WRITTEN   July 2016
-		
+
 		// PURPOSE OF THIS SUBROUTINE:
 		// To determine if any changes in interior movable insulation have happened.
 		// If there have been changes due to a schedule change AND a change in properties,
 		// then the matrices which are used to calculate interior radiation must be recalculated.
-				
+
 		MovableInsulationChange = false;
 		if ( Surface( SurfNum ).MaterialMovInsulInt > 0 ) {
 			Real64 HMovInsul; // "Resistance" value of movable insulation (if present)
@@ -476,7 +476,7 @@ namespace HeatBalanceIntRadExchange {
 		}
 
 	}
-	
+
 	void
 	InitInteriorRadExchange()
 	{
@@ -569,7 +569,7 @@ namespace HeatBalanceIntRadExchange {
 			}
 			ZoneInfo( ZoneNum ).NumOfSurfaces = NumOfZoneSurfaces;
 			MaxNumOfZoneSurfaces = max( MaxNumOfZoneSurfaces, NumOfZoneSurfaces );
-			if ( NumOfZoneSurfaces < 1 ) ShowFatalError( "No surfaces in a zone in InitInteriorRadExchange" );
+			if ( NumOfZoneSurfaces < 1 ) ShowFatalError( "No surfaces in a zone in InitInteriorRadExchange" );  // LCOV_EXCL_LINE
 
 			// Allocate the parts of the derived type
 			ZoneInfo( ZoneNum ).F.dimension( NumOfZoneSurfaces, NumOfZoneSurfaces, 0.0 );
@@ -775,7 +775,7 @@ namespace HeatBalanceIntRadExchange {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "InitInteriorRadExchange: Errors found during initialization of radiant exchange.  Program terminated." );
+			ShowFatalError( "InitInteriorRadExchange: Errors found during initialization of radiant exchange.  Program terminated." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1234,7 +1234,7 @@ namespace HeatBalanceIntRadExchange {
 				}
 				sumFixedF.deallocate();
 				if ( MaxFixedFRowSum < 1.0 ) {
-					ShowFatalError( " FixViewFactors: Three surface or less zone failing ViewFactorFix correction which should never happen.");
+					ShowFatalError( " FixViewFactors: Three surface or less zone failing ViewFactorFix correction which should never happen.");  // LCOV_EXCL_LINE
 				} else {
 					FixedF *= ( 1.0 / MaxFixedFRowSum );
 				}

--- a/src/EnergyPlus/HeatBalanceKivaManager.cc
+++ b/src/EnergyPlus/HeatBalanceKivaManager.cc
@@ -92,7 +92,7 @@ void kivaErrorCallback(
 		ShowWarningError( "Kiva: " + message );
 	} else /* if (messageType == Kiva::MSG_ERR) */ {
 		ShowSevereError( "Kiva: " + message );
-		ShowFatalError( "Kiva: Errors discovered, program terminates." );
+		ShowFatalError( "Kiva: Errors discovered, program terminates." );  // LCOV_EXCL_LINE
 	}
 }
 
@@ -448,7 +448,7 @@ void KivaManager::readWeatherData()
 	{
 		IOFlags flags; flags.ACTION( "read" ); gio::open( kivaWeatherFileUnitNumber, DataStringGlobals::inputWeatherFileName, flags );
 		if ( flags.err() )
-			ShowFatalError( "Kiva::ReadWeatherFile: Could not OPEN EPW Weather File" );
+			ShowFatalError( "Kiva::ReadWeatherFile: Could not OPEN EPW Weather File" );  // LCOV_EXCL_LINE
 	}
 
 	// Read in Header Information
@@ -461,7 +461,7 @@ void KivaManager::readWeatherData()
 		{
 			IOFlags flags; gio::read( kivaWeatherFileUnitNumber, "(A)", flags ) >> Line;
 			if ( flags.end() )
-				ShowFatalError( "Kiva::ReadWeatherFile: Unexpected End-of-File on EPW Weather file, while reading header information, looking for header=" + Header( HdLine ) );
+				ShowFatalError( "Kiva::ReadWeatherFile: Unexpected End-of-File on EPW Weather file, while reading header information, looking for header=" + Header( HdLine ) );  // LCOV_EXCL_LINE
 		}
 		// Use headers to know how to read data to memory (e.g., number of periods, number of intervals)
 		int endcol = len( Line );
@@ -469,7 +469,7 @@ void KivaManager::readWeatherData()
 			if ( int( Line[ endcol - 1 ] ) == DataSystemVariables::iUnicode_end ) {
 				ShowSevereError( "OpenWeatherFile: EPW Weather File appears to be a Unicode or binary file." );
 				ShowContinueError( "...This file cannot be read by this program. Please save as PC or Unix file and try again" );
-				ShowFatalError( "Program terminates due to previous condition." );
+				ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 			}
 		}
 		std::string::size_type Pos = FindNonSpace( Line );
@@ -482,7 +482,7 @@ void KivaManager::readWeatherData()
 		if ( ( Pos == std::string::npos ) && ( ! has_prefixi( Header( HdLine ), "COMMENTS" ) ) ) {
 			ShowSevereError( "Invalid Header line in in.epw -- no commas" );
 			ShowContinueError( "Line=" + Line );
-			ShowFatalError( "Previous conditions cause termination." );
+			ShowFatalError( "Previous conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 		if ( Pos != std::string::npos ) Line.erase( 0, Pos + 1 );
 

--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -468,7 +468,7 @@ namespace HeatBalanceManager {
 		CheckUsedConstructions( ErrorsFound );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in Building Input, Program Stopped" );
+			ShowFatalError( "Errors found in Building Input, Program Stopped" );  // LCOV_EXCL_LINE  // LCOV_EXCL_LINE
 		}
 
 		// following is done to "get internal heat gains" input so that lights are gotten before
@@ -5613,7 +5613,7 @@ namespace HeatBalanceManager {
 		OutputFileShadingFrac = GetNewUnitNumber();
 		{ IOFlags flags; flags.ACTION( "write" ); flags.STATUS( "UNKNOWN" ); gio::open( OutputFileShadingFrac, DataStringGlobals::outputExtShdFracFileName, flags ); write_stat = flags.ios(); }
 		if ( write_stat != 0 ) {
-			ShowFatalError( "OpenOutputFiles: Could not open file " + DataStringGlobals::outputExtShdFracFileName + " for output (write)." );
+			ShowFatalError( "OpenOutputFiles: Could not open file " + DataStringGlobals::outputExtShdFracFileName + " for output (write)." );   // LCOV_EXCL_LINE  // LCOV_EXCL_LINE
 		}
 		gio::write( OutputFileShadingFrac, fmtA ) << "This file contains external shading fractions for all shading surfaces of all zones.";
 		{ IOFlags flags; flags.ADVANCE("No"); gio::write( OutputFileShadingFrac, fmtA, flags ) << "Surface Name,"; }
@@ -5923,10 +5923,10 @@ namespace HeatBalanceManager {
 		CheckForActualFileName( DesiredFileName, exists, TempFullFileName );
 		//INQUIRE(FILE=TRIM(DesiredFileName), EXIST=exists)
 		if ( ! exists ) {
-			ShowSevereError( "HeatBalanceManager: SearchWindow5DataFile: Could not locate Window5 Data File, expecting it as file name=" + DesiredFileName );
-			ShowContinueError( "Certain run environments require a full path to be included with the file name in the input field." );
-			ShowContinueError( "Try again with putting full path and file name in the field." );
-			ShowFatalError( "Program terminates due to these conditions." );
+			ShowSevereError( "HeatBalanceManager: SearchWindow5DataFile: Could not locate Window5 Data File, expecting it as file name=" + DesiredFileName );   // LCOV_EXCL_LINE
+			ShowContinueError( "Certain run environments require a full path to be included with the file name in the input field." );   // LCOV_EXCL_LINE
+			ShowContinueError( "Try again with putting full path and file name in the field." );   // LCOV_EXCL_LINE
+			ShowFatalError( "Program terminates due to these conditions." );   // LCOV_EXCL_LINE  // LCOV_EXCL_LINE
 		}
 
 		W5DataFileNum = GetNewUnitNumber();
@@ -5937,7 +5937,7 @@ namespace HeatBalanceManager {
 			if ( int( NextLine[ endcol - 1 ] ) == iUnicode_end ) {
 				ShowSevereError( "SearchWindow5DataFile: For \"" + DesiredConstructionName + "\" in " + DesiredFileName + " fiile, appears to be a Unicode or binary file." );
 				ShowContinueError( "...This file cannot be read by this program. Please save as PC or Unix file and try again" );
-				ShowFatalError( "Program terminates due to previous condition." );
+				ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -5949,7 +5949,7 @@ namespace HeatBalanceManager {
 		++FileLineCount;
 		if ( ! has_prefixi( NextLine, "WINDOW5" ) ) {
 			ShowSevereError( "HeatBalanceManager: SearchWindow5DataFile: Error in Data File=" + DesiredFileName );
-			ShowFatalError( "Error reading Window5 Data File: first word of window entry is \"" + NextLine.substr( 0, 7 ) + "\", should be Window5." );
+			ShowFatalError( "Error reading Window5 Data File: first word of window entry is \"" + NextLine.substr( 0, 7 ) + "\", should be Window5." );  // LCOV_EXCL_LINE
 		}
 
 Label10: ;
@@ -5983,7 +5983,7 @@ Label20: ;
 			++FileLineCount;
 			gio::read( NextLine.substr( 19 ), "*" ) >> NGlSys;
 			if ( NGlSys <= 0 || NGlSys > 2 ) {
-				ShowFatalError( "Construction=" + DesiredConstructionName + " from the Window5 data file cannot be used: it has " + TrimSigDigits( NGlSys ) + " glazing systems; only 1 or 2 are allowed." );
+				ShowFatalError( "Construction=" + DesiredConstructionName + " from the Window5 data file cannot be used: it has " + TrimSigDigits( NGlSys ) + " glazing systems; only 1 or 2 are allowed." );  // LCOV_EXCL_LINE
 			}
 			{ IOFlags flags; gio::read( W5DataFileNum, fmtA, flags ) >> NextLine; ReadStat = flags.ios(); }
 			if ( ReadStat < GoodIOStatValue ) goto Label1000;
@@ -6144,7 +6144,7 @@ Label20: ;
 				}
 			}
 
-			if ( ErrorsFound ) ShowFatalError( "HeatBalanceManager: SearchWindow5DataFile: Construction=" + DesiredConstructionName + " from the Window5 data file cannot be used because of above errors" );
+			if ( ErrorsFound ) ShowFatalError( "HeatBalanceManager: SearchWindow5DataFile: Construction=" + DesiredConstructionName + " from the Window5 data file cannot be used because of above errors" );  // LCOV_EXCL_LINE
 
 			TotMaterialsPrev = TotMaterials;
 			for ( IGlSys = 1; IGlSys <= NGlSys; ++IGlSys ) {
@@ -6489,7 +6489,7 @@ Label20: ;
 				}
 				FileLineCount += 5;
 
-				if ( ErrorsFound ) ShowFatalError( "HeatBalanceManager: SearchWindow5DataFile: Construction=" + DesiredConstructionName + " from the Window5 data file cannot be used because of above errors" );
+				if ( ErrorsFound ) ShowFatalError( "HeatBalanceManager: SearchWindow5DataFile: Construction=" + DesiredConstructionName + " from the Window5 data file cannot be used because of above errors" );  // LCOV_EXCL_LINE
 
 				// Hemis
 				Construct( ConstrNum ).TransDiff = Tsol( 11 );
@@ -6603,7 +6603,7 @@ Label20: ;
 		return;
 
 Label999: ;
-		ShowFatalError( "HeatBalanceManager: SearchWindow5DataFile: Could not open Window5 Data File, expecting it as file name=" + DesiredFileName );
+		ShowFatalError( "HeatBalanceManager: SearchWindow5DataFile: Could not open Window5 Data File, expecting it as file name=" + DesiredFileName );  // LCOV_EXCL_LINE
 		return;
 
 Label1000: ;
@@ -7500,7 +7500,7 @@ Label1000: ;
 		//step 8.  Hemispherical terms are averaged using standard method
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Program halted because of input problem(s) in WindowMaterial:SimpleGlazingSystem" );
+			ShowFatalError( "Program halted because of input problem(s) in WindowMaterial:SimpleGlazingSystem" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -7850,7 +7850,7 @@ Label1000: ;
 				}
 			}
 
-			if ( ErrorsFound ) ShowFatalError( "Error in complex fenestration material input." );
+			if ( ErrorsFound ) ShowFatalError( "Error in complex fenestration material input." );  // LCOV_EXCL_LINE
 
 		}
 
@@ -8561,7 +8561,7 @@ Label1000: ;
 		if ( allocated( locAlphaArgs ) ) locAlphaArgs.deallocate();
 		if ( allocated( locNumericArgs ) ) locNumericArgs.deallocate();
 
-		if ( ErrorsFound ) ShowFatalError( "Error in complex fenestration input." );
+		if ( ErrorsFound ) ShowFatalError( "Error in complex fenestration input." );  // LCOV_EXCL_LINE
 
 	}
 

--- a/src/EnergyPlus/HeatBalanceMovableInsulation.cc
+++ b/src/EnergyPlus/HeatBalanceMovableInsulation.cc
@@ -119,7 +119,7 @@ namespace HeatBalanceMovableInsulation {
 				if ( ( Material( MaterialIndex ).Conductivity ) > 0.0 ) {
 					Material( MaterialIndex ).Resistance = Material( Surface( SurfNum ).MaterialMovInsulExt ).Thickness / Material( Surface( SurfNum ).MaterialMovInsulExt ).Conductivity;
 				} else {
-					ShowFatalError( "EvalOutsideMovableInsulation: No resistance or conductivity found for material " + Material( Surface( SurfNum ).MaterialMovInsulExt ).Name );
+					ShowFatalError( "EvalOutsideMovableInsulation: No resistance or conductivity found for material " + Material( Surface( SurfNum ).MaterialMovInsulExt ).Name );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -163,7 +163,7 @@ namespace HeatBalanceMovableInsulation {
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		Real64 MovInsulSchedVal; // Value of the movable insulation schedule for current time
-		
+
 		// FLOW:
 		MovInsulSchedVal = GetCurrentScheduleValue( Surface( SurfNum ).SchedMovInsulInt );
 
@@ -182,7 +182,7 @@ namespace HeatBalanceMovableInsulation {
 				if ( Material( thisMovableInt ).Conductivity > 0.0 && Material( thisMovableInt ).Thickness > 0.0 ) {
 					Material( thisMovableInt ).Resistance = Material( thisMovableInt ).Thickness / Material( thisMovableInt ).Conductivity;
 				} else {
-					ShowFatalError( "EvalInsideMovableInsulation: No resistance found for material " + Material( MaterialIndex ).Name );
+					ShowFatalError( "EvalInsideMovableInsulation: No resistance found for material " + Material( MaterialIndex ).Name );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -194,7 +194,7 @@ namespace HeatBalanceMovableInsulation {
 			} else {
 				AbsInt = Material( MaterialIndex ).AbsorpSolar;
 			} }
-			
+
 		} }
 
 	}

--- a/src/EnergyPlus/HeatBalanceSurfaceManager.cc
+++ b/src/EnergyPlus/HeatBalanceSurfaceManager.cc
@@ -328,7 +328,7 @@ namespace HeatBalanceSurfaceManager {
 		//                      Added calls to alternative daylighting analysis using DElight
 		//                      All modifications demarked with RJH (Rob Hitchcock)
 		//                      RJH, Jul 2004: add error handling for DElight calls
-		//       MODIFIED       Aug. 2017 
+		//       MODIFIED       Aug. 2017
 		//                      Add initializations of surface data to linked air node value if defined
 		//       RE-ENGINEERED  na
 
@@ -465,7 +465,7 @@ namespace HeatBalanceSurfaceManager {
 			}
 		}
 
-		// Overwriting surface and zone level environmental data with EMS override value 
+		// Overwriting surface and zone level environmental data with EMS override value
 		if ( AnyEnergyManagementSystemInModel ) {
 			for ( SurfNum = 1; SurfNum <= TotSurfaces; ++SurfNum ) {
 				if ( Surface( SurfNum ).OutDryBulbTempEMSOverrideOn ) {
@@ -476,7 +476,7 @@ namespace HeatBalanceSurfaceManager {
 				}
 				if ( Surface( SurfNum ).WindSpeedEMSOverrideOn ) {
 					Surface( SurfNum ).WindSpeed = Surface( SurfNum ).WindSpeedEMSOverrideValue;
-				} 
+				}
 				if ( Surface( SurfNum ).WindDirEMSOverrideOn ) {
 					Surface( SurfNum ).WindDir = Surface( SurfNum ).WindDirEMSOverrideValue;
 				}
@@ -602,7 +602,7 @@ namespace HeatBalanceSurfaceManager {
 						elOpened = false;
 					}
 					//            IF (iwriteStatus /= 0) THEN
-					//              CALL ShowFatalError('InitSurfaceHeatBalance: Could not open file "eplusout.delighteldmp" for output (readwrite).')
+					//              CALL ShowFatalError('InitSurfaceHeatBalance: Could not open file "eplusout.delighteldmp" for output (readwrite).')  // LCOV_EXCL_LINE
 					//            ENDIF
 					//            Open(unit=iDElightErrorFile, file='eplusout.delighteldmp', action='READ')
 
@@ -631,9 +631,9 @@ namespace HeatBalanceSurfaceManager {
 
 					// Close DElight Error File and delete
 					if ( elOpened ) { IOFlags flags; flags.DISPOSE( "DELETE" ); gio::close( iDElightErrorFile, flags ); };
-					// If any DElight Error occurred then ShowFatalError to terminate
+					// If any DElight Error occurred then ShowFatalError to terminate  // LCOV_EXCL_LINE
 					if ( iErrorFlag > 0 ) {
-						ShowFatalError( "End of DElight Error Messages" );
+						ShowFatalError( "End of DElight Error Messages" );  // LCOV_EXCL_LINE
 					}
 				} else { // RJH 2008-03-07: No errors
 					// extract reference point illuminance values from DElight Electric Lighting dump file for reporting
@@ -641,7 +641,7 @@ namespace HeatBalanceSurfaceManager {
 					iDElightErrorFile = GetNewUnitNumber();
 					{ IOFlags flags; flags.ACTION( "READWRITE" ); gio::open( iDElightErrorFile, DataStringGlobals::outputDelightEldmpFileName, flags ); iwriteStatus = flags.ios(); }
 					//            IF (iwriteStatus /= 0) THEN
-					//              CALL ShowFatalError('InitSurfaceHeatBalance: Could not open file "eplusout.delighteldmp" for output (readwrite).')
+					//              CALL ShowFatalError('InitSurfaceHeatBalance: Could not open file "eplusout.delighteldmp" for output (readwrite).')  // LCOV_EXCL_LINE
 					//            ENDIF
 					if ( iwriteStatus == 0 ) {
 						elOpened = true;
@@ -4657,7 +4657,7 @@ CalcHeatBalanceOutsideSurf( Optional_int_const ZoneToResimulate ) // if passed i
 	Real64 RhoVaporSat; // Local temporary saturated vapor density for checking
 	bool MovInsulErrorFlag; // Movable Insulation error flag
 	Real64 TSurf; // Absolute temperature of the outside surface of an exterior surface
-	
+
 
 	// FUNCTION DEFINITIONS:
 	// na
@@ -4867,7 +4867,7 @@ CalcHeatBalanceOutsideSurf( Optional_int_const ZoneToResimulate ) // if passed i
 			// Call the outside surface temp calculation and pass the necessary terms
 			if ( Surface( SurfNum ).HeatTransferAlgorithm == HeatTransferModel_CTF || Surface( SurfNum ).HeatTransferAlgorithm == HeatTransferModel_EMPD ) {
 				CalcOutsideSurfTemp( SurfNum, ZoneNum, ConstrNum, HMovInsul, TempExt, MovInsulErrorFlag );
-				if (MovInsulErrorFlag) ShowFatalError( "CalcOutsideSurfTemp: Program terminates due to preceding conditions." );
+				if (MovInsulErrorFlag) ShowFatalError( "CalcOutsideSurfTemp: Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 			}
 
 			// This ends the calculations for this surface and goes on to the next SurfNum
@@ -4909,7 +4909,7 @@ CalcHeatBalanceOutsideSurf( Optional_int_const ZoneToResimulate ) // if passed i
 				}
 
 				CalcOutsideSurfTemp( SurfNum, ZoneNum, ConstrNum, HMovInsul, TempExt, MovInsulErrorFlag );
-				if (MovInsulErrorFlag) ShowFatalError( "CalcOutsideSurfTemp: Program terminates due to preceding conditions." );
+				if (MovInsulErrorFlag) ShowFatalError( "CalcOutsideSurfTemp: Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 
 			} else if ( Surface( SurfNum ).HeatTransferAlgorithm == HeatTransferModel_CondFD || Surface( SurfNum ).HeatTransferAlgorithm == HeatTransferModel_HAMT ) {
 				if ( Surface( SurfNum ).ExtCavityPresent ) {
@@ -5031,9 +5031,9 @@ CalcHeatBalanceOutsideSurf( Optional_int_const ZoneToResimulate ) // if passed i
 			if ( Surface( SurfNum ).HeatTransferAlgorithm == HeatTransferModel_CTF || Surface( SurfNum ).HeatTransferAlgorithm == HeatTransferModel_EMPD ) {
 
 				CalcOutsideSurfTemp( SurfNum, ZoneNum, ConstrNum, HMovInsul, TempExt, MovInsulErrorFlag );
-				if (MovInsulErrorFlag) ShowFatalError( "CalcOutsideSurfTemp: Program terminates due to preceding conditions." );
+				if (MovInsulErrorFlag) ShowFatalError( "CalcOutsideSurfTemp: Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 			}
-			
+
 
 		} else if ( SELECT_CASE_var == KivaFoundation ) {
 			// Do nothing
@@ -5343,7 +5343,7 @@ CalcHeatBalanceInsideSurf( Optional_int_const ZoneToResimulate ) // if passed in
 			ZoneEquipConfigNum = ZoneNum;
 			// check whether this zone is a controlled zone or not
 			if ( ! Zone( ZoneNum ).IsControlled ) {
-				ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );
+				ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 				return;
 			}
 			// determine supply air conditions
@@ -5626,7 +5626,7 @@ CalcHeatBalanceInsideSurf( Optional_int_const ZoneToResimulate ) // if passed in
 							ShowContinueError( "Construction " + construct.Name + " contains an internal source or sink but also uses" );
 							ShowContinueError( "interior movable insulation " + Material( Surface( SurfNum ).MaterialMovInsulInt ).Name + " for a surface with that construction." );
 							ShowContinueError( "This is not currently allowed because the heat balance equations do not currently accommodate this combination." );
-							ShowFatalError( "CalcHeatBalanceInsideSurf: Program terminates due to preceding conditions." );
+							ShowFatalError( "CalcHeatBalanceInsideSurf: Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 
 						}
 
@@ -5754,7 +5754,7 @@ CalcHeatBalanceInsideSurf( Optional_int_const ZoneToResimulate ) // if passed in
 
 			//if ( std::isnan( TempSurfInRep( SurfNum ) ) ) { // Use IEEE_IS_NAN when GFortran supports it
 				//// throw Error
-				//ShowFatalError( "Inside surface temperature is out of bound = " + Surface( SurfNum ).Name );
+				//ShowFatalError( "Inside surface temperature is out of bound = " + Surface( SurfNum ).Name );  // LCOV_EXCL_LINE
 			//}
 			// sign convention is positive means energy going into inside face from the air.
 			auto const HConvInTemp_fac( -HConvIn_surf * ( TempSurfIn( SurfNum ) - RefAirTemp( SurfNum ) ) );
@@ -6046,10 +6046,10 @@ TestSurfTempCalcHeatBalanceInsideSurf(
 				if ( WarmupSurfTemp > 3 ) {
 					ShowSevereError( "CalcHeatBalanceInsideSurf: Zone=\"" + zone.Name + "\" has view factor enforced reciprocity" );
 					ShowContinueError( " and is having temperature out of bounds errors. Please correct zone geometry and rerun." );
-					ShowFatalError( "CalcHeatBalanceInsideSurf: Program terminates due to preceding conditions." );
+					ShowFatalError( "CalcHeatBalanceInsideSurf: Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 				}
 			} else if ( WarmupSurfTemp > 10 ) {
-				ShowFatalError( "CalcHeatBalanceInsideSurf: Program terminates due to preceding conditions." );
+				ShowFatalError( "CalcHeatBalanceInsideSurf: Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 			}
 		}
 	}
@@ -6078,7 +6078,7 @@ TestSurfTempCalcHeatBalanceInsideSurf(
 					}
 					zone.TempOutOfBoundsReported = true;
 				}
-				ShowFatalError( "Program terminates due to preceding condition." );
+				ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 			} else {
 				ShowSevereError( "Temperature (high) out of bounds [" + RoundSigDigits( TH12, 2 ) + "] for zone=\"" + zone.Name + "\", for surface=\"" + surface.Name + "\"" );
 				ShowContinueErrorTimeStamp( "" );
@@ -6102,14 +6102,14 @@ TestSurfTempCalcHeatBalanceInsideSurf(
 					}
 					zone.TempOutOfBoundsReported = true;
 				}
-				ShowFatalError( "Program terminates due to preceding condition." );
+				ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 			}
 		} else{
 			if ( TH12 < -10000. || TH12 > 10000. ) {
 				ShowSevereError( "CalcHeatBalanceInsideSurf: The temperature of " + RoundSigDigits( TH12, 2 ) + " C for zone=\"" + zone.Name + "\", for surface=\"" + surface.Name + "\"" );
 				ShowContinueError( "..is very far out of bounds during warmup. This may be an indication of a malformed zone." );
 				ShowContinueErrorTimeStamp( "" );
-				ShowFatalError( "Program terminates due to preceding condition." );
+				ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 			}
 		}
 	}
@@ -6326,7 +6326,7 @@ CalcOutsideSurfTemp(
 	QdotRadOutRep( SurfNum ) = Surface( SurfNum ).Area * HExtSurf_fac;
 	QdotRadOutRepPerArea( SurfNum ) = HExtSurf_fac;
 
-	//QdotRadOutRep( SurfNum ) = Surface( SurfNum ).Area * HExtSurf_fac + QRadLWOutSrdSurfs( SurfNum );	
+	//QdotRadOutRep( SurfNum ) = Surface( SurfNum ).Area * HExtSurf_fac + QRadLWOutSrdSurfs( SurfNum );
 	//QdotRadOutRepPerArea( SurfNum ) = QdotRadOutRep( SurfNum ) / Surface( SurfNum ).Area;
 
 	QRadOutReport( SurfNum ) = QdotRadOutRep( SurfNum ) * TimeStepZoneSec;

--- a/src/EnergyPlus/HeatPumpWaterToWaterCOOLING.cc
+++ b/src/EnergyPlus/HeatPumpWaterToWaterCOOLING.cc
@@ -188,17 +188,17 @@ namespace HeatPumpWaterToWaterCOOLING {
 		if ( CompIndex == 0 ) {
 			GSHPNum = FindItemInList( GSHPName, GSHP );
 			if ( GSHPNum == 0 ) {
-				ShowFatalError( "SimHPWatertoWaterCOOLING: Unit not found=" + GSHPName );
+				ShowFatalError( "SimHPWatertoWaterCOOLING: Unit not found=" + GSHPName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = GSHPNum;
 		} else {
 			GSHPNum = CompIndex;
 			if ( GSHPNum > NumGSHPs || GSHPNum < 1 ) {
-				ShowFatalError( "SimHPWatertoWaterCOOLING:  Invalid CompIndex passed=" + TrimSigDigits( GSHPNum ) + ", Number of Units=" + TrimSigDigits( NumGSHPs ) + ", Entered Unit name=" + GSHPName );
+				ShowFatalError( "SimHPWatertoWaterCOOLING:  Invalid CompIndex passed=" + TrimSigDigits( GSHPNum ) + ", Number of Units=" + TrimSigDigits( NumGSHPs ) + ", Entered Unit name=" + GSHPName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( GSHPNum ) ) {
 				if ( GSHPName != GSHP( GSHPNum ).Name ) {
-					ShowFatalError( "SimHPWatertoWaterCOOLING: Invalid CompIndex passed=" + TrimSigDigits( GSHPNum ) + ", Unit name=" + GSHPName + ", stored Unit Name for that index=" + GSHP( GSHPNum ).Name );
+					ShowFatalError( "SimHPWatertoWaterCOOLING: Invalid CompIndex passed=" + TrimSigDigits( GSHPNum ) + ", Unit name=" + GSHPName + ", stored Unit Name for that index=" + GSHP( GSHPNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( GSHPNum ) = false;
 			}
@@ -220,7 +220,7 @@ namespace HeatPumpWaterToWaterCOOLING {
 		} else if ( LoopNum == GSHP( GSHPNum ).SourceLoopNum ) { // condenser loop
 			UpdateChillerComponentCondenserSide( GSHP( GSHPNum ).SourceLoopNum, GSHP( GSHPNum ).SourceLoopSideNum, TypeOf_HPWaterEFCooling, GSHP( GSHPNum ).SourceSideInletNodeNum, GSHP( GSHPNum ).SourceSideOutletNodeNum, GSHPReport( GSHPNum ).QSource, GSHPReport( GSHPNum ).SourceSideWaterInletTemp, GSHPReport( GSHPNum ).SourceSideWaterOutletTemp, GSHPReport( GSHPNum ).SourceSidemdot, FirstHVACIteration );
 		} else {
-			ShowFatalError( "SimHPWatertoWaterCOOLING:: Invalid loop connection " + ModuleCompName + ", Requested Unit=" + GSHPName );
+			ShowFatalError( "SimHPWatertoWaterCOOLING:: Invalid loop connection " + ModuleCompName + ", Requested Unit=" + GSHPName );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -424,13 +424,13 @@ namespace HeatPumpWaterToWaterCOOLING {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors Found in getting Gshp input" );
+			ShowFatalError( "Errors Found in getting Gshp input" );  // LCOV_EXCL_LINE
 		}
 
 		GSHPRefrigIndex = FindRefrigerant( GSHPRefrigerant );
 		if ( GSHPRefrigIndex == 0 ) {
-			ShowFatalError( "Refrigerant for HeatPump:WaterToWater Heating not found, should have been=" + GSHPRefrigerant );
-			ShowFatalError( "FluidProperties:* objects for " + GSHPRefrigerant + " must be included in the idf file.");
+			ShowFatalError( "Refrigerant for HeatPump:WaterToWater Heating not found, should have been=" + GSHPRefrigerant );  // LCOV_EXCL_LINE
+			ShowFatalError( "FluidProperties:* objects for " + GSHPRefrigerant + " must be included in the idf file.");  // LCOV_EXCL_LINE
 		}
 
 		//CurrentModuleObject='HeatPump:WaterToWater:ParameterEstimation:Cooling'
@@ -461,7 +461,7 @@ namespace HeatPumpWaterToWaterCOOLING {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "GetWatertoWaterHPInput: Program terminated on scan for loop data" );
+				ShowFatalError( "GetWatertoWaterHPInput: Program terminated on scan for loop data" );  // LCOV_EXCL_LINE
 			}
 
 		}
@@ -509,7 +509,7 @@ namespace HeatPumpWaterToWaterCOOLING {
 			ScanPlantLoopsForObject( GSHP( GSHPNum ).Name, TypeOf_HPWaterPECooling, GSHP( GSHPNum ).SourceLoopNum, GSHP( GSHPNum ).SourceLoopSideNum, GSHP( GSHPNum ).SourceBranchNum, GSHP( GSHPNum ).SourceCompNum, _, _, _, GSHP( GSHPNum ).SourceSideInletNodeNum, _, errFlag );
 			ScanPlantLoopsForObject( GSHP( GSHPNum ).Name, TypeOf_HPWaterPECooling, GSHP( GSHPNum ).LoadLoopNum, GSHP( GSHPNum ).LoadLoopSideNum, GSHP( GSHPNum ).LoadBranchNum, GSHP( GSHPNum ).LoadCompNum, _, _, _, GSHP( GSHPNum ).LoadSideInletNodeNum, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitGshp: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitGshp: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			MyPlanScanFlag( GSHPNum ) = false;
 		}
@@ -788,14 +788,14 @@ namespace HeatPumpWaterToWaterCOOLING {
 				ShowSevereError( ModuleCompName + "=\"" + GSHPName + "\" Cooling Source Side Pressure Less than the Design Minimum" );
 				ShowContinueError( "Cooling Source Side Pressure=" + TrimSigDigits( SourceSidePressure, 2 ) + " and user specified Design Minimum Pressure=" + TrimSigDigits( LowPressCutoff, 2 ) );
 				ShowContinueErrorTimeStamp( "" );
-				ShowFatalError( "Preceding Conditions cause termination." );
+				ShowFatalError( "Preceding Conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( LoadSidePressure > HighPressCutoff ) {
 				ShowSevereError( ModuleCompName + "=\"" + GSHPName + "\" Cooling Load Side Pressure greater than the Design Maximum" );
 				ShowContinueError( "Cooling Load Side Pressure=" + TrimSigDigits( LoadSidePressure, 2 ) + " and user specified Design Maximum Pressure=" + TrimSigDigits( HighPressCutoff, 2 ) );
 				ShowContinueErrorTimeStamp( "" );
-				ShowFatalError( "Preceding Conditions cause termination." );
+				ShowFatalError( "Preceding Conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 			// Determine Suction Pressure at compressor inlet
 			SuctionPr = LoadSidePressure - PressureDrop;
@@ -806,14 +806,14 @@ namespace HeatPumpWaterToWaterCOOLING {
 				ShowSevereError( ModuleCompName + "=\"" + GSHPName + "\" Cooling Suction Pressure Less than the Design Minimum" );
 				ShowContinueError( "Cooling Suction Pressure=" + TrimSigDigits( SuctionPr, 2 ) + " and user specified Design Minimum Pressure=" + TrimSigDigits( LowPressCutoff, 2 ) );
 				ShowContinueErrorTimeStamp( "" );
-				ShowFatalError( "Preceding Conditions cause termination." );
+				ShowFatalError( "Preceding Conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( DischargePr > HighPressCutoff ) {
 				ShowSevereError( ModuleCompName + "=\"" + GSHPName + "\" Cooling Discharge Pressure greater than the Design Maximum" );
 				ShowContinueError( "Cooling Discharge Pressure=" + TrimSigDigits( DischargePr, 2 ) + " and user specified Design Maximum Pressure=" + TrimSigDigits( HighPressCutoff, 2 ) );
 				ShowContinueErrorTimeStamp( "" );
-				ShowFatalError( "Preceding Conditions cause termination." );
+				ShowFatalError( "Preceding Conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 
 			// Determine the Source Side Outlet Enthalpy

--- a/src/EnergyPlus/HeatPumpWaterToWaterHEATING.cc
+++ b/src/EnergyPlus/HeatPumpWaterToWaterHEATING.cc
@@ -187,17 +187,17 @@ namespace HeatPumpWaterToWaterHEATING {
 		if ( CompIndex == 0 ) {
 			GSHPNum = FindItemInList( GSHPName, GSHP );
 			if ( GSHPNum == 0 ) {
-				ShowFatalError( "SimHPWatertoWaterHEATING: Unit not found=" + GSHPName );
+				ShowFatalError( "SimHPWatertoWaterHEATING: Unit not found=" + GSHPName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = GSHPNum;
 		} else {
 			GSHPNum = CompIndex;
 			if ( GSHPNum > NumGSHPs || GSHPNum < 1 ) {
-				ShowFatalError( "SimHPWatertoWaterHEATING:  Invalid CompIndex passed=" + TrimSigDigits( GSHPNum ) + ", Number of Units=" + TrimSigDigits( NumGSHPs ) + ", Entered Unit name=" + GSHPName );
+				ShowFatalError( "SimHPWatertoWaterHEATING:  Invalid CompIndex passed=" + TrimSigDigits( GSHPNum ) + ", Number of Units=" + TrimSigDigits( NumGSHPs ) + ", Entered Unit name=" + GSHPName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( GSHPNum ) ) {
 				if ( GSHPName != GSHP( GSHPNum ).Name ) {
-					ShowFatalError( "SimHPWatertoWaterHEATING: Invalid CompIndex passed=" + TrimSigDigits( GSHPNum ) + ", Unit name=" + GSHPName + ", stored Unit Name for that index=" + GSHP( GSHPNum ).Name );
+					ShowFatalError( "SimHPWatertoWaterHEATING: Invalid CompIndex passed=" + TrimSigDigits( GSHPNum ) + ", Unit name=" + GSHPName + ", stored Unit Name for that index=" + GSHP( GSHPNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( GSHPNum ) = false;
 			}
@@ -220,7 +220,7 @@ namespace HeatPumpWaterToWaterHEATING {
 		} else if ( LoopNum == GSHP( GSHPNum ).SourceLoopNum ) { // condenser loop
 			UpdateChillerComponentCondenserSide( GSHP( GSHPNum ).SourceLoopNum, GSHP( GSHPNum ).SourceLoopSideNum, TypeOf_HPWaterEFHeating, GSHP( GSHPNum ).SourceSideInletNodeNum, GSHP( GSHPNum ).SourceSideOutletNodeNum, - GSHPReport( GSHPNum ).QSource, GSHPReport( GSHPNum ).SourceSideWaterInletTemp, GSHPReport( GSHPNum ).SourceSideWaterOutletTemp, GSHPReport( GSHPNum ).SourceSidemdot, FirstHVACIteration );
 		} else {
-			ShowFatalError( "SimHPWatertoWaterHEATING:: Invalid loop connection " + ModuleCompName + ", Requested Unit=" + GSHPName );
+			ShowFatalError( "SimHPWatertoWaterHEATING:: Invalid loop connection " + ModuleCompName + ", Requested Unit=" + GSHPName );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -418,12 +418,12 @@ namespace HeatPumpWaterToWaterHEATING {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors Found in getting " + ModuleCompNameUC + " Input" );
+			ShowFatalError( "Errors Found in getting " + ModuleCompNameUC + " Input" );  // LCOV_EXCL_LINE
 		}
 
 		GSHPRefrigIndex = FindRefrigerant( GSHPRefrigerant );
 		if ( GSHPRefrigIndex == 0 ) {
-			ShowFatalError( "Refrigerant for HeatPump:WaterToWater Heating not found, should have been=" + GSHPRefrigerant );
+			ShowFatalError( "Refrigerant for HeatPump:WaterToWater Heating not found, should have been=" + GSHPRefrigerant );  // LCOV_EXCL_LINE
 		}
 
 		// CurrentModuleObject='HeatPump:WaterToWater:ParameterEstimation:Heating'
@@ -454,7 +454,7 @@ namespace HeatPumpWaterToWaterHEATING {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "GetWatertoWaterHPInput: Program terminated on scan for loop data" );
+				ShowFatalError( "GetWatertoWaterHPInput: Program terminated on scan for loop data" );  // LCOV_EXCL_LINE
 			}
 
 		}
@@ -775,12 +775,12 @@ namespace HeatPumpWaterToWaterHEATING {
 			if ( SourceSidePressure < LowPressCutoff ) {
 				ShowSevereError( ModuleCompName + "=\"" + GSHPName + "\" Heating Source Side Pressure Less than the Design Minimum" );
 				ShowContinueError( "Source Side Pressure=" + TrimSigDigits( SourceSidePressure, 2 ) + " and user specified Design Minimum Pressure=" + TrimSigDigits( LowPressCutoff, 2 ) );
-				ShowFatalError( "Preceding Conditions cause termination." );
+				ShowFatalError( "Preceding Conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 			if ( LoadSidePressure > HighPressCutoff ) {
 				ShowSevereError( ModuleCompName + "=\"" + GSHPName + "\" Heating Load Side Pressure greater than the Design Maximum" );
 				ShowContinueError( "Load Side Pressure=" + TrimSigDigits( LoadSidePressure, 2 ) + " and user specified Design Maximum Pressure=" + TrimSigDigits( HighPressCutoff, 2 ) );
-				ShowFatalError( "Preceding Conditions cause termination." );
+				ShowFatalError( "Preceding Conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 
 			// Determine Suction Pressure at compressor inlet
@@ -791,12 +791,12 @@ namespace HeatPumpWaterToWaterHEATING {
 			if ( SuctionPr < LowPressCutoff ) {
 				ShowSevereError( ModuleCompName + "=\"" + GSHPName + "\" Heating Suction Pressure Less than the Design Minimum" );
 				ShowContinueError( "Heating Suction Pressure=" + TrimSigDigits( SuctionPr, 2 ) + " and user specified Design Minimum Pressure=" + TrimSigDigits( LowPressCutoff, 2 ) );
-				ShowFatalError( "Preceding Conditions cause termination." );
+				ShowFatalError( "Preceding Conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 			if ( DischargePr > HighPressCutoff ) {
 				ShowSevereError( ModuleCompName + "=\"" + GSHPName + "\" Heating Discharge Pressure greater than the Design Maximum" );
 				ShowContinueError( "Heating Discharge Pressure=" + TrimSigDigits( DischargePr, 2 ) + " and user specified Design Maximum Pressure=" + TrimSigDigits( HighPressCutoff, 2 ) );
-				ShowFatalError( "Preceding Conditions cause termination." );
+				ShowFatalError( "Preceding Conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 
 			// Determine the Source Side Outlet Enthalpy

--- a/src/EnergyPlus/HeatPumpWaterToWaterSimple.cc
+++ b/src/EnergyPlus/HeatPumpWaterToWaterSimple.cc
@@ -173,17 +173,17 @@ namespace HeatPumpWaterToWaterSimple {
 		if ( CompIndex == 0 ) {
 			GSHPNum = InputProcessor::FindItemInList( GSHPName, GSHP );
 			if ( GSHPNum == 0 ) {
-				ShowFatalError( "SimHPWatertoWaterSimple: Specified heat pump not one of valid heat pumps. Heat pump = " + GSHPName );
+				ShowFatalError( "SimHPWatertoWaterSimple: Specified heat pump not one of valid heat pumps. Heat pump = " + GSHPName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = GSHPNum;
 		} else {
 			GSHPNum = CompIndex;
 			if ( GSHPNum > NumGSHPs || GSHPNum < 1 ) {
-				ShowFatalError( "SimHPWatertoWaterSimple: Invalide component index pass = " + General::TrimSigDigits( GSHPNum ) + ", number of units = " + General::TrimSigDigits( NumGSHPs )+ ", entered unit name=" + GSHPName );
+				ShowFatalError( "SimHPWatertoWaterSimple: Invalide component index pass = " + General::TrimSigDigits( GSHPNum ) + ", number of units = " + General::TrimSigDigits( NumGSHPs )+ ", entered unit name=" + GSHPName );  // LCOV_EXCL_LINE
 			}
 			if ( GSHP( GSHPNum ).checkEquipName ) {
 				if ( GSHPName != GSHP( GSHPNum ).Name ) {
-					ShowFatalError( "SimHPWatertoWaterSimple: Invalid CompIndex passed=" + General::TrimSigDigits( GSHPNum ) + ", Unit name=" + GSHPName + ", stored Unit Name for that index=" + GSHP( GSHPNum ).Name );
+					ShowFatalError( "SimHPWatertoWaterSimple: Invalid CompIndex passed=" + General::TrimSigDigits( GSHPNum ) + ", Unit name=" + GSHPName + ", stored Unit Name for that index=" + GSHP( GSHPNum ).Name );  // LCOV_EXCL_LINE
 				}
 				GSHP( GSHPNum ).checkEquipName = false;
 			}
@@ -203,7 +203,7 @@ namespace HeatPumpWaterToWaterSimple {
 					MaxCap = GSHP( GSHPNum ).RatedCapHeat;
 					OptCap = GSHP( GSHPNum ).RatedCapHeat;
 				} else {
-					ShowFatalError( "SimHPWatertoWaterSimple: Module called with incorrect GSHPType=" + GSHPType );
+					ShowFatalError( "SimHPWatertoWaterSimple: Module called with incorrect GSHPType=" + GSHPType );  // LCOV_EXCL_LINE
 				}
 			} else {
 				MinCap = 0.0;
@@ -229,10 +229,10 @@ namespace HeatPumpWaterToWaterSimple {
 				} else if ( LoopNum == GSHP( GSHPNum ).SourceLoopNum ) { // condenser loop
 					PlantUtilities::UpdateChillerComponentCondenserSide( GSHP( GSHPNum ).SourceLoopNum, GSHP( GSHPNum ).SourceLoopSideNum, DataPlant::TypeOf_HPWaterEFCooling, GSHP( GSHPNum ).SourceSideInletNodeNum, GSHP( GSHPNum ).SourceSideOutletNodeNum, GSHPReport( GSHPNum ).QSource, GSHPReport( GSHPNum ).SourceSideInletTemp, GSHPReport( GSHPNum ).SourceSideOutletTemp, GSHPReport( GSHPNum ).SourceSideMassFlowRate, FirstHVACIteration );
 				} else {
-					ShowFatalError( "SimHPWatertoWaterSimple:: Invalid loop connection " + HPEqFitCooling + ", Requested Unit=" + GSHPName );
+					ShowFatalError( "SimHPWatertoWaterSimple:: Invalid loop connection " + HPEqFitCooling + ", Requested Unit=" + GSHPName );  // LCOV_EXCL_LINE
 				}
 			} else {
-				ShowFatalError( "SimHPWatertoWaterSimple:: Invalid " + HPEqFitCooling + ", Requested Unit=" + GSHPName );
+				ShowFatalError( "SimHPWatertoWaterSimple:: Invalid " + HPEqFitCooling + ", Requested Unit=" + GSHPName );  // LCOV_EXCL_LINE
 			}
 		} else if ( GSHPTypeNum == DataPlant::TypeOf_HPWaterEFHeating ) {
 			if ( GSHPNum != 0 ) {
@@ -244,13 +244,13 @@ namespace HeatPumpWaterToWaterSimple {
 				} else if ( LoopNum == GSHP( GSHPNum ).SourceLoopNum ) { // condenser loop
 					PlantUtilities::UpdateChillerComponentCondenserSide( GSHP( GSHPNum ).SourceLoopNum, GSHP( GSHPNum ).SourceLoopSideNum, DataPlant::TypeOf_HPWaterEFHeating, GSHP( GSHPNum ).SourceSideInletNodeNum, GSHP( GSHPNum ).SourceSideOutletNodeNum, - GSHPReport( GSHPNum ).QSource, GSHPReport( GSHPNum ).SourceSideInletTemp, GSHPReport( GSHPNum ).SourceSideOutletTemp, GSHPReport( GSHPNum ).SourceSideMassFlowRate, FirstHVACIteration );
 				} else {
-					ShowFatalError( "SimHPWatertoWaterSimple:: Invalid loop connection " + HPEqFitCooling + ", Requested Unit=" + GSHPName );
+					ShowFatalError( "SimHPWatertoWaterSimple:: Invalid loop connection " + HPEqFitCooling + ", Requested Unit=" + GSHPName );  // LCOV_EXCL_LINE
 				}
 			} else {
-				ShowFatalError( "SimHPWatertoWaterSimple:: Invalid " + HPEqFitHeating + ", Requested Unit=" + GSHPName );
+				ShowFatalError( "SimHPWatertoWaterSimple:: Invalid " + HPEqFitHeating + ", Requested Unit=" + GSHPName );  // LCOV_EXCL_LINE
 			}
 		} else {
-			ShowFatalError( "SimHPWatertoWaterSimple: Module called with incorrect GSHPType=" + GSHPType );
+			ShowFatalError( "SimHPWatertoWaterSimple: Module called with incorrect GSHPType=" + GSHPType );  // LCOV_EXCL_LINE
 		} // TypeOfEquip
 
 	}
@@ -372,9 +372,9 @@ namespace HeatPumpWaterToWaterSimple {
 				if ( ! DataIPShortCuts::lNumericFieldBlanks( 15 ) ) {
 					GSHP( GSHPNum ).refCOP = DataIPShortCuts::rNumericArgs( 15 );
 				} else {
-					GSHP( GSHPNum ).refCOP = 8.0; 
+					GSHP( GSHPNum ).refCOP = 8.0;
 				}
-			
+
 			} else {
 				GSHP( GSHPNum ).refCOP = 8.0;
 			}
@@ -464,9 +464,9 @@ namespace HeatPumpWaterToWaterSimple {
 				if ( ! DataIPShortCuts::lNumericFieldBlanks( 15 ) ) {
 					GSHP( GSHPNum ).refCOP = DataIPShortCuts::rNumericArgs( 15 );
 				} else {
-					GSHP( GSHPNum ).refCOP = 7.5; 
+					GSHP( GSHPNum ).refCOP = 7.5;
 				}
-			
+
 			} else {
 				GSHP( GSHPNum ).refCOP = 7.5;
 			}
@@ -523,7 +523,7 @@ namespace HeatPumpWaterToWaterSimple {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for Water to Water Heat Pumps" );
+			ShowFatalError( "Errors found in processing input for Water to Water Heat Pumps" );  // LCOV_EXCL_LINE
 		}
 
 		for ( GSHPNum = 1; GSHPNum <= NumGSHPs; ++GSHPNum ) {
@@ -548,7 +548,7 @@ namespace HeatPumpWaterToWaterSimple {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "GetWatertoWaterHPInput: Program terminated on scan for loop data" );
+				ShowFatalError( "GetWatertoWaterHPInput: Program terminated on scan for loop data" );  // LCOV_EXCL_LINE
 			}
 
 		}
@@ -776,7 +776,7 @@ namespace HeatPumpWaterToWaterSimple {
 				//now compare to companion coil and take higher
 				if ( GSHP( GSHPNum ).companionIdentified ) {
 					tmpLoadSideVolFlowRate = max ( tmpLoadSideVolFlowRate,GSHP( GSHPNum ).RatedLoadVolFlowHeat );
-					//store flow rate right away regardless of PlantFirstSizesOkayToFinalize so that data are available 
+					//store flow rate right away regardless of PlantFirstSizesOkayToFinalize so that data are available
 					GSHP( GSHPNum ).RatedLoadVolFlowCool = tmpLoadSideVolFlowRate;
 				}
 				Real64 rho = FluidProperties::GetDensityGlycol( DataPlant::PlantLoop( GSHP( GSHPNum ).LoadLoopNum ).FluidName, DataGlobals::CWInitConvTemp, DataPlant::PlantLoop( GSHP( GSHPNum ).LoadLoopNum ).FluidIndex, RoutineName );
@@ -787,7 +787,7 @@ namespace HeatPumpWaterToWaterSimple {
 				Real64 rho = FluidProperties::GetDensityGlycol( DataPlant::PlantLoop( GSHP( GSHPNum ).LoadLoopNum ).FluidName, DataGlobals::CWInitConvTemp, DataPlant::PlantLoop( GSHP( GSHPNum ).LoadLoopNum ).FluidIndex, RoutineName );
 				Real64 Cp = FluidProperties::GetSpecificHeatGlycol( DataPlant::PlantLoop( GSHP( GSHPNum ).LoadLoopNum ).FluidName, DataGlobals::CWInitConvTemp, DataPlant::PlantLoop( GSHP( GSHPNum ).LoadLoopNum ).FluidIndex, RoutineName );
 				tmpCoolingCap = Cp * rho * DataSizing::PlantSizData( pltLoadSizNum ).DeltaT * tmpLoadSideVolFlowRate;
-			} else { 
+			} else {
 				if ( GSHP( GSHPNum ).ratedCapCoolWasAutoSized ) tmpCoolingCap = 0.0;
 				if ( GSHP( GSHPNum ).ratedLoadVolFlowCoolWasAutoSized ) tmpLoadSideVolFlowRate = 0.0;
 			}
@@ -809,7 +809,7 @@ namespace HeatPumpWaterToWaterSimple {
 							} else {
 								ReportSizingManager::ReportSizingOutput( "HeatPump:WaterToWater:EquationFit:Cooling",GSHP( GSHPNum ).Name,"User-Specified Nominal Capacity [W]", nomCoolingCapUser );
 							}
-							
+
 							if ( DataGlobals::DisplayExtraWarnings ) {
 								if ( ( std::abs( tmpCoolingCap - nomCoolingCapUser ) / nomCoolingCapUser ) > DataSizing::AutoVsHardSizingThreshold ) {
 									ShowMessage( "sizeCoolingWaterToWaterHP: Potential issue with equipment sizing for " + GSHP( GSHPNum ).Name );
@@ -860,7 +860,7 @@ namespace HeatPumpWaterToWaterSimple {
 				if ( GSHP( GSHPNum ).ratedLoadVolFlowHeatWasAutoSized && GSHP( GSHPNum ).RatedLoadVolFlowHeat > 0.0 ) {
 					//fill load side flow rate size from companion coil
 					tmpLoadSideVolFlowRate = GSHP( GSHPNum ).RatedLoadVolFlowHeat;
-					if ( DataPlant::PlantFirstSizesOkayToFinalize ) { 
+					if ( DataPlant::PlantFirstSizesOkayToFinalize ) {
 						GSHP( GSHPNum ).RatedLoadVolFlowCool = tmpLoadSideVolFlowRate;
 						if ( DataPlant::PlantFinalSizesOkayToReport ) {
 							ReportSizingManager::ReportSizingOutput( "HeatPump:WaterToWater:EquationFit:Cooling",GSHP( GSHPNum ).Name, "Design Size Load Side Volume Flow Rate [m3/s]", tmpLoadSideVolFlowRate );
@@ -872,7 +872,7 @@ namespace HeatPumpWaterToWaterSimple {
 				}
 				if ( GSHP( GSHPNum ).ratedCapHeatWasAutoSized && GSHP( GSHPNum ).RatedCapHeat > 0.0 ) {
 					tmpCoolingCap = GSHP( GSHPNum ).RatedCapHeat;
-					if ( DataPlant::PlantFirstSizesOkayToFinalize ) { 
+					if ( DataPlant::PlantFirstSizesOkayToFinalize ) {
 						GSHP( GSHPNum ).RatedCapCool = tmpCoolingCap;
 						if ( DataPlant::PlantFinalSizesOkayToReport ) {
 							ReportSizingManager::ReportSizingOutput( "HeatPump:WaterToWater:EquationFit:Cooling",GSHP( GSHPNum ).Name, "Design Size Nominal Capacity [W]", tmpCoolingCap );
@@ -909,7 +909,7 @@ namespace HeatPumpWaterToWaterSimple {
 
 		if ( GSHP( GSHPNum ).ratedSourceVolFlowCoolWasAutoSized ) {
 			GSHP( GSHPNum ).RatedSourceVolFlowCool = tmpSourceSideVolFlowRate;
-			if ( DataPlant::PlantFinalSizesOkayToReport ) { 
+			if ( DataPlant::PlantFinalSizesOkayToReport ) {
 				ReportSizingManager::ReportSizingOutput( "HeatPump:WaterToWater:EquationFit:Cooling",GSHP( GSHPNum ).Name, "Design Size Source Side Volume Flow Rate [m3/s]", tmpSourceSideVolFlowRate );
 			}
 			if ( DataPlant::PlantFirstSizesOkayToReport ) {
@@ -984,7 +984,7 @@ namespace HeatPumpWaterToWaterSimple {
 		}
 
 		if ( errorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 	}
 
@@ -1100,7 +1100,7 @@ namespace HeatPumpWaterToWaterSimple {
 				if ( GSHP( GSHPNum ).ratedLoadVolFlowHeatWasAutoSized && GSHP( GSHPNum ).RatedLoadVolFlowCool > 0.0 ) {
 					//fill load side flow rate size from companion coil
 					tmpLoadSideVolFlowRate = GSHP( GSHPNum ).RatedLoadVolFlowCool;
-					if ( DataPlant::PlantFirstSizesOkayToFinalize ) { 
+					if ( DataPlant::PlantFirstSizesOkayToFinalize ) {
 						GSHP( GSHPNum ).RatedLoadVolFlowHeat = tmpLoadSideVolFlowRate;
 						if ( DataPlant::PlantFinalSizesOkayToReport ) {
 							ReportSizingManager::ReportSizingOutput( "HeatPump:WaterToWater:EquationFit:Heating",GSHP( GSHPNum ).Name, "Design Size Load Side Volume Flow Rate [m3/s]", tmpLoadSideVolFlowRate );
@@ -1113,7 +1113,7 @@ namespace HeatPumpWaterToWaterSimple {
 				}
 				if ( GSHP( GSHPNum ).ratedCapHeatWasAutoSized && GSHP( GSHPNum ).RatedCapCool > 0.0 ) {
 					tmpHeatingCap = GSHP( GSHPNum ).RatedCapCool;
-					if ( DataPlant::PlantFirstSizesOkayToFinalize ) { 
+					if ( DataPlant::PlantFirstSizesOkayToFinalize ) {
 						GSHP( GSHPNum ).RatedCapHeat = tmpHeatingCap;
 						if ( DataPlant::PlantFinalSizesOkayToReport ) {
 							ReportSizingManager::ReportSizingOutput( "HeatPump:WaterToWater:EquationFit:Heating",GSHP( GSHPNum ).Name, "Design Size Nominal Capacity [W]", tmpHeatingCap );
@@ -1150,7 +1150,7 @@ namespace HeatPumpWaterToWaterSimple {
 		}
 		if ( GSHP( GSHPNum ).ratedSourceVolFlowHeatWasAutoSized ) {
 			GSHP( GSHPNum ).RatedSourceVolFlowHeat = tmpSourceSideVolFlowRate;
-			if ( DataPlant::PlantFinalSizesOkayToReport ) { 
+			if ( DataPlant::PlantFinalSizesOkayToReport ) {
 				ReportSizingManager::ReportSizingOutput( "HeatPump:WaterToWater:EquationFit:Heating",GSHP( GSHPNum ).Name, "Design Size Source Side Volume Flow Rate [m3/s]", tmpSourceSideVolFlowRate );
 			}
 			if ( DataPlant::PlantFirstSizesOkayToReport ) {
@@ -1224,7 +1224,7 @@ namespace HeatPumpWaterToWaterSimple {
 			OutputReportPredefined::PreDefTableEntry( OutputReportPredefined::pdchMechNomCap, GSHP( GSHPNum ).Name, GSHP( GSHPNum ).RatedPowerHeat );
 		}
 		if ( errorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 	}
 

--- a/src/EnergyPlus/HeatRecovery.cc
+++ b/src/EnergyPlus/HeatRecovery.cc
@@ -224,7 +224,7 @@ namespace HeatRecovery {
 		Optional_bool_const RegenInletIsOANode, // flag to determine if supply inlet is OA node, if so air flow cycles
 		Optional_bool_const EconomizerFlag, // economizer operation flag passed by airloop or OA sys
 		Optional_bool_const HighHumCtrlFlag, // high humidity control flag passed by airloop or OA sys
-		Optional_int_const CompanionCoilType_Num // cooling coil type of coil 
+		Optional_int_const CompanionCoilType_Num // cooling coil type of coil
 	)
 	{
 
@@ -276,17 +276,17 @@ namespace HeatRecovery {
 		if ( CompIndex == 0 ) {
 			HeatExchNum = FindItemInList( CompName, ExchCond );
 			if ( HeatExchNum == 0 ) {
-				ShowFatalError( "SimHeatRecovery: Unit not found=" + CompName );
+				ShowFatalError( "SimHeatRecovery: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = HeatExchNum;
 		} else {
 			HeatExchNum = CompIndex;
 			if ( HeatExchNum > NumHeatExchangers || HeatExchNum < 1 ) {
-				ShowFatalError( "SimHeatRecovery:  Invalid CompIndex passed=" + TrimSigDigits( HeatExchNum ) + ", Number of Units=" + TrimSigDigits( NumHeatExchangers ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimHeatRecovery:  Invalid CompIndex passed=" + TrimSigDigits( HeatExchNum ) + ", Number of Units=" + TrimSigDigits( NumHeatExchangers ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( HeatExchNum ) ) {
 				if ( CompName != ExchCond( HeatExchNum ).Name ) {
-					ShowFatalError( "SimHeatRecovery: Invalid CompIndex passed=" + TrimSigDigits( HeatExchNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + ExchCond( HeatExchNum ).Name );
+					ShowFatalError( "SimHeatRecovery: Invalid CompIndex passed=" + TrimSigDigits( HeatExchNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + ExchCond( HeatExchNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( HeatExchNum ) = false;
 			}
@@ -684,7 +684,7 @@ namespace HeatRecovery {
 			cCurrentModuleObject = "HeatExchanger:Desiccant:BalancedFlow:PerformanceDataType1";
 			GetObjectItem( cCurrentModuleObject, PerfDataIndex, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
 			PerfDataNum = PerfDataIndex;
-						
+
 			BalDesDehumPerfNumericFields( PerfDataNum ).NumericFieldNames.allocate( NumNumbers );
 			BalDesDehumPerfNumericFields( PerfDataNum ).NumericFieldNames = "";
 			BalDesDehumPerfNumericFields( PerfDataNum ).NumericFieldNames = cNumericFieldNames;
@@ -1107,7 +1107,7 @@ namespace HeatRecovery {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1283,7 +1283,7 @@ namespace HeatRecovery {
 					}
 
 					if ( FatalError ) {
-						ShowFatalError( "Heat exchanger design calculation caused fatal error: program terminated." );
+						ShowFatalError( "Heat exchanger design calculation caused fatal error: program terminated." );  // LCOV_EXCL_LINE
 					}
 
 					ExchCond( ExIndex ).UA0 = NTU0 * CMin0 * CpAir;
@@ -1292,19 +1292,19 @@ namespace HeatRecovery {
 
 					// check validity
 					if ( ExchCond( ExIndex ).NomSupAirMassFlow * ExchCond( ExIndex ).NomSecAirMassFlow < SmallMassFlow * SmallMassFlow ) {
-						ShowFatalError( "Mass flow in HeatExchanger:AirToAir:FlatPlate too small in initialization." );
+						ShowFatalError( "Mass flow in HeatExchanger:AirToAir:FlatPlate too small in initialization." );  // LCOV_EXCL_LINE
 					}
 
 					if ( ExchCond( ExIndex ).mTSup0 < SmallMassFlow ) {
-						ShowFatalError( "(m*T)Sup,in in HeatExchanger:AirToAir:FlatPlate too small in initialization." );
+						ShowFatalError( "(m*T)Sup,in in HeatExchanger:AirToAir:FlatPlate too small in initialization." );  // LCOV_EXCL_LINE
 					}
 
 					if ( ExchCond( ExIndex ).mTSec0 < SmallMassFlow ) {
-						ShowFatalError( "(m*T)Sec,in in HeatExchanger:AirToAir:FlatPlate too small in initialization." );
+						ShowFatalError( "(m*T)Sec,in in HeatExchanger:AirToAir:FlatPlate too small in initialization." );  // LCOV_EXCL_LINE
 					}
 
 					if ( CMin0 < SmallMassFlow ) {
-						ShowFatalError( "CMin0 in HeatExchanger:AirToAir:FlatPlate too small in initialization." );
+						ShowFatalError( "CMin0 in HeatExchanger:AirToAir:FlatPlate too small in initialization." );  // LCOV_EXCL_LINE
 					}
 
 				} else if ( SELECT_CASE_var == HX_AIRTOAIR_GENERIC ) {
@@ -1314,7 +1314,7 @@ namespace HeatRecovery {
 							if ( ! AnyEnergyManagementSystemInModel ) {
 								ShowSevereError( "Missing temperature setpoint for " + cHXTypes( ExchCond( ExIndex ).ExchTypeNum ) + " \"" + ExchCond( ExIndex ).Name + "\" :" );
 								ShowContinueError( "  use a Setpoint Manager to establish a setpoint at the supply air outlet node of the Heat Exchanger." );
-								ShowFatalError( " Previous condition causes program termination." );
+								ShowFatalError( " Previous condition causes program termination." );  // LCOV_EXCL_LINE
 							} else {
 								// need call to EMS to check node
 								CheckIfNodeSetPointManagedByEMS( ExchCond( ExIndex ).SupOutletNode, iTemperatureSetPoint, FatalError );
@@ -1322,7 +1322,7 @@ namespace HeatRecovery {
 									ShowSevereError( "Missing temperature setpoint for " + cHXTypes( ExchCond( ExIndex ).ExchTypeNum ) + " \"" + ExchCond( ExIndex ).Name + "\" :" );
 									ShowContinueError( "  use a Setpoint Manager to establish a setpoint at the supply air outlet node of the Heat Exchanger." );
 									ShowContinueError( "  or use an EMS actuator to establish a setpoint at the supply air outlet node of the Heat Exchanger." );
-									ShowFatalError( " Previous condition causes program termination." );
+									ShowFatalError( " Previous condition causes program termination." );  // LCOV_EXCL_LINE
 								}
 							}
 						}
@@ -1513,7 +1513,7 @@ namespace HeatRecovery {
 				}
 				DataFractionUsedForSizing = 1.0;
 			} else {
-				if ( ZoneSizingRunDone ) {					
+				if ( ZoneSizingRunDone ) {
 					SizingMethod = AutoCalculateSizing;
 					if ( ZoneEqSizing( CurZoneEqNum ).DesignSizeFromParent ) {
 						// Heat recovery heat exchanger in zoneHVAC equipment should have been sized to OA flow in the parent equipment
@@ -3085,7 +3085,7 @@ namespace HeatRecovery {
 
 		// check input validity
 		if ( Z < 0.0 || Z > 1.0 ) {
-			ShowFatalError( "Variable Z (" + RoundSigDigits( Z, 2 ) + ") out of range [0.0,1.0] in CalculateEpsFromNTUandZ" );
+			ShowFatalError( "Variable Z (" + RoundSigDigits( Z, 2 ) + ") out of range [0.0,1.0] in CalculateEpsFromNTUandZ" );  // LCOV_EXCL_LINE
 		}
 
 		// effectiveness
@@ -3111,7 +3111,7 @@ namespace HeatRecovery {
 			} else if ( SELECT_CASE_var == Cross_Flow_Other ) { // CROSS FLOW, Cmax MIXED, Cmin UNMIXED
 				Eps = ( 1.0 - std::exp( -Z * ( 1.0 - std::exp( -NTU ) ) ) ) / Z;
 			} else {
-				ShowFatalError( "HeatRecovery: Illegal flow arrangement in CalculateEpsFromNTUandZ, Value=" + RoundSigDigits( FlowArr ) );
+				ShowFatalError( "HeatRecovery: Illegal flow arrangement in CalculateEpsFromNTUandZ, Value=" + RoundSigDigits( FlowArr ) );  // LCOV_EXCL_LINE
 			}}
 		}
 
@@ -3220,7 +3220,7 @@ namespace HeatRecovery {
 			} else if ( SELECT_CASE_var == Cross_Flow_Other ) { // CROSS FLOW, Cmax MIXED, Cmin UNMIXED
 				NTU = - std::log( 1.0 + std::log( 1.0 - Eps * Z ) / Z );
 			} else {
-				ShowFatalError( "HeatRecovery: Illegal flow arrangement in CalculateNTUfromEpsAndZ, Value=" + RoundSigDigits( FlowArr ) );
+				ShowFatalError( "HeatRecovery: Illegal flow arrangement in CalculateNTUfromEpsAndZ, Value=" + RoundSigDigits( FlowArr ) );  // LCOV_EXCL_LINE
 			}}
 		}
 
@@ -3286,9 +3286,9 @@ namespace HeatRecovery {
 		SolveRoot( Acc, MaxIte, SolFla, NTU, GetResidCrossFlowBothUnmixed, NTU0, NTU1, Par );
 
 		if ( SolFla == -2 ) {
-			ShowFatalError( "HeatRecovery: Bad initial bounds for NTU in GetNTUforCrossFlowBothUnmixed" );
+			ShowFatalError( "HeatRecovery: Bad initial bounds for NTU in GetNTUforCrossFlowBothUnmixed" );  // LCOV_EXCL_LINE
 		} else if ( SolFla == -1 ) {
-			ShowFatalError( "HeatRecovery: No convergence in solving for NTU in GetNTUforCrossFlowBothUnmixed" );
+			ShowFatalError( "HeatRecovery: No convergence in solving for NTU in GetNTUforCrossFlowBothUnmixed" );  // LCOV_EXCL_LINE
 		}
 
 		return NTU;

--- a/src/EnergyPlus/HeatingCoils.cc
+++ b/src/EnergyPlus/HeatingCoils.cc
@@ -250,17 +250,17 @@ namespace HeatingCoils {
 			if ( CompIndex == 0 ) {
 				CoilNum = FindItemInList( CompName, HeatingCoil );
 				if ( CoilNum == 0 ) {
-					ShowFatalError( "SimulateHeatingCoilComponents: Coil not found=" + CompName );
+					ShowFatalError( "SimulateHeatingCoilComponents: Coil not found=" + CompName );  // LCOV_EXCL_LINE
 				}
 				//    CompIndex=CoilNum
 			} else {
 				CoilNum = CompIndex;
 				if ( CoilNum > NumHeatingCoils || CoilNum < 1 ) {
-					ShowFatalError( "SimulateHeatingCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Heating Coils=" + TrimSigDigits( NumHeatingCoils ) + ", Coil name=" + CompName );
+					ShowFatalError( "SimulateHeatingCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Heating Coils=" + TrimSigDigits( NumHeatingCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 				}
 				if ( CheckEquipName( CoilNum ) ) {
 					if ( ! CompName.empty() && CompName != HeatingCoil( CoilNum ).Name ) {
-						ShowFatalError( "SimulateHeatingCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + HeatingCoil( CoilNum ).Name );
+						ShowFatalError( "SimulateHeatingCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + HeatingCoil( CoilNum ).Name );  // LCOV_EXCL_LINE
 					}
 					CheckEquipName( CoilNum ) = false;
 				}
@@ -268,7 +268,7 @@ namespace HeatingCoils {
 		} else {
 			ShowSevereError( "SimulateHeatingCoilComponents: CompIndex argument not used." );
 			ShowContinueError( "..CompName = " + CompName );
-			ShowFatalError( "Preceding conditions cause termination." );
+			ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( present( SuppHeat ) ) {
@@ -661,7 +661,7 @@ namespace HeatingCoils {
 			SetupOutputVariable( "Heating Coil Runtime Fraction", OutputProcessor::Unit::None, coil.RTF, "System", "Average", coil.Name );
 			SetupOutputVariable( "Heating Coil Ancillary " + FuelType + " Rate", OutputProcessor::Unit::W, coil.ParasiticFuelRate, "System", "Average", coil.Name );
 			SetupOutputVariable( "Heating Coil Ancillary " + FuelType + " Energy", OutputProcessor::Unit::J, coil.ParasiticFuelLoad, "System", "Sum", coil.Name, _, FuelType, "Heating", _, "System" );
-			
+
 		}
 
 		// Get the data for for gas multistage heating coils
@@ -940,7 +940,7 @@ namespace HeatingCoils {
 		}
 
 		if ( InputErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		Alphas.deallocate();
@@ -1116,7 +1116,7 @@ namespace HeatingCoils {
 
 		// delay fatal error until all coils are called
 		if ( ! FirstHVACIteration && HeatingCoilFatalError ) {
-			ShowFatalError( "... errors found in heating coil input." );
+			ShowFatalError( "... errors found in heating coil input." );  // LCOV_EXCL_LINE
 		}
 
 		// Find the heating source index for the desuperheater heating coil if not already found. This occurs when zone heating
@@ -1262,7 +1262,7 @@ namespace HeatingCoils {
 		RequestSizing( CompType, CompName, HeatingCapacitySizing, SizingString, TempCap, bPRINT, RoutineName );
 		DataCoilIsSuppHeater = false; // reset global to false so other heating coils are not affected
 		DataDesicRegCoil = false; // reset global to false so other heating coils are not affected
-		DataDesInletAirTemp = 0.0; // reset global data to zero so other heating coils are not 
+		DataDesInletAirTemp = 0.0; // reset global data to zero so other heating coils are not
 		DataDesOutletAirTemp = 0.0; // reset global data to zero so other heating coils are not affected
 
 		if ( HeatingCoil( CoilNum ).HCoilType_Num == Coil_HeatingElectric_MultiStage || HeatingCoil( CoilNum ).HCoilType_Num == Coil_HeatingGas_MultiStage ) {
@@ -1315,7 +1315,7 @@ namespace HeatingCoils {
 			for ( StageNum = 1; StageNum <= HeatingCoil( CoilNum ).NumOfStages - 1; ++StageNum ) {
 				if ( HeatingCoil( CoilNum ).MSNominalCapacity( StageNum ) > HeatingCoil( CoilNum ).MSNominalCapacity( StageNum + 1 ) ) {
 					ShowSevereError( "SizeHeatingCoil: " + HeatingCoil( CoilNum ).HeatingCoilType + ' ' + HeatingCoil( CoilNum ).Name + ", Stage " + TrimSigDigits( StageNum ) + " Nominal Capacity (" + RoundSigDigits( HeatingCoil( CoilNum ).MSNominalCapacity( StageNum ), 2 ) + " W) must be less than or equal to Stage " + TrimSigDigits( StageNum + 1 ) + " Nominal Capacity (" + RoundSigDigits( HeatingCoil( CoilNum ).MSNominalCapacity( StageNum + 1 ), 2 ) + " W)." );
-					ShowFatalError( "Preceding conditions cause termination." );
+					ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 				}
 			}
 		} else { // not a multi-speed coil
@@ -1368,7 +1368,7 @@ namespace HeatingCoils {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rich Liesen
 		//       DATE WRITTEN   May 2000
-		//       MODIFIED       Jul. 2016, R. Zhang, Applied the coil supply air temperature sensor offset 
+		//       MODIFIED       Jul. 2016, R. Zhang, Applied the coil supply air temperature sensor offset
 		//       RE-ENGINEERED  na
 
 		// PURPOSE OF THIS SUBROUTINE:
@@ -1425,7 +1425,7 @@ namespace HeatingCoils {
 			//update the TempSetPoint
 			TempSetPoint -= HeatingCoil( CoilNum ).FaultyCoilSATOffset;
 		}
-		
+
 		//  adjust mass flow rates for cycling fan cycling coil operation
 		if ( FanOpMode == CycFanCycCoil ) {
 			if ( PartLoadRatio > 0.0 ) {
@@ -2636,24 +2636,24 @@ namespace HeatingCoils {
 		if ( CompIndex == 0 ) {
 			CoilNum = FindItem( CompName, HeatingCoil );
 			if ( CoilNum == 0 ) {
-				ShowFatalError( "CheckHeatingCoilSchedule: Coil not found=\"" + CompName + "\"." );
+				ShowFatalError( "CheckHeatingCoilSchedule: Coil not found=\"" + CompName + "\"." );  // LCOV_EXCL_LINE
 			}
 			if ( ! SameString( CompType, cAllCoilTypes( HeatingCoil( CoilNum ).HCoilType_Num ) ) ) {
 				ShowSevereError( "CheckHeatingCoilSchedule: Coil=\"" + CompName + "\"" );
 				ShowContinueError( "...expected type=\"" + CompType + "\", actual type=\"" + cAllCoilTypes( HeatingCoil( CoilNum ).HCoilType_Num ) + "\"." );
-				ShowFatalError( "Program terminates due to preceding conditions." );
+				ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CoilNum;
 			Value = GetCurrentScheduleValue( HeatingCoil( CoilNum ).SchedPtr ); // not scheduled?
 		} else {
 			CoilNum = CompIndex;
 			if ( CoilNum > NumHeatingCoils || CoilNum < 1 ) {
-				ShowFatalError( "CheckHeatingCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Heating Coils=" + TrimSigDigits( NumHeatingCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "CheckHeatingCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Heating Coils=" + TrimSigDigits( NumHeatingCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CompName != HeatingCoil( CoilNum ).Name ) {
 				ShowSevereError( "CheckHeatingCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + HeatingCoil( CoilNum ).Name );
 				ShowContinueError( "...expected type=\"" + CompType + "\", actual type=\"" + cAllCoilTypes( HeatingCoil( CoilNum ).HCoilType_Num ) + "\"." );
-				ShowFatalError( "Program terminates due to preceding conditions." );
+				ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 			}
 			Value = GetCurrentScheduleValue( HeatingCoil( CoilNum ).SchedPtr ); // not scheduled?
 		}
@@ -3424,7 +3424,7 @@ namespace HeatingCoils {
 		return NumberOfStages;
 
 	}
- 
+
 	// Clears the global data in HeatingCoils.
 	// Needed for unit tests, should not be normally called.
 	void
@@ -3450,7 +3450,7 @@ namespace HeatingCoils {
 		int const CoilNum, // Number of electric or gas heating Coil
 		bool & ErrorsFound, // Set to true if certain errors found
 		Optional_bool DesiccantRegenerationCoil, // Flag that this coil is used as regeneration air heating coil
-		Optional_int DesiccantDehumIndex // Index for the desiccant dehum system where this coil is used 
+		Optional_int DesiccantDehumIndex // Index for the desiccant dehum system where this coil is used
 		) {
 
 		// FUNCTION INFORMATION:
@@ -3465,7 +3465,7 @@ namespace HeatingCoils {
 		// Using/Aliasing
 		using General::TrimSigDigits;
 
-		if ( GetCoilsInputFlag ) { 
+		if ( GetCoilsInputFlag ) {
 			GetHeatingCoilInput();
 			GetCoilsInputFlag = false;
 		}

--- a/src/EnergyPlus/HighTempRadiantSystem.cc
+++ b/src/EnergyPlus/HighTempRadiantSystem.cc
@@ -178,7 +178,7 @@ namespace HighTempRadiantSystem {
 		HighTempRadSysNumericFields.deallocate();
 	}
 
-	
+
 	void
 	SimHighTempRadiantSystem(
 		std::string const & CompName, // name of the low temperature radiant system
@@ -230,7 +230,7 @@ namespace HighTempRadiantSystem {
 		if ( GetInputFlag ) {
 			ErrorsFoundInGet = false;
 			GetHighTempRadiantSystem( ErrorsFoundInGet );
-			if ( ErrorsFoundInGet ) ShowFatalError( "GetHighTempRadiantSystem: Errors found in input.  Preceding condition(s) cause termination." );
+			if ( ErrorsFoundInGet ) ShowFatalError( "GetHighTempRadiantSystem: Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			GetInputFlag = false;
 		}
 
@@ -238,17 +238,17 @@ namespace HighTempRadiantSystem {
 		if ( CompIndex == 0 ) {
 			RadSysNum = FindItemInList( CompName, HighTempRadSys );
 			if ( RadSysNum == 0 ) {
-				ShowFatalError( "SimHighTempRadiantSystem: Unit not found=" + CompName );
+				ShowFatalError( "SimHighTempRadiantSystem: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = RadSysNum;
 		} else {
 			RadSysNum = CompIndex;
 			if ( RadSysNum > NumOfHighTempRadSys || RadSysNum < 1 ) {
-				ShowFatalError( "SimHighTempRadiantSystem:  Invalid CompIndex passed=" + TrimSigDigits( RadSysNum ) + ", Number of Units=" + TrimSigDigits( NumOfHighTempRadSys ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimHighTempRadiantSystem:  Invalid CompIndex passed=" + TrimSigDigits( RadSysNum ) + ", Number of Units=" + TrimSigDigits( NumOfHighTempRadSys ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( RadSysNum ) ) {
 				if ( CompName != HighTempRadSys( RadSysNum ).Name ) {
-					ShowFatalError( "SimHighTempRadiantSystem: Invalid CompIndex passed=" + TrimSigDigits( RadSysNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + HighTempRadSys( RadSysNum ).Name );
+					ShowFatalError( "SimHighTempRadiantSystem: Invalid CompIndex passed=" + TrimSigDigits( RadSysNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + HighTempRadSys( RadSysNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( RadSysNum ) = false;
 			}
@@ -1386,7 +1386,7 @@ namespace HighTempRadiantSystem {
 						ShowContinueError( "Occurs in ZoneHVAC:HighTemperatureRadiant = " + HighTempRadSys( RadSysNum ).Name );
 						ShowContinueError( "Radiation intensity = " + RoundSigDigits( ThisSurfIntensity, 2 ) + " [W/m2]" );
 						ShowContinueError( "Assign a larger surface area or more surfaces in ZoneHVAC:HighTemperatureRadiant" );
-						ShowFatalError( "DistributeHTRadGains:  excessive thermal radiation heat flux intensity detected" );
+						ShowFatalError( "DistributeHTRadGains:  excessive thermal radiation heat flux intensity detected" );  // LCOV_EXCL_LINE
 					}
 				} else { // small surface
 					ShowSevereError( "DistributeHTRadGains:  surface not large enough to receive thermal radiation heat flux" );
@@ -1394,7 +1394,7 @@ namespace HighTempRadiantSystem {
 					ShowContinueError( "Surface area = " + RoundSigDigits( Surface( SurfNum ).Area, 3 ) + " [m2]" );
 					ShowContinueError( "Occurs in ZoneHVAC:HighTemperatureRadiant = " + HighTempRadSys( RadSysNum ).Name );
 					ShowContinueError( "Assign a larger surface area or more surfaces in ZoneHVAC:HighTemperatureRadiant" );
-					ShowFatalError( "DistributeHTRadGains:  surface not large enough to receive thermal radiation heat flux" );
+					ShowFatalError( "DistributeHTRadGains:  surface not large enough to receive thermal radiation heat flux" );  // LCOV_EXCL_LINE
 
 				}
 

--- a/src/EnergyPlus/Humidifiers.cc
+++ b/src/EnergyPlus/Humidifiers.cc
@@ -203,23 +203,23 @@ namespace Humidifiers {
 		if ( CompIndex == 0 ) {
 			HumNum = FindItemInList( CompName, Humidifier );
 			if ( HumNum == 0 ) {
-				ShowFatalError( "SimHumidifier: Unit not found=" + CompName );
+				ShowFatalError( "SimHumidifier: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = HumNum;
 		} else {
 			HumNum = CompIndex;
 			if ( HumNum > NumHumidifiers || HumNum < 1 ) {
-				ShowFatalError( "SimHumidifier: Invalid CompIndex passed=" + TrimSigDigits( HumNum ) + ", Number of Units=" + TrimSigDigits( NumHumidifiers ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimHumidifier: Invalid CompIndex passed=" + TrimSigDigits( HumNum ) + ", Number of Units=" + TrimSigDigits( NumHumidifiers ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( HumNum ) ) {
 				if ( CompName != Humidifier( HumNum ).Name ) {
-					ShowFatalError( "SimHumidifier: Invalid CompIndex passed=" + TrimSigDigits( HumNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + Humidifier( HumNum ).Name );
+					ShowFatalError( "SimHumidifier: Invalid CompIndex passed=" + TrimSigDigits( HumNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + Humidifier( HumNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( HumNum ) = false;
 			}
 		}
 		if ( HumNum <= 0 ) {
-			ShowFatalError( "SimHumidifier: Unit not found=" + CompName );
+			ShowFatalError( "SimHumidifier: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 		}
 
 		auto & thisHum( Humidifier( HumNum ) );
@@ -242,7 +242,7 @@ namespace Humidifiers {
 		} else {
 			ShowSevereError( "SimHumidifier: Invalid Humidifier Type Code=" + TrimSigDigits( thisHum.HumType_Code ) );
 			ShowContinueError( "...Component Name=[" + CompName + "]." );
-			ShowFatalError( "Preceding Condition causes termination." );
+			ShowFatalError( "Preceding Condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -504,7 +504,7 @@ namespace Humidifiers {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input." );
+			ShowFatalError( RoutineName + "Errors found in input." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -859,7 +859,7 @@ namespace Humidifiers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( CalledFrom + ": Mismatch was found in the Rated Gas Use Rate and Thermal Efficiency for gas fired steam humidifier = " + Name + ". " );
+			ShowFatalError( CalledFrom + ": Mismatch was found in the Rated Gas Use Rate and Thermal Efficiency for gas fired steam humidifier = " + Name + ". " );  // LCOV_EXCL_LINE
 		}
 	}
 

--- a/src/EnergyPlus/HybridModel.cc
+++ b/src/EnergyPlus/HybridModel.cc
@@ -64,7 +64,7 @@ namespace EnergyPlus {
 namespace HybridModel {
 
 	// MODULE INFORMATION:
-	//       AUTHOR         Sang Hoon Lee, Tianzhen Hong, Rongpeng Zhang. LBNL 
+	//       AUTHOR         Sang Hoon Lee, Tianzhen Hong, Rongpeng Zhang. LBNL
 	//       DATE WRITTEN   Oct 2015
 
 	// PURPOSE OF THIS MODULE:
@@ -83,7 +83,7 @@ namespace HybridModel {
 	using namespace InputProcessor;
 	using DataGlobals::ScheduleAlwaysOn;
 	using General::CheckCreatedZoneItemName;
-	
+
 	bool FlagHybridModel( false ); // True if hybrid model is activated
 	int NumOfHybridModelZones( 0 ); // Number of hybrid model zones in the model
 	std::string CurrentModuleObject; // to assist in getting input
@@ -114,10 +114,10 @@ namespace HybridModel {
 		Array1D_string cAlphaFieldNames( 10 );
 		Array1D_string cNumericFieldNames( 10 );
 		Array1D< Real64 > rNumericArgs( 10 ); // Numeric input items for object
-		int HybridModelStartMonth( 0 ); // Hybrid model start month 
-		int HybridModelStartDate( 0 ); // Hybrid model start date of month 
-		int HybridModelEndMonth( 0 ); // Hybrid model end month 
-		int HybridModelEndDate( 0 ); // Hybrid model end date of month 
+		int HybridModelStartMonth( 0 ); // Hybrid model start month
+		int HybridModelStartDate( 0 ); // Hybrid model start date of month
+		int HybridModelEndMonth( 0 ); // Hybrid model end month
+		int HybridModelEndDate( 0 ); // Hybrid model end date of month
 		int HMStartDay( 0 );
 		int HMEndDay( 0 );
 
@@ -131,7 +131,7 @@ namespace HybridModel {
 			for ( int HybridModelNum = 1; HybridModelNum <= NumOfHybridModelZones; ++HybridModelNum ) {
 
 				GetObjectItem( CurrentModuleObject, HybridModelNum, cAlphaArgs, NumAlphas, rNumericArgs, NumNumbers, IOStatus, lNumericFieldBlanks, lAlphaFieldBlanks, cAlphaFieldNames, cNumericFieldNames );
-				
+
 				ZoneListPtr = 0;
 				ZonePtr = FindItemInList( cAlphaArgs( 2 ), Zone );
 				if ( ZonePtr == 0 && NumOfZoneLists > 0 ) ZoneListPtr = FindItemInList( cAlphaArgs( 2 ), ZoneList );
@@ -210,7 +210,7 @@ namespace HybridModel {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Errors getting Hybrid Model input data. Preceding condition(s) cause termination." );
+				ShowFatalError( "Errors getting Hybrid Model input data. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 		}
 	}

--- a/src/EnergyPlus/ICEngineElectricGenerator.cc
+++ b/src/EnergyPlus/ICEngineElectricGenerator.cc
@@ -161,16 +161,16 @@ namespace ICEngineElectricGenerator {
 		//SELECT and CALL MODELS
 		if ( GeneratorIndex == 0 ) {
 			GenNum = FindItemInList( GeneratorName, ICEngineGenerator );
-			if ( GenNum == 0 ) ShowFatalError( "SimICEngineGenerator: Specified Generator not one of Valid ICEngine Generators " + GeneratorName );
+			if ( GenNum == 0 ) ShowFatalError( "SimICEngineGenerator: Specified Generator not one of Valid ICEngine Generators " + GeneratorName );  // LCOV_EXCL_LINE
 			GeneratorIndex = GenNum;
 		} else {
 			GenNum = GeneratorIndex;
 			if ( GenNum > NumICEngineGenerators || GenNum < 1 ) {
-				ShowFatalError( "SimICEngineGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Number of IC Engine Generators=" + TrimSigDigits( NumICEngineGenerators ) + ", Generator name=" + GeneratorName );
+				ShowFatalError( "SimICEngineGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Number of IC Engine Generators=" + TrimSigDigits( NumICEngineGenerators ) + ", Generator name=" + GeneratorName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( GenNum ) ) {
 				if ( GeneratorName != ICEngineGenerator( GenNum ).Name ) {
-					ShowFatalError( "SimICEngineGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + ICEngineGenerator( GenNum ).Name );
+					ShowFatalError( "SimICEngineGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + ICEngineGenerator( GenNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( GenNum ) = false;
 			}
@@ -291,7 +291,7 @@ namespace ICEngineElectricGenerator {
 		if ( InitLoopEquip ) {
 			CompNum = FindItemInList( CompName, ICEngineGenerator );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimICEPlantHeatRecovery: ICE Generator Unit not found=" + CompName );
+				ShowFatalError( "SimICEPlantHeatRecovery: ICE Generator Unit not found=" + CompName );  // LCOV_EXCL_LINE
 				return;
 			}
 			MinCap = 0.0;
@@ -511,7 +511,7 @@ namespace ICEngineElectricGenerator {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( GeneratorNum = 1; GeneratorNum <= NumICEngineGenerators; ++GeneratorNum ) {
@@ -947,7 +947,7 @@ namespace ICEngineElectricGenerator {
 			errFlag = false;
 			ScanPlantLoopsForObject( ICEngineGenerator( GeneratorNum ).Name, TypeOf_Generator_ICEngine, ICEngineGenerator( GeneratorNum ).HRLoopNum, ICEngineGenerator( GeneratorNum ).HRLoopSideNum, ICEngineGenerator( GeneratorNum ).HRBranchNum, ICEngineGenerator( GeneratorNum ).HRCompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitICEngineGenerators: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitICEngineGenerators: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			MyPlantScanFlag( GeneratorNum ) = false;

--- a/src/EnergyPlus/IceThermalStorage.cc
+++ b/src/EnergyPlus/IceThermalStorage.cc
@@ -292,17 +292,17 @@ namespace IceThermalStorage {
 		if ( CompIndex == 0 ) {
 			IceStorageNum = FindItemInList( IceStorageName, IceStorageTypeMap, TotalIceStorages );
 			if ( IceStorageNum == 0 ) {
-				ShowFatalError( "SimIceStorage: Unit not found=" + IceStorageName );
+				ShowFatalError( "SimIceStorage: Unit not found=" + IceStorageName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = IceStorageNum;
 		} else {
 			IceStorageNum = CompIndex;
 			if ( IceStorageNum > TotalIceStorages || IceStorageNum < 1 ) {
-				ShowFatalError( "SimIceStorage:  Invalid CompIndex passed=" + TrimSigDigits( IceStorageNum ) + ", Number of Units=" + TrimSigDigits( TotalIceStorages ) + ", Entered Unit name=" + IceStorageName );
+				ShowFatalError( "SimIceStorage:  Invalid CompIndex passed=" + TrimSigDigits( IceStorageNum ) + ", Number of Units=" + TrimSigDigits( TotalIceStorages ) + ", Entered Unit name=" + IceStorageName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( IceStorageNum ) ) {
 				if ( IceStorageName != IceStorageTypeMap( IceStorageNum ).Name ) {
-					ShowFatalError( "SimIceStorage: Invalid CompIndex passed=" + TrimSigDigits( IceStorageNum ) + ", Unit name=" + IceStorageName + ", stored Unit Name for that index=" + IceStorageTypeMap( IceStorageNum ).Name );
+					ShowFatalError( "SimIceStorage: Invalid CompIndex passed=" + TrimSigDigits( IceStorageNum ) + ", Unit name=" + IceStorageName + ", stored Unit Name for that index=" + IceStorageTypeMap( IceStorageNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( IceStorageNum ) = false;
 			}
@@ -420,7 +420,7 @@ namespace IceThermalStorage {
 			ReportDetailedIceStorage(); // Report detailed ice storage
 
 		} else {
-			ShowFatalError( "Specified IceStorage not found in SimIceStorage" + IceStorageType );
+			ShowFatalError( "Specified IceStorage not found in SimIceStorage" + IceStorageType );  // LCOV_EXCL_LINE
 		}}
 
 	}
@@ -824,7 +824,7 @@ namespace IceThermalStorage {
 
 		} else { // Shouldn't get here ever (print error if we do)
 
-			ShowFatalError( "Detailed Ice Storage systemic code error--contact EnergyPlus support" );
+			ShowFatalError( "Detailed Ice Storage systemic code error--contact EnergyPlus support" );  // LCOV_EXCL_LINE
 
 		}
 
@@ -962,7 +962,7 @@ namespace IceThermalStorage {
 		} // IceNum
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		// Setup Output Variables to Report  CurrentModuleObject='ThermalStorage:Ice:Simple'
@@ -1169,7 +1169,7 @@ namespace IceThermalStorage {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		// Setup Output Variables to Report CurrentModuleObject='ThermalStorage:Ice:Detailed'
@@ -1372,7 +1372,7 @@ namespace IceThermalStorage {
 			errFlag = false;
 			ScanPlantLoopsForObject( IceStorage( IceNum ).Name, TypeOf_TS_IceSimple, IceStorage( IceNum ).LoopNum, IceStorage( IceNum ).LoopSideNum, IceStorage( IceNum ).BranchNum, IceStorage( IceNum ).CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitSimpleIceStorage: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitSimpleIceStorage: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			MyPlantScanFlag( IceNum ) = false;
 		}

--- a/src/EnergyPlus/InputProcessor.cc
+++ b/src/EnergyPlus/InputProcessor.cc
@@ -367,7 +367,7 @@ namespace InputProcessor {
 		{ IOFlags flags; flags.ACTION( "write" ); gio::open( EchoInputFile, outputAuditFileName, flags ); write_stat = flags.ios(); }
 		if ( write_stat != 0 ) {
 			DisplayString( "Could not open (write) "+ outputAuditFileName + " ." );
-			ShowFatalError( "ProcessInput: Could not open file " + outputAuditFileName + " for output (write)." );
+			ShowFatalError( "ProcessInput: Could not open file " + outputAuditFileName + " for output (write)." );  // LCOV_EXCL_LINE
 		}
 		echo_stream = gio::out_stream( EchoInputFile );
 
@@ -376,7 +376,7 @@ namespace InputProcessor {
 			CacheIPErrorFile = GetNewUnitNumber();
 			{ IOFlags flags; flags.ACTION( "read" ); gio::open( CacheIPErrorFile, outputIperrFileName, flags ); read_stat = flags.ios(); }
 			if ( read_stat != 0 ) {
-				ShowFatalError( "EnergyPlus: Could not open file "+outputIperrFileName+" for input (read)." );
+				ShowFatalError( "EnergyPlus: Could not open file "+outputIperrFileName+" for input (read)." );  // LCOV_EXCL_LINE
 			}
 			{ IOFlags flags; flags.DISPOSE( "delete" ); gio::close( CacheIPErrorFile, flags ); }
 		}
@@ -384,16 +384,16 @@ namespace InputProcessor {
 		{ IOFlags flags; flags.ACTION( "write" ); gio::open( CacheIPErrorFile, outputIperrFileName, flags ); write_stat = flags.ios(); }
 		if ( write_stat != 0 ) {
 			DisplayString( "Could not open (write) "+outputIperrFileName );
-			ShowFatalError( "ProcessInput: Could not open file " + outputIperrFileName + " for output (write)." );
+			ShowFatalError( "ProcessInput: Could not open file " + outputIperrFileName + " for output (write)." );  // LCOV_EXCL_LINE
 		}
 
 		std::ifstream idd_stream( inputIddFileName, std::ios_base::in | std::ios_base::binary );
 		if ( ! idd_stream ) {
 			if ( idd_stream.is_open() ) idd_stream.close();
 			if ( ! gio::file_exists( inputIddFileName ) ) { // No such file
-				ShowFatalError( "ProcessInput: Energy+.idd missing. Program terminates. Fullname=" + inputIddFileName );
+				ShowFatalError( "ProcessInput: Energy+.idd missing. Program terminates. Fullname=" + inputIddFileName );  // LCOV_EXCL_LINE
 			} else {
-				ShowFatalError( "ProcessInput: Could not open file \"" + inputIddFileName + "\" for input (read)." );
+				ShowFatalError( "ProcessInput: Could not open file \"" + inputIddFileName + "\" for input (read)." );  // LCOV_EXCL_LINE
 			}
 		}
 		NumLines = 0;
@@ -415,7 +415,7 @@ namespace InputProcessor {
 		ObjectGotCount.dimension( NumObjectDefs, 0 );
 
 		if ( NumObjectDefs == 0 ) {
-			ShowFatalError( "ProcessInput: No objects found in IDD.  Program will terminate." );
+			ShowFatalError( "ProcessInput: No objects found in IDD.  Program will terminate." );  // LCOV_EXCL_LINE
 			ErrorsInIDD = true;
 		}
 		//  If no fatal to here, rewind EchoInputFile -- only keep processing data...
@@ -442,7 +442,7 @@ namespace InputProcessor {
 		std::ifstream idf_stream( inputIdfFileName, std::ios_base::in | std::ios_base::binary );
 		if ( ! idf_stream ) {
 			if ( idf_stream.is_open() ) idf_stream.close();
-			ShowFatalError( "ProcessInput: Could not open file \"" + inputIdfFileName + "\" for input (read)." );
+			ShowFatalError( "ProcessInput: Could not open file \"" + inputIdfFileName + "\" for input (read)." );  // LCOV_EXCL_LINE
 		}
 		NumLines = 0;
 		EchoInputLine = true;
@@ -615,7 +615,7 @@ namespace InputProcessor {
 			if ( int( InputLine[ len_line - 1 ] ) == iUnicode_end ) {
 				ShowSevereError( "ProcessInput: \"Energy+.idd\" appears to be a Unicode or binary file." );
 				ShowContinueError( "...This file cannot be read by this program. Please save as PC or Unix file and try again" );
-				ShowFatalError( "Program terminates due to previous condition." );
+				ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 			}
 			if ( has( InputLine, "!IDD_Version" ) ) {
 				IDDVerString = InputLine.substr( 1, len( InputLine ) - 1 );
@@ -1266,7 +1266,7 @@ namespace InputProcessor {
 			if ( int( InputLine[ len_line - 1 ] ) == iUnicode_end ) {
 				ShowSevereError( "ProcessInput: \"in.idf\" appears to be a Unicode or binary file." );
 				ShowContinueError( "...This file cannot be read by this program. Please save as PC or Unix file and try again" );
-				ShowFatalError( "Program terminates due to previous condition." );
+				ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 			}
 		}
 		if ( idf_stream ) idf_stream.seekg( 0, std::ios::beg );
@@ -2024,7 +2024,7 @@ namespace InputProcessor {
 
 		int Found = FindItemInList( MakeUPPERCase( SectionWord ), ListOfSections, NumSectionDefs );
 		if ( Found == 0 ) {
-			//    CALL ShowFatalError('Requested Section not found in Definitions: '//TRIM(SectionWord))
+			//    CALL ShowFatalError('Requested Section not found in Definitions: '//TRIM(SectionWord))  // LCOV_EXCL_LINE
 			GetNumSectionsFound = 0;
 		} else {
 			GetNumSectionsFound = SectionDef( Found ).NumFound;
@@ -2335,14 +2335,14 @@ namespace InputProcessor {
 			Found = FindItemInList( UCObject, ListOfObjects, NumObjectDefs );
 		}
 		if ( Found == 0 ) { //  This is more of a developer problem
-			ShowFatalError( "IP: GetObjectItem: Requested object=" + UCObject + ", not found in Object Definitions -- incorrect IDD attached." );
+			ShowFatalError( "IP: GetObjectItem: Requested object=" + UCObject + ", not found in Object Definitions -- incorrect IDD attached." );  // LCOV_EXCL_LINE
 		}
 
 		if ( ObjectDef( Found ).NumAlpha > 0 ) {
 			if ( ObjectDef( Found ).NumAlpha > MaxAlphas ) {
 				cfld1 = IPTrimSigDigits( ObjectDef( Found ).NumAlpha );
 				cfld2 = IPTrimSigDigits( MaxAlphas );
-				ShowFatalError( "IP: GetObjectItem: " + Object + ", Number of ObjectDef Alpha Args [" + cfld1 + "] > Size of AlphaArg array [" + cfld2 + "]." );
+				ShowFatalError( "IP: GetObjectItem: " + Object + ", Number of ObjectDef Alpha Args [" + cfld1 + "] > Size of AlphaArg array [" + cfld2 + "]." );  // LCOV_EXCL_LINE
 			}
 			Alphas( {1,ObjectDef( Found ).NumAlpha} ) = BlankString;
 		}
@@ -2350,7 +2350,7 @@ namespace InputProcessor {
 			if ( ObjectDef( Found ).NumNumeric > MaxNumbers ) {
 				cfld1 = IPTrimSigDigits( ObjectDef( Found ).NumNumeric );
 				cfld2 = IPTrimSigDigits( MaxNumbers );
-				ShowFatalError( "IP: GetObjectItem: " + Object + ", Number of ObjectDef Numeric Args [" + cfld1 + "] > Size of NumericArg array [" + cfld2 + "]." );
+				ShowFatalError( "IP: GetObjectItem: " + Object + ", Number of ObjectDef Numeric Args [" + cfld1 + "] > Size of NumericArg array [" + cfld2 + "]." );  // LCOV_EXCL_LINE
 			}
 			Numbers( {1,ObjectDef( Found ).NumNumeric} ) = 0.0;
 		}
@@ -2375,7 +2375,7 @@ namespace InputProcessor {
 					// Read this one
 					GetObjectItemfromFile( LoopIndex, ObjectWord, NumAlphas, NumNumbers, AlphaArgs, NumberArgs, AlphaArgsBlank, NumberArgsBlank );
 					if ( NumAlphas > MaxAlphas || NumNumbers > MaxNumbers ) {
-						ShowFatalError( "IP: GetObjectItem: Too many actual arguments for those expected on Object: " + ObjectWord, EchoInputFile );
+						ShowFatalError( "IP: GetObjectItem: Too many actual arguments for those expected on Object: " + ObjectWord, EchoInputFile );  // LCOV_EXCL_LINE
 					}
 					NumAlphas = min( MaxAlphas, NumAlphas );
 					NumNumbers = min( MaxNumbers, NumNumbers );
@@ -2787,7 +2787,7 @@ namespace InputProcessor {
 						if ( has_prefix( UCInputLine, "\\EXTENSIBLE" ) ) { // Extensible arg
 							ExtensibleObject = true;
 							if ( UCInputLine[ 11 ] != ':' ) {
-								ShowFatalError( "IP: IDD Line=" + IPTrimSigDigits( NumLines ) + " Illegal definition for extensible object, should be \"\\extensible:<num>\"", EchoInputFile );
+								ShowFatalError( "IP: IDD Line=" + IPTrimSigDigits( NumLines ) + " Illegal definition for extensible object, should be \"\\extensible:<num>\"", EchoInputFile );  // LCOV_EXCL_LINE
 							} else { // process number
 								std::string const number_str( UCInputLine.substr( 12 ) );
 								NSpace = scan( number_str, " !" );
@@ -3001,7 +3001,7 @@ namespace InputProcessor {
 						if ( has_prefix( UCInputLine, "\\EXTENSIBLE" ) ) { // Extensible arg
 							ExtensibleObject = true;
 							if ( UCInputLine[ 11 ] != ':' ) {
-								ShowFatalError( "IP: IDD Line=" + IPTrimSigDigits( NumLines ) + " Illegal definition for extensible object, should be \"\\extensible:<num>\"", EchoInputFile );
+								ShowFatalError( "IP: IDD Line=" + IPTrimSigDigits( NumLines ) + " Illegal definition for extensible object, should be \"\\extensible:<num>\"", EchoInputFile );  // LCOV_EXCL_LINE
 							} else { // process number
 								std::string const number_str( UCInputLine.substr( 12 ) );
 								NSpace = scan( number_str, " !" );
@@ -4027,7 +4027,7 @@ namespace InputProcessor {
 			} else if ( ( errorCheck == 'F' ) || ( errorCheck == 'f' ) ) {
 				ShowSevereError( Message1 );
 				ShowContinueError( Message2 );
-				ShowFatalError( "Program terminates due to preceding condition(s)." );
+				ShowFatalError( "Program terminates due to preceding condition(s)." );  // LCOV_EXCL_LINE
 
 			} else {
 				ShowSevereError( Message1 );
@@ -4805,8 +4805,8 @@ namespace InputProcessor {
 		// na
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-		if ( ! equali( LineItem.Name, "OUTPUT:REPORTS" ) ) ShowFatalError( "Invalid object for deferred transition=" + LineItem.Name );
-		if ( LineItem.NumAlphas < 1 ) ShowFatalError( "Invalid object for deferred transition=" + LineItem.Name );
+		if ( ! equali( LineItem.Name, "OUTPUT:REPORTS" ) ) ShowFatalError( "Invalid object for deferred transition=" + LineItem.Name );  // LCOV_EXCL_LINE
+		if ( LineItem.NumAlphas < 1 ) ShowFatalError( "Invalid object for deferred transition=" + LineItem.Name );  // LCOV_EXCL_LINE
 
 		{ auto const makeTransition( uppercased( LineItem.Alphas( 1 ) ) );
 
@@ -4881,7 +4881,7 @@ namespace InputProcessor {
 		ObjPtr = FindItemInList( LineItem.Name, ListOfObjects, NumObjectDefs );
 		ObjPtr = iListOfObjects( ObjPtr );
 
-		if ( ObjPtr == 0 ) ShowFatalError( "No Object Def for " + LineItem.Name );
+		if ( ObjPtr == 0 ) ShowFatalError( "No Object Def for " + LineItem.Name );  // LCOV_EXCL_LINE
 		++ObjectDef( ObjPtr ).NumFound;
 
 	}
@@ -5201,7 +5201,7 @@ namespace InputProcessor {
 		}
 
 		if ( CompactObjectsFound ) {
-			ShowFatalError( "Program Terminates: The ExpandObjects program has not been run or is not in your EnergyPlus.exe folder." );
+			ShowFatalError( "Program Terminates: The ExpandObjects program has not been run or is not in your EnergyPlus.exe folder." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -5246,7 +5246,7 @@ namespace InputProcessor {
 			auto const & Name( IDFRecords( i ).Name );
 			if ( has_prefixi( Name, "Parametric:" ) ) {
 				ShowSevereError( "Parametric objects are found in the IDF File." );
-				ShowFatalError( "Program Terminates: The ParametricPreprocessor program has not been run." );
+				ShowFatalError( "Program Terminates: The ParametricPreprocessor program has not been run." );  // LCOV_EXCL_LINE
 				break;
 			}
 		}

--- a/src/EnergyPlus/IntegratedHeatPump.cc
+++ b/src/EnergyPlus/IntegratedHeatPump.cc
@@ -140,20 +140,20 @@ namespace EnergyPlus {
 			if ( CompIndex == 0 ) {
 				DXCoilNum = FindItemInList( CompName, IntegratedHeatPumps );
 				if ( DXCoilNum == 0 ) {
-					ShowFatalError( "Integrated Heat Pump not found=" + CompName );
+					ShowFatalError( "Integrated Heat Pump not found=" + CompName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = DXCoilNum;
 			}
 			else {
 				DXCoilNum = CompIndex;
 				if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-					ShowFatalError( "SimIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+					ShowFatalError( "SimIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 					                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 					                ", IHP name=" +
 					                CompName );
 				}
 				if ( !CompName.empty() && CompName != IntegratedHeatPumps( DXCoilNum ).Name ) {
-					ShowFatalError( "SimIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+					ShowFatalError( "SimIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 					                ", Integrated HP name=" + CompName + ", stored Integrated HP Name for that index=" +
 					                IntegratedHeatPumps( DXCoilNum ).Name );
 				}
@@ -1067,7 +1067,7 @@ namespace EnergyPlus {
 
 
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject +
+				ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject +  // LCOV_EXCL_LINE
 				                " input.  Preceding condition(s) causes termination." );
 			}
 			else {
@@ -1116,7 +1116,7 @@ namespace EnergyPlus {
 			};
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "SizeIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "SizeIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -1135,7 +1135,7 @@ namespace EnergyPlus {
 
 			SizeVarSpeedCoil( IntegratedHeatPumps( DXCoilNum ).SCCoilIndex );//size cooling coil
 			if ( ErrorsFound ) {
-				ShowFatalError(
+				ShowFatalError(  // LCOV_EXCL_LINE
 					"SizeIHP: failed to size SC coil\"" + IntegratedHeatPumps( DXCoilNum ).SCCoilName + "\"" );
 				ErrorsFound = false;
 			}
@@ -1248,7 +1248,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "InitializeIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "InitializeIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -1288,7 +1288,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "UpdateIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "UpdateIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -1446,7 +1446,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "DecideWorkMode: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "DecideWorkMode: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -1470,7 +1470,7 @@ namespace EnergyPlus {
 					IntegratedHeatPumps( DXCoilNum ).WHtankType, IntegratedHeatPumps( DXCoilNum ).WHtankName,
 					IntegratedHeatPumps( DXCoilNum ).WHtankID,
 					false, false,
-					MyLoad, MaxCap, MinCap, OptCap, true, IntegratedHeatPumps( DXCoilNum ).LoopNum, 
+					MyLoad, MaxCap, MinCap, OptCap, true, IntegratedHeatPumps( DXCoilNum ).LoopNum,
 					IntegratedHeatPumps( DXCoilNum ).LoopSideNum );
 			}
 			IntegratedHeatPumps( DXCoilNum ).CheckWHCall = false;//clear checking flag
@@ -1573,7 +1573,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "ClearCoils: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "ClearCoils: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -1611,7 +1611,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "GetCurWorkMode: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "GetCurWorkMode: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -1960,7 +1960,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "GetLowSpeedNumIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "GetLowSpeedNumIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -2010,7 +2010,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "GetMaxSpeedNumIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "GetMaxSpeedNumIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -2070,7 +2070,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "GetAirVolFlowRateIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "GetAirVolFlowRateIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -2183,7 +2183,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "GetWaterVolFlowRateIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "GetWaterVolFlowRateIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}
@@ -2268,7 +2268,7 @@ namespace EnergyPlus {
 			}
 
 			if ( DXCoilNum > static_cast< int >( IntegratedHeatPumps.size() ) || DXCoilNum < 1 ) {
-				ShowFatalError( "GetAirMassFlowRateIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +
+				ShowFatalError( "GetAirMassFlowRateIHP: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) +  // LCOV_EXCL_LINE
 				                ", Number of Integrated HPs=" + TrimSigDigits( IntegratedHeatPumps.size() ) +
 				                ", IHP name=" + "AS-IHP" );
 			}

--- a/src/EnergyPlus/InternalHeatGains.cc
+++ b/src/EnergyPlus/InternalHeatGains.cc
@@ -2792,7 +2792,7 @@ namespace InternalHeatGains {
 		AlphaName.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in Getting Internal Gains Input, Program Stopped" );
+			ShowFatalError( RoutineName + "Errors found in Getting Internal Gains Input, Program Stopped" );  // LCOV_EXCL_LINE
 		}
 
 		gio::write( OutputFileInits, Format_721 );
@@ -3906,7 +3906,7 @@ namespace InternalHeatGains {
 					TSupply = Node( SupplyNodeNum ).Temp;
 					WSupply = Node( SupplyNodeNum ).HumRat;
 				} else {
-					ShowFatalError( RoutineName + ": ElectricEquipment:ITE:AirCooled " + ZoneITEq( Loop ).Name );
+					ShowFatalError( RoutineName + ": ElectricEquipment:ITE:AirCooled " + ZoneITEq( Loop ).Name );  // LCOV_EXCL_LINE
 					ShowContinueError( "Air Inlet Connection Type = AdjustedSupply but no Supply Air Node is specified." );
 				}
 				if ( ZoneITEq( Loop ).RecircFLTCurve != 0 ) {
@@ -4377,7 +4377,7 @@ namespace InternalHeatGains {
 		int Loop;
 
 		if ( GetInternalHeatGainsInputFlag ) {
-			ShowFatalError( "GetDesignLightingLevelForZone: Function called prior to Getting Lights Input." );
+			ShowFatalError( "GetDesignLightingLevelForZone: Function called prior to Getting Lights Input." );  // LCOV_EXCL_LINE
 		}
 
 		DesignLightingLevelSum = 0.0;
@@ -4437,7 +4437,7 @@ namespace InternalHeatGains {
 		int NumLights; // Number of Lights statement for that zone.
 
 		if ( GetInternalHeatGainsInputFlag ) {
-			ShowFatalError( "CheckLightsReplaceableMinMaxForZone: Function called prior to Getting Lights Input." );
+			ShowFatalError( "CheckLightsReplaceableMinMaxForZone: Function called prior to Getting Lights Input." );  // LCOV_EXCL_LINE
 		}
 
 		LightsRepMin = 99999.0;

--- a/src/EnergyPlus/LowTempRadiantSystem.cc
+++ b/src/EnergyPlus/LowTempRadiantSystem.cc
@@ -329,7 +329,7 @@ namespace LowTempRadiantSystem {
 		//      IF (RadSysNum > 0) THEN  ! Found it and it is an electric system
 		//        SystemType = ConstantFlowSystem
 		//      ELSE  ! RadSysNum is still <= 0 so this CompName was not found among either radiant system type-->error
-		//        CALL ShowFatalError('SimLowTempRadiantSystem: Radiant System not found = '//TRIM(CompName))
+		//        CALL ShowFatalError('SimLowTempRadiantSystem: Radiant System not found = '//TRIM(CompName))  // LCOV_EXCL_LINE
 		//      END IF
 		//    END IF
 		//  END IF
@@ -338,7 +338,7 @@ namespace LowTempRadiantSystem {
 		if ( CompIndex == 0 ) {
 			RadSysNum = FindItemInList( CompName, RadSysTypes );
 			if ( RadSysNum == 0 ) {
-				ShowFatalError( "SimLowTempRadiantSystem: Unit not found=" + CompName );
+				ShowFatalError( "SimLowTempRadiantSystem: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = RadSysNum;
 			SystemType = RadSysTypes( RadSysNum ).SystemType;
@@ -354,11 +354,11 @@ namespace LowTempRadiantSystem {
 			RadSysNum = CompIndex;
 			SystemType = RadSysTypes( RadSysNum ).SystemType;
 			if ( RadSysNum > TotalNumOfRadSystems || RadSysNum < 1 ) {
-				ShowFatalError( "SimLowTempRadiantSystem:  Invalid CompIndex passed=" + TrimSigDigits( RadSysNum ) + ", Number of Units=" + TrimSigDigits( TotalNumOfRadSystems ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimLowTempRadiantSystem:  Invalid CompIndex passed=" + TrimSigDigits( RadSysNum ) + ", Number of Units=" + TrimSigDigits( TotalNumOfRadSystems ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( RadSysNum ) ) {
 				if ( CompName != RadSysTypes( RadSysNum ).Name ) {
-					ShowFatalError( "SimLowTempRadiantSystem: Invalid CompIndex passed=" + TrimSigDigits( RadSysNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + RadSysTypes( RadSysNum ).Name );
+					ShowFatalError( "SimLowTempRadiantSystem: Invalid CompIndex passed=" + TrimSigDigits( RadSysNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + RadSysTypes( RadSysNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( RadSysNum ) = false;
 			}
@@ -366,7 +366,7 @@ namespace LowTempRadiantSystem {
 
 		InitLowTempRadiantSystem( FirstHVACIteration, RadSysTypes( RadSysNum ).CompIndex, SystemType, InitErrorFound );
 		if ( InitErrorFound ) {
-			ShowFatalError( "InitLowTempRadiantSystem: Preceding error is not allowed to proceed with the simulation.  Correct this input problem." );
+			ShowFatalError( "InitLowTempRadiantSystem: Preceding error is not allowed to proceed with the simulation.  Correct this input problem." );  // LCOV_EXCL_LINE
 		}
 
 		{ auto const SELECT_CASE_var( SystemType );
@@ -377,7 +377,7 @@ namespace LowTempRadiantSystem {
 		} else if ( SELECT_CASE_var == ElectricSystem ) {
 			CalcLowTempElecRadiantSystem( RadSysTypes( RadSysNum ).CompIndex, LoadMet );
 		} else {
-			ShowFatalError( "SimLowTempRadiantSystem: Illegal system type for system " + CompName );
+			ShowFatalError( "SimLowTempRadiantSystem: Illegal system type for system " + CompName );  // LCOV_EXCL_LINE
 		}}
 
 		UpdateLowTempRadiantSystem( FirstHVACIteration, RadSysTypes( RadSysNum ).CompIndex, SystemType );
@@ -1436,7 +1436,7 @@ namespace LowTempRadiantSystem {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input. Preceding conditions cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input. Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Set up the output variables for low temperature radiant systems
@@ -1565,7 +1565,7 @@ namespace LowTempRadiantSystem {
 		// FLOW:
 
 		InitErrorsFound = false;
-		
+
 		if ( MyOneTimeFlag ) {
 			MyEnvrnFlagHydr.allocate( NumOfHydrLowTempRadSys );
 			MyEnvrnFlagCFlo.allocate( NumOfCFloLowTempRadSys );
@@ -1650,13 +1650,13 @@ namespace LowTempRadiantSystem {
 				if ( HydrRadSys( RadSysNum ).HotWaterInNode > 0 ) {
 					ScanPlantLoopsForObject( HydrRadSys( RadSysNum ).Name, TypeOf_LowTempRadiant_VarFlow, HydrRadSys( RadSysNum ).HWLoopNum, HydrRadSys( RadSysNum ).HWLoopSide, HydrRadSys( RadSysNum ).HWBranchNum, HydrRadSys( RadSysNum ).HWCompNum, _, _, _, HydrRadSys( RadSysNum ).HotWaterInNode, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitLowTempRadiantSystem: Program terminated due to previous condition(s)." );
+						ShowFatalError( "InitLowTempRadiantSystem: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 					}
 				}
 				if ( HydrRadSys( RadSysNum ).ColdWaterInNode > 0 ) {
 					ScanPlantLoopsForObject( HydrRadSys( RadSysNum ).Name, TypeOf_LowTempRadiant_VarFlow, HydrRadSys( RadSysNum ).CWLoopNum, HydrRadSys( RadSysNum ).CWLoopSide, HydrRadSys( RadSysNum ).CWBranchNum, HydrRadSys( RadSysNum ).CWCompNum, _, _, _, HydrRadSys( RadSysNum ).ColdWaterInNode, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitLowTempRadiantSystem: Program terminated due to previous condition(s)." );
+						ShowFatalError( "InitLowTempRadiantSystem: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 					}
 				}
 				MyPlantScanFlagHydr( RadSysNum ) = false;
@@ -1671,13 +1671,13 @@ namespace LowTempRadiantSystem {
 				if ( CFloRadSys( RadSysNum ).HotWaterInNode > 0 ) {
 					ScanPlantLoopsForObject( CFloRadSys( RadSysNum ).Name, TypeOf_LowTempRadiant_ConstFlow, CFloRadSys( RadSysNum ).HWLoopNum, CFloRadSys( RadSysNum ).HWLoopSide, CFloRadSys( RadSysNum ).HWBranchNum, CFloRadSys( RadSysNum ).HWCompNum, _, _, _, CFloRadSys( RadSysNum ).HotWaterInNode, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitLowTempRadiantSystem: Program terminated due to previous condition(s)." );
+						ShowFatalError( "InitLowTempRadiantSystem: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 					}
 				}
 				if ( CFloRadSys( RadSysNum ).ColdWaterInNode > 0 ) {
 					ScanPlantLoopsForObject( CFloRadSys( RadSysNum ).Name, TypeOf_LowTempRadiant_ConstFlow, CFloRadSys( RadSysNum ).CWLoopNum, CFloRadSys( RadSysNum ).CWLoopSide, CFloRadSys( RadSysNum ).CWBranchNum, CFloRadSys( RadSysNum ).CWCompNum, _, _, _, CFloRadSys( RadSysNum ).ColdWaterInNode, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitLowTempRadiantSystem: Program terminated due to previous condition(s)." );
+						ShowFatalError( "InitLowTempRadiantSystem: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 					}
 				}
 				MyPlantScanFlagCFlo( RadSysNum ) = false;
@@ -1895,7 +1895,7 @@ namespace LowTempRadiantSystem {
 
 				ShowSevereError( "Radiant system entered without specification of type: electric, constant flow, or hydronic?" );
 				ShowContinueError( "Occurs in Radiant System=" + HydrRadSys( RadSysNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			}}
 
@@ -2586,7 +2586,7 @@ namespace LowTempRadiantSystem {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2601,7 +2601,7 @@ namespace LowTempRadiantSystem {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rick Strand
 		//       DATE WRITTEN   August 2017
-		
+
 		// PURPOSE OF THIS SUBROUTINE:
 		// This subroutine figures out the tube length based on the spacing of tubes.
 		// For single surface systems, this is fairly easy as there is only one spacing
@@ -2610,10 +2610,10 @@ namespace LowTempRadiantSystem {
 
 		// Return value
 		Real64 SizeRadSysTubeLength;
-		
+
 		int SurfNum; // index for counting through the surfaces that are part of this radiant system
 		Real64 TubeLength; // temporary holding place for the function calculation
-		
+
 		// HydrRadSys( RadNum ).TotalSurfaceArea = 0.0;
 		// for ( SurfNum = 1; SurfNum <= HydrRadSys( RadNum ).NumOfSurfaces; ++SurfNum ) {
 		// 	HydrRadSys( RadNum ).TotalSurfaceArea += Surface( HydrRadSys( RadNum ).SurfacePtr( SurfNum ) ).Area;
@@ -2647,12 +2647,12 @@ namespace LowTempRadiantSystem {
 			ShowWarningError( "SizeRadSysTubeLength: Illegal system type passed into this routine.  This should never happen." );
 			TubeLength = 60.0; // Assign a length to avoid any divide by zero errors. This length is a 3m by 3m room with 0.15m spacing.
 		}
-			
+
 		SizeRadSysTubeLength = TubeLength;
 		return SizeRadSysTubeLength;
-		
+
 	}
-	
+
 	void
 	CalcLowTempHydrRadiantSystem(
 		int const RadSysNum, // name of the low temperature radiant system
@@ -2767,7 +2767,7 @@ namespace LowTempRadiantSystem {
 			} else { // Should never get here
 				ControlTemp = MAT( ZoneNum );
 				ShowSevereError( "Illegal control type in low temperature radiant system: " + HydrRadSys( RadSysNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}}
 
 			if ( HydrRadSys( RadSysNum ).HotSetptSchedPtr > 0 ) {
@@ -2788,7 +2788,7 @@ namespace LowTempRadiantSystem {
 			if ( OffTempHeat > OffTempCool ) {
 				MassFlowFrac = 0.0;
 				ShowSevereError( "Overlapping heating and cooling control temps in radiant system: " + HydrRadSys( RadSysNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			} else { // Temperatures for heating and cooling do not overlap--calculate the mass flow fraction
 
@@ -2947,7 +2947,7 @@ namespace LowTempRadiantSystem {
 			WaterNodeIn = 0; // Suppress uninitialized warning
 			ShowSevereError( "Illegal low temperature radiant system operating mode" );
 			ShowContinueError( "Occurs in Radiant System=" + HydrRadSys( RadSysNum ).Name );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 		}}
 		ZoneNum = HydrRadSys( RadSysNum ).ZonePtr;
 		SysWaterMassFlow = Node( WaterNodeIn ).MassFlowRate;
@@ -3390,7 +3390,7 @@ namespace LowTempRadiantSystem {
 			} else { // Should never get here
 				SetPointTemp = 0.0; // Suppress uninitialized warning
 				ShowSevereError( "Illegal control type in low temperature radiant system: " + CFloRadSys( RadSysNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}}
 
 			// Avoid problems when there is no heating or cooling control because the system only cools or heats
@@ -3409,7 +3409,7 @@ namespace LowTempRadiantSystem {
 			if ( SetPointTemp < OffTempHeat && CFloRadSys( RadSysNum ).HeatingSystem ) { // HEATING MODE
 
 				OperatingMode = HeatingMode;
-				
+
 				CFloRadSys( RadSysNum ).WaterMassFlowRate = CFloRadSys( RadSysNum ).HotWaterMassFlowRate;
 
 				if ( ! CFloRadSys( RadSysNum ).HeatingSystem ) {
@@ -3423,7 +3423,7 @@ namespace LowTempRadiantSystem {
 					if ( SetPointTempHi < SetPointTempLo ) {
 						ShowSevereError( "Heating setpoint temperature mismatch in" + CFloRadSys( RadSysNum ).Name );
 						ShowContinueError( "High setpoint temperature is less than low setpoint temperature--check your schedule input" );
-						ShowFatalError( "Preceding condition causes termination." );
+						ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 					}
 
 					WaterTempHi = GetCurrentScheduleValue( CFloRadSys( RadSysNum ).HotWaterHiTempSchedPtr );
@@ -3431,7 +3431,7 @@ namespace LowTempRadiantSystem {
 					if ( WaterTempHi < WaterTempLo ) {
 						ShowSevereError( "Heating water temperature mismatch in" + CFloRadSys( RadSysNum ).Name );
 						ShowContinueError( "High water temperature is less than low water temperature--check your schedule input" );
-						ShowFatalError( "Preceding condition causes termination." );
+						ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 					}
 
 					if ( SetPointTemp >= SetPointTempHi ) {
@@ -3451,7 +3451,7 @@ namespace LowTempRadiantSystem {
 			} else if ( SetPointTemp > OffTempCool && CFloRadSys( RadSysNum ).CoolingSystem ) { // COOLING MODE
 
 				OperatingMode = CoolingMode;
-				
+
 				CFloRadSys( RadSysNum ).WaterMassFlowRate = CFloRadSys( RadSysNum ).ChWaterMassFlowRate;
 
 				if ( ! CFloRadSys( RadSysNum ).CoolingSystem ) {
@@ -3465,7 +3465,7 @@ namespace LowTempRadiantSystem {
 					if ( SetPointTempHi < SetPointTempLo ) {
 						ShowSevereError( "Cooling setpoint temperature mismatch in" + CFloRadSys( RadSysNum ).Name );
 						ShowContinueError( "High setpoint temperature is less than low setpoint temperature--check your schedule input" );
-						ShowFatalError( "Preceding condition causes termination." );
+						ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 					}
 
 					WaterTempHi = GetCurrentScheduleValue( CFloRadSys( RadSysNum ).ColdWaterHiTempSchedPtr );
@@ -3473,7 +3473,7 @@ namespace LowTempRadiantSystem {
 					if ( WaterTempHi < WaterTempLo ) {
 						ShowSevereError( "Cooling water temperature mismatch in" + CFloRadSys( RadSysNum ).Name );
 						ShowContinueError( "High water temperature is less than low water temperature--check your schedule input" );
-						ShowFatalError( "Preceding condition causes termination." );
+						ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 					}
 
 					if ( SetPointTemp <= SetPointTempLo ) {
@@ -3926,7 +3926,7 @@ namespace LowTempRadiantSystem {
 		} else {
 			ShowSevereError( "Illegal low temperature radiant system operating mode" );
 			ShowContinueError( "Occurs in Radiant System=" + CFloRadSys( RadSysNum ).Name );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 		}}
 		ZoneNum = CFloRadSys( RadSysNum ).ZonePtr;
 		ZoneMult = double( Zone( ZoneNum ).Multiplier * Zone( ZoneNum ).ListMultiplier );
@@ -4368,7 +4368,7 @@ namespace LowTempRadiantSystem {
 			} else { // Should never get here
 				ControlTemp = MAT( ZoneNum );
 				ShowSevereError( "Illegal control type in low temperature radiant system: " + ElecRadSys( RadSysNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}}
 
 			if ( ControlTemp < OffTemp ) { // HEATING MODE

--- a/src/EnergyPlus/MatrixDataManager.cc
+++ b/src/EnergyPlus/MatrixDataManager.cc
@@ -215,7 +215,7 @@ namespace MatrixDataManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetMatrixInput: Errors found in Matrix objects. Preceding condition(s) cause termination." );
+			ShowFatalError( "GetMatrixInput: Errors found in Matrix objects. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/MicroCHPElectricGenerator.cc
+++ b/src/EnergyPlus/MicroCHPElectricGenerator.cc
@@ -199,16 +199,16 @@ namespace MicroCHPElectricGenerator {
 
 		if ( GeneratorIndex == 0 ) {
 			GenNum = FindItemInList( GeneratorName, MicroCHP );
-			if ( GenNum == 0 ) ShowFatalError( "SimMicroCHPGenerator: Specified Generator not one of Valid Micro CHP Generators " + GeneratorName );
+			if ( GenNum == 0 ) ShowFatalError( "SimMicroCHPGenerator: Specified Generator not one of Valid Micro CHP Generators " + GeneratorName );  // LCOV_EXCL_LINE
 			GeneratorIndex = GenNum;
 		} else {
 			GenNum = GeneratorIndex;
 			if ( GenNum > NumMicroCHPs || GenNum < 1 ) {
-				ShowFatalError( "SimMicroCHPGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Number of Micro CHP Generators=" + TrimSigDigits( NumMicroCHPs ) + ", Generator name=" + GeneratorName );
+				ShowFatalError( "SimMicroCHPGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Number of Micro CHP Generators=" + TrimSigDigits( NumMicroCHPs ) + ", Generator name=" + GeneratorName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( GenNum ) ) {
 				if ( GeneratorName != MicroCHP( GenNum ).Name ) {
-					ShowFatalError( "SimMicroCHPNoNormalizeGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + MicroCHP( GenNum ).Name );
+					ShowFatalError( "SimMicroCHPNoNormalizeGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( GenNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + MicroCHP( GenNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( GenNum ) = false;
 			}
@@ -481,7 +481,7 @@ namespace MicroCHPElectricGenerator {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+				ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 			}
 
 			//setup report variables
@@ -625,7 +625,7 @@ namespace MicroCHPElectricGenerator {
 			ScanPlantLoopsForObject( MicroCHP( GeneratorNum ).Name, TypeOf_Generator_MicroCHP, MicroCHP( GeneratorNum ).CWLoopNum, MicroCHP( GeneratorNum ).CWLoopSideNum, MicroCHP( GeneratorNum ).CWBranchNum, MicroCHP( GeneratorNum ).CWCompNum, _, _, _, _, _, errFlag );
 
 			if ( errFlag ) {
-				ShowFatalError( "InitMicroCHPNoNormalizeGenerators: Program terminated for previous conditions." );
+				ShowFatalError( "InitMicroCHPNoNormalizeGenerators: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ! MicroCHP( GeneratorNum ).A42Model.InternalFlowControl ) {
@@ -1555,7 +1555,7 @@ namespace MicroCHPElectricGenerator {
 		if ( InitLoopEquip ) {
 			CompNum = FindItemInList( CompName, MicroCHP );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimMicroCHPPlantHeatRecovery: MicroCHP Generator Unit not found=" + CompName );
+				ShowFatalError( "SimMicroCHPPlantHeatRecovery: MicroCHP Generator Unit not found=" + CompName );  // LCOV_EXCL_LINE
 				return;
 			}
 			InitMicroCHPNoNormalizeGenerators( CompNum, FirstHVACIteration );

--- a/src/EnergyPlus/MicroturbineElectricGenerator.cc
+++ b/src/EnergyPlus/MicroturbineElectricGenerator.cc
@@ -173,17 +173,17 @@ namespace MicroturbineElectricGenerator {
 		// SELECT and CALL GENERATOR MODEL
 		if ( GeneratorIndex == 0 ) {
 			GenNum = FindItemInList( GeneratorName, MTGenerator );
-			if ( GenNum == 0 ) ShowFatalError( "SimMTGenerator: Specified Generator not a valid COMBUSTION Turbine Generator " + GeneratorName );
+			if ( GenNum == 0 ) ShowFatalError( "SimMTGenerator: Specified Generator not a valid COMBUSTION Turbine Generator " + GeneratorName );  // LCOV_EXCL_LINE
 			GeneratorIndex = GenNum;
 		} else {
 			GenNum = GeneratorIndex;
 			if ( GenNum > NumMTGenerators || GenNum < 1 ) {
-				ShowFatalError( "SimMTGenerator: Invalid GeneratorIndex passed = " + TrimSigDigits( GenNum ) + ", Number of CT Engine Generators = " + TrimSigDigits( NumMTGenerators ) + ", Generator name = " + GeneratorName );
+				ShowFatalError( "SimMTGenerator: Invalid GeneratorIndex passed = " + TrimSigDigits( GenNum ) + ", Number of CT Engine Generators = " + TrimSigDigits( NumMTGenerators ) + ", Generator name = " + GeneratorName );  // LCOV_EXCL_LINE
 			}
 
 			if ( CheckEquipName( GenNum ) ) {
 				if ( GeneratorName != MTGenerator( GenNum ).Name ) {
-					ShowFatalError( "SimMTGenerator: Invalid GeneratorIndex passed = " + TrimSigDigits( GenNum ) + ", Generator name = " + GeneratorName + ", stored Generator Name for that index = " + MTGenerator( GenNum ).Name );
+					ShowFatalError( "SimMTGenerator: Invalid GeneratorIndex passed = " + TrimSigDigits( GenNum ) + ", Generator name = " + GeneratorName + ", stored Generator Name for that index = " + MTGenerator( GenNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( GenNum ) = false;
 			}
@@ -253,7 +253,7 @@ namespace MicroturbineElectricGenerator {
 		if ( InitLoopEquip ) {
 			CompNum = FindItemInList( CompName, MTGenerator );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimMTPlantHeatRecovery: Microturbine Generator Unit not found=" + CompName );
+				ShowFatalError( "SimMTPlantHeatRecovery: Microturbine Generator Unit not found=" + CompName );  // LCOV_EXCL_LINE
 				return;
 			}
 			MinCap = MTGenerator( CompNum ).MinThermalPowerOutput;
@@ -1038,7 +1038,7 @@ namespace MicroturbineElectricGenerator {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( GeneratorNum = 1; GeneratorNum <= NumMTGenerators; ++GeneratorNum ) {
@@ -1176,7 +1176,7 @@ namespace MicroturbineElectricGenerator {
 			errFlag = false;
 			ScanPlantLoopsForObject( MTGenerator( GenNum ).Name, TypeOf_Generator_MicroTurbine, MTGenerator( GenNum ).HRLoopNum, MTGenerator( GenNum ).HRLoopSideNum, MTGenerator( GenNum ).HRBranchNum, MTGenerator( GenNum ).HRCompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitMTGenerators: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitMTGenerators: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			MyPlantScanFlag( GenNum ) = false;
@@ -2052,7 +2052,7 @@ namespace MicroturbineElectricGenerator {
 		CompNum = FindItemInList( CompName, MTGenerator );
 
 		if ( CompNum == 0 ) {
-			ShowFatalError( "GetMTGeneratorExhaustNode: Unit not found=" + CompName );
+			ShowFatalError( "GetMTGeneratorExhaustNode: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 		} else {
 			ExhaustOutletNodeNum = MTGenerator( CompNum ).CombustionAirOutletNodeNum;
 		}

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -419,7 +419,7 @@ namespace MixedAir {
 		if ( OASysNum == 0 ) {
 			OASysNum = FindItemInList( OASysName, OutsideAirSys );
 			if ( OASysNum == 0 ) {
-				ShowFatalError( "ManageOutsideAirSystem: AirLoopHVAC:OutdoorAirSystem not found=" + OASysName );
+				ShowFatalError( "ManageOutsideAirSystem: AirLoopHVAC:OutdoorAirSystem not found=" + OASysName );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -562,7 +562,7 @@ namespace MixedAir {
 				}
 			}
 			MyOneTimeErrorFlag( OASysNum ) = false;
-			if ( FatalErrorFlag ) ShowFatalError( "Previous severe error(s) cause program termination" );
+			if ( FatalErrorFlag ) ShowFatalError( "Previous severe error(s) cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 		CurOASysNum = 0;
@@ -661,7 +661,7 @@ namespace MixedAir {
 				CompIndex = HVACFan::getFanObjectVectorIndex( CompName ) + 1; // + 1 for shift from zero-based vector to 1-based compIndex
 			}
 			if ( Sim ) {
-				HVACFan::fanObjs[ CompIndex - 1 ]->simulate(_,_,_,_); // vector is 0 based, but CompIndex is 1 based so shift 
+				HVACFan::fanObjs[ CompIndex - 1 ]->simulate(_,_,_,_); // vector is 0 based, but CompIndex is 1 based so shift
 			}
 			//cpw22Aug2010 Add Fan:ComponentModel (new num=18)
 		} else if ( SELECT_CASE_var == Fan_ComponentModel ) { // 'Fan:ComponentModel'
@@ -789,7 +789,7 @@ namespace MixedAir {
 			}
 
 		} else {
-			ShowFatalError( "Invalid Outside Air Component=" + CompType );
+			ShowFatalError( "Invalid Outside Air Component=" + CompType );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -842,7 +842,7 @@ namespace MixedAir {
 			OAMixerNum = FindItemInList( CompName, OAMixer );
 			CompIndex = OAMixerNum;
 			if ( OAMixerNum == 0 ) {
-				ShowFatalError( "SimOAMixer: OutdoorAir:Mixer not found=" + CompName );
+				ShowFatalError( "SimOAMixer: OutdoorAir:Mixer not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 		} else {
 			OAMixerNum = CompIndex;
@@ -910,7 +910,7 @@ namespace MixedAir {
 			}
 			CtrlIndex = OAControllerNum;
 			if ( OAControllerNum == 0 ) {
-				ShowFatalError( "SimOAController: Outside Air Controller not found=" + CtrlName );
+				ShowFatalError( "SimOAController: Outside Air Controller not found=" + CtrlName );  // LCOV_EXCL_LINE
 			}
 		} else {
 			OAControllerNum = CtrlIndex;
@@ -1259,7 +1259,7 @@ namespace MixedAir {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + '.' );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + '.' );  // LCOV_EXCL_LINE
 		}
 
 		AlphArray.deallocate();
@@ -1430,7 +1430,7 @@ namespace MixedAir {
 				lAlphaBlanks.deallocate();
 				cAlphaFields.deallocate();
 				cNumericFields.deallocate();
-				ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " inputs." );
+				ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " inputs." );  // LCOV_EXCL_LINE
 			}
 
 		}
@@ -1958,7 +1958,7 @@ namespace MixedAir {
 		cNumericFields.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found when getting " + CurrentModuleObject + " inputs." );
+			ShowFatalError( RoutineName + "Errors found when getting " + CurrentModuleObject + " inputs." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2101,7 +2101,7 @@ namespace MixedAir {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		GetOAMixerInputFlag = false;
@@ -2905,7 +2905,7 @@ namespace MixedAir {
 					PreDefTableEntry( pdchDCVperArea, zoneName, vent_mech.ZoneOAAreaRate( jZone ), 6 );
 					PreDefTableEntry( pdchDCVperZone, zoneName, vent_mech.ZoneOAFlowRate( jZone ), 6 );
 					PreDefTableEntry( pdchDCVperACH, zoneName, vent_mech.ZoneOAACHRate( jZone ), 6 );
-					PreDefTableEntry( pdchDCVMethod, zoneName, cOAFlowMethodTypes( vent_mech.ZoneOAFlowMethod( jZone ) ) ); 
+					PreDefTableEntry( pdchDCVMethod, zoneName, cOAFlowMethodTypes( vent_mech.ZoneOAFlowMethod( jZone ) ) );
 					if ( vent_mech.ZoneOASchPtr( jZone ) > 0 ) {
 						PreDefTableEntry( pdchDCVOASchName, zoneName, GetScheduleName( vent_mech.ZoneOASchPtr( jZone ) ) );
 					} else {
@@ -3232,7 +3232,7 @@ namespace MixedAir {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Error in " + CurrentModuleObjects( CMO_OAController ) + "; program terminated" );
+			ShowFatalError( "Error in " + CurrentModuleObjects( CMO_OAController ) + "; program terminated" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -4166,7 +4166,7 @@ namespace MixedAir {
 					} else {
 						AirLoopControlInfo( AirLoopNum ).EconomizerFlowLocked = false;
 						this->HRHeatingCoilActive = 0;
-					} 
+					}
 					AirLoopControlInfo( AirLoopNum ).CheckHeatRecoveryBypassStatus = false;
 				}
 			}
@@ -4704,7 +4704,7 @@ namespace MixedAir {
 			} // End of component loop
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -5257,7 +5257,7 @@ namespace MixedAir {
 		}
 
 		if ( OAMixerNum > NumOAMixers ) {
-			ShowFatalError( "GetOAMixerReliefNodeNumber: Requested Mixer #=" + TrimSigDigits( OAMixerNum ) + ", which is > number of OA Mixers=" + TrimSigDigits( NumOAMixers ) );
+			ShowFatalError( "GetOAMixerReliefNodeNumber: Requested Mixer #=" + TrimSigDigits( OAMixerNum ) + ", which is > number of OA Mixers=" + TrimSigDigits( NumOAMixers ) );  // LCOV_EXCL_LINE
 		}
 
 		ReliefNodeNumber = OAMixer( OAMixerNum ).RelNode;

--- a/src/EnergyPlus/MixerComponent.cc
+++ b/src/EnergyPlus/MixerComponent.cc
@@ -195,17 +195,17 @@ namespace MixerComponent {
 		if ( CompIndex == 0 ) {
 			MixerNum = FindItemInList( CompName, MixerCond, &MixerConditions::MixerName );
 			if ( MixerNum == 0 ) {
-				ShowFatalError( "SimAirLoopMixer: Mixer not found=" + CompName );
+				ShowFatalError( "SimAirLoopMixer: Mixer not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = MixerNum;
 		} else {
 			MixerNum = CompIndex;
 			if ( MixerNum > NumMixers || MixerNum < 1 ) {
-				ShowFatalError( "SimAirLoopMixer: Invalid CompIndex passed=" + TrimSigDigits( MixerNum ) + ", Number of Mixers=" + TrimSigDigits( NumMixers ) + ", Mixer name=" + CompName );
+				ShowFatalError( "SimAirLoopMixer: Invalid CompIndex passed=" + TrimSigDigits( MixerNum ) + ", Number of Mixers=" + TrimSigDigits( NumMixers ) + ", Mixer name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( MixerNum ) ) {
 				if ( CompName != MixerCond( MixerNum ).MixerName ) {
-					ShowFatalError( "SimAirLoopMixer: Invalid CompIndex passed=" + TrimSigDigits( MixerNum ) + ", Mixer name=" + CompName + ", stored Mixer Name for that index=" + MixerCond( MixerNum ).MixerName );
+					ShowFatalError( "SimAirLoopMixer: Invalid CompIndex passed=" + TrimSigDigits( MixerNum ) + ", Mixer name=" + CompName + ", stored Mixer Name for that index=" + MixerCond( MixerNum ).MixerName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( MixerNum ) = false;
 			}
@@ -385,7 +385,7 @@ namespace MixerComponent {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input." );
+			ShowFatalError( RoutineName + "Errors found in getting input." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/MoistureBalanceEMPDManager.cc
+++ b/src/EnergyPlus/MoistureBalanceEMPDManager.cc
@@ -347,7 +347,7 @@ namespace MoistureBalanceEMPDManager {
 		ReportMoistureBalanceEMPD();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetMoistureBalanceEMPDInput: Errors found getting EMPD material properties, program terminated." );
+			ShowFatalError( "GetMoistureBalanceEMPDInput: Errors found getting EMPD material properties, program terminated." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/MundtSimMgr.cc
+++ b/src/EnergyPlus/MundtSimMgr.cc
@@ -208,7 +208,7 @@ namespace MundtSimMgr {
 			// setup Mundt model
 			ErrorsFound = false;
 			SetupMundtModel( ZoneNum, ErrorsFound );
-			if ( ErrorsFound ) ShowFatalError( "ManageMundtModel: Errors in setting up Mundt Model. Preceding condition(s) cause termination." );
+			if ( ErrorsFound ) ShowFatalError( "ManageMundtModel: Errors in setting up Mundt Model. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 
 			// perform Mundt model calculations
 			CalcMundtModel( ZoneNum );
@@ -366,7 +366,7 @@ namespace MundtSimMgr {
 
 						// error check for debugging
 						if ( AirNodeBeginNum > TotNumOfAirNodes ) {
-							ShowFatalError( "An array bound exceeded. Error in InitMundtModel subroutine of MundtSimMgr." );
+							ShowFatalError( "An array bound exceeded. Error in InitMundtModel subroutine of MundtSimMgr." );  // LCOV_EXCL_LINE
 						}
 
 						AirNodeFoundFlag = false;
@@ -415,7 +415,7 @@ namespace MundtSimMgr {
 
 		}
 
-		if ( ErrorsFound ) ShowFatalError( "InitMundtModel: Preceding condition(s) cause termination." );
+		if ( ErrorsFound ) ShowFatalError( "InitMundtModel: Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 
 		// allocate arrays
 		RoomNodeIDs.allocate( MaxNumOfRoomNodes );
@@ -501,7 +501,7 @@ namespace MundtSimMgr {
 		ZoneEquipConfigNum = ZoneNum;
 		// check whether this zone is a controlled zone or not
 		if ( ! Zone( ZoneNum ).IsControlled ) {
-			ShowFatalError( "Zones must be controlled for Mundt air model. No system serves zone " + Zone( ZoneNum ).Name );
+			ShowFatalError( "Zones must be controlled for Mundt air model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 			return;
 		}
 

--- a/src/EnergyPlus/NodeInputManager.cc
+++ b/src/EnergyPlus/NodeInputManager.cc
@@ -236,7 +236,7 @@ namespace NodeInputManager {
 			ShowSevereError( RoutineName + NodeObjectType + "=\"" + NodeObjectName + "\", invalid fluid type." );
 			ShowContinueError( "..Invalid FluidType=" + cNodeFluidType );
 			ErrorsFound = true;
-			ShowFatalError( "Preceding issue causes termination." );
+			ShowFatalError( "Preceding issue causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( not_blank( Name ) ) {
@@ -660,7 +660,7 @@ namespace NodeInputManager {
 		rNumbers.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + CurrentModuleObject + ": Error getting input - causes termination." );
+			ShowFatalError( RoutineName + CurrentModuleObject + ": Error getting input - causes termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -716,7 +716,7 @@ namespace NodeInputManager {
 			strip( cNodeFluidType );
 			ShowSevereError( "AssignNodeNumber: Invalid FluidType=" + cNodeFluidType );
 			ErrorsFound = true;
-			ShowFatalError( "AssignNodeNumber: Preceding issue causes termination." );
+			ShowFatalError( "AssignNodeNumber: Preceding issue causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		NumNode = 0;
@@ -909,10 +909,10 @@ namespace NodeInputManager {
 		}
 
 		if ( ! CurCheckContextName.empty() ) {
-			ShowFatalError( "Init Uniqueness called for \"" + ContextName + ", but checks for \"" + CurCheckContextName + "\" was already in progress." );
+			ShowFatalError( "Init Uniqueness called for \"" + ContextName + ", but checks for \"" + CurCheckContextName + "\" was already in progress." );  // LCOV_EXCL_LINE
 		}
 		if ( ContextName == BlankString ) {
-			ShowFatalError( "Init Uniqueness called with Blank Context Name" );
+			ShowFatalError( "Init Uniqueness called with Blank Context Name" );  // LCOV_EXCL_LINE
 		}
 		if ( allocated( UniqueNodeNames ) ) {
 			UniqueNodeNames.deallocate();
@@ -981,7 +981,7 @@ namespace NodeInputManager {
 
 		if ( nodeType == "NodeName" ) {
 			if ( ! present( CheckName ) ) {
-				ShowFatalError( "Routine CheckUniqueNodes called with Nodetypes=NodeName, but did not include CheckName argument." );
+				ShowFatalError( "Routine CheckUniqueNodes called with Nodetypes=NodeName, but did not include CheckName argument." );  // LCOV_EXCL_LINE
 			}
 			if ( ! CheckName().empty() ) {
 				Found = FindItemInList( CheckName, UniqueNodeNames, NumCheckNodes );
@@ -1003,7 +1003,7 @@ namespace NodeInputManager {
 
 		} else if ( nodeType == "NodeNumber" ) {
 			if ( ! present( CheckNumber ) ) {
-				ShowFatalError( "Routine CheckUniqueNodes called with Nodetypes=NodeNumber, but did not include CheckNumber argument." );
+				ShowFatalError( "Routine CheckUniqueNodes called with Nodetypes=NodeNumber, but did not include CheckNumber argument." );  // LCOV_EXCL_LINE
 			}
 			if ( CheckNumber != 0 ) {
 				Found = FindItemInList( NodeID( CheckNumber ), UniqueNodeNames, NumCheckNodes );
@@ -1024,7 +1024,7 @@ namespace NodeInputManager {
 			}
 
 		} else {
-			ShowFatalError( "CheckUniqueNodes called with invalid Check Type=" + CheckType );
+			ShowFatalError( "CheckUniqueNodes called with invalid Check Type=" + CheckType );  // LCOV_EXCL_LINE
 			ErrorsFound = true;
 
 		}}
@@ -1069,10 +1069,10 @@ namespace NodeInputManager {
 		// na
 
 		if ( CurCheckContextName != ContextName ) {
-			ShowFatalError( "End Uniqueness called for \"" + ContextName + ", but checks for \"" + CurCheckContextName + "\" was in progress." );
+			ShowFatalError( "End Uniqueness called for \"" + ContextName + ", but checks for \"" + CurCheckContextName + "\" was in progress." );  // LCOV_EXCL_LINE
 		}
 		if ( ContextName == BlankString ) {
-			ShowFatalError( "End Uniqueness called with Blank Context Name" );
+			ShowFatalError( "End Uniqueness called with Blank Context Name" );  // LCOV_EXCL_LINE
 		}
 		CurCheckContextName = BlankString;
 		if ( allocated( UniqueNodeNames ) ) {

--- a/src/EnergyPlus/OutAirNodeManager.cc
+++ b/src/EnergyPlus/OutAirNodeManager.cc
@@ -287,7 +287,7 @@ namespace OutAirNodeManager {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input." );
+				ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -315,7 +315,7 @@ namespace OutAirNodeManager {
 					continue;
 				}
 
-				
+
 
 				if ( ! any_eq( TmpNums, NodeNums( 1 ) ) ) {
 					++ListSize;
@@ -357,7 +357,7 @@ namespace OutAirNodeManager {
 				}
 			}
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input." );
+				ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -442,7 +442,7 @@ namespace OutAirNodeManager {
 
 			Node( NodeNum ).Temp = Node( NodeNum ).OutAirDryBulb;
 			if ( Node( NodeNum ).OutAirDryBulbSchedNum != 0 || Node( NodeNum ).OutAirWetBulbSchedNum != 0 ) {
-				Node( NodeNum ).HumRat = PsyWFnTdbTwbPb( Node( NodeNum ).OutAirDryBulb, Node( NodeNum ).OutAirWetBulb, OutBaroPress );				
+				Node( NodeNum ).HumRat = PsyWFnTdbTwbPb( Node( NodeNum ).OutAirDryBulb, Node( NodeNum ).OutAirWetBulb, OutBaroPress );
 			}
 			else {
 				Node(NodeNum).HumRat = OutHumRat;

--- a/src/EnergyPlus/OutdoorAirUnit.cc
+++ b/src/EnergyPlus/OutdoorAirUnit.cc
@@ -269,17 +269,17 @@ namespace OutdoorAirUnit {
 		if ( CompIndex == 0 ) {
 			OAUnitNum = FindItemInList( CompName, OutAirUnit );
 			if ( OAUnitNum == 0 ) {
-				ShowFatalError( "ZoneHVAC:OutdoorAirUnit not found=" + CompName );
+				ShowFatalError( "ZoneHVAC:OutdoorAirUnit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = OAUnitNum;
 		} else {
 			OAUnitNum = CompIndex;
 			if ( OAUnitNum > NumOfOAUnits || OAUnitNum < 1 ) {
-				ShowFatalError( "SimOutdoorAirUnit:  Invalid CompIndex passed=" + TrimSigDigits( OAUnitNum ) + ", Number of Units=" + TrimSigDigits( NumOfOAUnits ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimOutdoorAirUnit:  Invalid CompIndex passed=" + TrimSigDigits( OAUnitNum ) + ", Number of Units=" + TrimSigDigits( NumOfOAUnits ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( OAUnitNum ) ) {
 				if ( CompName != OutAirUnit( OAUnitNum ).Name ) {
-					ShowFatalError( "SimOutdoorAirUnit: Invalid CompIndex passed=" + TrimSigDigits( OAUnitNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + OutAirUnit( OAUnitNum ).Name );
+					ShowFatalError( "SimOutdoorAirUnit: Invalid CompIndex passed=" + TrimSigDigits( OAUnitNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + OutAirUnit( OAUnitNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( OAUnitNum ) = false;
 			}
@@ -803,7 +803,7 @@ namespace OutdoorAirUnit {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + '.' );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + '.' );  // LCOV_EXCL_LINE
 		}
 
 		AlphArray.deallocate();
@@ -957,7 +957,7 @@ namespace OutdoorAirUnit {
 					errFlag = false;
 					ScanPlantLoopsForObject( OutAirUnit( OAUnitNum ).OAEquip( compLoop ).ComponentName, OutAirUnit( OAUnitNum ).OAEquip( compLoop ).CoilPlantTypeOfNum, OutAirUnit( OAUnitNum ).OAEquip( compLoop ).LoopNum, OutAirUnit( OAUnitNum ).OAEquip( compLoop ).LoopSideNum, OutAirUnit( OAUnitNum ).OAEquip( compLoop ).BranchNum, OutAirUnit( OAUnitNum ).OAEquip( compLoop ).CompNum, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitOutdoorAirUnit: Program terminated for previous conditions." );
+						ShowFatalError( "InitOutdoorAirUnit: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -1285,8 +1285,8 @@ namespace OutdoorAirUnit {
 		if( OutAirUnit(OAUnitNum).SFanMaxAirVolFlow == AutoSize ) {
 			if ( OutAirUnit( OAUnitNum ).SFanType != DataHVACGlobals::FanType_SystemModelObject ) {
 				Fans::SimulateFanComponents( OutAirUnit( OAUnitNum ).SFanName, true, OutAirUnit( OAUnitNum ).SFan_Index, _, false, false );
-				OutAirUnit( OAUnitNum ).SFanMaxAirVolFlow = GetFanDesignVolumeFlowRate( cFanTypes( OutAirUnit( OAUnitNum ).SFanType ), OutAirUnit( OAUnitNum ).SFanName, ErrorsFound );			
-			
+				OutAirUnit( OAUnitNum ).SFanMaxAirVolFlow = GetFanDesignVolumeFlowRate( cFanTypes( OutAirUnit( OAUnitNum ).SFanType ), OutAirUnit( OAUnitNum ).SFanName, ErrorsFound );
+
 			} else {
 				HVACFan::fanObjs[ OutAirUnit( OAUnitNum ).SFan_Index ]->simulate(_,_,_,_);
 				OutAirUnit( OAUnitNum ).SFanMaxAirVolFlow = HVACFan::fanObjs[ OutAirUnit( OAUnitNum ).SFan_Index ]->designAirVolFlowRate;
@@ -1330,7 +1330,7 @@ namespace OutdoorAirUnit {
 		}
 
 		if( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1469,7 +1469,7 @@ namespace OutdoorAirUnit {
 				} else {
 					HVACFan::fanObjs[ OutAirUnit( OAUnitNum ).SFan_Index ]->simulate(_,ZoneCompTurnFansOn,ZoneCompTurnFansOff,_);
 				}
-				
+
 				SimZoneOutAirUnitComps( OAUnitNum, FirstHVACIteration );
 				if ( OutAirUnit( OAUnitNum ).ExtFan ) {
 					if ( OutAirUnit( OAUnitNum ).ExtFanType != DataHVACGlobals::FanType_SystemModelObject ) {
@@ -2022,7 +2022,7 @@ namespace OutdoorAirUnit {
 			}
 
 		} else {
-			ShowFatalError( "Invalid Outdoor Air Unit Component=" + EquipType ); // validate
+			ShowFatalError( "Invalid Outdoor Air Unit Component=" + EquipType ); // validate  // LCOV_EXCL_LINE
 		}}
 
 	}

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -927,7 +927,7 @@ namespace OutputProcessor {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetReportVariableInput:" + cCurrentModuleObject + ": errors in input." );
+			ShowFatalError( "GetReportVariableInput:" + cCurrentModuleObject + ": errors in input." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1224,7 +1224,7 @@ namespace OutputProcessor {
 		//  The following should never happen to a user!!!!
 		ShowSevereError( "OutputProcessor/ValidateIndexType: Invalid Index Key passed to ValidateIndexType=" + IndexTypeKey );
 		ShowContinueError( "..Should be \"ZONE\", \"SYSTEM\", \"HVAC\"... was called from:" + CalledFrom );
-		ShowFatalError( "Preceding condition causes termination." );
+		ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		return ValidateIndexType;
 
@@ -1454,7 +1454,7 @@ namespace OutputProcessor {
 		OutputFileMeterDetails = GetNewUnitNumber();
 		{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputFileMeterDetails, DataStringGlobals::outputMtdFileName, flags ); write_stat = flags.ios(); }
 		if ( write_stat != 0 ) {
-			ShowFatalError( "InitializeMeters: Could not open file "+DataStringGlobals::outputMtdFileName+" for output (write)." );
+			ShowFatalError( "InitializeMeters: Could not open file "+DataStringGlobals::outputMtdFileName+" for output (write)." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2297,7 +2297,7 @@ namespace OutputProcessor {
 			EnergyMeters( NumEnergyMeters ).FinYrSMMinValDate = 0;
 		}
 		else {
-			ShowFatalError( "Requested to Add Meter which was already present=" + Name );
+			ShowFatalError( "Requested to Add Meter which was already present=" + Name );  // LCOV_EXCL_LINE
 		}
 		if ( ! ResourceType.empty() ) {
 			bool errFlag;
@@ -4035,7 +4035,7 @@ namespace OutputProcessor {
 		std::string const & variableName, // The variable's actual name
 		int const indexType,
 		OutputProcessor::Unit const & unitsForVar, // The variables units
-		Optional_string_const customUnitName, 
+		Optional_string_const customUnitName,
 		Optional_string_const ScheduleName
 	)
 	{
@@ -5233,7 +5233,7 @@ namespace OutputProcessor {
 			return OutputProcessor::Unit::kg_kg;
 		} else if ( unitUpper == "%" ) {
 			return OutputProcessor::Unit::Perc;
-		} else if ( unitUpper == "DEG" ) { 
+		} else if ( unitUpper == "DEG" ) {
 			return OutputProcessor::Unit::deg;
 		} else if ( unitUpper == "S" ) {
 			return OutputProcessor::Unit::s;
@@ -5823,7 +5823,7 @@ UpdateDataandReport( int const IndexTypeKey ) // What kind of data to update (Zo
 
 	IndexType = IndexTypeKey;
 	if ( IndexType != ZoneTSReporting && IndexType != HVACTSReporting ) {
-		ShowFatalError( "Invalid reporting requested -- UpdateDataAndReport" );
+		ShowFatalError( "Invalid reporting requested -- UpdateDataAndReport" );  // LCOV_EXCL_LINE
 	}
 
 	if ( ( IndexType >= ZoneVar ) && ( IndexType <= HVACVar ) ) {
@@ -6627,7 +6627,7 @@ UpdateMeterReporting()
 	ReportMeterDetails();
 
 	if ( ErrorsLogged ) {
-		ShowFatalError( "UpdateMeterReporting: Previous Meter Specification errors cause program termination." );
+		ShowFatalError( "UpdateMeterReporting: Previous Meter Specification errors cause program termination." );  // LCOV_EXCL_LINE
 	}
 
 	MeterValue.dimension( NumEnergyMeters, 0.0 );
@@ -7248,11 +7248,11 @@ GetInternalVariableValue(
 		resultVal = 0.0;
 	} else if ( varType == 1 ) { // Integer
 		if ( keyVarIndex > NumOfIVariable ) {
-			ShowFatalError( "GetInternalVariableValue: Integer variable passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValue: Integer variable passed index beyond range of array." );  // LCOV_EXCL_LINE
 			ShowContinueError( "Index = " + General::TrimSigDigits( keyVarIndex ) + " Number of integer variables = " + General::TrimSigDigits( NumOfIVariable ) );
 		}
 		if ( keyVarIndex < 1 ) {
-			ShowFatalError( "GetInternalVariableValue: Integer variable passed index <1. Index = " + General::TrimSigDigits( keyVarIndex ) );
+			ShowFatalError( "GetInternalVariableValue: Integer variable passed index <1. Index = " + General::TrimSigDigits( keyVarIndex ) );  // LCOV_EXCL_LINE
 		}
 
 		IVar >>= IVariableTypes( keyVarIndex ).VarPtr;
@@ -7260,11 +7260,11 @@ GetInternalVariableValue(
 		resultVal = double( IVar().Which );
 	} else if ( varType == 2 ) { // real
 		if ( keyVarIndex > NumOfRVariable ) {
-			ShowFatalError( "GetInternalVariableValue: Real variable passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValue: Real variable passed index beyond range of array." );  // LCOV_EXCL_LINE
 			ShowContinueError( "Index = " + General::TrimSigDigits( keyVarIndex ) + " Number of real variables = " + General::TrimSigDigits( NumOfRVariable ) );
 		}
 		if ( keyVarIndex < 1 ) {
-			ShowFatalError( "GetInternalVariableValue: Integer variable passed index <1. Index = " + General::TrimSigDigits( keyVarIndex ) );
+			ShowFatalError( "GetInternalVariableValue: Integer variable passed index <1. Index = " + General::TrimSigDigits( keyVarIndex ) );  // LCOV_EXCL_LINE
 		}
 
 		RVar >>= RVariableTypes( keyVarIndex ).VarPtr;
@@ -7334,10 +7334,10 @@ GetInternalVariableValueExternalInterface(
 		resultVal = 0.0;
 	} else if ( varType == 1 ) { // Integer
 		if ( keyVarIndex > NumOfIVariable ) {
-			ShowFatalError( "GetInternalVariableValueExternalInterface: passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValueExternalInterface: passed index beyond range of array." );  // LCOV_EXCL_LINE
 		}
 		if ( keyVarIndex < 1 ) {
-			ShowFatalError( "GetInternalVariableValueExternalInterface: passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValueExternalInterface: passed index beyond range of array." );  // LCOV_EXCL_LINE
 		}
 
 		IVar >>= IVariableTypes( keyVarIndex ).VarPtr;
@@ -7345,10 +7345,10 @@ GetInternalVariableValueExternalInterface(
 		resultVal = double( IVar().EITSValue );
 	} else if ( varType == 2 ) { // REAL(r64)
 		if ( keyVarIndex > NumOfRVariable ) {
-			ShowFatalError( "GetInternalVariableValueExternalInterface: passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValueExternalInterface: passed index beyond range of array." );  // LCOV_EXCL_LINE
 		}
 		if ( keyVarIndex < 1 ) {
-			ShowFatalError( "GetInternalVariableValueExternalInterface: passed index beyond range of array." );
+			ShowFatalError( "GetInternalVariableValueExternalInterface: passed index beyond range of array." );  // LCOV_EXCL_LINE
 		}
 
 		RVar >>= RVariableTypes( keyVarIndex ).VarPtr;
@@ -7845,7 +7845,7 @@ GetVariableKeys(
 					if ( ! Duplicate ) {
 						++numKeys;
 						if ( ( numKeys > maxKeyNames ) || ( numKeys > maxkeyVarIndexes ) ) {
-							ShowFatalError( "Invalid array size in GetVariableKeys" );
+							ShowFatalError( "Invalid array size in GetVariableKeys" );  // LCOV_EXCL_LINE
 						}
 						keyNames( numKeys ) = IVariableTypes( Loop ).VarNameUC.substr( 0, Position );
 						keyVarIndexes( numKeys ) = Loop;
@@ -7867,7 +7867,7 @@ GetVariableKeys(
 				if ( ! Duplicate ) {
 					++numKeys;
 					if ( ( numKeys > maxKeyNames ) || ( numKeys > maxkeyVarIndexes ) ) {
-						ShowFatalError( "Invalid array size in GetVariableKeys" );
+						ShowFatalError( "Invalid array size in GetVariableKeys" );  // LCOV_EXCL_LINE
 					}
 					keyNames( numKeys ) = RVariableTypes( Loop ).KeyNameOnlyUC;
 					keyVarIndexes( numKeys ) = Loop;
@@ -7877,14 +7877,14 @@ GetVariableKeys(
 	} else if ( varType == VarType_Meter ) { // Meter
 		numKeys = 1;
 		if ( ( numKeys > maxKeyNames ) || ( numKeys > maxkeyVarIndexes ) ) {
-			ShowFatalError( "Invalid array size in GetVariableKeys" );
+			ShowFatalError( "Invalid array size in GetVariableKeys" );  // LCOV_EXCL_LINE
 		}
 		keyNames( 1 ) = "Meter";
 		keyVarIndexes( 1 ) = GetMeterIndex( varName );
 	} else if ( varType == VarType_Schedule ) { // Schedule
 		numKeys = 1;
 		if ( ( numKeys > maxKeyNames ) || ( numKeys > maxkeyVarIndexes ) ) {
-			ShowFatalError( "Invalid array size in GetVariableKeys" );
+			ShowFatalError( "Invalid array size in GetVariableKeys" );  // LCOV_EXCL_LINE
 		}
 		keyNames( 1 ) = "Environment";
 		keyVarIndexes( 1 ) = GetScheduleIndex( varName );
@@ -8187,26 +8187,26 @@ ProduceRDDMDD()
 	if ( ProduceReportVDD == ReportVDD_Yes ) {
 		rdd_stream.open( DataStringGlobals::outputRddFileName ); // Text mode so we use \n as terminator
 		if ( ! rdd_stream ) {
-			ShowFatalError( "ProduceRDDMDD: Could not open file \"" + DataStringGlobals::outputRddFileName + "\" for output (write)." );
+			ShowFatalError( "ProduceRDDMDD: Could not open file \"" + DataStringGlobals::outputRddFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 		}
 		rdd_stream << "Program Version," << VerString << ',' << IDDVerString << '\n';
 		rdd_stream << "Var Type (reported time step),Var Report Type,Variable Name [Units]" << '\n';
 		mdd_stream.open( DataStringGlobals::outputMddFileName );
 		if ( ! mdd_stream ) {
-			ShowFatalError( "ProduceRDDMDD: Could not open file \"" + DataStringGlobals::outputMddFileName + "\" for output (write)." );
+			ShowFatalError( "ProduceRDDMDD: Could not open file \"" + DataStringGlobals::outputMddFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 		}
 		mdd_stream << "Program Version," << VerString << ',' << IDDVerString << '\n';
 		mdd_stream << "Var Type (reported time step),Var Report Type,Variable Name [Units]" << '\n';
 	} else if ( ProduceReportVDD == ReportVDD_IDF ) {
 		rdd_stream.open( DataStringGlobals::outputRddFileName ); // Text mode so we use \n as terminator
 		if ( ! rdd_stream ) {
-			ShowFatalError( "ProduceRDDMDD: Could not open file \"" + DataStringGlobals::outputRddFileName + "\" for output (write)." );
+			ShowFatalError( "ProduceRDDMDD: Could not open file \"" + DataStringGlobals::outputRddFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 		}
 		rdd_stream << "! Program Version," << VerString << ',' << IDDVerString << '\n';
 		rdd_stream << "! Output:Variable Objects (applicable to this run)" << '\n';
 		mdd_stream.open( DataStringGlobals::outputMddFileName );
 		if ( ! mdd_stream ) {
-			ShowFatalError( "ProduceRDDMDD: Could not open file \"" + DataStringGlobals::outputMddFileName + "\" for output (write)." );
+			ShowFatalError( "ProduceRDDMDD: Could not open file \"" + DataStringGlobals::outputMddFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 		}
 		mdd_stream << "! Program Version," << VerString << ',' << IDDVerString << '\n';
 		mdd_stream << "! Output:Meter Objects (applicable to this run)" << '\n';

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -744,7 +744,7 @@ namespace OutputReportTabular {
 
 
 		if ( IndexTypeKey != ZoneTSReporting && IndexTypeKey != HVACTSReporting ) {
-			ShowFatalError( "Invalid reporting requested -- UpdateTabularReports" );
+			ShowFatalError( "Invalid reporting requested -- UpdateTabularReports" );  // LCOV_EXCL_LINE
 		}
 
 		if ( UpdateTabularReportsGetInput ) {
@@ -757,7 +757,7 @@ namespace OutputReportTabular {
 			// noel -- noticed this was called once and very slow -- sped up a little by caching keys
 			InitializeTabularMonthly();
 			if ( isInvalidAggregationOrder( ) ) {
-				ShowFatalError( "OutputReportTabular: Invalid aggregations detected, no simulation performed." );
+				ShowFatalError( "OutputReportTabular: Invalid aggregations detected, no simulation performed." );  // LCOV_EXCL_LINE
 			}
 			GetInputFuelAndPollutionFactors();
 			SetupUnitConversions();
@@ -2181,7 +2181,7 @@ namespace OutputReportTabular {
 			ErrorsFound = true;
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( CurrentModuleObject + ": Preceding errors cause termination." );
+			ShowFatalError( CurrentModuleObject + ": Preceding errors cause termination." );  // LCOV_EXCL_LINE
 		}
 		// if the BEPS report has been called for than initialize its arrays
 		if ( displayTabularBEPS || displayDemandEndUse || displaySourceEnergyEndUseSummary || displayLEEDSummary ) {
@@ -2517,14 +2517,14 @@ namespace OutputReportTabular {
 		namedMonthly( 62 ).title = "MechanicalVentilationLoadsMonthly";
 
 		if ( numNamedMonthly != NumMonthlyReports ) {
-			ShowFatalError( "InitializePredefinedMonthlyTitles: Number of Monthly Reports in OutputReportTabular=[" + RoundSigDigits( numNamedMonthly ) + "] does not match number in DataOutputs=[" + RoundSigDigits( NumMonthlyReports ) + "]." );
+			ShowFatalError( "InitializePredefinedMonthlyTitles: Number of Monthly Reports in OutputReportTabular=[" + RoundSigDigits( numNamedMonthly ) + "] does not match number in DataOutputs=[" + RoundSigDigits( NumMonthlyReports ) + "]." );  // LCOV_EXCL_LINE
 		} else {
 			for ( xcount = 1; xcount <= numNamedMonthly; ++xcount ) {
 				if ( ! SameString( MonthlyNamedReports( xcount ), namedMonthly( xcount ).title ) ) {
 					ShowSevereError( "InitializePredefinedMonthlyTitles: Monthly Report Titles in OutputReportTabular do not match titles in DataOutput." );
 					ShowContinueError( "first mismatch at ORT [" + RoundSigDigits( numNamedMonthly ) + "] =\"" + namedMonthly( xcount ).title + "\"." );
 					ShowContinueError( "same location in DO =\"" + MonthlyNamedReports( xcount ) + "\"." );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -3490,7 +3490,7 @@ namespace OutputReportTabular {
 					DisplayString( "Writing tabular output file results using comma format." );
 					tbl_stream.open( DataStringGlobals::outputTblCsvFileName );
 					if ( ! tbl_stream ) {
-						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblCsvFileName + "\" for output (write)." );
+						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblCsvFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 					}
 					tbl_stream << "Program Version:" << curDel << VerString << '\n';
 					tbl_stream << "Tabular Output Report in Format: " << curDel << "Comma\n";
@@ -3506,7 +3506,7 @@ namespace OutputReportTabular {
 					DisplayString( "Writing tabular output file results using tab format." );
 					tbl_stream.open( DataStringGlobals::outputTblTabFileName );
 					if ( ! tbl_stream ) {
-						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblTabFileName + "\" for output (write)." );
+						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblTabFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 					}
 					tbl_stream << "Program Version" << curDel << VerString << '\n';
 					tbl_stream << "Tabular Output Report in Format: " << curDel << "Tab\n";
@@ -3522,7 +3522,7 @@ namespace OutputReportTabular {
 					DisplayString( "Writing tabular output file results using HTML format." );
 					tbl_stream.open( DataStringGlobals::outputTblHtmFileName );
 					if ( ! tbl_stream ) {
-						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblHtmFileName + "\" for output (write)." );
+						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblHtmFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 					}
 					tbl_stream << "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\"http://www.w3.org/TR/html4/loose.dtd\">\n";
 					tbl_stream << "<html>\n";
@@ -3553,7 +3553,7 @@ namespace OutputReportTabular {
 					DisplayString( "Writing tabular output file results using XML format." );
 					tbl_stream.open( DataStringGlobals::outputTblXmlFileName );
 					if ( ! tbl_stream ) {
-						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblXmlFileName + "\" for output (write)." );
+						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblXmlFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 					}
 					tbl_stream << "<?xml version=\"1.0\"?>\n";
 					tbl_stream << "<EnergyPlusTabularReports>\n";
@@ -3574,7 +3574,7 @@ namespace OutputReportTabular {
 					DisplayString( "Writing tabular output file results using text format." );
 					tbl_stream.open( DataStringGlobals::outputTblTxtFileName );
 					if ( ! tbl_stream ) {
-						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblTxtFileName + "\" for output (write)." );
+						ShowFatalError( "OpenOutputTabularFile: Could not open file \"" + DataStringGlobals::outputTblTxtFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 					}
 					tbl_stream << "Program Version: " << VerString << '\n';
 					tbl_stream << "Tabular Output Report in Format: " << curDel << "Fixed\n";
@@ -5473,7 +5473,7 @@ namespace OutputReportTabular {
 			statFile = GetNewUnitNumber();
 			{ IOFlags flags; flags.ACTION( "READ" ); gio::open( statFile, DataStringGlobals::inStatFileName, flags ); readStat = flags.ios(); }
 			if ( readStat != 0 ) {
-				ShowFatalError( "FillWeatherPredefinedEntries: Could not open file "+DataStringGlobals::inStatFileName+" for input (read)." );
+				ShowFatalError( "FillWeatherPredefinedEntries: Could not open file "+DataStringGlobals::inStatFileName+" for input (read)." );  // LCOV_EXCL_LINE
 			}
 			IOFlags flags;
 			while ( readStat == 0 ) { //end of file, or error
@@ -7732,13 +7732,13 @@ namespace OutputReportTabular {
 			unconvert = largeConversionFactor / 1000000000.0; //to avoid double converting, the values for the LEED report should be in GJ
 			//  Energy Use Intensities
 			if ( buildingGrossFloorArea > 0 ) {
-				PreDefTableEntry( pdchLeedEuiElec, "Interior Lighting (All)", unconvert * 1000 * useVal( colElectricity, 3 ) / buildingGrossFloorArea, 2 ); 
+				PreDefTableEntry( pdchLeedEuiElec, "Interior Lighting (All)", unconvert * 1000 * useVal( colElectricity, 3 ) / buildingGrossFloorArea, 2 );
 				PreDefTableEntry( pdchLeedEuiElec, "Space Heating", unconvert * 1000 * useVal( colElectricity, 1 ) / buildingGrossFloorArea, 2 );
 				PreDefTableEntry( pdchLeedEuiElec, "Space Cooling", unconvert * 1000 * useVal( colElectricity, 2 ) / buildingGrossFloorArea, 2 );
-				PreDefTableEntry( pdchLeedEuiElec, "Fans (All)", unconvert * 1000 * useVal( colElectricity, 7 ) / buildingGrossFloorArea, 2 );  
+				PreDefTableEntry( pdchLeedEuiElec, "Fans (All)", unconvert * 1000 * useVal( colElectricity, 7 ) / buildingGrossFloorArea, 2 );
 				PreDefTableEntry( pdchLeedEuiElec, "Service Water Heating", unconvert * 1000 * useVal( colElectricity, 12 ) / buildingGrossFloorArea, 2 );
 				PreDefTableEntry( pdchLeedEuiElec, "Receptacle Equipment", unconvert * 1000 * useVal( colElectricity, 5 ) / buildingGrossFloorArea, 2 );
-				PreDefTableEntry( pdchLeedEuiElec, "Miscellaneous (All)", unconvert * 1000 * ( useVal( colElectricity, 15 ) ) / buildingGrossFloorArea, 2 ); 
+				PreDefTableEntry( pdchLeedEuiElec, "Miscellaneous (All)", unconvert * 1000 * ( useVal( colElectricity, 15 ) ) / buildingGrossFloorArea, 2 );
 				PreDefTableEntry( pdchLeedEuiElec, "Subtotal", unconvert * 1000 * useVal( colElectricity, 15 ) / buildingGrossFloorArea, 2 );
 			}
 
@@ -7757,7 +7757,7 @@ namespace OutputReportTabular {
 			if ( buildingGrossFloorArea > 0 ) {
 				PreDefTableEntry( pdchLeedEuiNatG, "Space Heating", unconvert * 1000 * useVal( colGas, 1 ) / buildingGrossFloorArea, 2 );
 				PreDefTableEntry( pdchLeedEuiNatG, "Service Water Heating", unconvert * 1000 * useVal( colGas, 12 ) / buildingGrossFloorArea, 2 );
-				PreDefTableEntry( pdchLeedEuiNatG, "Miscellaneous (All)", unconvert * 1000 * useVal( colGas, 15 ) / buildingGrossFloorArea, 2 ); 
+				PreDefTableEntry( pdchLeedEuiNatG, "Miscellaneous (All)", unconvert * 1000 * useVal( colGas, 15 ) / buildingGrossFloorArea, 2 );
 				PreDefTableEntry( pdchLeedEuiNatG, "Subtotal", unconvert * 1000 * useVal( colGas, 15 ) / buildingGrossFloorArea, 2 );
 			}
 			PreDefTableEntry( pdchLeedEusTotal, "Natural Gas", unconvert * useVal( colGas, 15 ), 2 );
@@ -7794,10 +7794,10 @@ namespace OutputReportTabular {
 			leedSiteRecept = 0.0;
 			leedSiteTotal = 0.0;
 			for ( iResource = 1; iResource <= 5; ++iResource ) { // don't bother with water
-				leedSiteIntLite += useVal( iResource, 3 ); 
+				leedSiteIntLite += useVal( iResource, 3 );
 				leedSiteSpHeat += useVal( iResource, 1 );
 				leedSiteSpCool += useVal( iResource, 2 );
-				leedSiteFanInt += useVal( iResource, 7 ); 
+				leedSiteFanInt += useVal( iResource, 7 );
 				leedSiteSrvWatr += useVal( iResource, 12 );
 				leedSiteRecept += useVal( iResource, 5 );
 				leedSiteTotal += useVal( iResource, 15 );

--- a/src/EnergyPlus/OutputReportTabularAnnual.cc
+++ b/src/EnergyPlus/OutputReportTabularAnnual.cc
@@ -261,11 +261,11 @@ namespace EnergyPlus {
 				}
 			}
 			if ( invalidAggregationOrderFound ) {
-				ShowFatalError( "OutputReportTabularAnnual: Invalid aggregations detected, no simulation performed." );
+				ShowFatalError( "OutputReportTabularAnnual: Invalid aggregations detected, no simulation performed." );  // LCOV_EXCL_LINE
 			}
 		}
 
-		// Generate an error message if an advanced aggregation kind columns don't follow the appropriate column - Glazer 2017 
+		// Generate an error message if an advanced aggregation kind columns don't follow the appropriate column - Glazer 2017
 		bool
 		AnnualTable::invalidAggregationOrder( )
 		{

--- a/src/EnergyPlus/OutputReports.cc
+++ b/src/EnergyPlus/OutputReports.cc
@@ -279,7 +279,7 @@ LinesOut( std::string const & option )
 	unit = GetNewUnitNumber();
 	{ IOFlags flags; flags.ACTION( "write" ); gio::open( unit, DataStringGlobals::outputSlnFileName, flags ); write_stat = flags.ios(); }
 	if ( write_stat != 0 ) {
-		ShowFatalError( "LinesOut: Could not open file "+ DataStringGlobals::outputSlnFileName +" for output (write)." );
+		ShowFatalError( "LinesOut: Could not open file "+ DataStringGlobals::outputSlnFileName +" for output (write)." );  // LCOV_EXCL_LINE
 	}
 
 	if ( option != "IDF" ) {
@@ -468,7 +468,7 @@ DXFOut(
 	unit = GetNewUnitNumber();
 	{ IOFlags flags; flags.ACTION( "write" ); gio::open( unit, DataStringGlobals::outputDxfFileName, flags ); write_stat = flags.ios(); }
 	if ( write_stat != 0 ) {
-		ShowFatalError( "DXFOut: Could not open file "+DataStringGlobals::outputDxfFileName+" for output (write)." );
+		ShowFatalError( "DXFOut: Could not open file "+DataStringGlobals::outputDxfFileName+" for output (write)." );  // LCOV_EXCL_LINE
 	}
 
 	gio::write( unit, Format_702 ); // Start of Entities section
@@ -960,7 +960,7 @@ DXFOutLines( std::string const & ColorScheme )
 	unit = GetNewUnitNumber();
 	{ IOFlags flags; flags.ACTION( "write" ); gio::open( unit, DataStringGlobals::outputDxfFileName, flags ); write_stat = flags.ios(); }
 	if ( write_stat != 0 ) {
-		ShowFatalError( "DXFOutLines: Could not open file "+DataStringGlobals::outputDxfFileName+" for output (write)." );
+		ShowFatalError( "DXFOutLines: Could not open file "+DataStringGlobals::outputDxfFileName+" for output (write)." );  // LCOV_EXCL_LINE
 	}
 
 	gio::write( unit, Format_702 ); // Start of Entities section
@@ -1386,7 +1386,7 @@ DXFOutWireFrame( std::string const & ColorScheme )
 	unit = GetNewUnitNumber();
 	{ IOFlags flags; flags.ACTION( "write" ); gio::open( unit, DataStringGlobals::outputDxfFileName, flags ); write_stat = flags.ios(); }
 	if ( write_stat != 0 ) {
-		ShowFatalError( "DXFOutWireFrame: Could not open file "+DataStringGlobals::outputDxfFileName+" for output (write)." );
+		ShowFatalError( "DXFOutWireFrame: Could not open file "+DataStringGlobals::outputDxfFileName+" for output (write)." );  // LCOV_EXCL_LINE
 	}
 
 	gio::write( unit, Format_702 ); // Start of Entities section
@@ -2148,7 +2148,7 @@ CostInfoOut()
 	// .sci = surface cost info
 	{ IOFlags flags; flags.ACTION( "write" ); gio::open( unit, DataStringGlobals::outputSciFileName, flags ); write_stat = flags.ios(); }
 	if ( write_stat != 0 ) {
-		ShowFatalError( "CostInfoOut: Could not open file "+DataStringGlobals::outputSciFileName+" for output (write)." );
+		ShowFatalError( "CostInfoOut: Could not open file "+DataStringGlobals::outputSciFileName+" for output (write)." );  // LCOV_EXCL_LINE
 	}
 	gio::write( unit, fmtLD ) << TotSurfaces << int( count( uniqueSurf ) );
 	gio::write( unit, fmtLD ) << "data for surfaces useful for cost information";
@@ -2276,7 +2276,7 @@ VRMLOut(
 	unit = GetNewUnitNumber();
 	{ IOFlags flags; flags.ACTION( "write" ); gio::open( unit, DataStringGlobals::outputWrlFileName, flags ); write_stat = flags.ios(); }
 	if ( write_stat != 0 ) {
-		ShowFatalError( "VRMLOut: Could not open file "+ DataStringGlobals::outputWrlFileName +" for output (write)." );
+		ShowFatalError( "VRMLOut: Could not open file "+ DataStringGlobals::outputWrlFileName +" for output (write)." );  // LCOV_EXCL_LINE
 	}
 
 	gio::write( unit, Format_702 ); // Beginning

--- a/src/EnergyPlus/OutsideEnergySources.cc
+++ b/src/EnergyPlus/OutsideEnergySources.cc
@@ -197,17 +197,17 @@ namespace OutsideEnergySources {
 		if ( CompIndex == 0 ) {
 			EqNum = FindItemInList( EquipName, EnergySource );
 			if ( EqNum == 0 ) {
-				ShowFatalError( "SimOutsideEnergy: Unit not found=" + EquipName );
+				ShowFatalError( "SimOutsideEnergy: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = EqNum;
 		} else {
 			EqNum = CompIndex;
 			if ( EnergySource( EqNum ).CheckEquipName ) {
 				if ( EqNum > NumDistrictUnits || EqNum < 1 ) {
-					ShowFatalError( "SimOutsideEnergy:  Invalid CompIndex passed=" + TrimSigDigits( EqNum ) + ", Number of Units=" + TrimSigDigits( NumDistrictUnits ) + ", Entered Unit name=" + EquipName );
+					ShowFatalError( "SimOutsideEnergy:  Invalid CompIndex passed=" + TrimSigDigits( EqNum ) + ", Number of Units=" + TrimSigDigits( NumDistrictUnits ) + ", Entered Unit name=" + EquipName );  // LCOV_EXCL_LINE
 				}
 				if ( EquipName != EnergySource( EqNum ).Name ) {
-					ShowFatalError( "SimOutsideEnergy: Invalid CompIndex passed=" + TrimSigDigits( EqNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + EnergySource( EqNum ).Name );
+					ShowFatalError( "SimOutsideEnergy: Invalid CompIndex passed=" + TrimSigDigits( EqNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + EnergySource( EqNum ).Name );  // LCOV_EXCL_LINE
 				}
 				EnergySource( EqNum ).CheckEquipName = false;
 			}
@@ -349,7 +349,7 @@ namespace OutsideEnergySources {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject + ", Preceding condition caused termination." );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject + ", Preceding condition caused termination." );  // LCOV_EXCL_LINE
 		}
 
 		EnergySourceNum = 0;
@@ -413,7 +413,7 @@ namespace OutsideEnergySources {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject + ", Preceding condition caused termination." );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject + ", Preceding condition caused termination." );  // LCOV_EXCL_LINE
 		}
 
 		EnergySourceNum = NumDistrictUnitsHeat; //To initialize counter
@@ -493,13 +493,13 @@ namespace OutsideEnergySources {
 			} else if ( EnergySource( EnergySourceNum ).EnergyType == EnergyType_DistrictCooling ) {
 				TempTypeFlag = TypeOf_PurchChilledWater;
 			} else {
-				ShowFatalError( "InitSimVars: Invalid EnergyType for District Heating/Cooling=" + EnergySource( EnergySourceNum ).Name );
+				ShowFatalError( "InitSimVars: Invalid EnergyType for District Heating/Cooling=" + EnergySource( EnergySourceNum ).Name );  // LCOV_EXCL_LINE
 			}
 			// Locate the unit on the plant loops for later usage
 			errFlag = false;
 			ScanPlantLoopsForObject( EnergySource( EnergySourceNum ).Name, TempTypeFlag, EnergySource( EnergySourceNum ).LoopNum, EnergySource( EnergySourceNum ).LoopSideNum, EnergySource( EnergySourceNum ).BranchNum, EnergySource( EnergySourceNum ).CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitSimVars: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitSimVars: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			// set limits on outlet node temps to plant loop limits
 			PlantLoop( EnergySource( EnergySourceNum ).LoopNum ).LoopSide( EnergySource( EnergySourceNum ).LoopSideNum ).Branch( EnergySource( EnergySourceNum ).BranchNum ).Comp( EnergySource( EnergySourceNum ).CompNum ).MinOutletTemp = PlantLoop( EnergySource( EnergySourceNum ).LoopNum ).MinTemp;
@@ -636,7 +636,7 @@ namespace OutsideEnergySources {
 			}
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 	}
 

--- a/src/EnergyPlus/PackagedTerminalHeatPump.cc
+++ b/src/EnergyPlus/PackagedTerminalHeatPump.cc
@@ -280,7 +280,7 @@ namespace PackagedTerminalHeatPump {
 		if ( CompIndex == 0 ) {
 			PTUnitNum = FindItemInList( CompName, PTUnit );
 			if ( PTUnitNum == 0 ) {
-				ShowFatalError( "SimPackagedTerminalUnit: Unit not found=" + CompName );
+				ShowFatalError( "SimPackagedTerminalUnit: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = PTUnit( PTUnitNum ).PTObjectIndex;
 		} else {
@@ -295,11 +295,11 @@ namespace PackagedTerminalHeatPump {
 				assert( false );
 			}}
 			if ( PTUnitNum > NumPTUs || PTUnitNum < 1 ) {
-				ShowFatalError( "SimPackagedTerminalUnit:  Invalid CompIndex passed=" + TrimSigDigits( PTUnitNum ) + ", Number of Units=" + TrimSigDigits( NumPTUs ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimPackagedTerminalUnit:  Invalid CompIndex passed=" + TrimSigDigits( PTUnitNum ) + ", Number of Units=" + TrimSigDigits( NumPTUs ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( PTUnitNum ) ) {
 				if ( CompName != PTUnit( PTUnitNum ).Name ) {
-					ShowFatalError( "SimPackagedTerminalUnit: Invalid CompIndex passed=" + TrimSigDigits( PTUnitNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + PTUnit( PTUnitNum ).Name );
+					ShowFatalError( "SimPackagedTerminalUnit: Invalid CompIndex passed=" + TrimSigDigits( PTUnitNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + PTUnit( PTUnitNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( PTUnitNum ) = false;
 			}
@@ -2853,7 +2853,7 @@ namespace PackagedTerminalHeatPump {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input." );
+			ShowFatalError( RoutineName + "Errors found in getting input." );  // LCOV_EXCL_LINE
 			ShowContinueError( "... Preceding condition causes termination." );
 		}
 
@@ -3053,7 +3053,7 @@ namespace PackagedTerminalHeatPump {
 					ScanPlantLoopsForObject( PTUnit( PTUnitNum ).ACHeatCoilName, TypeOf_CoilWaterSimpleHeating, PTUnit( PTUnitNum ).LoopNum, PTUnit( PTUnitNum ).LoopSide, PTUnit( PTUnitNum ).BranchNum, PTUnit( PTUnitNum ).CompNum, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
 						ShowContinueError( "Reference Unit=\"" + PTUnit( PTUnitNum ).Name + "\", type=" + PTUnit( PTUnitNum ).UnitType );
-						ShowFatalError( "InitPTUnit: Program terminated for previous conditions." );
+						ShowFatalError( "InitPTUnit: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 
 					PTUnit( PTUnitNum ).MaxHeatCoilFluidFlow = GetCoilMaxWaterFlowRate( "Coil:Heating:Water", PTUnit( PTUnitNum ).ACHeatCoilName, ErrorsFound );
@@ -3070,7 +3070,7 @@ namespace PackagedTerminalHeatPump {
 					ScanPlantLoopsForObject( PTUnit( PTUnitNum ).ACHeatCoilName, TypeOf_CoilSteamAirHeating, PTUnit( PTUnitNum ).LoopNum, PTUnit( PTUnitNum ).LoopSide, PTUnit( PTUnitNum ).BranchNum, PTUnit( PTUnitNum ).CompNum, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
 						ShowContinueError( "Reference Unit=\"" + PTUnit( PTUnitNum ).Name + "\", type=" + PTUnit( PTUnitNum ).UnitType );
-						ShowFatalError( "InitPTUnit: Program terminated for previous conditions." );
+						ShowFatalError( "InitPTUnit: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 
 					PTUnit( PTUnitNum ).MaxHeatCoilFluidFlow = GetCoilMaxSteamFlowRate( PTUnit( PTUnitNum ).ACHeatCoilIndex, ErrorsFound );
@@ -3092,7 +3092,7 @@ namespace PackagedTerminalHeatPump {
 					errFlag = false;
 					ScanPlantLoopsForObject( PTUnit( PTUnitNum ).SuppHeatCoilName, TypeOf_CoilWaterSimpleHeating, PTUnit( PTUnitNum ).LoopNum, PTUnit( PTUnitNum ).LoopSide, PTUnit( PTUnitNum ).BranchNum, PTUnit( PTUnitNum ).CompNum, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitPTUnit: Program terminated for previous conditions." );
+						ShowFatalError( "InitPTUnit: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 					PTUnit( PTUnitNum ).MaxSuppCoilFluidFlow = GetCoilMaxWaterFlowRate( "Coil:Heating:Water", PTUnit( PTUnitNum ).SuppHeatCoilName, ErrorsFound );
 
@@ -3104,7 +3104,7 @@ namespace PackagedTerminalHeatPump {
 					errFlag = false;
 					ScanPlantLoopsForObject( PTUnit( PTUnitNum ).SuppHeatCoilName, TypeOf_CoilSteamAirHeating, PTUnit( PTUnitNum ).LoopNum, PTUnit( PTUnitNum ).LoopSide, PTUnit( PTUnitNum ).BranchNum, PTUnit( PTUnitNum ).CompNum, _, _, _, _, _, errFlag );
 					if ( errFlag ) {
-						ShowFatalError( "InitPTUnit: Program terminated for previous conditions." );
+						ShowFatalError( "InitPTUnit: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 					}
 					PTUnit( PTUnitNum ).MaxSuppCoilFluidFlow = GetCoilMaxSteamFlowRate( PTUnit( PTUnitNum ).SuppHeatCoilIndex, ErrorsFound );
 					if ( PTUnit( PTUnitNum ).MaxSuppCoilFluidFlow > 0.0 ) {
@@ -3203,7 +3203,7 @@ namespace PackagedTerminalHeatPump {
 					GetFanVolFlow( PTUnit( PTUnitNum ).FanIndex, PTUnit( PTUnitNum ).ActualFanVolFlowRate );
 				}
 
-				
+
 			}
 		}
 
@@ -3255,7 +3255,7 @@ namespace PackagedTerminalHeatPump {
 				} else {
 					GetFanVolFlow( PTUnit( PTUnitNum ).FanIndex, PTUnit( PTUnitNum ).FanVolFlow );
 				}
-				
+
 				if ( PTUnit( PTUnitNum ).FanVolFlow != AutoSize ) {
 					//     Check fan versus system supply air flow rates
 					if ( PTUnit( PTUnitNum ).FanVolFlow + 1e-10 < PTUnit( PTUnitNum ).CoolVolumeFlowRate( NumOfSpeedCooling ) ) {
@@ -4200,9 +4200,9 @@ namespace PackagedTerminalHeatPump {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
-		
+
 		DataScalableCapSizingON = false;
 
 	}
@@ -4592,7 +4592,7 @@ namespace PackagedTerminalHeatPump {
 			} else {
 				Fans::SimulateFanComponents( PTUnit( PTUnitNum ).FanName, FirstHVACIteration, PTUnit( PTUnitNum ).FanIndex, FanSpeedRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
 			}
-			
+
 		}
 
 		if ( CoolingLoad && OutsideDryBulbTemp > PTUnit( PTUnitNum ).MinOATCompressorCooling ) {
@@ -6013,7 +6013,7 @@ namespace PackagedTerminalHeatPump {
 						}
 					}
 				} else if ( SolFla == -2 ) {
-					ShowFatalError( "VS WSHP unit cycling ratio calculation failed: cycling limits exceeded, for unit=" + PTUnit( PTUnitNum ).Name );
+					ShowFatalError( "VS WSHP unit cycling ratio calculation failed: cycling limits exceeded, for unit=" + PTUnit( PTUnitNum ).Name );  // LCOV_EXCL_LINE
 				}
 			} else {
 				// Check to see which speed to meet the load
@@ -6064,7 +6064,7 @@ namespace PackagedTerminalHeatPump {
 						}
 					}
 				} else if ( SolFla == -2 ) {
-					ShowFatalError( "VS WSHP unit compressor speed calculation failed: speed limits exceeded, for unit=" + PTUnit( PTUnitNum ).Name );
+					ShowFatalError( "VS WSHP unit compressor speed calculation failed: speed limits exceeded, for unit=" + PTUnit( PTUnitNum ).Name );  // LCOV_EXCL_LINE
 				}
 			}
 		}

--- a/src/EnergyPlus/PackagedThermalStorageCoil.cc
+++ b/src/EnergyPlus/PackagedThermalStorageCoil.cc
@@ -219,17 +219,17 @@ namespace PackagedThermalStorageCoil {
 		if ( CompIndex == 0 ) {
 			TESCoilNum = FindItemInList( CompName, TESCoil );
 			if ( TESCoilNum == 0 ) {
-				ShowFatalError( "Thermal Energy Storage Cooling Coil not found=" + CompName );
+				ShowFatalError( "Thermal Energy Storage Cooling Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = TESCoilNum;
 		} else {
 			TESCoilNum = CompIndex;
 			if ( TESCoilNum > NumTESCoils || TESCoilNum < 1 ) {
-				ShowFatalError( "SimTESCoil: Invalid CompIndex passed=" + TrimSigDigits( TESCoilNum ) + ", Number of Thermal Energy Storage Cooling Coil Coils=" + TrimSigDigits( NumTESCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "SimTESCoil: Invalid CompIndex passed=" + TrimSigDigits( TESCoilNum ) + ", Number of Thermal Energy Storage Cooling Coil Coils=" + TrimSigDigits( NumTESCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( TESCoilNum ) ) {
 				if ( ! CompName.empty() && CompName != TESCoil( TESCoilNum ).Name ) {
-					ShowFatalError( "SimTESCoil: Invalid CompIndex passed=" + TrimSigDigits( TESCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + TESCoil( TESCoilNum ).Name );
+					ShowFatalError( "SimTESCoil: Invalid CompIndex passed=" + TrimSigDigits( TESCoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + TESCoil( TESCoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( TESCoilNum ) = false;
 			}
@@ -1618,7 +1618,7 @@ namespace PackagedThermalStorageCoil {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + cCurrentModuleObject + " input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + cCurrentModuleObject + " input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		// setup reporting
@@ -1765,7 +1765,7 @@ namespace PackagedThermalStorageCoil {
 
 				// double check node names match
 				if ( errFlag ) {
-					ShowFatalError( "InitTESCoil: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitTESCoil: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				TESCoil( TESCoilNum ).TESPlantLoopNum = plloopnum;
 				TESCoil( TESCoilNum ).TESPlantLoopSideNum = lsnum;
@@ -1782,7 +1782,7 @@ namespace PackagedThermalStorageCoil {
 					errFlag = true;
 				}
 				if ( errFlag ) {
-					ShowFatalError( "InitTESCoil: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitTESCoil: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 
 			} // any plant connection to TES

--- a/src/EnergyPlus/PhaseChangeModeling/HysteresisModel.cc
+++ b/src/EnergyPlus/PhaseChangeModeling/HysteresisModel.cc
@@ -371,14 +371,14 @@ namespace EnergyPlus {
 				// still validate the name to make sure there aren't any duplicates or blanks
 				// blanks are easy: fatal if blank
 				if ( DataIPShortCuts::lAlphaFieldBlanks[0] ) {
-					ShowFatalError( "Invalid input for " + DataIPShortCuts::cCurrentModuleObject +
+					ShowFatalError( "Invalid input for " + DataIPShortCuts::cCurrentModuleObject +  // LCOV_EXCL_LINE
 									" object: Name cannot be blank" );
 				}
 
 				// we just need to loop over the existing vector elements to check for duplicates since we haven't add this one yet
 				for ( auto &existingHysteresisModel : hysteresisPhaseChangeModels ) {
 					if ( DataIPShortCuts::cAlphaArgs( 1 ) == existingHysteresisModel.name ) {
-						ShowFatalError( "Invalid input for " + DataIPShortCuts::cCurrentModuleObject +
+						ShowFatalError( "Invalid input for " + DataIPShortCuts::cCurrentModuleObject +  // LCOV_EXCL_LINE
 										" object: Duplicate name found: " + existingHysteresisModel.name );
 					}
 				}

--- a/src/EnergyPlus/PhotovoltaicThermalCollectors.cc
+++ b/src/EnergyPlus/PhotovoltaicThermalCollectors.cc
@@ -212,22 +212,22 @@ namespace PhotovoltaicThermalCollectors {
 			if ( PVTnum == 0 ) {
 				PVTnum = FindItemInList( PVTName, PVT );
 				if ( PVTnum == 0 ) {
-					ShowFatalError( "SimPVTcollectors: Unit not found=" + PVTName() );
+					ShowFatalError( "SimPVTcollectors: Unit not found=" + PVTName() );  // LCOV_EXCL_LINE
 				}
 			} else {
 				if ( PVTnum > NumPVT || PVTnum < 1 ) {
-					ShowFatalError( "SimPVTcollectors: Invalid PVT index passed = " + TrimSigDigits( PVTnum ) + ", Number of PVT units=" + TrimSigDigits( NumPVT ) + ", Entered Unit name=" + PVTName() );
+					ShowFatalError( "SimPVTcollectors: Invalid PVT index passed = " + TrimSigDigits( PVTnum ) + ", Number of PVT units=" + TrimSigDigits( NumPVT ) + ", Entered Unit name=" + PVTName() );  // LCOV_EXCL_LINE
 				}
 				if ( CheckEquipName( PVTnum ) ) {
 					if ( PVTName != PVT( PVTnum ).Name ) {
-						ShowFatalError( "SimPVTcollectors: Invalid PVT index passed = " + TrimSigDigits( PVTnum ) + ", Unit name=" + PVTName() + ", stored name for that index=" + PVT( PVTnum ).Name );
+						ShowFatalError( "SimPVTcollectors: Invalid PVT index passed = " + TrimSigDigits( PVTnum ) + ", Unit name=" + PVTName() + ", stored name for that index=" + PVT( PVTnum ).Name );  // LCOV_EXCL_LINE
 					}
 					CheckEquipName( PVTnum ) = false;
 				}
 			}
 		} else {
 			if ( PVTnum > NumPVT || PVTnum < 1 ) {
-				ShowFatalError( "SimPVTcollectors: Invalid PVT index passed = " + TrimSigDigits( PVTnum ) + ", Number of PVT units=" + TrimSigDigits( NumPVT ) + ", Entered Unit name=" + PVTName() );
+				ShowFatalError( "SimPVTcollectors: Invalid PVT index passed = " + TrimSigDigits( PVTnum ) + ", Number of PVT units=" + TrimSigDigits( NumPVT ) + ", Entered Unit name=" + PVTName() );  // LCOV_EXCL_LINE
 			}
 		} // compName present
 
@@ -520,7 +520,7 @@ namespace PhotovoltaicThermalCollectors {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for photovoltaic thermal collectors" );
+			ShowFatalError( "Errors found in processing input for photovoltaic thermal collectors" );  // LCOV_EXCL_LINE
 		}
 
 		if ( allocated( tmpSimplePVTperf ) ) tmpSimplePVTperf.deallocate();
@@ -588,7 +588,7 @@ namespace PhotovoltaicThermalCollectors {
 				errFlag = false;
 				ScanPlantLoopsForObject( PVT( PVTnum ).Name, PVT( PVTnum ).TypeNum, PVT( PVTnum ).WLoopNum, PVT( PVTnum ).WLoopSideNum, PVT( PVTnum ).WLoopBranchNum, PVT( PVTnum ).WLoopCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitPVTcollectors: Program terminated for previous conditions." );
+					ShowFatalError( "InitPVTcollectors: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				SetLoopIndexFlag( PVTnum ) = false;
 			}
@@ -916,7 +916,7 @@ namespace PhotovoltaicThermalCollectors {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/Photovoltaics.cc
+++ b/src/EnergyPlus/Photovoltaics.cc
@@ -202,17 +202,17 @@ namespace Photovoltaics {
 		if ( GeneratorIndex == 0 ) {
 			PVnum = FindItemInList( GeneratorName, PVarray );
 			if ( PVnum == 0 ) {
-				ShowFatalError( "SimPhotovoltaicGenerator: Specified PV not one of valid Photovoltaic Generators " + GeneratorName );
+				ShowFatalError( "SimPhotovoltaicGenerator: Specified PV not one of valid Photovoltaic Generators " + GeneratorName );  // LCOV_EXCL_LINE
 			}
 			GeneratorIndex = PVnum;
 		} else {
 			PVnum = GeneratorIndex;
 			if ( PVnum > NumPVs || PVnum < 1 ) {
-				ShowFatalError( "SimPhotovoltaicGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( PVnum ) + ", Number of PVs=" + TrimSigDigits( NumPVs ) + ", Generator name=" + GeneratorName );
+				ShowFatalError( "SimPhotovoltaicGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( PVnum ) + ", Number of PVs=" + TrimSigDigits( NumPVs ) + ", Generator name=" + GeneratorName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( PVnum ) ) {
 				if ( GeneratorName != PVarray( PVnum ).Name ) {
-					ShowFatalError( "SimPhotovoltaicGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( PVnum ) + ", Generator name=" + GeneratorName + ", stored PV Name for that index=" + PVarray( PVnum ).Name );
+					ShowFatalError( "SimPhotovoltaicGenerator: Invalid GeneratorIndex passed=" + TrimSigDigits( PVnum ) + ", Generator name=" + GeneratorName + ", stored PV Name for that index=" + PVarray( PVnum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( PVnum ) = false;
 			}
@@ -238,7 +238,7 @@ namespace Photovoltaics {
 
 		} else {
 
-			ShowFatalError( "Specified generator model type not found for PV generator = " + GeneratorName );
+			ShowFatalError( "Specified generator model type not found for PV generator = " + GeneratorName );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -753,7 +753,7 @@ namespace Photovoltaics {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting photovoltaic input" );
+			ShowFatalError( "Errors found in getting photovoltaic input" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -764,7 +764,7 @@ namespace Photovoltaics {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Rick Strand
 		//       DATE WRITTEN   Sept 2017
-		
+
 		// PURPOSE OF THIS SUBROUTINE:
 		// Get the zone number for this PV array for use when zone multipliers are applied
 
@@ -772,20 +772,20 @@ namespace Photovoltaics {
 		using DataGlobals::NumOfZones;
 		using DataSurfaces::Surface;
 		using InputProcessor::FindItemInList;
-		
+
 		int GetPVZone( 0 );
-		
+
 		if ( SurfNum > 0 ) {
 			GetPVZone = Surface( SurfNum ).Zone;
 				if ( GetPVZone == 0 ) { // might need to get the zone number from the name
 					GetPVZone = FindItemInList( Surface( SurfNum ).ZoneName, Zone, NumOfZones );
 				}
 		}
-		
+
 		return GetPVZone;
-		
+
 	}
-	
+
 	// **************************************
 
 	void
@@ -901,7 +901,7 @@ namespace Photovoltaics {
 		int thisZone; // working index for zones
 
 		PVarray( PVnum ).Report.DCEnergy = PVarray( PVnum ).Report.DCPower * ( TimeStepSys * SecInHour );
-		
+
 		// add check for multiplier.  if surface is attached to a zone that is on a multiplier
 		// then PV production should be multiplied out as well
 
@@ -1725,7 +1725,7 @@ namespace Photovoltaics {
 			ShowContinueError( "Check input data in " + cPVEquiv1DiodePerfObjectName );
 			ShowContinueError( "VV (voltage) = " + RoundSigDigits( VV, 5 ) );
 			ShowContinueError( "II (current) = " + RoundSigDigits( II, 5 ) );
-			ShowFatalError( "FUN: EnergyPlus terminates because of numerical problem in EquivalentOne-Diode PV model" );
+			ShowFatalError( "FUN: EnergyPlus terminates because of numerical problem in EquivalentOne-Diode PV model" );  // LCOV_EXCL_LINE
 		}
 
 		return FUN;
@@ -1785,7 +1785,7 @@ namespace Photovoltaics {
 			ShowContinueError( "Check input data in " + cPVEquiv1DiodePerfObjectName );
 			ShowContinueError( "VV (voltage) = " + RoundSigDigits( VV, 5 ) );
 			ShowContinueError( "II (current) = " + RoundSigDigits( II, 5 ) );
-			ShowFatalError( "FI: EnergyPlus terminates because of numerical problem in EquivalentOne-Diode PV model" );
+			ShowFatalError( "FI: EnergyPlus terminates because of numerical problem in EquivalentOne-Diode PV model" );  // LCOV_EXCL_LINE
 		}
 
 		return FI;
@@ -1846,7 +1846,7 @@ namespace Photovoltaics {
 			ShowContinueError( "Check input data in " + cPVEquiv1DiodePerfObjectName );
 			ShowContinueError( "VV (voltage) = " + RoundSigDigits( VV, 5 ) );
 			ShowContinueError( "II (current) = " + RoundSigDigits( II, 5 ) );
-			ShowFatalError( "FI: EnergyPlus terminates because of numerical problem in EquivalentOne-Diode PV model" );
+			ShowFatalError( "FI: EnergyPlus terminates because of numerical problem in EquivalentOne-Diode PV model" );  // LCOV_EXCL_LINE
 		}
 
 		return FV;
@@ -2719,7 +2719,7 @@ namespace Photovoltaics {
 
 		if ( SurfacePtr == 0 ) {
 			// should be trapped already
-			ShowFatalError( "Invalid surface passed to GetExtVentedCavityIndex" );
+			ShowFatalError( "Invalid surface passed to GetExtVentedCavityIndex" );  // LCOV_EXCL_LINE
 		}
 
 		CavNum = 0;
@@ -2734,7 +2734,7 @@ namespace Photovoltaics {
 		}
 
 		if ( ! Found ) {
-			ShowFatalError( "Did not find surface in Exterior Vented Cavity description in GetExtVentedCavityIndex, Surface name = " + Surface( SurfacePtr ).Name );
+			ShowFatalError( "Did not find surface in Exterior Vented Cavity description in GetExtVentedCavityIndex, Surface name = " + Surface( SurfacePtr ).Name );  // LCOV_EXCL_LINE
 		} else {
 
 			VentCavIndex = CavNum;

--- a/src/EnergyPlus/PipeHeatTransfer.cc
+++ b/src/EnergyPlus/PipeHeatTransfer.cc
@@ -177,7 +177,7 @@ namespace PipeHeatTransfer {
 			}
 		}
 		// If we didn't find it, fatal
-		ShowFatalError( "PipeHTFactory: Error getting inputs for pipe named: " + objectName );
+		ShowFatalError( "PipeHTFactory: Error getting inputs for pipe named: " + objectName );  // LCOV_EXCL_LINE
 		// Shut up the compiler
 		return nullptr;
 	}
@@ -662,7 +662,7 @@ namespace PipeHeatTransfer {
 
 		// final error check
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetPipesHeatTransfer: Errors found in input. Preceding conditions cause termination." );
+			ShowFatalError( "GetPipesHeatTransfer: Errors found in input. Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Set up the output variables CurrentModuleObject='Pipe:Indoor/Outdoor/Underground'
@@ -871,7 +871,7 @@ namespace PipeHeatTransfer {
 			errFlag = false;
 			ScanPlantLoopsForObject( this->Name, this->TypeOf, this->LoopNum, this->LoopSideNum, this->BranchNum, this->CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitPipesHeatTransfer: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitPipesHeatTransfer: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			// unset one-time flag
 			this->OneTimeInit = false;

--- a/src/EnergyPlus/Pipes.cc
+++ b/src/EnergyPlus/Pipes.cc
@@ -135,7 +135,7 @@ namespace Pipes {
 			}
 		}
 		// If we didn't find it, fatal
-		ShowFatalError( "LocalPipeDataFactory: Error getting inputs for pipe named: " + objectName );
+		ShowFatalError( "LocalPipeDataFactory: Error getting inputs for pipe named: " + objectName );  // LCOV_EXCL_LINE
 		// Shut up the compiler
 		return nullptr;
 	}
@@ -146,10 +146,10 @@ namespace Pipes {
 			bool errFlag = false;
 			DataPlant::ScanPlantLoopsForObject( this->Name, this->TypeOf, this->LoopNum, this->LoopSide, this->BranchIndex, this->CompIndex, _, _, FoundOnLoop, _, _, errFlag );
 			if ( FoundOnLoop == 0 ) {
-				ShowFatalError( "SimPipes: Pipe=\"" + this->Name + "\" not found on a Plant Loop." );
+				ShowFatalError( "SimPipes: Pipe=\"" + this->Name + "\" not found on a Plant Loop." );  // LCOV_EXCL_LINE
 			}
 			if ( errFlag ) {
-				ShowFatalError( "SimPipes: Program terminated due to previous condition(s)." );
+				ShowFatalError( "SimPipes: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			this->OneTimeInit = false;
 		}
@@ -265,7 +265,7 @@ namespace Pipes {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetPipeInput: Errors getting input for pipes" );
+			ShowFatalError( "GetPipeInput: Errors getting input for pipes" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/PlantCentralGSHP.cc
+++ b/src/EnergyPlus/PlantCentralGSHP.cc
@@ -204,17 +204,17 @@ namespace PlantCentralGSHP {
 		if ( CompIndex == 0 ) {
 			WrapperNum = FindItemInList( WrapperName, Wrapper );
 			if ( WrapperNum == 0 ) {
-				ShowFatalError( "SimCentralGroundSourceHeatPump: Specified Wrapper not one of Valid Wrappers=" + WrapperName );
+				ShowFatalError( "SimCentralGroundSourceHeatPump: Specified Wrapper not one of Valid Wrappers=" + WrapperName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = WrapperNum;
 		} else {
 			WrapperNum = CompIndex;
 			if ( WrapperNum > NumWrappers || WrapperNum < 1 ) {
-				ShowFatalError( "SimCentralGroundSourceHeatPump:  Invalid CompIndex passed=" + TrimSigDigits( WrapperNum ) + ", Number of Units=" + TrimSigDigits( NumWrappers ) + ", Entered Unit name=" + WrapperName );
+				ShowFatalError( "SimCentralGroundSourceHeatPump:  Invalid CompIndex passed=" + TrimSigDigits( WrapperNum ) + ", Number of Units=" + TrimSigDigits( NumWrappers ) + ", Entered Unit name=" + WrapperName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( WrapperNum ) ) {
 				if ( WrapperName != Wrapper( WrapperNum ).Name ) {
-					ShowFatalError( "SimCentralGroundSourceHeatPump:  Invalid CompIndex passed=" + TrimSigDigits( WrapperNum ) + ", Unit name=" + WrapperName + ", stored Unit Name for that index=" + Wrapper( WrapperNum ).Name );
+					ShowFatalError( "SimCentralGroundSourceHeatPump:  Invalid CompIndex passed=" + TrimSigDigits( WrapperNum ) + ", Unit name=" + WrapperName + ", stored Unit Name for that index=" + Wrapper( WrapperNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( WrapperNum ) = false;
 			}
@@ -558,7 +558,7 @@ namespace PlantCentralGSHP {
 				}
 
 				if ( ErrorsFound ) {
-					ShowFatalError( "Preceding sizing errors cause program termination" );
+					ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 				}
 
 			}
@@ -737,12 +737,12 @@ namespace PlantCentralGSHP {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "GetWrapperInput: Invalid " + cCurrentModuleObject + " Input, preceding condition(s) cause termination." );
+				ShowFatalError( "GetWrapperInput: Invalid " + cCurrentModuleObject + " Input, preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 
 			// ALLOCATE ARRAYS
 			if ( ( NumChillerHeaters == 0 ) && ( Wrapper( WrapperNum ).ControlMode == SmartMixing ) ) {
-				ShowFatalError( "SmartMixing Control Mode in object " + cCurrentModuleObject + " : " + Wrapper( WrapperNum ).Name + " need to apply to ChillerHeaterPerformance:Electric:EIR object(s)." );
+				ShowFatalError( "SmartMixing Control Mode in object " + cCurrentModuleObject + " : " + Wrapper( WrapperNum ).Name + " need to apply to ChillerHeaterPerformance:Electric:EIR object(s)." );  // LCOV_EXCL_LINE
 			}
 
 		}
@@ -768,7 +768,7 @@ namespace PlantCentralGSHP {
 					if ( CompIndex <= 0 ) {
 						ShowSevereError( "GetWrapperInput: Invalid Chiller Heater Modules Performance Component Name =" + CompName );
 						ShowContinueError( "Select the name of ChillerHeaterPerformance:Electric:EIR object(s) from the object list." );
-						ShowFatalError( "Program terminates due to preceding condition." );
+						ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 					}
 					Wrapper( WrapperNum ).WrapperComp( Comp ).WrapperPerformanceObjectIndex = CompIndex;
 					if ( ChillerHeater( CompIndex ).VariableFlow ) {
@@ -1226,7 +1226,7 @@ namespace PlantCentralGSHP {
 		}
 
 		if ( CHErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1660,7 +1660,7 @@ namespace PlantCentralGSHP {
 			if ( CompNum > Wrapper( WrapperNum ).NumOfComp ) {
 				ShowSevereError( "CalcChillerModel: ChillerHeater=\"" + Wrapper( WrapperNum ).Name + "\", calculated component number too big." );
 				ShowContinueError( "Max number of components=[" + RoundSigDigits( Wrapper( WrapperNum ).NumOfComp ) + "], indicated component number=[" + RoundSigDigits( CompNum ) + "]." );
-				ShowFatalError( "Program terminates due to preceding condition." );
+				ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 			}
 
 			// Check whether this chiller heater needs to run

--- a/src/EnergyPlus/PlantChillers.cc
+++ b/src/EnergyPlus/PlantChillers.cc
@@ -336,17 +336,17 @@ namespace PlantChillers {
 			if ( CompIndex == 0 ) {
 				ChillNum = FindItemInList( ChillerName, ElectricChiller.ma( &ElectricChillerSpecs::Base ) );
 				if ( ChillNum == 0 ) {
-					ShowFatalError( "SimElectricChiller: Specified Chiller not one of Valid Electric Chillers=" + ChillerName );
+					ShowFatalError( "SimElectricChiller: Specified Chiller not one of Valid Electric Chillers=" + ChillerName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = ChillNum;
 			} else {
 				ChillNum = CompIndex;
 				if ( ChillNum > NumElectricChillers || ChillNum < 1 ) {
-					ShowFatalError( "SimElectricChiller:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumElectricChillers ) + ", Entered Unit name=" + ChillerName );
+					ShowFatalError( "SimElectricChiller:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumElectricChillers ) + ", Entered Unit name=" + ChillerName );  // LCOV_EXCL_LINE
 				}
 				if ( ElectricChiller( ChillNum ).Base.CheckEquipName ) {
 					if ( ChillerName != ElectricChiller( ChillNum ).Base.Name ) {
-						ShowFatalError( "SimElectricChiller: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + ChillerName + ", stored Unit Name for that index=" + ElectricChiller( ChillNum ).Base.Name );
+						ShowFatalError( "SimElectricChiller: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + ChillerName + ", stored Unit Name for that index=" + ElectricChiller( ChillNum ).Base.Name );  // LCOV_EXCL_LINE
 					}
 					ElectricChiller( ChillNum ).Base.CheckEquipName = false;
 				}
@@ -398,17 +398,17 @@ namespace PlantChillers {
 			if ( CompIndex == 0 ) {
 				ChillNum = FindItemInList( ChillerName, EngineDrivenChiller.ma( &EngineDrivenChillerSpecs::Base ) );
 				if ( ChillNum == 0 ) {
-					ShowFatalError( "SimEngineDrivenChiller: Specified Chiller not one of Valid EngineDriven Chillers=" + ChillerName );
+					ShowFatalError( "SimEngineDrivenChiller: Specified Chiller not one of Valid EngineDriven Chillers=" + ChillerName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = ChillNum;
 			} else {
 				ChillNum = CompIndex;
 				if ( ChillNum > NumEngineDrivenChillers || ChillNum < 1 ) {
-					ShowFatalError( "SimEngineDrivenChiller:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumEngineDrivenChillers ) + ", Entered Unit name=" + ChillerName );
+					ShowFatalError( "SimEngineDrivenChiller:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumEngineDrivenChillers ) + ", Entered Unit name=" + ChillerName );  // LCOV_EXCL_LINE
 				}
 				if ( EngineDrivenChiller( ChillNum ).Base.CheckEquipName ) {
 					if ( ChillerName != EngineDrivenChiller( ChillNum ).Base.Name ) {
-						ShowFatalError( "SimEngineDrivenChiller: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + ChillerName + ", stored Unit Name for that index=" + EngineDrivenChiller( ChillNum ).Base.Name );
+						ShowFatalError( "SimEngineDrivenChiller: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + ChillerName + ", stored Unit Name for that index=" + EngineDrivenChiller( ChillNum ).Base.Name );  // LCOV_EXCL_LINE
 					}
 					EngineDrivenChiller( ChillNum ).Base.CheckEquipName = false;
 				}
@@ -457,17 +457,17 @@ namespace PlantChillers {
 			if ( CompIndex == 0 ) {
 				ChillNum = FindItemInList( ChillerName, GTChiller.ma( &GTChillerSpecs::Base ) );
 				if ( ChillNum == 0 ) {
-					ShowFatalError( "SimGTChiller: Specified Chiller not one of Valid Gas Turbine Chillers=" + ChillerName );
+					ShowFatalError( "SimGTChiller: Specified Chiller not one of Valid Gas Turbine Chillers=" + ChillerName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = ChillNum;
 			} else {
 				ChillNum = CompIndex;
 				if ( ChillNum > NumGTChillers || ChillNum < 1 ) {
-					ShowFatalError( "SimGTChiller:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumGTChillers ) + ", Entered Unit name=" + ChillerName );
+					ShowFatalError( "SimGTChiller:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumGTChillers ) + ", Entered Unit name=" + ChillerName );  // LCOV_EXCL_LINE
 				}
 				if ( GTChiller( ChillNum ).Base.CheckEquipName ) {
 					if ( ChillerName != GTChiller( ChillNum ).Base.Name ) {
-						ShowFatalError( "SimGTChiller: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + ChillerName + ", stored Unit Name for that index=" + GTChiller( ChillNum ).Base.Name );
+						ShowFatalError( "SimGTChiller: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + ChillerName + ", stored Unit Name for that index=" + GTChiller( ChillNum ).Base.Name );  // LCOV_EXCL_LINE
 					}
 					GTChiller( ChillNum ).Base.CheckEquipName = false;
 				}
@@ -520,17 +520,17 @@ namespace PlantChillers {
 			if ( CompIndex == 0 ) {
 				ChillNum = FindItemInList( ChillerName, ConstCOPChiller.ma( &ConstCOPChillerSpecs::Base ) );
 				if ( ChillNum == 0 ) {
-					ShowFatalError( "SimConstCOPChiller: Specified Chiller not one of Valid Constant COP Chillers=" + ChillerName );
+					ShowFatalError( "SimConstCOPChiller: Specified Chiller not one of Valid Constant COP Chillers=" + ChillerName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = ChillNum;
 			} else {
 				ChillNum = CompIndex;
 				if ( ChillNum > NumConstCOPChillers || ChillNum < 1 ) {
-					ShowFatalError( "SimConstCOPChiller:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumConstCOPChillers ) + ", Entered Unit name=" + ChillerName );
+					ShowFatalError( "SimConstCOPChiller:  Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Number of Units=" + TrimSigDigits( NumConstCOPChillers ) + ", Entered Unit name=" + ChillerName );  // LCOV_EXCL_LINE
 				}
 				if ( ConstCOPChiller( ChillNum ).Base.CheckEquipName ) {
 					if ( ChillerName != ConstCOPChiller( ChillNum ).Base.Name ) {
-						ShowFatalError( "SimConstCOPChiller: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + ChillerName + ", stored Unit Name for that index=" + ConstCOPChiller( ChillNum ).Base.Name );
+						ShowFatalError( "SimConstCOPChiller: Invalid CompIndex passed=" + TrimSigDigits( ChillNum ) + ", Unit name=" + ChillerName + ", stored Unit Name for that index=" + ConstCOPChiller( ChillNum ).Base.Name );  // LCOV_EXCL_LINE
 					}
 					ConstCOPChiller( ChillNum ).Base.CheckEquipName = false;
 				}
@@ -912,7 +912,7 @@ namespace PlantChillers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( ChillerNum = 1; ChillerNum <= NumElectricChillers; ++ChillerNum ) {
@@ -1240,7 +1240,7 @@ namespace PlantChillers {
 
 			EngineDrivenChiller( ChillerNum ).FuelHeatingValue = rNumericArgs( 25 );
 
-			// add support of autosize to this. 
+			// add support of autosize to this.
 
 			EngineDrivenChiller( ChillerNum ).DesignHeatRecVolFlowRate = rNumericArgs( 26 );
 			if ( EngineDrivenChiller( ChillerNum ).DesignHeatRecVolFlowRate > 0.0 || EngineDrivenChiller( ChillerNum ).DesignHeatRecVolFlowRate ==  DataSizing::AutoSize ) {
@@ -1353,7 +1353,7 @@ namespace PlantChillers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( ChillerNum = 1; ChillerNum <= NumEngineDrivenChillers; ++ChillerNum ) {
@@ -1795,7 +1795,7 @@ namespace PlantChillers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( ChillerNum = 1; ChillerNum <= NumGTChillers; ++ChillerNum ) {
@@ -2092,7 +2092,7 @@ namespace PlantChillers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( ChillerNum = 1; ChillerNum <= NumConstCOPChillers; ++ChillerNum ) {
@@ -2235,7 +2235,7 @@ namespace PlantChillers {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "InitElectricChiller: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitElectricChiller: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ElectricChiller( ChillNum ).Base.FlowMode == ConstantFlow ) {
@@ -2517,7 +2517,7 @@ namespace PlantChillers {
 				InterConnectTwoPlantLoopSides( EngineDrivenChiller( ChillNum ).Base.CDLoopNum, EngineDrivenChiller( ChillNum ).Base.CDLoopSideNum, EngineDrivenChiller( ChillNum ).HRLoopNum, EngineDrivenChiller( ChillNum ).HRLoopSideNum, TypeOf_Chiller_EngineDriven, false );
 			}
 			if ( errFlag ) {
-				ShowFatalError( "InitEngineDrivenChiller: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitEngineDrivenChiller: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( EngineDrivenChiller( ChillNum ).Base.FlowMode == ConstantFlow ) {
@@ -2757,7 +2757,7 @@ namespace PlantChillers {
 				InterConnectTwoPlantLoopSides( GTChiller( ChillNum ).Base.CDLoopNum, GTChiller( ChillNum ).Base.CDLoopSideNum, GTChiller( ChillNum ).HRLoopNum, GTChiller( ChillNum ).HRLoopSideNum, TypeOf_Chiller_CombTurbine, false );
 			}
 			if ( errFlag ) {
-				ShowFatalError( "InitGTChiller: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitGTChiller: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( GTChiller( ChillNum ).Base.FlowMode == ConstantFlow ) {
@@ -2975,7 +2975,7 @@ namespace PlantChillers {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "CalcConstCOPChillerModel: Program terminated due to previous condition(s)." );
+				ShowFatalError( "CalcConstCOPChillerModel: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			if ( ConstCOPChiller( ChillNum ).Base.FlowMode == ConstantFlow ) {
 				// reset flow priority
@@ -3305,7 +3305,7 @@ namespace PlantChillers {
 			RegisterPlantCompDesignFlow( ElectricChiller( ChillNum ).Base.CondInletNodeNum, tmpCondVolFlowRate );
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ElectricChiller( ChillNum ).HeatRecActive ) {
@@ -3592,7 +3592,7 @@ namespace PlantChillers {
 			RegisterPlantCompDesignFlow( EngineDrivenChiller( ChillNum ).Base.CondInletNodeNum, tmpCondVolFlowRate );
 		}
 
-		// autosize support for heat recovery flow rate. 
+		// autosize support for heat recovery flow rate.
 		if ( EngineDrivenChiller( ChillNum ).HeatRecActive ) {
 			Real64 tmpHeatRecVolFlowRate = tmpCondVolFlowRate * EngineDrivenChiller( ChillNum ).HeatRecCapacityFraction;
 			if ( PlantFirstSizesOkayToFinalize ) {
@@ -3644,7 +3644,7 @@ namespace PlantChillers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -3878,7 +3878,7 @@ namespace PlantChillers {
 		// save the design condenser water volumetric flow rate for use by the condenser water loop sizing algorithms
 		if ( GTChiller( ChillNum ).Base.CondenserType == WaterCooled ) RegisterPlantCompDesignFlow( GTChiller( ChillNum ).Base.CondInletNodeNum, tmpCondVolFlowRate );
 
-		GTEngineCapacityDes = GTChiller( ChillNum ).Base.NomCap / ( GTChiller( ChillNum ).engineCapacityScalar * GTChiller( ChillNum ).Base.COP ); 
+		GTEngineCapacityDes = GTChiller( ChillNum ).Base.NomCap / ( GTChiller( ChillNum ).engineCapacityScalar * GTChiller( ChillNum ).Base.COP );
 		if ( PlantFirstSizesOkayToFinalize ) {
 			if ( GTChiller( ChillNum ).GTEngineCapacityWasAutoSized ) {
 				GTChiller( ChillNum ).GTEngineCapacity = GTEngineCapacityDes;
@@ -3909,7 +3909,7 @@ namespace PlantChillers {
 			}
 		}
 
-		// autosize support for heat recovery flow rate. 
+		// autosize support for heat recovery flow rate.
 		if ( GTChiller( ChillNum ).HeatRecActive ) {
 			Real64 tmpHeatRecVolFlowRate = GTChiller( ChillNum ).Base.CondVolFlowRate * GTChiller( ChillNum ).HeatRecCapacityFraction;
 			if ( PlantFirstSizesOkayToFinalize ) {
@@ -3960,7 +3960,7 @@ namespace PlantChillers {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -4193,7 +4193,7 @@ namespace PlantChillers {
 		if ( ConstCOPChiller( ChillNum ).Base.CondenserType == WaterCooled ) RegisterPlantCompDesignFlow( ConstCOPChiller( ChillNum ).Base.CondInletNodeNum, tmpCondVolFlowRate );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 		//create predefined report
@@ -4425,16 +4425,16 @@ namespace PlantChillers {
 			int FaultIndex = ElectricChiller( ChillNum ).Base.FaultyChillerFoulingIndex;
 			Real64 NomCap_ff = ChillerNomCap;
 			Real64 RatedCOP_ff = RatedCOP;
-			
+
 			//calculate the Faulty Chiller Fouling Factor using fault information
 			ElectricChiller( ChillNum ).Base.FaultyChillerFoulingFactor = FaultsChillerFouling( FaultIndex ).CalFoulingFactor();
-			
+
 			//update the Chiller nominal capacity and COP at faulty cases
 			ChillerNomCap = NomCap_ff * ElectricChiller( ChillNum ).Base.FaultyChillerFoulingFactor;
 			RatedCOP = RatedCOP_ff * ElectricChiller( ChillNum ).Base.FaultyChillerFoulingFactor;
-			
+
 		}
-		
+
 		// initialize outlet air humidity ratio of air or evap cooled chillers
 		CondOutletHumRat = Node( CondInletNode ).HumRat;
 
@@ -4483,15 +4483,15 @@ namespace PlantChillers {
 		if( ElectricChiller( ChillNum ).Base.FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = ElectricChiller( ChillNum ).Base.FaultyChillerSWTIndex;
 			Real64 EvapOutletTemp_ff = TempEvapOut;
-			
+
 			//calculate the sensor offset using fault information
 			ElectricChiller( ChillNum ).Base.FaultyChillerSWTOffset = FaultsChillerSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempEvapOut
 			TempEvapOut = max( ElectricChiller( ChillNum ).TempLowLimitEvapOut, min( Node( EvapInletNode ).Temp, EvapOutletTemp_ff - ElectricChiller( ChillNum ).Base.FaultyChillerSWTOffset ));
 			ElectricChiller( ChillNum ).Base.FaultyChillerSWTOffset = EvapOutletTemp_ff - TempEvapOut;
-			
+
 		}
-		
+
 		//Calculate chiller performance from this set of performance equations.
 		//  from BLAST...Z=(TECONDW-ADJTC(1))/ADJTC(2)-(TLCHLRW-ADJTC(3))
 
@@ -4695,7 +4695,7 @@ namespace PlantChillers {
 					EvapOutletTemp = Node( EvapInletNode ).Temp;
 				}
 			}
-		
+
 			//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 			if( ElectricChiller( ChillNum ).Base.FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) && ( EvapMassFlowRate > 0 )){
 				//calculate directly affected variables at faulty case: EvapOutletTemp, EvapMassFlowRate, QEvaporator
@@ -4791,7 +4791,7 @@ namespace PlantChillers {
 					ShowContinueError( "Check input for condenser plant loop, especially cooling tower" );
 					ShowContinueError( "Evaporator inlet temperature: " + RoundSigDigits( Node( EvapInletNode ).Temp, 2 ) );
 
-					ShowFatalError( "Program Terminates due to previous error condition" );
+					ShowFatalError( "Program Terminates due to previous error condition" );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( ! WarmupFlag ) {
@@ -4801,7 +4801,7 @@ namespace PlantChillers {
 					ShowContinueError( "Check input for Capacity Ratio Curve" );
 					ShowContinueError( "Condenser inlet temperature: " + RoundSigDigits( CondInletTemp, 2 ) );
 					ShowContinueError( "Evaporator inlet temperature: " + RoundSigDigits( Node( EvapInletNode ).Temp, 2 ) );
-					ShowFatalError( "Program Terminates due to previous error condition" );
+					ShowFatalError( "Program Terminates due to previous error condition" );  // LCOV_EXCL_LINE
 				}
 			}
 			// If makes it here, set limits, chiller can't have negative energy/power
@@ -5084,20 +5084,20 @@ namespace PlantChillers {
 		LoopNum = EngineDrivenChiller( ChillerNum ).Base.CWLoopNum;
 		LoopSideNum = EngineDrivenChiller( ChillerNum ).Base.CWLoopSideNum;
 		EvapMassFlowRateMax = EngineDrivenChiller( ChillerNum ).Base.EvapMassFlowRateMax;
-		
+
 		//If there is a fault of chiller fouling (zrp_Nov2016)
 		if( EngineDrivenChiller( ChillerNum ).Base.FaultyChillerFoulingFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = EngineDrivenChiller( ChillerNum ).Base.FaultyChillerFoulingIndex;
 			Real64 NomCap_ff = ChillerNomCap;
 			Real64 COP_ff = COP;
-			
+
 			//calculate the Faulty Chiller Fouling Factor using fault information
 			EngineDrivenChiller( ChillerNum ).Base.FaultyChillerFoulingFactor = FaultsChillerFouling( FaultIndex ).CalFoulingFactor();
-			
+
 			//update the Chiller nominal capacity and COP at faulty cases
 			ChillerNomCap = NomCap_ff * EngineDrivenChiller( ChillerNum ).Base.FaultyChillerFoulingFactor;
 			COP = COP_ff * EngineDrivenChiller( ChillerNum ).Base.FaultyChillerFoulingFactor;
-			
+
 		}
 
 		//*********************************
@@ -5106,13 +5106,13 @@ namespace PlantChillers {
 		if( EngineDrivenChiller( ChillerNum ).Base.FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = EngineDrivenChiller( ChillerNum ).Base.FaultyChillerSWTIndex;
 			Real64 EvapOutletTemp_ff = TempEvapOut;
-			
+
 			//calculate the sensor offset using fault information
 			EngineDrivenChiller( ChillerNum ).Base.FaultyChillerSWTOffset = FaultsChillerSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempEvapOut
 			TempEvapOut = max( EngineDrivenChiller( ChillerNum ).TempLowLimitEvapOut, min( Node( EvapInletNode ).Temp, EvapOutletTemp_ff - EngineDrivenChiller( ChillerNum ).Base.FaultyChillerSWTOffset ));
 			EngineDrivenChiller( ChillerNum ).Base.FaultyChillerSWTOffset = EvapOutletTemp_ff - TempEvapOut;
-			
+
 		}
 
 		//Calculate chiller performance from this set of performance equations.
@@ -5220,7 +5220,7 @@ namespace PlantChillers {
 				// ChillerPartLoadRatio = PartLoadRat;
 				EvapDeltaTemp = Node( EvapInletNode ).Temp - EvapOutletTemp;
 			}
-			
+
 		} else { // If FlowLock is True
 
 			EvapMassFlowRate = Node( EvapInletNode ).MassFlowRate;
@@ -5298,7 +5298,7 @@ namespace PlantChillers {
 					EvapOutletTemp = Node( EvapInletNode ).Temp;
 				}
 			}
-		
+
 			//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 			if( EngineDrivenChiller( ChillerNum ).Base.FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) && ( EvapMassFlowRate > 0 )){
 				//calculate directly affected variables at faulty case: EvapOutletTemp, EvapMassFlowRate, QEvaporator
@@ -5451,7 +5451,7 @@ namespace PlantChillers {
 					ShowContinueError( "Check input for condenser plant loop, especially cooling tower" );
 					ShowContinueError( "Evaporator inlet temperature: " + RoundSigDigits( Node( EvapInletNode ).Temp, 2 ) );
 
-					ShowFatalError( "Program Terminates due to previous error condition" );
+					ShowFatalError( "Program Terminates due to previous error condition" );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( ! WarmupFlag ) {
@@ -5461,7 +5461,7 @@ namespace PlantChillers {
 					ShowContinueError( "Check input for Capacity Ratio Curve" );
 					ShowContinueError( "Condenser inlet temperature: " + RoundSigDigits( CondInletTemp, 2 ) );
 					ShowContinueError( "Evaporator inlet temperature: " + RoundSigDigits( Node( EvapInletNode ).Temp, 2 ) );
-					ShowFatalError( "Program Terminates due to previous error condition" );
+					ShowFatalError( "Program Terminates due to previous error condition" );  // LCOV_EXCL_LINE
 				}
 			}
 			// If makes it here, set limits, chiller can't have negative energy/power
@@ -5736,20 +5736,20 @@ namespace PlantChillers {
 		EvapMassFlowRateMax = GTChiller( ChillerNum ).Base.EvapMassFlowRateMax;
 		LoopNum = GTChiller( ChillerNum ).Base.CWLoopNum;
 		LoopSideNum = GTChiller( ChillerNum ).Base.CWLoopSideNum;
-		
+
 		//If there is a fault of chiller fouling (zrp_Nov2016)
 		if( GTChiller( ChillerNum ).Base.FaultyChillerFoulingFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation )){
 			int FaultIndex = GTChiller( ChillerNum ).Base.FaultyChillerFoulingIndex;
 			Real64 NomCap_ff = ChillerNomCap;
 			Real64 COP_ff = COP;
-			
+
 			//calculate the Faulty Chiller Fouling Factor using fault information
 			GTChiller( ChillerNum ).Base.FaultyChillerFoulingFactor = FaultsChillerFouling( FaultIndex ).CalFoulingFactor();
-			
+
 			//update the Chiller nominal capacity and COP at faulty cases
-			ChillerNomCap = NomCap_ff * GTChiller( ChillerNum ).Base.FaultyChillerFoulingFactor;			
+			ChillerNomCap = NomCap_ff * GTChiller( ChillerNum ).Base.FaultyChillerFoulingFactor;
 			COP = COP_ff * GTChiller( ChillerNum ).Base.FaultyChillerFoulingFactor;
-			
+
 		}
 
 		//*********************************
@@ -5758,13 +5758,13 @@ namespace PlantChillers {
 		if( GTChiller( ChillerNum ).Base.FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = GTChiller( ChillerNum ).Base.FaultyChillerSWTIndex;
 			Real64 EvapOutletTemp_ff = TempEvapOut;
-			
+
 			//calculate the sensor offset using fault information
 			GTChiller( ChillerNum ).Base.FaultyChillerSWTOffset = FaultsChillerSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempEvapOut
 			TempEvapOut = max( GTChiller( ChillerNum ).TempLowLimitEvapOut, min( Node( EvapInletNode ).Temp, EvapOutletTemp_ff - GTChiller( ChillerNum ).Base.FaultyChillerSWTOffset ));
 			GTChiller( ChillerNum ).Base.FaultyChillerSWTOffset = EvapOutletTemp_ff - TempEvapOut;
-			
+
 		}
 
 		//Calculate chiller performance from this set of performance equations.
@@ -5870,7 +5870,7 @@ namespace PlantChillers {
 				// ChillerPartLoadRatio = PartLoadRat;
 				EvapDeltaTemp = Node( EvapInletNode ).Temp - EvapOutletTemp;
 			}
-			
+
 		} else { // If FlowLock is True
 
 			EvapMassFlowRate = Node( EvapInletNode ).MassFlowRate;
@@ -5942,7 +5942,7 @@ namespace PlantChillers {
 					EvapOutletTemp = Node( EvapInletNode ).Temp;
 				}
 			}
-		
+
 			//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 			if( GTChiller( ChillerNum ).Base.FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) && ( EvapMassFlowRate > 0 )){
 				//calculate directly affected variables at faulty case: EvapOutletTemp, EvapMassFlowRate, QEvaporator
@@ -6188,7 +6188,7 @@ namespace PlantChillers {
 					ShowContinueError( "Check input for condenser plant loop, especially cooling tower" );
 					ShowContinueError( "Evaporator inlet temperature: " + RoundSigDigits( Node( EvapInletNode ).Temp, 2 ) );
 
-					ShowFatalError( "Program Terminates due to previous error condition" );
+					ShowFatalError( "Program Terminates due to previous error condition" );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( ! WarmupFlag ) {
@@ -6198,7 +6198,7 @@ namespace PlantChillers {
 					ShowContinueError( "Check input for Capacity Ratio Curve" );
 					ShowContinueError( "Condenser inlet temperature: " + RoundSigDigits( CondInletTemp, 2 ) );
 					ShowContinueError( "Evaporator inlet temperature: " + RoundSigDigits( Node( EvapInletNode ).Temp, 2 ) );
-					ShowFatalError( "Program Terminates due to previous error condition" );
+					ShowFatalError( "Program Terminates due to previous error condition" );  // LCOV_EXCL_LINE
 				}
 			}
 			// If makes it here, set limits, chiller can't have negative energy/power
@@ -6219,7 +6219,7 @@ namespace PlantChillers {
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Dan Fisher
 		//       DATE WRITTEN   Sept. 1998
-		//       MODIFIED       Nov.-Dec. 2001, Jan. 2002, Richard Liesen 
+		//       MODIFIED       Nov.-Dec. 2001, Jan. 2002, Richard Liesen
 		//                      Feb. 2010, Chandan Sharma, FSEC. Added basin heater
 		//                      Jun. 2016, Rongpeng Zhang, LBNL. Applied the chiller supply water temperature sensor fault model
 		//                      Nov. 2016, Rongpeng Zhang, LBNL. Added Fouling Chiller fault
@@ -6300,16 +6300,16 @@ namespace PlantChillers {
 			int FaultIndex = ConstCOPChiller( ChillNum ).Base.FaultyChillerFoulingIndex;
 			Real64 NomCap_ff = ChillerNomCap;
 			Real64 COP_ff = COP;
-			
+
 			//calculate the Faulty Chiller Fouling Factor using fault information
 			ConstCOPChiller( ChillNum ).Base.FaultyChillerFoulingFactor = FaultsChillerFouling( FaultIndex ).CalFoulingFactor();
-			
+
 			//update the Chiller nominal capacity and COP at faulty cases
 			ChillerNomCap = NomCap_ff * ConstCOPChiller( ChillNum ).Base.FaultyChillerFoulingFactor;
-			COP = COP_ff * ConstCOPChiller( ChillNum ).Base.FaultyChillerFoulingFactor; 
-			
+			COP = COP_ff * ConstCOPChiller( ChillNum ).Base.FaultyChillerFoulingFactor;
+
 		}
-		
+
 		//set module level chiller inlet and temperature variables
 		LoopNum = ConstCOPChiller( ChillNum ).Base.CWLoopNum;
 		LoopSideNum = ConstCOPChiller( ChillNum ).Base.CWLoopSideNum;
@@ -6332,15 +6332,15 @@ namespace PlantChillers {
 		if( ConstCOPChiller( ChillNum ).Base.FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) ){
 			int FaultIndex = ConstCOPChiller( ChillNum ).Base.FaultyChillerSWTIndex;
 			Real64 EvapOutletTemp_ff = TempEvapOutSetPoint;
-			
+
 			//calculate the sensor offset using fault information
 			ConstCOPChiller( ChillNum ).Base.FaultyChillerSWTOffset = FaultsChillerSWTSensor( FaultIndex ).CalFaultOffsetAct();
 			//update the TempEvapOutSetPoint
 			TempEvapOutSetPoint = min( Node( EvapInletNode ).Temp, EvapOutletTemp_ff - ConstCOPChiller( ChillNum ).Base.FaultyChillerSWTOffset );
 			ConstCOPChiller( ChillNum ).Base.FaultyChillerSWTOffset = EvapOutletTemp_ff - TempEvapOutSetPoint;
-			
+
 		}
-		
+
 		EvapDeltaTemp = std::abs( Node( EvapInletNode ).Temp - TempEvapOutSetPoint );
 		EvapInletTemp = Node( EvapInletNode ).Temp;
 
@@ -6575,7 +6575,7 @@ namespace PlantChillers {
 					EvapOutletTemp = Node( EvapInletNode ).Temp;
 				}
 			}
-		
+
 			//If there is a fault of Chiller SWT Sensor (zrp_Jun2016)
 			if( ConstCOPChiller( ChillNum ).Base.FaultyChillerSWTFlag && ( ! WarmupFlag ) && ( ! DoingSizing ) && ( ! KickOffSimulation ) && ( EvapMassFlowRate > 0 )){
 				//calculate directly affected variables at faulty case: EvapOutletTemp, EvapMassFlowRate, QEvaporator
@@ -6647,7 +6647,7 @@ namespace PlantChillers {
 					ShowContinueError( "Check input for condenser plant loop, especially cooling tower" );
 					ShowContinueError( "Evaporator inlet temperature: " + RoundSigDigits( Node( EvapInletNode ).Temp, 2 ) );
 
-					ShowFatalError( "Program Terminates due to previous error condition" );
+					ShowFatalError( "Program Terminates due to previous error condition" );  // LCOV_EXCL_LINE
 				}
 			}
 			// If makes it here, set limits, chiller can't have negative energy/power

--- a/src/EnergyPlus/PlantComponentTemperatureSources.cc
+++ b/src/EnergyPlus/PlantComponentTemperatureSources.cc
@@ -168,17 +168,17 @@ namespace PlantComponentTemperatureSources {
 		if ( CompIndex == 0 ) {
 			SourceNum = FindItemInList( SourceName, WaterSource );
 			if ( SourceNum == 0 ) {
-				ShowFatalError( "SimWaterSource: Specified heat exchanger not one of Valid heat exchangers=" + SourceName );
+				ShowFatalError( "SimWaterSource: Specified heat exchanger not one of Valid heat exchangers=" + SourceName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = SourceNum;
 		} else {
 			SourceNum = CompIndex;
 			if ( SourceNum > NumSources || SourceNum < 1 ) {
-				ShowFatalError( "SimWaterSource:  Invalid CompIndex passed=" + TrimSigDigits( SourceNum ) + ", Number of Units=" + TrimSigDigits( NumSources ) + ", Entered Unit name=" + SourceName );
+				ShowFatalError( "SimWaterSource:  Invalid CompIndex passed=" + TrimSigDigits( SourceNum ) + ", Number of Units=" + TrimSigDigits( NumSources ) + ", Entered Unit name=" + SourceName );  // LCOV_EXCL_LINE
 			}
 			if ( WaterSource( SourceNum ).CheckEquipName ) {
 				if ( SourceName != WaterSource( SourceNum ).Name ) {
-					ShowFatalError( "SimWaterSource: Invalid CompIndex passed=" + TrimSigDigits( SourceNum ) + ", Unit name=" + SourceName + ", stored Unit Name for that index=" + WaterSource( SourceNum ).Name );
+					ShowFatalError( "SimWaterSource: Invalid CompIndex passed=" + TrimSigDigits( SourceNum ) + ", Unit name=" + SourceName + ", stored Unit Name for that index=" + WaterSource( SourceNum ).Name );  // LCOV_EXCL_LINE
 				}
 				WaterSource( SourceNum ).CheckEquipName = false;
 			}
@@ -312,7 +312,7 @@ namespace PlantComponentTemperatureSources {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		for ( SourceNum = 1; SourceNum <= NumSources; ++SourceNum ) {
@@ -389,7 +389,7 @@ namespace PlantComponentTemperatureSources {
 			errFlag = false;
 			ScanPlantLoopsForObject( WaterSource( SourceNum ).Name, TypeOf_WaterSource, WaterSource( SourceNum ).Location.loopNum, WaterSource( SourceNum ).Location.loopSideNum, WaterSource( SourceNum ).Location.branchNum, WaterSource( SourceNum ).Location.compNum, _, _, _, WaterSource( SourceNum ).InletNodeNum, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( RoutineName + ": Program terminated due to previous condition(s)." );
+				ShowFatalError( RoutineName + ": Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			WaterSource( SourceNum ).MyFlag = false;
 		}
@@ -570,7 +570,7 @@ namespace PlantComponentTemperatureSources {
 		RegisterPlantCompDesignFlow( WaterSource( SourceNum ).InletNodeNum, tmpVolFlowRate );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/PlantCondLoopOperation.cc
+++ b/src/EnergyPlus/PlantCondLoopOperation.cc
@@ -291,7 +291,7 @@ namespace PlantCondLoopOperation {
 			RangeVariable = FindRangeVariable( LoopNum, CurSchemePtr, CurSchemeType );
 		} else {
 			// No controls specified.  This is a fatal error
-			ShowFatalError( "Invalid Operation Scheme Type Requested=" + PlantLoop( LoopNum ).OpScheme( CurSchemePtr ).TypeOf + ", in ManagePlantLoadDistribution" );
+			ShowFatalError( "Invalid Operation Scheme Type Requested=" + PlantLoop( LoopNum ).OpScheme( CurSchemePtr ).TypeOf + ", in ManagePlantLoadDistribution" );  // LCOV_EXCL_LINE
 		}
 
 		//Find the proper list within the specified scheme
@@ -549,7 +549,7 @@ namespace PlantCondLoopOperation {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input for PlantEquipmentOperationSchemes or CondenserEquipmentOperationSchemes" );
+			ShowFatalError( RoutineName + "Errors found in getting input for PlantEquipmentOperationSchemes or CondenserEquipmentOperationSchemes" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -647,7 +647,7 @@ namespace PlantCondLoopOperation {
 		NumSchemes = CLRBO + HLRBO + DBRBO + WBRBO + DPRBO + RHRBO + CSPBO + DBTDBO + WBTDBO + DPTDBO + NumUserDefOpSchemes + TESSPBO;
 		NumUncontrolledSchemes = GetNumObjectsFound( "PlantEquipmentOperation:Uncontrolled" );
 		if ( ( NumSchemes + NumUncontrolledSchemes ) <= 0 ) {
-			ShowFatalError( "No PlantEquipmentOperation:* objects specified. Stop simulation." );
+			ShowFatalError( "No PlantEquipmentOperation:* objects specified. Stop simulation." );  // LCOV_EXCL_LINE
 		}
 
 		// test for blank or duplicates -- this section just determines if there are any duplicate operation scheme names
@@ -696,7 +696,7 @@ namespace PlantCondLoopOperation {
 				CurrentModuleObject = "PlantEquipmentOperation:ThermalEnergyStorage";
 				Count = Num - CLRBO - HLRBO - DBRBO - WBRBO - DPRBO - RHRBO - CSPBO - DBTDBO - WBTDBO - DPTDBO - NumUncontrolledSchemes - NumUserDefOpSchemes;
 			} else {
-				ShowFatalError( "Error in control scheme identification" );
+				ShowFatalError( "Error in control scheme identification" );  // LCOV_EXCL_LINE
 			}
 
 			GetObjectItem( CurrentModuleObject, Count, cAlphaArgs, NumAlphas, rNumericArgs, NumNums, IOStat );
@@ -814,7 +814,7 @@ namespace PlantCondLoopOperation {
 
 		// Validate that component names/types in each list correspond to a valid component in input file
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );
+			ShowFatalError( RoutineName + "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 		}
 	}
 
@@ -1279,7 +1279,7 @@ namespace PlantCondLoopOperation {
 				}
 			}
 			if ( ErrorsFound ) {
-				ShowFatalError( "LoadEquipList/GetEquipmentLists: Failed due to preceding errors." );
+				ShowFatalError( "LoadEquipList/GetEquipmentLists: Failed due to preceding errors." );  // LCOV_EXCL_LINE
 			}
 			LoadEquipListOneTimeFlag = false;
 		}
@@ -1854,7 +1854,7 @@ namespace PlantCondLoopOperation {
 								ShowContinueError( "Operation Scheme name = " + this_op_scheme.Name );
 								ShowContinueError( "Loop name = " + this_plant_loop.Name );
 								ShowContinueError( "Component name = " + this_equip.Name );
-								ShowFatalError( "InitLoadDistribution: Simulation terminated because of error in operation scheme." );
+								ShowFatalError( "InitLoadDistribution: Simulation terminated because of error in operation scheme." );  // LCOV_EXCL_LINE
 							}
 
 							this_equip.LoopNumPtr = DummyLoopNum;
@@ -2101,7 +2101,7 @@ namespace PlantCondLoopOperation {
 		}
 
 		if ( errFlag2 ) {
-			ShowFatalError( "InitLoadDistribution: Fatal error caused by previous severe error(s)." );
+			ShowFatalError( "InitLoadDistribution: Fatal error caused by previous severe error(s)." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/PlantHeatExchangerFluidToFluid.cc
+++ b/src/EnergyPlus/PlantHeatExchangerFluidToFluid.cc
@@ -206,17 +206,17 @@ namespace PlantHeatExchangerFluidToFluid {
 		if ( CompIndex == 0 ) {
 			CompNum = FindItemInList( EquipName, FluidHX );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimFluidHeatExchanger: HeatExchanger:FluidToFluid not found" );
+				ShowFatalError( "SimFluidHeatExchanger: HeatExchanger:FluidToFluid not found" );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CompNum;
 		} else {
 			CompNum = CompIndex;
 			if ( CompNum < 1 || CompNum > NumberOfPlantFluidHXs ) {
-				ShowFatalError( "SimFluidHeatExchanger: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of heat exchangers =" + TrimSigDigits( NumberOfPlantFluidHXs ) + ", Entered heat exchanger name = " + EquipName );
+				ShowFatalError( "SimFluidHeatExchanger: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of heat exchangers =" + TrimSigDigits( NumberOfPlantFluidHXs ) + ", Entered heat exchanger name = " + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckFluidHXs( CompNum ) ) {
 				if ( EquipName != FluidHX( CompNum ).Name ) {
-					ShowFatalError( "SimFluidHeatExchanger: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", heat exchanger name=" + EquipName + ", stored name for that index=" + FluidHX( CompNum ).Name );
+					ShowFatalError( "SimFluidHeatExchanger: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", heat exchanger name=" + EquipName + ", stored name for that index=" + FluidHX( CompNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckFluidHXs( CompNum ) = false;
 			}
@@ -568,7 +568,7 @@ namespace PlantHeatExchangerFluidToFluid {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in processing " + cCurrentModuleObject + " input." );
+			ShowFatalError( RoutineName + "Errors found in processing " + cCurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 		for ( CompLoop = 1; CompLoop <= NumberOfPlantFluidHXs; ++CompLoop ) {
@@ -706,7 +706,7 @@ namespace PlantHeatExchangerFluidToFluid {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( RoutineName + "Program terminated due to previous condition(s)." );
+				ShowFatalError( RoutineName + "Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			MyFlag( CompNum ) = false;
 		} // plant setup

--- a/src/EnergyPlus/PlantLoadProfile.cc
+++ b/src/EnergyPlus/PlantLoadProfile.cc
@@ -115,7 +115,7 @@ namespace PlantLoadProfile {
 			}
 		}
 		// If we didn't find it, fatal
-		ShowFatalError( "PlantLoadProfile::factory: Error getting inputs for pipe named: " + objectName );
+		ShowFatalError( "PlantLoadProfile::factory: Error getting inputs for pipe named: " + objectName );  // LCOV_EXCL_LINE
 		// Shut up the compiler
 		return nullptr;
 	}
@@ -217,7 +217,7 @@ namespace PlantLoadProfile {
 				errFlag = false;
 				ScanPlantLoopsForObject( this->Name, this->TypeNum, this->WLoopNum, this->WLoopSideNum, this->WLoopBranchNum, this->WLoopCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitPlantProfile: Program terminated for previous conditions." );
+					ShowFatalError( "InitPlantProfile: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 
 				this->SetLoopIndexFlag = false;
@@ -445,7 +445,7 @@ namespace PlantLoadProfile {
 					SetupEMSActuator( "Plant Load Profile", PlantProfile( ProfileNum ).Name, "Power", "[W]", PlantProfile( ProfileNum ).EMSOverridePower, PlantProfile( ProfileNum ).EMSPowerValue );
 				}
 
-				if ( ErrorsFound ) ShowFatalError( "Errors in " + cCurrentModuleObject + " input." );
+				if ( ErrorsFound ) ShowFatalError( "Errors in " + cCurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 
 			} // ProfileNum
 		}

--- a/src/EnergyPlus/PlantLoopEquip.cc
+++ b/src/EnergyPlus/PlantLoopEquip.cc
@@ -316,7 +316,7 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Pipe Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_Pump ) {
@@ -449,13 +449,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Chiller Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Chiller=" + sim_component.TypeOf );
 				ShowContinueError( "..Chiller Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			//HEAT PUMPS
@@ -515,13 +515,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Heat Pump Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for HeatPump=" + sim_component.TypeOf );
 				ShowContinueError( "..HeatPump Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			//TOWERS
@@ -582,13 +582,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Tower Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Cooling Tower=" + sim_component.TypeOf );
 				ShowContinueError( "..Tower Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			//FLUID COOLERS
@@ -617,13 +617,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid FluidCooler Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Fluid Cooler=" + sim_component.TypeOf );
 				ShowContinueError( "..Fluid Cooler Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_EvapFluidCooler ) {
@@ -651,13 +651,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid EvapFluidCooler Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Fluid Cooler=" + sim_component.TypeOf );
 				ShowContinueError( "..Fluid Cooler Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			//BOILERS
@@ -689,13 +689,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Boiler Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Boiler=" + sim_component.TypeOf );
 				ShowContinueError( "..Boiler Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			//WATER HEATER
@@ -723,13 +723,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Water Heater Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Water Heater=" + sim_component.TypeOf );
 				ShowContinueError( "..Water Thermal Tank Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			//PURCHASED
@@ -755,13 +755,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid District Energy Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for District Energy=" + sim_component.TypeOf );
 				ShowContinueError( "..District Cooling/Heating Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_HeatExchanger ) {
@@ -778,7 +778,7 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Heat Exchanger Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			}
 
@@ -852,13 +852,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Chilled/Ice Thermal Storage Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Thermal Storage=" + sim_component.TypeOf );
 				ShowContinueError( "..Chilled/Ice Thermal Storage Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_Valve ) {
@@ -873,13 +873,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Valve Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Valves=" + sim_component.TypeOf );
 				ShowContinueError( "..Valve Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_Generator ) {
@@ -942,14 +942,14 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Generator Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			}
 
 			if ( InitLoopEquip && EquipNum == 0 ) {
 				ShowSevereError( "InitLoop did not set Equipment Index for Generator=" + sim_component.TypeOf );
 				ShowContinueError( "..Generator Name=" + sim_component.Name + ", in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_LoadProfile ) { // DSU2 draft out InitLoopEquip on a demand side component
@@ -964,7 +964,7 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Load Profile Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_DemandCoil ) { //DSU3
@@ -1010,7 +1010,7 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Load Coil Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			} //DSU3
 
@@ -1026,7 +1026,7 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Load Coil Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_SolarCollector ) {
@@ -1050,7 +1050,7 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Solar Collector Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_ZoneHVACDemand ) { //ZoneHVAC and air terminal models with direct plant connections
@@ -1083,7 +1083,7 @@ namespace PlantLoopEquip {
 
 				ShowSevereError( "SimPlantEquip: Invalid ZoneHVAC Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			}
 
@@ -1106,7 +1106,7 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Refrigeration Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( GeneralEquipType == GenEquipTypes_PlantComponent ) {
@@ -1134,7 +1134,7 @@ namespace PlantLoopEquip {
 			} else {
 				//        CALL ShowSevereError('SimPlantEquip: Invalid Component Equipment Type='//TRIM(EquipType))
 				//        CALL ShowContinueError('Occurs in Plant Loop='//TRIM(PlantLoop(LoopNum)%Name))
-				//        CALL ShowFatalError('Preceding condition causes termination.')
+				//        CALL ShowFatalError('Preceding condition causes termination.')  // LCOV_EXCL_LINE
 
 			}
 
@@ -1157,13 +1157,13 @@ namespace PlantLoopEquip {
 			} else {
 				ShowSevereError( "SimPlantEquip: Invalid Central Heat Pump System Type=" + sim_component.TypeOf );
 				ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} else {
 			ShowSevereError( "SimPlantEquip: Invalid Equipment Type=" + sim_component.TypeOf );
 			ShowContinueError( "Occurs in Plant Loop=" + PlantLoop( LoopNum ).Name );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 		} // TypeOfEquip
 
 	}

--- a/src/EnergyPlus/PlantLoopSolver.cc
+++ b/src/EnergyPlus/PlantLoopSolver.cc
@@ -229,7 +229,7 @@ namespace PlantLoopSolver {
 			// Now that the op scheme types are updated, do LoopSide validation
 			IsLoopSideValid = ValidateFlowControlPaths( LoopNum, ThisSide );
 			if ( ! IsLoopSideValid.Valid ) {
-				ShowFatalError( "ERROR:" + IsLoopSideValid.Reason );
+				ShowFatalError( "ERROR:" + IsLoopSideValid.Reason );  // LCOV_EXCL_LINE
 			}
 
 			// Set the flag to false so we won't do these again this time step
@@ -493,7 +493,7 @@ namespace PlantLoopSolver {
 			} else if ( SELECT_CASE_var == UnknownStatusOpSchemeType ) { //~ Uninitialized, this should be a sufficient place to catch for this on branch 1
 				//throw fatal
 				ShowSevereError( "ValidateFlowControlPaths: Uninitialized operation scheme type for component Name: " + this_component.Name );
-				ShowFatalError( "ValidateFlowControlPaths: developer notice, Inlet path validation loop" );
+				ShowFatalError( "ValidateFlowControlPaths: developer notice, Inlet path validation loop" );  // LCOV_EXCL_LINE
 			} else { //~ Other control type
 				if ( EncounteredLRB ) {
 					EncounteredNonLRBAfterLRB = true;
@@ -555,7 +555,7 @@ namespace PlantLoopSolver {
 					} else if ( SELECT_CASE_var == UnknownStatusOpSchemeType ) { //~ Uninitialized, this should be sufficient place to catch for this on other branches
 						//throw fatal error
 						ShowSevereError( "ValidateFlowControlPaths: Uninitialized operation scheme type for component Name: " + this_component.Name );
-						ShowFatalError( "ValidateFlowControlPaths: developer notice, problem in Parallel path validation loop" );
+						ShowFatalError( "ValidateFlowControlPaths: developer notice, problem in Parallel path validation loop" );  // LCOV_EXCL_LINE
 					} else { //~ Other control type
 						if ( EncounteredLRB ) {
 							EncounteredNonLRBAfterLRB = true;
@@ -995,13 +995,13 @@ namespace PlantLoopSolver {
 			} else if ( ThisSide == SupplySide ) {
 				ShowContinueError( "Add a pump to the supply side of the plant loop" );
 			}
-			ShowFatalError( "Program terminates due to preceding conditions." );
+			ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 
 		} else if ( ! ThisSideHasPumps && ! OtherSideHasPumps ) {
 			ShowSevereError( "SetupLoopFlowRequest: Problem in plant topology, no pumps specified on the loop" );
 			ShowContinueError( "Occurs on plant loop name =\"" + PlantLoop( LoopNum ).Name + "\"" );
 			ShowContinueError( "All plant loops require at least one pump" );
-			ShowFatalError( "Program terminates due to preceding conditions." );
+			ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1405,7 +1405,7 @@ namespace PlantLoopSolver {
 					break;
 				default:
 					if ( ( CurOpSchemeType >= LoadRangeBasedMin ) && ( CurOpSchemeType <= LoadRangeBasedMax ) ) { //~ load range based
-						ShowFatalError( "Encountered Load Based Object after other components, invalid." );
+						ShowFatalError( "Encountered Load Based Object after other components, invalid." );  // LCOV_EXCL_LINE
 					} else { //~ Typical control equipment
 						SimPlantEquip( LoopNum, LoopSideNum, BranchCounter, CompCounter, FirstHVACIteration, DummyInit, DoNotGetCompSizFac );
 					}
@@ -1746,7 +1746,7 @@ namespace PlantLoopSolver {
 						ShowContinueError( "Loop Heating Low Setpoint=" + RoundSigDigits( LoopSetPointTemperatureLo, 2 ) );
 						ShowContinueError( "Loop Cooling High Setpoint=" + RoundSigDigits( LoopSetPointTemperatureHi, 2 ) );
 
-						ShowFatalError( "Program terminates due to above conditions." );
+						ShowFatalError( "Program terminates due to above conditions." );  // LCOV_EXCL_LINE
 					}
 					if ( LoadToHeatingSetPoint > 0.0 && LoadToCoolingSetPoint > 0.0 ) {
 						LoadToLoopSetPoint = LoadToHeatingSetPoint;
@@ -1760,7 +1760,7 @@ namespace PlantLoopSolver {
 						ShowContinueError( "LoadToHeatingSetPoint=" + RoundSigDigits( LoadToHeatingSetPoint, 3 ) + ", LoadToCoolingSetPoint=" + RoundSigDigits( LoadToCoolingSetPoint, 3 ) );
 						ShowContinueError( "Loop Heating Setpoint=" + RoundSigDigits( LoopSetPointTemperatureLo, 2 ) );
 						ShowContinueError( "Loop Cooling Setpoint=" + RoundSigDigits( LoopSetPointTemperatureHi, 2 ) );
-						ShowFatalError( "Program terminates due to above conditions." );
+						ShowFatalError( "Program terminates due to above conditions." );  // LCOV_EXCL_LINE
 					}
 				} else {
 					LoadToLoopSetPoint = 0.0;
@@ -2034,7 +2034,7 @@ namespace PlantLoopSolver {
 				ShowSevereError( "Plant topology problem for PlantLoop: " + PlantLoop( LoopNum ).Name + ", " + LoopSideName( LoopSideNum ) + " side." );
 				ShowContinueError( "There are multiple branches, yet no splitter.  This is an invalid configuration." );
 				ShowContinueError( "Add a set of connectors, use put components on a single branch." );
-				ShowFatalError( "Invalid plant topology causes program termination." );
+				ShowFatalError( "Invalid plant topology causes program termination." );  // LCOV_EXCL_LINE
 				return;
 			}
 		}
@@ -2049,7 +2049,7 @@ namespace PlantLoopSolver {
 				ShowSevereError( "Plant topology problem for PlantLoop: " + PlantLoop( LoopNum ).Name + ", " + LoopSideName( LoopSideNum ) + " side." );
 				ShowContinueError( "Diagnostic error in PlantLoopSolver::ResolveParallelFlows." );
 				ShowContinueError( "Splitter improperly specified, no splitter outlets." );
-				ShowFatalError( "Invalid plant topology causes program termination." );
+				ShowFatalError( "Invalid plant topology causes program termination." );  // LCOV_EXCL_LINE
 			}
 
 			NumActiveBranches = 0;

--- a/src/EnergyPlus/PlantManager.cc
+++ b/src/EnergyPlus/PlantManager.cc
@@ -703,7 +703,7 @@ namespace PlantManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in processing input. Preceding conditions cause termination." );
+			ShowFatalError( RoutineName + "Errors found in processing input. Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		// set up loop status (set by system availability managers) report variables
@@ -1421,7 +1421,7 @@ namespace PlantManager {
 				}
 
 				if ( ErrorsFound ) {
-					ShowFatalError( "GetPlantInput: Previous Severe errors cause termination." );
+					ShowFatalError( "GetPlantInput: Previous Severe errors cause termination." );  // LCOV_EXCL_LINE
 				}
 
 				NumConnectorsInLoop = NumofSplitters + NumofMixers;
@@ -1571,7 +1571,7 @@ namespace PlantManager {
 							if ( TempLoop.Branch( BranchNum ).Comp( CompNum ).TypeOf_Num == TypeOf_Pipe || TempLoop.Branch( BranchNum ).Comp( CompNum ).TypeOf_Num == TypeOf_PipeSteam || TempLoop.Branch( BranchNum ).Comp( CompNum ).TypeOf_Num == TypeOf_PipeInterior || TempLoop.Branch( BranchNum ).Comp( CompNum ).TypeOf_Num == TypeOf_PipeUnderground || TempLoop.Branch( BranchNum ).Comp( CompNum ).TypeOf_Num == TypeOf_PipeExterior ) {
 
 								++PipeNum;
-								if ( PipeNum > NumOfPipesInLoop ) ShowFatalError( "Pipe counting problem in GetPlantSideLoops" );
+								if ( PipeNum > NumOfPipesInLoop ) ShowFatalError( "Pipe counting problem in GetPlantSideLoops" );  // LCOV_EXCL_LINE
 
 								LoopPipe( HalfLoopNum ).NumPipes = NumOfPipesInLoop;
 								LoopPipe( HalfLoopNum ).Pipe( PipeNum ).Name = TempLoop.Branch( BranchNum ).Comp( CompNum ).Name;
@@ -1745,7 +1745,7 @@ namespace PlantManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetPlantInput: Errors in getting PlantLoop Input" );
+			ShowFatalError( "GetPlantInput: Errors in getting PlantLoop Input" );  // LCOV_EXCL_LINE
 		}
 
 		if ( NumPlantLoops > 0 ) VentRepPlantSupplySide.allocate( NumPlantLoops );
@@ -2409,7 +2409,7 @@ namespace PlantManager {
 		} //
 		if ( ! BeginEnvrnFlag ) SupplyEnvrnFlag = true;
 
-		if ( ErrorsFound ) ShowFatalError( "Preceding errors caused termination" );
+		if ( ErrorsFound ) ShowFatalError( "Preceding errors caused termination" );  // LCOV_EXCL_LINE
 
 	}
 
@@ -3274,7 +3274,7 @@ namespace PlantManager {
 
 			} else {
 				if (PlantFirstSizesOkayToFinalize) {
-					ShowFatalError( "Autosizing of plant loop requires a loop Sizing:Plant object" );
+					ShowFatalError( "Autosizing of plant loop requires a loop Sizing:Plant object" );  // LCOV_EXCL_LINE
 					ShowContinueError( "Occurs in PlantLoop object=" + PlantLoop( LoopNum ).Name );
 					ErrorsFound = true;
 				}
@@ -3324,7 +3324,7 @@ namespace PlantManager {
 		PlantLoop( LoopNum ).MinMassFlowRate = PlantLoop( LoopNum ).MinVolFlowRate * FluidDensity;
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 
@@ -3475,7 +3475,7 @@ namespace PlantManager {
 		PlantLoop( LoopNum ).MinMassFlowRate = PlantLoop( LoopNum ).MinVolFlowRate * FluidDensity;
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 
@@ -4464,7 +4464,7 @@ namespace PlantManager {
 								ShowSevereError( "A pipe used as a bypass should not be in series with another component" );
 								ShowContinueError( "Occurs in Branch = " + PlantLoop( LoopCtr ).LoopSide( LoopSideCtr ).Branch( BranchCtr ).Name );
 								ShowContinueError( "Occurs in PlantLoop = " + PlantLoop( LoopCtr ).Name );
-								ShowFatalError( "SetupBranchControlTypes: preceding condition causes termination." );
+								ShowFatalError( "SetupBranchControlTypes: preceding condition causes termination." );  // LCOV_EXCL_LINE
 							}
 
 						} else if ( SELECT_CASE_var == ControlType_Passive ) {

--- a/src/EnergyPlus/PlantPipingSystemsManager.cc
+++ b/src/EnergyPlus/PlantPipingSystemsManager.cc
@@ -194,18 +194,18 @@ namespace PlantPipingSystemsManager {
 			CircuitNum = FindItemInList( EquipName, PipingSystemCircuits );
 			if ( CircuitNum == 0 ) {
 				// Catch any bad names before crashing
-				ShowFatalError( RoutineName + ": Piping circuit requested not found=" + EquipName );
+				ShowFatalError( RoutineName + ": Piping circuit requested not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			EqNum = CircuitNum;
 		} else {
 			CircuitNum = EqNum;
 			int const NumOfPipeCircuits = isize( PipingSystemCircuits );
 			if ( CircuitNum > NumOfPipeCircuits || CircuitNum < 1 ) {
-				ShowFatalError( RoutineName + ":  Invalid component index passed=" + TrimSigDigits( CircuitNum ) + ", Number of Units=" + TrimSigDigits( NumOfPipeCircuits ) + ", Entered Unit name=" + EquipName ); //Autodesk:Uninit DomainNum was uninitialized
+				ShowFatalError( RoutineName + ":  Invalid component index passed=" + TrimSigDigits( CircuitNum ) + ", Number of Units=" + TrimSigDigits( NumOfPipeCircuits ) + ", Entered Unit name=" + EquipName ); //Autodesk:Uninit DomainNum was uninitialized  // LCOV_EXCL_LINE
 			}
 			if ( PipingSystemCircuits( CircuitNum ).CheckEquipName ) {
 				if ( EquipName != PipingSystemCircuits( CircuitNum ).Name ) {
-					ShowFatalError( RoutineName + ": Invalid component name passed=" + TrimSigDigits( CircuitNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + PipingSystemCircuits( CircuitNum ).Name );
+					ShowFatalError( RoutineName + ": Invalid component name passed=" + TrimSigDigits( CircuitNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + PipingSystemCircuits( CircuitNum ).Name );  // LCOV_EXCL_LINE
 				}
 				PipingSystemCircuits( CircuitNum ).CheckEquipName = false;
 			}
@@ -520,7 +520,7 @@ namespace PlantPipingSystemsManager {
 		ReadBasementInputs( NumGeneralizedDomains + NumHorizontalTrenches + NumZoneCoupledDomains + 1, NumBasements, ErrorsFound );
 
 		// Report errors that are purely input problems
-		if ( ErrorsFound ) ShowFatalError( RoutineName + ": Preceding input errors cause program termination." );
+		if ( ErrorsFound ) ShowFatalError( RoutineName + ": Preceding input errors cause program termination." );  // LCOV_EXCL_LINE
 
 		// Setup output variables
 		SetupPipingSystemOutputVariables( TotalNumSegments, TotalNumCircuits );
@@ -602,7 +602,7 @@ namespace PlantPipingSystemsManager {
 
 		// If we encountered any other errors that we couldn't handle separately than stop now
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + ':' + ObjName_ug_GeneralDomain + ": Errors found in input." );
+			ShowFatalError( RoutineName + ':' + ObjName_ug_GeneralDomain + ": Errors found in input." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2148,7 +2148,7 @@ namespace PlantPipingSystemsManager {
 			bool errFlag = false;
 			DataPlant::ScanPlantLoopsForObject( thisCircuit.Name, TypeToLookFor, thisCircuit.LoopNum, thisCircuit.LoopSideNum, thisCircuit.BranchNum, thisCircuit.CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "PipingSystems:" + RoutineName + ": Program terminated due to previous condition(s)." );
+				ShowFatalError( "PipingSystems:" + RoutineName + ": Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 
 			// Once we find ourselves on the plant loop, we can do other things
@@ -2170,7 +2170,7 @@ namespace PlantPipingSystemsManager {
 						ShowSevereError( "PipingSystems:" + RoutineName + ":Pipe segment index not set." );
 						ShowContinueError( "...Possibly because pipe segment was placed outside of the domain." );
 						ShowContinueError( "...Verify piping system domain inputs, circuits, and segments." );
-						ShowFatalError( "Preceding error causes program termination" );
+						ShowFatalError( "Preceding error causes program termination" );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -3317,7 +3317,7 @@ namespace PlantPipingSystemsManager {
 				ShowSevereError( "PlantPipingSystems::" + RoutineName + ": Invalid partition location in domain." );
 				ShowContinueError( "Occurs during mesh development for domain=" + this->Name );
 				ShowContinueError( "A pipe or basement is located outside of the domain extents." );
-				ShowFatalError( "Preceding error causes program termination." );
+				ShowFatalError( "Preceding error causes program termination." );  // LCOV_EXCL_LINE
 			}
 
 			// Scan all grid regions to make sure this range doesn't fall within an already entered range
@@ -3331,7 +3331,7 @@ namespace PlantPipingSystemsManager {
 						ShowContinueError( "A mesh conflict was encountered where partitions were overlapping." );
 						ShowContinueError( "Ensure that all pipes exactly line up or are separated to allow meshing in between them" );
 						ShowContinueError( "Also verify the pipe and basement dimensions to avoid conflicts there." );
-						ShowFatalError( "Preceding error causes program termination" );
+						ShowFatalError( "Preceding error causes program termination" );  // LCOV_EXCL_LINE
 
 					}
 
@@ -3344,7 +3344,7 @@ namespace PlantPipingSystemsManager {
 						ShowContinueError( "A mesh conflict was encountered where partitions were overlapping." );
 						ShowContinueError( "Ensure that all pipes exactly line up or are separated to allow meshing in between them" );
 						ShowContinueError( "Also verify the pipe and basement dimensions to avoid conflicts there." );
-						ShowFatalError( "Preceding error causes program termination" );
+						ShowFatalError( "Preceding error causes program termination" );  // LCOV_EXCL_LINE
 
 					}
 				}
@@ -4290,7 +4290,7 @@ namespace PlantPipingSystemsManager {
 			ThisMesh.thisMeshDistribution = MeshDistribution::Uniform;
 			//ShowSevereError( "Invalid RegionType passed to PlantPipingSystems::FullDomainStructureInfo::getCellWidths; should be x, y, or z direction only." );
 			//ShowContinueError( "This is a developer problem, as the code should never reach this point." );
-			//ShowFatalError( "EnergyPlus aborts due to the previous severe error" );
+			//ShowFatalError( "EnergyPlus aborts due to the previous severe error" );  // LCOV_EXCL_LINE
 		}
 
 		// just one cell for extremely tight regions
@@ -5254,7 +5254,7 @@ namespace PlantPipingSystemsManager {
 		}
 
 		if ( RunningVolume <= 0.0 ) {
-			ShowFatalError( "FullDomainStructureInfo::GetAverageTempByType calculated zero volume, program aborts" );
+			ShowFatalError( "FullDomainStructureInfo::GetAverageTempByType calculated zero volume, program aborts" );  // LCOV_EXCL_LINE
 		}
 
 		return RunningSummation / RunningVolume;
@@ -5422,7 +5422,7 @@ namespace PlantPipingSystemsManager {
 				Increment = -1;
 				break;
 			default:
-				ShowFatalError( "Debug error: invalid flow direction on piping system segment" );
+				ShowFatalError( "Debug error: invalid flow direction on piping system segment" );  // LCOV_EXCL_LINE
 			}
 
 			//'find the cell we are working on in order to retrieve cell and neighbor information
@@ -6293,17 +6293,17 @@ namespace PlantPipingSystemsManager {
 				ShowSevereError( "Site:GroundDomain:Slab" + RoutineName + ": Out of range temperatures detected in the ground domain." );
 				ShowContinueError( "This could be due to the size of the loads on the domain." );
 				ShowContinueError( "Verify inputs are correct. If problem persists, notify EnergyPlus support." );
-				ShowFatalError( "Preceding error(s) cause program termination" );
+				ShowFatalError( "Preceding error(s) cause program termination" );  // LCOV_EXCL_LINE
 			} else if ( thisDomain.HasZoneCoupledBasement ) {
 				ShowSevereError( "Site:GroundDomain:Basement" + RoutineName + ": Out of range temperatures detected in the ground domain." );
 				ShowContinueError( "This could be due to the size of the loads on the domain." );
 				ShowContinueError( "Verify inputs are correct. If problem persists, notify EnergyPlus support." );
-				ShowFatalError( "Preceding error(s) cause program termination" );
+				ShowFatalError( "Preceding error(s) cause program termination" );  // LCOV_EXCL_LINE
 			} else {
 				ShowSevereError( "PipingSystems:" + RoutineName + ": Out of range temperatures detected in piping system simulation." );
 				ShowContinueError( "This could be due to the size of the pipe circuit in relation to the loads being imposed." );
 				ShowContinueError( "Try increasing the size of the pipe circuit and investigate sizing effects." );
-				ShowFatalError( "Preceding error(s) cause program termination" );
+				ShowFatalError( "Preceding error(s) cause program termination" );  // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/EnergyPlus/PlantPressureSystem.cc
+++ b/src/EnergyPlus/PlantPressureSystem.cc
@@ -304,7 +304,7 @@ namespace PlantPressureSystem {
 
 			} //Has pressure components
 
-			if ( ErrorsFound ) ShowFatalError( "Preceding errors cause program termination" );
+			if ( ErrorsFound ) ShowFatalError( "Preceding errors cause program termination" );  // LCOV_EXCL_LINE
 
 			//Also issue one time warning if there is a mismatch between plant loop simulation type and whether objects were entered
 			if ( loop.HasPressureComponents && ( loop.PressureSimType == Press_NoPressure ) ) {
@@ -574,7 +574,7 @@ namespace PlantPressureSystem {
 						ShowSevereError( "Pressure system information was found in a demand pump (common pipe) simulation" );
 						ShowContinueError( "Currently the pressure simulation is not set up to handle common pipe simulations" );
 						ShowContinueError( "Either modify simulation to avoid common pipe, or remove pressure curve information" );
-						ShowFatalError( "Pressure configuration mismatch causes program termination" );
+						ShowFatalError( "Pressure configuration mismatch causes program termination" );  // LCOV_EXCL_LINE
 					}
 					// If we are on the supply side, we simply hit the branch pump, so we exit the IF statement as
 					//  we don't need to simulate the splitter or inlet branch
@@ -718,7 +718,7 @@ namespace PlantPressureSystem {
 				}
 				ShowContinueError( "Branch contains only a single pump component, yet also a pressure drop component." );
 				ShowContinueError( "Either add a second component to this branch after the pump, or move pressure drop data." );
-				ShowFatalError( "Preceding pressure drop error causes program termination" );
+				ShowFatalError( "Preceding pressure drop error causes program termination" );  // LCOV_EXCL_LINE
 			}
 			return;
 		}

--- a/src/EnergyPlus/PlantUtilities.cc
+++ b/src/EnergyPlus/PlantUtilities.cc
@@ -367,7 +367,7 @@ namespace PlantUtilities {
 					SeriesBranchMinAvail = 0.0;
 
 					// inserting EMS On/Off Supervisory control here to series branch constraint and assuming EMS should shut off flow completely
-					// action here means EMS will not impact the FlowLock == FlowLocked condition (which should still show EMS intent) 
+					// action here means EMS will not impact the FlowLock == FlowLocked condition (which should still show EMS intent)
 					EMSLoadOverride = false;
 
 					for ( CompNum = 1; CompNum <= loop_side.Branch( BranchIndex ).TotalComponents; ++CompNum ) {
@@ -413,7 +413,7 @@ namespace PlantUtilities {
 					Node( OutletNode ).MassFlowRate = min( Node( InletNode ).MassFlowRateMax, Node( OutletNode ).MassFlowRate );
 
 					// inserting EMS On/Off Supervisory control here to override min constraint assuming EMS should shut off flow completely
-					// action here means EMS will not impact the FlowLock == FlowLocked condition (which should still show EMS intent) 
+					// action here means EMS will not impact the FlowLock == FlowLocked condition (which should still show EMS intent)
 					EMSLoadOverride = false;
 
 					for ( CompNum = 1; CompNum <= loop_side.Branch( BranchIndex ).TotalComponents; ++CompNum ) {
@@ -436,7 +436,7 @@ namespace PlantUtilities {
 			Node( OutletNode ).MassFlowRate = Node( InletNode ).MassFlowRate;
 			CompFlow = Node( OutletNode ).MassFlowRate;
 		} else {
-			ShowFatalError( "SetComponentFlowRate: Flow lock out of range" ); //DEBUG error...should never get here
+			ShowFatalError( "SetComponentFlowRate: Flow lock out of range" ); //DEBUG error...should never get here  // LCOV_EXCL_LINE
 		}
 
 		if ( comp.CurOpSchemeType == DemandOpSchemeType ) {
@@ -535,7 +535,7 @@ namespace PlantUtilities {
 					// add MassFlowRateMin hardware constraints
 
 					// inserting EMS On/Off Supervisory control here to override min constraint assuming EMS should shut off flow completely
-					// action here means EMS will not impact the FlowLock == FlowLocked condition (which should still show EMS intent) 
+					// action here means EMS will not impact the FlowLock == FlowLocked condition (which should still show EMS intent)
 					EMSLoadOverride = false;
 					// check to see if any component on branch uses EMS On/Off Supervisory control to shut down flow
 					for ( int CompNum = 1, CompNum_end = branch.TotalComponents; CompNum <= CompNum_end; ++CompNum ) {
@@ -586,7 +586,7 @@ namespace PlantUtilities {
 					ShowContinueError( "Node minimum flow rate available [kg/s] = " + RoundSigDigits( a_node.MassFlowRateMinAvail, 8 ) );
 				}
 			} else {
-				ShowFatalError( "SetActuatedBranchFlowRate: Flowlock out of range, value=" + RoundSigDigits( loop_side.FlowLock ) ); //DEBUG error...should never get here
+				ShowFatalError( "SetActuatedBranchFlowRate: Flowlock out of range, value=" + RoundSigDigits( loop_side.FlowLock ) ); //DEBUG error...should never get here  // LCOV_EXCL_LINE
 			}
 
 			Real64 const a_node_MasFlowRate( a_node.MassFlowRate );
@@ -983,7 +983,7 @@ namespace PlantUtilities {
 						ShowContinueError( "Plant Connector:Splitter name= " + PlantLoop( LoopNum ).LoopSide( LoopSideNum ).Splitter( SplitNum ).Name );
 						ShowContinueError( "Splitter inlet mass flow rate= " + RoundSigDigits( Node( SplitterInletNode ).MassFlowRate, 6 ) + " {kg/s}" );
 						ShowContinueError( "Difference in two mass flow rates= " + RoundSigDigits( AbsDifference, 6 ) + " {kg/s}" );
-						ShowFatalError( "CheckPlantMixerSplitterConsistency: Simulation terminated because of problems in plant flow resolver" );
+						ShowFatalError( "CheckPlantMixerSplitterConsistency: Simulation terminated because of problems in plant flow resolver" );  // LCOV_EXCL_LINE
 					}
 				}
 
@@ -1026,7 +1026,7 @@ namespace PlantUtilities {
 					//                                    TRIM(RoundSigDigits(Node(SplitterInletNode)%MassFlowRate,6))//' {kg/s}')
 					//          CALL ShowContinueError('Difference in two mass flow rates= '//  &
 					//                                    TRIM(RoundSigDigits(AbsDifference,6))//' {kg/s}')
-					//          CALL ShowFatalError('CheckPlantMixerSplitterConsistency: Simulation terminated because of problems in plant flow resolver')
+					//          CALL ShowFatalError('CheckPlantMixerSplitterConsistency: Simulation terminated because of problems in plant flow resolver')  // LCOV_EXCL_LINE
 					//        ENDIF
 				}
 
@@ -1203,7 +1203,7 @@ namespace PlantUtilities {
 			ShowContinueError( "    lots of node time series data to see what is going wrong." );
 			ShowContinueError( "  If this is happening during Warmup, you can use Output:Diagnostics,ReportDuringWarmup;" );
 			ShowContinueError( "  This is detected at the loop level, but the typical problems are in the components." );
-			ShowFatalError( "CheckForRunawayPlantTemps: Simulation terminated because of run away plant temperatures, too " + hotcold );
+			ShowFatalError( "CheckForRunawayPlantTemps: Simulation terminated because of run away plant temperatures, too " + hotcold );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/PlantValves.cc
+++ b/src/EnergyPlus/PlantValves.cc
@@ -173,17 +173,17 @@ namespace PlantValves {
 		if ( CompNum == 0 ) {
 			EqNum = FindItemInList( CompName, TemperValve );
 			if ( EqNum == 0 ) {
-				ShowFatalError( "SimPlantValves: Unit not found=" + CompName );
+				ShowFatalError( "SimPlantValves: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompNum = EqNum;
 		} else {
 			EqNum = CompNum;
 			if ( EqNum > NumTemperingValves || EqNum < 1 ) {
-				ShowFatalError( "SimPlantValves:  Invalid CompNum passed=" + TrimSigDigits( EqNum ) + ", Number of Units=" + TrimSigDigits( NumTemperingValves ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimPlantValves:  Invalid CompNum passed=" + TrimSigDigits( EqNum ) + ", Number of Units=" + TrimSigDigits( NumTemperingValves ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( EqNum ) ) {
 				if ( CompName != TemperValve( EqNum ).Name ) {
-					ShowFatalError( "SimPlantValves: Invalid CompNum passed=" + TrimSigDigits( EqNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + TemperValve( EqNum ).Name );
+					ShowFatalError( "SimPlantValves: Invalid CompNum passed=" + TrimSigDigits( EqNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + TemperValve( EqNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( EqNum ) = false;
 			}
@@ -291,7 +291,7 @@ namespace PlantValves {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetPlantValvesInput: " + CurrentModuleObject + " Errors found in input" );
+			ShowFatalError( "GetPlantValvesInput: " + CurrentModuleObject + " Errors found in input" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -378,7 +378,7 @@ namespace PlantValves {
 					ScanPlantLoopsForObject( TemperValve( CompNum ).Name, TypeOf_ValveTempering, TemperValve( CompNum ).LoopNum, TemperValve( CompNum ).LoopSideNum, TemperValve( CompNum ).BranchNum, TemperValve( CompNum ).CompNum, _, _, _, _, _, errFlag );
 
 					if ( errFlag ) {
-						ShowFatalError( "InitPlantValves: Program terminated due to previous condition(s)." );
+						ShowFatalError( "InitPlantValves: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 					}
 					// init logical flags
 					ErrorsFound = false;
@@ -500,7 +500,7 @@ namespace PlantValves {
 						ErrorsFound = true;
 					}
 					if ( ErrorsFound ) {
-						ShowFatalError( "Errors found in input, TemperingValve object " + TemperValve( CompNum ).Name );
+						ShowFatalError( "Errors found in input, TemperingValve object " + TemperValve( CompNum ).Name );  // LCOV_EXCL_LINE
 					}
 					MyTwoTimeFlag( CompNum ) = false;
 				} // my two time flag for input checking

--- a/src/EnergyPlus/PollutionModule.cc
+++ b/src/EnergyPlus/PollutionModule.cc
@@ -1217,7 +1217,7 @@ namespace PollutionModule {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting Pollution Calculation Reporting Input" );
+			ShowFatalError( "Errors found in getting Pollution Calculation Reporting Input" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/PondGroundHeatExchanger.cc
+++ b/src/EnergyPlus/PondGroundHeatExchanger.cc
@@ -177,7 +177,7 @@ namespace PondGroundHeatExchanger {
 			}
 		}
 		// If we didn't find it, fatal
-		ShowFatalError( "Pond Heat Exchanger Factory: Error getting inputs for GHX named: " + objectName );
+		ShowFatalError( "Pond Heat Exchanger Factory: Error getting inputs for GHX named: " + objectName );  // LCOV_EXCL_LINE
 		// Shut up the compiler
 		return nullptr;
 	}
@@ -364,7 +364,7 @@ namespace PondGroundHeatExchanger {
 
 		// final error check
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		// Set up the output variables
@@ -469,7 +469,7 @@ namespace PondGroundHeatExchanger {
 			errFlag = false;
 			ScanPlantLoopsForObject( this->Name, TypeOf_GrndHtExchgPond, this->LoopNum, this->LoopSideNum, this->BranchNum, this->CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitPondGroundHeatExchanger: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitPondGroundHeatExchanger: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			rho = GetDensityGlycol( PlantLoop( this->LoopNum ).FluidName, constant_zero, PlantLoop( this->LoopNum ).FluidIndex, RoutineName );
 			Cp = GetSpecificHeatGlycol( PlantLoop( this->LoopNum ).FluidName, constant_zero, PlantLoop( this->LoopNum ).FluidIndex, RoutineName );
@@ -1004,7 +1004,7 @@ namespace PondGroundHeatExchanger {
 			}
 			ShowRecurringWarningErrorAtEnd( "GroundHeatExchanger:Pond=\"" + this->Name + "\", is frozen", this->FrozenErrIndex, PondTemperature, PondTemperature, _, "[C]", "[C]" );
 			if ( this->ConsecutiveFrozen >= NumOfTimeStepInHour * 30 ) {
-				ShowFatalError( "GroundHeatExchanger:Pond=\"" + this->Name + "\" has been frozen for 30 consecutive hours.  Program terminates." );
+				ShowFatalError( "GroundHeatExchanger:Pond=\"" + this->Name + "\" has been frozen for 30 consecutive hours.  Program terminates." );  // LCOV_EXCL_LINE
 			}
 		} else {
 			this->ConsecutiveFrozen = 0;

--- a/src/EnergyPlus/PoweredInductionUnits.cc
+++ b/src/EnergyPlus/PoweredInductionUnits.cc
@@ -231,17 +231,17 @@ namespace PoweredInductionUnits {
 		if ( CompIndex == 0 ) {
 			PIUNum = FindItemInList( CompName, PIU );
 			if ( PIUNum == 0 ) {
-				ShowFatalError( "SimPIU: PIU Unit not found=" + CompName );
+				ShowFatalError( "SimPIU: PIU Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = PIUNum;
 		} else {
 			PIUNum = CompIndex;
 			if ( PIUNum > NumPIUs || PIUNum < 1 ) {
-				ShowFatalError( "SimPIU: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of PIU Units=" + TrimSigDigits( NumPIUs ) + ", PIU Unit name=" + CompName );
+				ShowFatalError( "SimPIU: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of PIU Units=" + TrimSigDigits( NumPIUs ) + ", PIU Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( PIUNum ) ) {
 				if ( CompName != PIU( PIUNum ).Name ) {
-					ShowFatalError( "SimPIU: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", PIU Unit name=" + CompName + ", stored PIU Unit Name for that index=" + PIU( PIUNum ).Name );
+					ShowFatalError( "SimPIU: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", PIU Unit name=" + CompName + ", stored PIU Unit Name for that index=" + PIU( PIUNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( PIUNum ) = false;
 			}
@@ -267,7 +267,7 @@ namespace PoweredInductionUnits {
 		} else {
 			ShowSevereError( "Illegal PI Unit Type used=" + PIU( PIUNum ).UnitType );
 			ShowContinueError( "Occurs in PI Unit=" + PIU( PIUNum ).Name );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -671,7 +671,7 @@ namespace PoweredInductionUnits {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input.  Preceding conditions cause termination." );
+			ShowFatalError( RoutineName + "Errors found in getting input.  Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		for ( PIUNum = 1; PIUNum <= NumPIUs; ++PIUNum ) {
@@ -753,7 +753,7 @@ namespace PoweredInductionUnits {
 				errFlag = false;
 				ScanPlantLoopsForObject( PIU( PIUNum ).HCoil, PIU( PIUNum ).HCoil_PlantTypeNum, PIU( PIUNum ).HWLoopNum, PIU( PIUNum ).HWLoopSide, PIU( PIUNum ).HWBranchNum, PIU( PIUNum ).HWCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitPIU: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitPIU: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				PIU( PIUNum ).HotCoilOutNodeNum = PlantLoop( PIU( PIUNum ).HWLoopNum ).LoopSide( PIU( PIUNum ).HWLoopSide ).Branch( PIU( PIUNum ).HWBranchNum ).Comp( PIU( PIUNum ).HWCompNum ).NodeNumOut;
 			}
@@ -1291,7 +1291,7 @@ namespace PoweredInductionUnits {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/Psychrometrics.cc
+++ b/src/EnergyPlus/Psychrometrics.cc
@@ -325,7 +325,7 @@ namespace Psychrometrics {
 			} else {
 				ShowContinueErrorTimeStamp( " Routine=Unknown," );
 			}
-			ShowFatalError( "Program terminates due to preceding condition." );
+			ShowFatalError( "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 		}
 	}
 #endif

--- a/src/EnergyPlus/Pumps.cc
+++ b/src/EnergyPlus/Pumps.cc
@@ -240,17 +240,17 @@ namespace Pumps {
 		if ( PumpIndex == 0 ) {
 			PumpNum = FindItemInList( PumpName, PumpEquip ); // Determine which pump to simulate
 			if ( PumpNum == 0 ) {
-				ShowFatalError( "ManagePumps: Pump requested not found =" + PumpName ); // Catch any bad names before crashing
+				ShowFatalError( "ManagePumps: Pump requested not found =" + PumpName ); // Catch any bad names before crashing  // LCOV_EXCL_LINE
 			}
 			PumpIndex = PumpNum;
 		} else {
 			PumpNum = PumpIndex;
 			if ( PumpEquip( PumpNum ).CheckEquipName ) {
 				if ( PumpNum > NumPumps || PumpNum < 1 ) {
-					ShowFatalError( "ManagePumps: Invalid PumpIndex passed=" + TrimSigDigits( PumpNum ) + ", Number of Pumps=" + TrimSigDigits( NumPumps ) + ", Pump name=" + PumpName );
+					ShowFatalError( "ManagePumps: Invalid PumpIndex passed=" + TrimSigDigits( PumpNum ) + ", Number of Pumps=" + TrimSigDigits( NumPumps ) + ", Pump name=" + PumpName );  // LCOV_EXCL_LINE
 				}
 				if ( PumpName != PumpEquip( PumpNum ).Name ) {
-					ShowFatalError( "ManagePumps: Invalid PumpIndex passed=" + TrimSigDigits( PumpNum ) + ", Pump name=" + PumpName + ", stored Pump Name for that index=" + PumpEquip( PumpNum ).Name );
+					ShowFatalError( "ManagePumps: Invalid PumpIndex passed=" + TrimSigDigits( PumpNum ) + ", Pump name=" + PumpName + ", stored Pump Name for that index=" + PumpEquip( PumpNum ).Name );  // LCOV_EXCL_LINE
 				}
 				PumpEquip( PumpNum ).CheckEquipName = false;
 			}
@@ -995,7 +995,7 @@ namespace Pumps {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in getting Pump input" );
+			ShowFatalError( "Errors found in getting Pump input" );  // LCOV_EXCL_LINE
 		}
 
 		for ( PumpNum = 1; PumpNum <= NumPumps; ++PumpNum ) { //CurrentModuleObject='Pumps'
@@ -1142,7 +1142,7 @@ namespace Pumps {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "InitializePumps: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitializePumps: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			PlantLoop( PumpEquip( PumpNum ).LoopNum ).LoopSide( PumpEquip( PumpNum ).LoopSideNum ).Branch( PumpEquip( PumpNum ).BranchNum ).Comp( PumpEquip( PumpNum ).CompNum ).CompNum = PumpNum;
 
@@ -1166,7 +1166,7 @@ namespace Pumps {
 					ShowSevereError( "Check input.  Calculated Pump Efficiency=" + RoundSigDigits( PumpEquip( PumpNum ).PumpEffic * 100.0, 3 ) + "% which is bigger than 100%, for pump=" + PumpEquip( PumpNum ).Name );
 					ShowContinueError( "Calculated Pump_Efficiency % =Total_Efficiency % [" + RoundSigDigits( TotalEffic * 100.0, 1 ) + "] / Motor_Efficiency % [" + RoundSigDigits( PumpEquip( PumpNum ).MotorEffic * 100.0, 1 ) + ']' );
 					ShowContinueError( "Total_Efficiency % =(Rated_Volume_Flow_Rate [" + RoundSigDigits( PumpEquip( PumpNum ).NomVolFlowRate, 1 ) + "] * Rated_Pump_Head [" + RoundSigDigits( PumpEquip( PumpNum ).NomPumpHead, 1 ) + "] / Rated_Power_Use [" + RoundSigDigits( PumpEquip( PumpNum ).NomPowerUse, 1 ) + "]) * 100." );
-					ShowFatalError( "Errors found in Pump input" );
+					ShowFatalError( "Errors found in Pump input" );  // LCOV_EXCL_LINE
 				}
 			} else {
 				ShowWarningError( "Check input. Pump nominal power or motor efficiency is set to 0, for pump=" + PumpEquip( PumpNum ).Name );
@@ -1657,7 +1657,7 @@ namespace Pumps {
 				if ( TotalEffic == 0.0 ) {
 					ShowSevereError( RoutineName + " Plant pressure simulation encountered a pump with zero efficiency: " + PumpEquip( PumpNum ).Name );
 					ShowContinueError( "Check efficiency inputs for this pump component." );
-					ShowFatalError( "Errors in plant calculation would result in divide-by-zero cause program termination." );
+					ShowFatalError( "Errors in plant calculation would result in divide-by-zero cause program termination." );  // LCOV_EXCL_LINE
 				}
 				Power = VolFlowRate * PlantLoop( PumpEquip( PumpNum ).LoopNum ).PressureDrop / TotalEffic;
 			}
@@ -1670,7 +1670,7 @@ namespace Pumps {
 			if ( TotalEffic == 0.0 ) {
 				ShowSevereError( RoutineName + " Plant pump simulation encountered a pump with zero efficiency: " + PumpEquip( PumpNum ).Name );
 				ShowContinueError( "Check efficiency inputs for this pump component." );
-				ShowFatalError( "Errors in plant calculation would result in divide-by-zero cause program termination." );
+				ShowFatalError( "Errors in plant calculation would result in divide-by-zero cause program termination." );  // LCOV_EXCL_LINE
 			}
 			Power = VolFlowRate * PumpEquip( PumpNum ).EMSPressureOverrideValue / TotalEffic;
 		}
@@ -1902,7 +1902,7 @@ namespace Pumps {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/PurchasedAirManager.cc
+++ b/src/EnergyPlus/PurchasedAirManager.cc
@@ -264,17 +264,17 @@ namespace PurchasedAirManager {
 		if ( CompIndex == 0 ) {
 			PurchAirNum = FindItemInList( PurchAirName, PurchAir );
 			if ( PurchAirNum == 0 ) {
-				ShowFatalError( "SimPurchasedAir: Unit not found=" + PurchAirName );
+				ShowFatalError( "SimPurchasedAir: Unit not found=" + PurchAirName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = PurchAirNum;
 		} else {
 			PurchAirNum = CompIndex;
 			if ( PurchAirNum > NumPurchAir || PurchAirNum < 1 ) {
-				ShowFatalError( "SimPurchasedAir:  Invalid CompIndex passed=" + TrimSigDigits( PurchAirNum ) + ", Number of Units=" + TrimSigDigits( NumPurchAir ) + ", Entered Unit name=" + PurchAirName );
+				ShowFatalError( "SimPurchasedAir:  Invalid CompIndex passed=" + TrimSigDigits( PurchAirNum ) + ", Number of Units=" + TrimSigDigits( NumPurchAir ) + ", Entered Unit name=" + PurchAirName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( PurchAirNum ) ) {
 				if ( PurchAirName != PurchAir( PurchAirNum ).Name ) {
-					ShowFatalError( "SimPurchasedAir: Invalid CompIndex passed=" + TrimSigDigits( PurchAirNum ) + ", Unit name=" + PurchAirName + ", stored Unit Name for that index=" + PurchAir( PurchAirNum ).Name );
+					ShowFatalError( "SimPurchasedAir: Invalid CompIndex passed=" + TrimSigDigits( PurchAirNum ) + ", Unit name=" + PurchAirName + ", stored Unit Name for that index=" + PurchAir( PurchAirNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( PurchAirNum ) = false;
 			}
@@ -794,7 +794,7 @@ namespace PurchasedAirManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input. Preceding conditions cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input. Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -906,7 +906,7 @@ namespace PurchasedAirManager {
 					ShowSevereError( "InitPurchasedAir: In " + PurchAir( PurchAirNum ).cObjectName + " = " + PurchAir( PurchAirNum ).Name );
 					ShowContinueError( "Zone Supply Air Node Name=" + NodeID( SupplyNodeNum ) + " is not a zone inlet node." );
 					ShowContinueError( "Check ZoneHVAC:EquipmentConnections for zone=" + ZoneEquipConfig( ControlledZoneNum ).ZoneName );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -933,9 +933,9 @@ namespace PurchasedAirManager {
 				if ( ZoneEquipConfig( ControlledZoneNum ).ReturnAirNode > 0 ) {
 					PurchAir( PurchAirNum ).ZoneRecircAirNodeNum = ZoneEquipConfig( ControlledZoneNum ).ReturnAirNode;
 				} else {
-					ShowFatalError( "InitPurchasedAir: In " + PurchAir( PurchAirNum ).cObjectName + " = " + PurchAir( PurchAirNum ).Name );
+					ShowFatalError( "InitPurchasedAir: In " + PurchAir( PurchAirNum ).cObjectName + " = " + PurchAir( PurchAirNum ).Name );  // LCOV_EXCL_LINE
 					ShowContinueError( " Invalid recirculation node. No exhaust or return node has been specified for this zone in ZoneHVAC:EquipmentConnections." );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 			}
 			// If there is OA and economizer is active, then there must be a limit on cooling flow rate
@@ -1037,7 +1037,7 @@ namespace PurchasedAirManager {
 			}
 		}
 		//      IF (ErrorsFound .and. .not. WarmupFlag) THEN
-		//        CALL ShowFatalError('Preceding conditions cause termination.')
+		//        CALL ShowFatalError('Preceding conditions cause termination.')  // LCOV_EXCL_LINE
 		//      ENDIF
 
 	}
@@ -3038,7 +3038,7 @@ namespace PurchasedAirManager {
 		// FUNCTION LOCAL VARIABLE DECLARATIONS:
 		int ReturnPlenumIndex; // index to ZoneHVAC:ReturnPlenum object
 		int ReturnPlenumNum; // loop counter
-		bool PlenumNotFound; // logical to determine if same plenum is used by other ideal loads air systems 
+		bool PlenumNotFound; // logical to determine if same plenum is used by other ideal loads air systems
 		int Loop; // loop counters
 		int Loop2; // loop counters
 		Array1D_int TempPurchArray; // temporary array used for dynamic allocation

--- a/src/EnergyPlus/RefrigeratedCase.cc
+++ b/src/EnergyPlus/RefrigeratedCase.cc
@@ -3846,7 +3846,7 @@ namespace RefrigeratedCase {
 					//^^^^^^^Now look at input and once-only calculations required only for liquid/brine secondary loops^^^^^^^^^^^^^^^^^^^^^^
 					//   Ensure that required input data is not missing prior to performing the following once-only calculations
 					if ( ErrorsFound ) {
-						ShowFatalError( RoutineName + CurrentModuleObject + "=\"" + Secondary( SecondaryNum ).Name + "\", Program terminated due to previous condition(s)." );
+						ShowFatalError( RoutineName + CurrentModuleObject + "=\"" + Secondary( SecondaryNum ).Name + "\", Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 					} // ErrorsFound
 
 					if ( Secondary( SecondaryNum ).FluidType == SecFluidTypeAlwaysLiquid ) {
@@ -5801,7 +5801,7 @@ namespace RefrigeratedCase {
 		ReportRefrigerationComponents();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + " Previous errors cause program termination" );
+			ShowFatalError( RoutineName + " Previous errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -6922,7 +6922,7 @@ namespace RefrigeratedCase {
 				errFlag = false;
 				ScanPlantLoopsForObject( Condenser( RefCondLoop ).Name, TypeOf_RefrigSystemWaterCondenser, Condenser( RefCondLoop ).PlantLoopNum, Condenser( RefCondLoop ).PlantLoopSideNum, Condenser( RefCondLoop ).PlantBranchNum, Condenser( RefCondLoop ).PlantCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitRefrigerationPlantConnections: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitRefrigerationPlantConnections: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 
 				rho = GetDensityGlycol( PlantLoop( Condenser( RefCondLoop ).PlantLoopNum ).FluidName, 20.0, PlantLoop( Condenser( RefCondLoop ).PlantLoopNum ).FluidIndex, RoutineName );
@@ -6941,7 +6941,7 @@ namespace RefrigeratedCase {
 				errFlag = false;
 				ScanPlantLoopsForObject( RefrigRack( RefCompRackLoop ).Name, TypeOf_RefrigerationWaterCoolRack, RefrigRack( RefCompRackLoop ).PlantLoopNum, RefrigRack( RefCompRackLoop ).PlantLoopSideNum, RefrigRack( RefCompRackLoop ).PlantBranchNum, RefrigRack( RefCompRackLoop ).PlantCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitRefrigerationPlantConnections: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitRefrigerationPlantConnections: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 
 				rho = GetDensityGlycol( PlantLoop( RefrigRack( RefCompRackLoop ).PlantLoopNum ).FluidName, 20.0, PlantLoop( RefrigRack( RefCompRackLoop ).PlantLoopNum ).FluidIndex, RoutineName );
@@ -7958,11 +7958,11 @@ namespace RefrigeratedCase {
 			} else if ( SELECT_CASE_var == TypeOf_RefrigSystemWaterCondenser ) {
 				Num = FindItemInList( CompName, Condenser );
 			} else {
-				ShowFatalError( "SimRefrigCondenser: invalid system type passed" );
+				ShowFatalError( "SimRefrigCondenser: invalid system type passed" );  // LCOV_EXCL_LINE
 			}}
 
 			if ( Num == 0 ) {
-				ShowFatalError( "SimRefrigCondenser: Specified refrigeration condenser not Valid =" + CompName );
+				ShowFatalError( "SimRefrigCondenser: Specified refrigeration condenser not Valid =" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = Num;
 		} else {
@@ -7971,22 +7971,22 @@ namespace RefrigeratedCase {
 			{ auto const SELECT_CASE_var( SysType );
 			if ( SELECT_CASE_var == TypeOf_RefrigerationWaterCoolRack ) {
 				if ( Num > NumRefrigeratedRacks || Num < 1 ) {
-					ShowFatalError( "SimRefrigCondenser: Invalid CompIndex passed=" + TrimSigDigits( Num ) + ", Number of Units=" + TrimSigDigits( NumRefrigeratedRacks ) + ", Entered Unit name=" + CompName );
+					ShowFatalError( "SimRefrigCondenser: Invalid CompIndex passed=" + TrimSigDigits( Num ) + ", Number of Units=" + TrimSigDigits( NumRefrigeratedRacks ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 				}
 				if ( CheckEquipNameRackWaterCondenser( Num ) ) {
 					if ( CompName != RefrigRack( Num ).Name ) {
-						ShowFatalError( "SimRefrigCondenser: Invalid CompIndex passed=" + TrimSigDigits( Num ) + ", Entered Unit name=" + CompName + ", stored Unit name for that index=" + RefrigRack( Num ).Name );
+						ShowFatalError( "SimRefrigCondenser: Invalid CompIndex passed=" + TrimSigDigits( Num ) + ", Entered Unit name=" + CompName + ", stored Unit name for that index=" + RefrigRack( Num ).Name );  // LCOV_EXCL_LINE
 					}
 					CheckEquipNameRackWaterCondenser( Num ) = false;
 				}
 
 			} else if ( SELECT_CASE_var == TypeOf_RefrigSystemWaterCondenser ) {
 				if ( Num > NumRefrigCondensers || Num < 1 ) {
-					ShowFatalError( "SimRefrigCondenser: Invalid CompIndex passed=" + TrimSigDigits( Num ) + ", Number of Units=" + TrimSigDigits( NumRefrigCondensers ) + ", Entered Unit name=" + CompName );
+					ShowFatalError( "SimRefrigCondenser: Invalid CompIndex passed=" + TrimSigDigits( Num ) + ", Number of Units=" + TrimSigDigits( NumRefrigCondensers ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 				}
 				if ( CheckEquipNameWaterCondenser( Num ) ) {
 					if ( CompName != Condenser( Num ).Name ) {
-						ShowFatalError( "SimRefrigCondenser: Invalid CompIndex passed=" + TrimSigDigits( Num ) + ", Entered Unit name=" + CompName + ", stored Unit name for that index=" + Condenser( Num ).Name );
+						ShowFatalError( "SimRefrigCondenser: Invalid CompIndex passed=" + TrimSigDigits( Num ) + ", Entered Unit name=" + CompName + ", stored Unit name for that index=" + Condenser( Num ).Name );  // LCOV_EXCL_LINE
 					}
 					CheckEquipNameWaterCondenser( Num ) = false;
 				}
@@ -12056,17 +12056,17 @@ namespace RefrigeratedCase {
 		if ( AirChillerSetPtr == 0 ) {
 			ChillerSetID = FindItemInList( AirChillerSetName, AirChillerSet );
 			if ( ChillerSetID == 0 ) {
-				ShowFatalError( "SimAirChillerSet: Unit not found=" + AirChillerSetName );
+				ShowFatalError( "SimAirChillerSet: Unit not found=" + AirChillerSetName );  // LCOV_EXCL_LINE
 			} // chillersetid ==0 because not in list
 			AirChillerSetPtr = ChillerSetID;
 		} else { //airchllersetpointer passed in call to subroutine not ==0
 			ChillerSetID = AirChillerSetPtr;
 			if ( ChillerSetID > NumRefrigChillerSets || ChillerSetID < 1 ) {
-				ShowFatalError( "SimAirChillerSet:  Invalid AirChillerSetPtr passed=" + TrimSigDigits( ChillerSetID ) + ", Number of Units=" + TrimSigDigits( NumRefrigChillerSets ) + ", Entered Unit name=" + AirChillerSetName );
+				ShowFatalError( "SimAirChillerSet:  Invalid AirChillerSetPtr passed=" + TrimSigDigits( ChillerSetID ) + ", Number of Units=" + TrimSigDigits( NumRefrigChillerSets ) + ", Entered Unit name=" + AirChillerSetName );  // LCOV_EXCL_LINE
 			} //ChillerSetID makes no sense
 			if ( CheckChillerSetName( ChillerSetID ) ) {
 				if ( AirChillerSetName != AirChillerSet( ChillerSetID ).Name ) {
-					ShowFatalError( "SimAirChillerSet:  Invalid AirChillerSetPtr passed=" + TrimSigDigits( ChillerSetID ) + ", Unit name=" + AirChillerSetName + ", stored Unit Name for that index=" + AirChillerSet( ChillerSetID ).Name );
+					ShowFatalError( "SimAirChillerSet:  Invalid AirChillerSetPtr passed=" + TrimSigDigits( ChillerSetID ) + ", Unit name=" + AirChillerSetName + ", stored Unit Name for that index=" + AirChillerSet( ChillerSetID ).Name );  // LCOV_EXCL_LINE
 				} //name not equal correct name
 				CheckChillerSetName( ChillerSetID ) = false;
 			} //CheckChillerSetName logical test

--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -180,7 +180,7 @@ namespace ReportSizingManager {
 			gio::write( OutputFileInits, Format_991 ) << CompType << CompName << UsrDesc << RoundSigDigits( UsrValue, 5 );
 			AddCompSizeTableEntry( CompType, CompName, UsrDesc, UsrValue );
 		} else if ( present( UsrDesc ) || present( UsrValue ) ) {
-			ShowFatalError( "ReportSizingOutput: (Developer Error) - called with user-specified description or value but not both." );
+			ShowFatalError( "ReportSizingOutput: (Developer Error) - called with user-specified description or value but not both." );  // LCOV_EXCL_LINE
 		}
 
 		// add to SQL output
@@ -472,7 +472,7 @@ namespace ReportSizingManager {
 			} else {
 				ShowSevereError( CallingRoutine + ' ' + CompType + ' ' + CompName );
 				ShowContinueError( "... DataConstantUsedForSizing and DataFractionUsedForSizing used for autocalculating " + SizingString + " must both be greater than 0." );
-				ShowFatalError( "Preceding conditions cause termination." );
+				ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 			bCheckForZero = false;
 		} else if ( CurZoneEqNum > 0 ) {
@@ -1557,7 +1557,7 @@ namespace ReportSizingManager {
 					}
 				} else if ( SizingType == CoolingWaterflowSizing ) {
 					if ( CurOASysNum > 0 ) {
-						CoilDesWaterDeltaT = 0.5 * DataWaterCoilSizCoolDeltaT;						 
+						CoilDesWaterDeltaT = 0.5 * DataWaterCoilSizCoolDeltaT;
 					} else {
 						CoilDesWaterDeltaT = DataWaterCoilSizCoolDeltaT;
 					}
@@ -1770,7 +1770,7 @@ namespace ReportSizingManager {
 					} else {
 						ShowSevereError( CallingRoutine + ' ' + CompType + ' ' + CompName );
 						ShowContinueError( "... DataFlowUsedForSizing and DataCapacityUsedForSizing " + SizingString + " must both be greater than 0." );
-						ShowFatalError( "Preceding conditions cause termination." );
+						ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 					}
 				} else if ( SizingType == CoolingCapacitySizing ) {
 					DataFracOfAutosizedCoolingCapacity = 1.0;
@@ -2268,7 +2268,7 @@ namespace ReportSizingManager {
 				} else {
 					ShowSevereError( CallingRoutine + ' ' + CompType + ' ' + CompName + ", Developer Error: Component sizing incomplete." );
 					ShowContinueError( "SizingString = " + SizingString + ", SizingResult = " + TrimSigDigits( SizingResult, 1 ) );
-					// ShowFatalError( " Previous errors cause program termination" );
+					// ShowFatalError( " Previous errors cause program termination" );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -2330,11 +2330,11 @@ namespace ReportSizingManager {
 			if ( !HardSizeNoDesRun || DataScalableSizingON || DataScalableCapSizingON ) {
 				if ( IsAutoSize ) { // Design Size values are available for both autosized and hard - sized
 					// check capacity to make sure design volume flow per total capacity is within range
-					
+
 					// Note: the VolFlowPerRatedTotCap check is not applicable for VRF-FluidTCtrl coil model, which implements variable flow fans and determines capacity using physical calculations instead of emperical curves
 					bool FlagCheckVolFlowPerRatedTotCap = true;
 					if ( SameString( CompType, "Coil:Cooling:DX:VariableRefrigerantFlow:FluidTemperatureControl" ) || SameString( CompType, "Coil:Heating:DX:VariableRefrigerantFlow:FluidTemperatureControl" ) ) FlagCheckVolFlowPerRatedTotCap = false;
-						
+
 					if ( DataIsDXCoil && FlagCheckVolFlowPerRatedTotCap && ( SizingType == CoolingCapacitySizing || SizingType == HeatingCapacitySizing ) ) {
 						if ( SizingResult > 0.0 ) {
 							RatedVolFlowPerRatedTotCap = DesVolFlow / SizingResult;

--- a/src/EnergyPlus/ReturnAirPathManager.cc
+++ b/src/EnergyPlus/ReturnAirPathManager.cc
@@ -261,7 +261,7 @@ namespace ReturnAirPathManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found getting AirLoopHVAC:ReturnPath.  Preceding condition(s) causes termination." );
+			ShowFatalError( "Errors found getting AirLoopHVAC:ReturnPath.  Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -325,7 +325,7 @@ namespace ReturnAirPathManager {
 			} else {
 				ShowSevereError( "Invalid AirLoopHVAC:ReturnPath Component=" + ReturnAirPath( ReturnAirPathNum ).ComponentType( ComponentNum ) );
 				ShowContinueError( "Occurs in AirLoopHVAC:ReturnPath =" + ReturnAirPath( ReturnAirPathNum ).Name );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			}}
 

--- a/src/EnergyPlus/RoomAirModelAirflowNetwork.cc
+++ b/src/EnergyPlus/RoomAirModelAirflowNetwork.cc
@@ -190,7 +190,7 @@ namespace RoomAirModelAirflowNetwork {
 		RAFNNum = RoomAirflowNetworkZoneInfo( ZoneNum ).RAFNNum;
 
 		if ( RAFNNum == 0 ) {
-			ShowFatalError( "SimRoomAirModelAirflowNetwork: Zone is not defined in the RoomAirModelAirflowNetwork model =" + Zone(ZoneNum).Name );
+			ShowFatalError( "SimRoomAirModelAirflowNetwork: Zone is not defined in the RoomAirModelAirflowNetwork model =" + Zone(ZoneNum).Name );  // LCOV_EXCL_LINE
 		}
 
 		auto & thisRAFN( RAFN( RAFNNum ) );
@@ -250,7 +250,7 @@ namespace RoomAirModelAirflowNetwork {
 		RAFNNum = RoomAirflowNetworkZoneInfo( ZoneNum ).RAFNNum;
 
 		if ( RAFNNum == 0 ) {
-			ShowFatalError( "LoadPredictionRoomAirModelAirflowNetwork: Zone is not defined in the RoomAirModelAirflowNetwork model =" + Zone( ZoneNum ).Name );
+			ShowFatalError( "LoadPredictionRoomAirModelAirflowNetwork: Zone is not defined in the RoomAirModelAirflowNetwork model =" + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 		}
 		auto & thisRAFN( RAFN( RAFNNum ) );
 		thisRAFN.ZoneNum = ZoneNum;
@@ -485,7 +485,7 @@ namespace RoomAirModelAirflowNetwork {
 				InitRoomAirModelAirflowNetworkOneTimeFlagConf = false;
 				if ( allocated( NodeFound ) ) NodeFound.deallocate( );
 				if ( ErrorsFound ) {
-					ShowFatalError( "GetRoomAirflowNetworkData: Errors found getting air model input.  Program terminates." );
+					ShowFatalError( "GetRoomAirflowNetworkData: Errors found getting air model input.  Program terminates." );  // LCOV_EXCL_LINE
 				}
 			}
 		} //End of InitRoomAirModelAirflowNetworkOneTimeFlagConf
@@ -1085,7 +1085,7 @@ namespace RoomAirModelAirflowNetwork {
 			} else if ( Surface( SurfNum ).TAirRef == ZoneSupplyAirTemp ) {
 				// check whether this zone is a controlled zone or not
 				if ( !ControlledZoneAirFlag ) {
-					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );
+					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 					return;
 				}
 				// determine supply air temperature as a weighted average of the inlet temperatures.

--- a/src/EnergyPlus/RoomAirModelManager.cc
+++ b/src/EnergyPlus/RoomAirModelManager.cc
@@ -295,7 +295,7 @@ namespace RoomAirModelManager {
 		GetUFADZoneData( ErrorsFound );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetAirModelData: Errors found getting air model input.  Program terminates." );
+			ShowFatalError( "GetAirModelData: Errors found getting air model input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -842,7 +842,7 @@ namespace RoomAirModelManager {
 
 					// terminate the program due to a severe error in the specified input
 					if ( ( NumSurfsInvolved ) > NumOfSurfs ) {
-						ShowFatalError( "GetAirNodeData: Mundt Room Air Model: Number of surfaces connected to " + AirNode( AirNodeNum ).Name + " is greater than number of surfaces in " + Zone( ZoneNum ).Name );
+						ShowFatalError( "GetAirNodeData: Mundt Room Air Model: Number of surfaces connected to " + AirNode( AirNodeNum ).Name + " is greater than number of surfaces in " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 						return;
 					}
 

--- a/src/EnergyPlus/RoomAirModelUserTempPattern.cc
+++ b/src/EnergyPlus/RoomAirModelUserTempPattern.cc
@@ -381,7 +381,7 @@ namespace RoomAirModelUserTempPattern {
 
 			if ( CurPatrnID == 0 ) {
 				// throw error here ? way to test schedules before getting to this point?
-				ShowFatalError( "User defined room air pattern index not found: " + IntToStr( CurntPatternKey ) );
+				ShowFatalError( "User defined room air pattern index not found: " + IntToStr( CurntPatternKey ) );  // LCOV_EXCL_LINE
 				return;
 			}
 

--- a/src/EnergyPlus/RootFinder.cc
+++ b/src/EnergyPlus/RootFinder.cc
@@ -249,7 +249,7 @@ namespace RootFinder {
 			ShowSevereError( "SetupRootFinder: Invalid function slope specification. Valid choices are:" );
 			ShowContinueError( "SetupRootFinder: iSlopeIncreasing=" + TrimSigDigits( iSlopeIncreasing ) );
 			ShowContinueError( "SetupRootFinder: iSlopeDecreasing=" + TrimSigDigits( iSlopeDecreasing ) );
-			ShowFatalError( "SetupRootFinder: Preceding error causes program termination." );
+			ShowFatalError( "SetupRootFinder: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 		}
 		RootFinderData.Controls.SlopeType = SlopeType;
 
@@ -261,26 +261,26 @@ namespace RootFinder {
 			ShowContinueError( "SetupRootFinder: iMethodFalsePosition=" + TrimSigDigits( iMethodFalsePosition ) );
 			ShowContinueError( "SetupRootFinder: iMethodSecant=" + TrimSigDigits( iMethodSecant ) );
 			ShowContinueError( "SetupRootFinder: iMethodBrent=" + TrimSigDigits( iMethodBrent ) );
-			ShowFatalError( "SetupRootFinder: Preceding error causes program termination." );
+			ShowFatalError( "SetupRootFinder: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 
 		}
 		RootFinderData.Controls.MethodType = MethodType;
 
 		// Load relative tolerance parameter for X variables
 		if ( TolX < 0.0 ) {
-			ShowFatalError( "SetupRootFinder: Invalid tolerance specification for X variables. TolX >= 0" );
+			ShowFatalError( "SetupRootFinder: Invalid tolerance specification for X variables. TolX >= 0" );  // LCOV_EXCL_LINE
 		}
 		RootFinderData.Controls.TolX = TolX;
 
 		// Load absolute tolerance parameter for X variables
 		if ( ATolX < 0.0 ) {
-			ShowFatalError( "SetupRootFinder: Invalid absolute tolerance specification for X variables. ATolX >= 0" );
+			ShowFatalError( "SetupRootFinder: Invalid absolute tolerance specification for X variables. ATolX >= 0" );  // LCOV_EXCL_LINE
 		}
 		RootFinderData.Controls.ATolX = ATolX;
 
 		// Load absolute tolerance parameter for Y variables
 		if ( ATolY < 0.0 ) {
-			ShowFatalError( "SetupRootFinder: Invalid absolute tolerance specification for Y variables. ATolY >= 0" );
+			ShowFatalError( "SetupRootFinder: Invalid absolute tolerance specification for Y variables. ATolY >= 0" );  // LCOV_EXCL_LINE
 		}
 		RootFinderData.Controls.ATolY = ATolY;
 
@@ -427,7 +427,7 @@ namespace RootFinder {
 			if ( XMax == 0.0 ) {
 				XMinReset = XMax;
 			} else {
-				ShowFatalError( "InitializeRootFinder: Invalid min/max bounds XMin=" + TrimSigDigits( XMin, 6 ) + " must be smaller than XMax=" + TrimSigDigits( XMax, 6 ) );
+				ShowFatalError( "InitializeRootFinder: Invalid min/max bounds XMin=" + TrimSigDigits( XMin, 6 ) + " must be smaller than XMax=" + TrimSigDigits( XMax, 6 ) );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -785,7 +785,7 @@ namespace RootFinder {
 				ShowSevereError( "CheckInternalConsistency: Invalid function slope specification. Valid choices are:" );
 				ShowContinueError( "CheckInternalConsistency: iSlopeIncreasing=" + TrimSigDigits( iSlopeIncreasing ) );
 				ShowContinueError( "CheckInternalConsistency: iSlopeDecreasing=" + TrimSigDigits( iSlopeDecreasing ) );
-				ShowFatalError( "CheckInternalConsistency: Preceding error causes program termination." );
+				ShowFatalError( "CheckInternalConsistency: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 			}}
 
 			// Check for in singularity with respect to the existing lower and upper points
@@ -819,7 +819,7 @@ namespace RootFinder {
 				ShowSevereError( "CheckInternalConsistency: Invalid function slope specification. Valid choices are:" );
 				ShowContinueError( "CheckInternalConsistency: iSlopeIncreasing=" + TrimSigDigits( iSlopeIncreasing ) );
 				ShowContinueError( "CheckInternalConsistency: iSlopeDecreasing=" + TrimSigDigits( iSlopeDecreasing ) );
-				ShowFatalError( "CheckInternalConsistency: Preceding error causes program termination." );
+				ShowFatalError( "CheckInternalConsistency: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 			}}
 		}
 
@@ -843,7 +843,7 @@ namespace RootFinder {
 				ShowSevereError( "CheckInternalConsistency: Invalid function slope specification. Valid choices are:" );
 				ShowContinueError( "CheckInternalConsistency: iSlopeIncreasing=" + TrimSigDigits( iSlopeIncreasing ) );
 				ShowContinueError( "CheckInternalConsistency: iSlopeDecreasing=" + TrimSigDigits( iSlopeDecreasing ) );
-				ShowFatalError( "CheckInternalConsistency: Preceding error causes program termination." );
+				ShowFatalError( "CheckInternalConsistency: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 			}}
 		}
 
@@ -1107,7 +1107,7 @@ namespace RootFinder {
 			ShowSevereError( "CheckSlope: Invalid function slope specification. Valid choices are:" );
 			ShowContinueError( "CheckSlope: iSlopeIncreasing=" + TrimSigDigits( iSlopeIncreasing ) );
 			ShowContinueError( "CheckSlope: iSlopeDecreasing=" + TrimSigDigits( iSlopeDecreasing ) );
-			ShowFatalError( "CheckSlope: Preceding error causes program termination." );
+			ShowFatalError( "CheckSlope: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -1252,7 +1252,7 @@ namespace RootFinder {
 			ShowSevereError( "CheckMinConstraint: Invalid function slope specification. Valid choices are:" );
 			ShowContinueError( "CheckMinConstraint: iSlopeIncreasing=" + TrimSigDigits( iSlopeIncreasing ) );
 			ShowContinueError( "CheckMinConstraint: iSlopeDecreasing=" + TrimSigDigits( iSlopeDecreasing ) );
-			ShowFatalError( "CheckMinConstraint: Preceding error causes program termination." );
+			ShowFatalError( "CheckMinConstraint: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 		}}
 
 		CheckMinConstraint = false;
@@ -1325,7 +1325,7 @@ namespace RootFinder {
 			ShowSevereError( "CheckMaxConstraint: Invalid function slope specification. Valid choices are:" );
 			ShowContinueError( "CheckMaxConstraint: iSlopeIncreasing=" + TrimSigDigits( iSlopeIncreasing ) );
 			ShowContinueError( "CheckMaxConstraint: iSlopeDecreasing=" + TrimSigDigits( iSlopeDecreasing ) );
-			ShowFatalError( "CheckMaxConstraint: Preceding error causes program termination." );
+			ShowFatalError( "CheckMaxConstraint: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 		}}
 
 		CheckMaxConstraint = false;
@@ -1647,7 +1647,7 @@ namespace RootFinder {
 						ShowSevereError( "UpdateBracket: Current iterate is smaller than the lower bracket." );
 						ShowContinueError( "UpdateBracket: X=" + TrimSigDigits( X, 15 ) + ", Y=" + TrimSigDigits( Y, 15 ) );
 						ShowContinueError( "UpdateBracket: XLower=" + TrimSigDigits( RootFinderData.LowerPoint.X, 15 ) + ", YLower=" + TrimSigDigits( RootFinderData.LowerPoint.Y, 15 ) );
-						ShowFatalError( "UpdateBracket: Preceding error causes program termination." );
+						ShowFatalError( "UpdateBracket: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 					}
 				}
 
@@ -1672,7 +1672,7 @@ namespace RootFinder {
 						ShowSevereError( "UpdateBracket: Current iterate is greater than the upper bracket." );
 						ShowContinueError( "UpdateBracket: X=" + TrimSigDigits( X, 15 ) + ", Y=" + TrimSigDigits( Y, 15 ) );
 						ShowContinueError( "UpdateBracket: XUpper=" + TrimSigDigits( RootFinderData.UpperPoint.X, 15 ) + ", YUpper=" + TrimSigDigits( RootFinderData.UpperPoint.Y, 15 ) );
-						ShowFatalError( "UpdateBracket: Preceding error causes program termination." );
+						ShowFatalError( "UpdateBracket: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -1700,7 +1700,7 @@ namespace RootFinder {
 						ShowSevereError( "UpdateBracket: Current iterate is smaller than the lower bracket." );
 						ShowContinueError( "UpdateBracket: X=" + TrimSigDigits( X, 15 ) + ", Y=" + TrimSigDigits( Y, 15 ) );
 						ShowContinueError( "UpdateBracket: XLower=" + TrimSigDigits( RootFinderData.LowerPoint.X, 15 ) + ", YLower=" + TrimSigDigits( RootFinderData.LowerPoint.Y, 15 ) );
-						ShowFatalError( "UpdateBracket: Preceding error causes program termination." );
+						ShowFatalError( "UpdateBracket: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 					}
 				}
 
@@ -1725,7 +1725,7 @@ namespace RootFinder {
 						ShowSevereError( "UpdateBracket: Current iterate is greater than the upper bracket." );
 						ShowContinueError( "UpdateBracket: X=" + TrimSigDigits( X, 15 ) + ", Y=" + TrimSigDigits( Y, 15 ) );
 						ShowContinueError( "UpdateBracket: XUpper=" + TrimSigDigits( RootFinderData.UpperPoint.X, 15 ) + ", YUpper=" + TrimSigDigits( RootFinderData.UpperPoint.Y, 15 ) );
-						ShowFatalError( "UpdateBracket: Preceding error causes program termination." );
+						ShowFatalError( "UpdateBracket: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -1735,7 +1735,7 @@ namespace RootFinder {
 			ShowSevereError( "UpdateBracket: Invalid function slope specification. Valid choices are:" );
 			ShowContinueError( "UpdateBracket: iSlopeIncreasing=" + TrimSigDigits( iSlopeIncreasing ) );
 			ShowContinueError( "UpdateBracket: iSlopeDecreasing=" + TrimSigDigits( iSlopeDecreasing ) );
-			ShowFatalError( "UpdateBracket: Preceding error causes program termination." );
+			ShowFatalError( "UpdateBracket: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -2039,7 +2039,7 @@ namespace RootFinder {
 					RootFinderData.XCandidate = RootFinderData.MinPoint.X;
 				} else {
 					// Should never happen
-					ShowFatalError( "AdvanceRootFinder: Cannot find lower bracket." );
+					ShowFatalError( "AdvanceRootFinder: Cannot find lower bracket." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -2054,7 +2054,7 @@ namespace RootFinder {
 					RootFinderData.XCandidate = RootFinderData.MaxPoint.X;
 				} else {
 					// Should never happen
-					ShowFatalError( "AdvanceRootFinder: Cannot find upper bracket." );
+					ShowFatalError( "AdvanceRootFinder: Cannot find upper bracket." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -2100,7 +2100,7 @@ namespace RootFinder {
 					ShowContinueError( "AdvanceRootFinder: iMethodFalsePosition=" + TrimSigDigits( iMethodFalsePosition ) );
 					ShowContinueError( "AdvanceRootFinder: iMethodSecant=" + TrimSigDigits( iMethodSecant ) );
 					ShowContinueError( "AdvanceRootFinder: iMethodBrent=" + TrimSigDigits( iMethodBrent ) );
-					ShowFatalError( "AdvanceRootFinder: Preceding error causes program termination." );
+					ShowFatalError( "AdvanceRootFinder: Preceding error causes program termination." );  // LCOV_EXCL_LINE
 				}}
 			}}
 		}

--- a/src/EnergyPlus/RuntimeLanguageProcessor.cc
+++ b/src/EnergyPlus/RuntimeLanguageProcessor.cc
@@ -1024,7 +1024,7 @@ namespace RuntimeLanguageProcessor {
 					}
 				}
 			} else {
-				ShowFatalError( "Fatal error in RunStack:  Unknown keyword." );
+				ShowFatalError( "Fatal error in RunStack:  Unknown keyword." );  // LCOV_EXCL_LINE
 
 			}}
 
@@ -1126,7 +1126,7 @@ namespace RuntimeLanguageProcessor {
 			ShowContinueError( "Erl program line text: " + LineString );
 			ShowContinueError( "Error message: " + cValueString );
 			ShowContinueErrorTimeStamp( "" );
-			ShowFatalError( "Previous EMS error caused program termination.");
+			ShowFatalError( "Previous EMS error caused program termination.");  // LCOV_EXCL_LINE
 		}
 
 
@@ -1220,7 +1220,7 @@ namespace RuntimeLanguageProcessor {
 				ShowSevereError( "EMS ParseExpression: Entity=" + ErlStack( StackNum ).Name );
 				ShowContinueError( "...Line=" + Line );
 				ShowContinueError( "...Failed to process String=\"" + String + "\"." );
-				ShowFatalError( "...program terminates due to preceding condition." );
+				ShowFatalError( "...program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 			}
 			NextChar = String[ Pos ];
 			if ( NextChar == ' ' ) {
@@ -1692,7 +1692,7 @@ namespace RuntimeLanguageProcessor {
 						Pos += 10;
 					} else { // throw error
 						if ( DeveloperFlag ) gio::write( OutputFileDebug, fmtA ) << "ERROR \"" + String + "\"";
-						ShowFatalError( "EMS Runtime Language: did not find valid input for built-in function =" + String );
+						ShowFatalError( "EMS Runtime Language: did not find valid input for built-in function =" + String );  // LCOV_EXCL_LINE
 					}
 				} else {
 					// Check for remaining single character operators
@@ -1742,7 +1742,7 @@ namespace RuntimeLanguageProcessor {
 					} else {
 						// Uh OH, this should never happen! throw error
 						if ( DeveloperFlag ) gio::write( OutputFileDebug, fmtA ) << "ERROR \"" + StringToken + "\"";
-						ShowFatalError( "EMS, caught unexpected token = \"" + StringToken + "\" ; while parsing string=" + String );
+						ShowFatalError( "EMS, caught unexpected token = \"" + StringToken + "\" ; while parsing string=" + String );  // LCOV_EXCL_LINE
 
 					}
 				}
@@ -1775,7 +1775,7 @@ namespace RuntimeLanguageProcessor {
 
 		if ( NumErrors > 0 ) {
 			if ( DeveloperFlag ) gio::write( OutputFileDebug, fmtA ) << "ERROR OUT";
-			ShowFatalError( "EMS, previous errors cause termination." );
+			ShowFatalError( "EMS, previous errors cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		ExpressionNum = ProcessTokens( Token, NumTokens, StackNum, String );
@@ -1903,7 +1903,7 @@ namespace RuntimeLanguageProcessor {
 		if ( ParenthWhileCounter == 50 ) { // symptom of mismatched parenthesis
 			ShowSevereError( "EMS error parsing parentheses, check that parentheses are balanced" );
 			ShowContinueError( "String being parsed=\"" + ParsingString + "\"." );
-			ShowFatalError( "Program terminates due to preceding error." );
+			ShowFatalError( "Program terminates due to preceding error." );  // LCOV_EXCL_LINE
 		}
 
 		SetupPossibleOperators(); // includes built-in functions
@@ -1952,7 +1952,7 @@ namespace RuntimeLanguageProcessor {
 							ErlExpression( ExpressionNum ).Operand( 3 ).Expression = Token( Pos + 3 ).Expression;
 							ErlExpression( ExpressionNum ).Operand( 3 ).Variable = Token( Pos + 3 ).Variable;
 							if ( ( NumOperands == 3 ) && ( NumTokens - 4 > 0 ) ) { // too many tokens for this non-binary operator
-								ShowFatalError( "EMS error parsing tokens, too many for built-in function" );
+								ShowFatalError( "EMS error parsing tokens, too many for built-in function" );  // LCOV_EXCL_LINE
 							}
 						}
 
@@ -1962,7 +1962,7 @@ namespace RuntimeLanguageProcessor {
 							ErlExpression( ExpressionNum ).Operand( 4 ).Expression = Token( Pos + 4 ).Expression;
 							ErlExpression( ExpressionNum ).Operand( 4 ).Variable = Token( Pos + 4 ).Variable;
 							if ( ( NumOperands == 4 ) && ( NumTokens - 5 > 0 ) ) { // too many tokens for this non-binary operator
-								ShowFatalError( "EMS error parsing tokens, too many for built-in function" );
+								ShowFatalError( "EMS error parsing tokens, too many for built-in function" );  // LCOV_EXCL_LINE
 							}
 						}
 
@@ -1972,7 +1972,7 @@ namespace RuntimeLanguageProcessor {
 							ErlExpression( ExpressionNum ).Operand( 5 ).Expression = Token( Pos + 5 ).Expression;
 							ErlExpression( ExpressionNum ).Operand( 5 ).Variable = Token( Pos + 5 ).Variable;
 							if ( ( NumOperands == 5 ) && ( NumTokens - 6 > 0 ) ) { // too many tokens for this non-binary operator
-								ShowFatalError( "EMS error parsing tokens, too many for  built-in function" );
+								ShowFatalError( "EMS error parsing tokens, too many for  built-in function" );  // LCOV_EXCL_LINE
 							}
 						}
 						break;
@@ -2454,7 +2454,7 @@ namespace RuntimeLanguageProcessor {
 
 				ShowSevereError( "EMS user program found serious problem and is halting simulation" );
 				ShowContinueErrorTimeStamp( "" );
-				ShowFatalError( "EMS user program halted simulation with error code = " + TrimSigDigits( Operand( 1 ).Number, 2 ) );
+				ShowFatalError( "EMS user program halted simulation with error code = " + TrimSigDigits( Operand( 1 ).Number, 2 ) );  // LCOV_EXCL_LINE
 				ReturnValue = SetErlValueNumber( Operand( 1 ).Number ); // returns back the error code
 			} else if ( SELECT_CASE_var == FuncSevereWarnEp ) {
 
@@ -2623,7 +2623,7 @@ namespace RuntimeLanguageProcessor {
 
 			} else {
 				// throw Error!
-				ShowFatalError( "caught unexpected Expression(ExpressionNum)%Operator in EvaluateExpression" );
+				ShowFatalError( "caught unexpected Expression(ExpressionNum)%Operator in EvaluateExpression" );  // LCOV_EXCL_LINE
 			}}
 			}
 			Operand.deallocate();
@@ -3095,7 +3095,7 @@ namespace RuntimeLanguageProcessor {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Errors found in getting EMS Runtime Language input. Preceding condition causes termination." );
+				ShowFatalError( "Errors found in getting EMS Runtime Language input. Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			// Parse the runtime language code
@@ -3112,7 +3112,7 @@ namespace RuntimeLanguageProcessor {
 			} // StackNum
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Errors found in parsing EMS Runtime Language input. Preceding condition causes termination." );
+				ShowFatalError( "Errors found in parsing EMS Runtime Language input. Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 			if ( ( NumEMSOutputVariables > 0 ) || ( NumEMSMeteredOutputVariables > 0 ) ) {
@@ -3534,7 +3534,7 @@ namespace RuntimeLanguageProcessor {
 			lNumericFieldBlanks.deallocate();
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Errors found in getting EMS Runtime Language input. Preceding condition causes termination." );
+				ShowFatalError( "Errors found in getting EMS Runtime Language input. Preceding condition causes termination." );  // LCOV_EXCL_LINE
 			}
 
 		} // GetInput

--- a/src/EnergyPlus/SQLiteProcedures.cc
+++ b/src/EnergyPlus/SQLiteProcedures.cc
@@ -109,7 +109,7 @@ std::unique_ptr<SQLite> CreateSQLiteDatabase()
 		std::shared_ptr<std::ofstream> errorStream = std::make_shared<std::ofstream>( DataStringGlobals::outputSqliteErrFileName, std::ofstream::out | std::ofstream::trunc );
 		return std::unique_ptr<SQLite>(new SQLite( errorStream, DataStringGlobals::outputSqlFileName, DataStringGlobals::outputSqliteErrFileName, writeOutputToSQLite, writeTabularDataToSQLite ));
 	} catch( const std::runtime_error& error ) {
-		ShowFatalError(error.what());
+		ShowFatalError(error.what());  // LCOV_EXCL_LINE
 		return nullptr;
 	}
 }

--- a/src/EnergyPlus/ScheduleManager.cc
+++ b/src/EnergyPlus/ScheduleManager.cc
@@ -1469,7 +1469,7 @@ namespace ScheduleManager {
 				if ( read_stat != 0 ) {
 					ShowSevereError( RoutineName + CurrentModuleObject + "=\"" + Alphas( 1 ) + "\", " + cAlphaFields( 3 ) + "=\"" + Alphas( 3 ) + "\" cannot be opened." );
 					ShowContinueError( "... It may be open in another program (such as Excel).  Please close and try again." );
-					ShowFatalError( "Program terminates due to previous condition." );
+					ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 				}
 				// check for stripping
 				{ IOFlags flags; gio::read( SchdFile, fmtA, flags ) >> LineIn; read_stat = flags.ios(); }
@@ -1479,7 +1479,7 @@ namespace ScheduleManager {
 						gio::close( SchdFile );
 						ShowSevereError( RoutineName + CurrentModuleObject + "=\"" + Alphas( 1 ) + "\", " + cAlphaFields( 3 ) + "=\"" + Alphas( 3 ) + " appears to be a Unicode or binary file." );
 						ShowContinueError( "...This file cannot be read by this program. Please save as PC or Unix file and try again" );
-						ShowFatalError( "Program terminates due to previous condition." );
+						ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 					}
 				}
 				gio::backspace( SchdFile );
@@ -1869,7 +1869,7 @@ namespace ScheduleManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Preceding Errors cause termination." );
+			ShowFatalError( RoutineName + "Preceding Errors cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( NumScheduleTypes + NumDaySchedules + NumWeekSchedules + NumSchedules > 0 ) { // Report to EIO file
@@ -3467,7 +3467,7 @@ namespace ScheduleManager {
 			MinValue = 0.0;
 			MaxValue = 0.0;
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "CheckScheduleValueMinMax called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckScheduleValueMinMax called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -3579,7 +3579,7 @@ namespace ScheduleManager {
 			MinValue = 0.0;
 			MaxValue = 0.0;
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "CheckScheduleValueMinMax called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckScheduleValueMinMax called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -3684,7 +3684,7 @@ namespace ScheduleManager {
 			MinValue = 0.0;
 			MaxValue = 0.0;
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "CheckScheduleValueMinMax called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckScheduleValueMinMax called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -3785,7 +3785,7 @@ namespace ScheduleManager {
 			MinValue = 0.0;
 			MaxValue = 0.0;
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "CheckScheduleValueMinMax called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckScheduleValueMinMax called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -3886,7 +3886,7 @@ namespace ScheduleManager {
 		} else if ( ScheduleIndex == 0 ) {
 			CheckScheduleValue = ( Value == 0.0 );
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "CheckScheduleValue called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckScheduleValue called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -3960,7 +3960,7 @@ namespace ScheduleManager {
 		} else if ( ScheduleIndex == 0 ) {
 			CheckScheduleValue = ( Value == 0 );
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "CheckScheduleValue called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckScheduleValue called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -4039,7 +4039,7 @@ namespace ScheduleManager {
 			MinValue = 0.0;
 			MaxValue = 0.0;
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumDaySchedules ) {
-			ShowFatalError( "CheckDayScheduleValueMinMax called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckDayScheduleValueMinMax called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -4134,7 +4134,7 @@ namespace ScheduleManager {
 			MinValue = 0.0;
 			MaxValue = 0.0;
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumDaySchedules ) {
-			ShowFatalError( "CheckDayScheduleValueMinMax called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckDayScheduleValueMinMax called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -4217,7 +4217,7 @@ namespace ScheduleManager {
 		if ( ScheduleIndex == -1 || ScheduleIndex == 0 ) {
 
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "HasFractionalScheduleValue called with ScheduleIndex out of range" );
+			ShowFatalError( "HasFractionalScheduleValue called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		HasFractions = false;
@@ -4309,7 +4309,7 @@ namespace ScheduleManager {
 			MinValue = 0.0;
 			MaxValue = 0.0;
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "GetScheduleMinValue called with ScheduleIndex out of range" );
+			ShowFatalError( "GetScheduleMinValue called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -4395,7 +4395,7 @@ namespace ScheduleManager {
 			MinValue = 0.0;
 			MaxValue = 0.0;
 		} else if ( ScheduleIndex < 1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "CheckScheduleMaxValue called with ScheduleIndex out of range" );
+			ShowFatalError( "CheckScheduleMaxValue called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		if ( ScheduleIndex > 0 ) {
@@ -4699,7 +4699,7 @@ namespace ScheduleManager {
 	)
 	{
 		// J. Glazer - July 2017
-		// adapted from Linda K. Lawrie original code for ScheduleAverageHoursPerWeek() 
+		// adapted from Linda K. Lawrie original code for ScheduleAverageHoursPerWeek()
 
 		int DaysInYear;
 
@@ -4710,7 +4710,7 @@ namespace ScheduleManager {
 		}
 
 		if ( ScheduleIndex < -1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "ScheduleAnnualFullLoadHours called with ScheduleIndex out of range" );
+			ShowFatalError( "ScheduleAnnualFullLoadHours called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		int DayT = StartDayOfWeek;
@@ -4758,7 +4758,7 @@ namespace ScheduleManager {
 		}
 
 		if ( ScheduleIndex < -1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "ScheduleAverageHoursPerWeek called with ScheduleIndex out of range" );
+			ShowFatalError( "ScheduleAverageHoursPerWeek called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		Real64 TotalHours = ScheduleAnnualFullLoadHours( ScheduleIndex , StartDayOfWeek, isItLeapYear );
@@ -4776,7 +4776,7 @@ namespace ScheduleManager {
 		)
 	{
 		// J. Glazer - July 2017
-		// adapted from Linda K. Lawrie original code for ScheduleAverageHoursPerWeek() 
+		// adapted from Linda K. Lawrie original code for ScheduleAverageHoursPerWeek()
 
 		int DaysInYear;
 
@@ -4787,7 +4787,7 @@ namespace ScheduleManager {
 		}
 
 		if ( ScheduleIndex < -1 || ScheduleIndex > NumSchedules ) {
-			ShowFatalError( "ScheduleHoursGT1perc called with ScheduleIndex out of range" );
+			ShowFatalError( "ScheduleHoursGT1perc called with ScheduleIndex out of range" );  // LCOV_EXCL_LINE
 		}
 
 		int DayT = StartDayOfWeek;

--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -524,7 +524,7 @@ namespace SetPointManager {
 		GetSetPointManagerInputData( ErrorsFound );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -3867,7 +3867,7 @@ namespace SetPointManager {
 			InitSetPointManagersOneTimeFlag = false;
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "InitSetPointManagers: Errors found in getting SetPointManager input." );
+				ShowFatalError( "InitSetPointManagers: Errors found in getting SetPointManager input." );  // LCOV_EXCL_LINE
 			}
 
 		}
@@ -4298,7 +4298,7 @@ namespace SetPointManager {
 			if ( ! InitSetPointManagersOneTimeFlag ) InitSetPointManagersOneTimeFlag2 = false;
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "InitSetPointManagers: Errors found. Program Terminates." );
+				ShowFatalError( "InitSetPointManagers: Errors found. Program Terminates." );  // LCOV_EXCL_LINE
 			}
 
 		} // end begin environment inits
@@ -5437,7 +5437,7 @@ namespace SetPointManager {
 					ShowSevereError( "CalcOAPretreatSetPoint: Missing reference setpoint for Outdoor Air Pretreat Setpoint Manager " + this->Name );
 					ShowContinueError( "Node Referenced =" + NodeID( RefNode ) );
 					ShowContinueError( "use a Setpoint Manager to establish a setpoint at this node." );
-					ShowFatalError( "Missing reference setpoint." );
+					ShowFatalError( "Missing reference setpoint." );  // LCOV_EXCL_LINE
 				} else {
 					LocalSetPointCheckFailed = false;
 					{ auto const SELECT_CASE_var( this->CtrlTypeMode );
@@ -5455,7 +5455,7 @@ namespace SetPointManager {
 						ShowContinueError( "Node Referenced =" + NodeID( RefNode ) );
 						ShowContinueError( "use a Setpoint Manager to establish a setpoint at this node." );
 						ShowContinueError( "Or use an EMS actuator to control a setpoint at this node." );
-						ShowFatalError( "Missing reference setpoint." );
+						ShowFatalError( "Missing reference setpoint." );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -5635,7 +5635,7 @@ namespace SetPointManager {
 				SetPointTemp = max( SetPointTemp, ZoneSetPointTemp );
 			}
 		} else {
-			// single-duct or central heated and cooled zones 
+			// single-duct or central heated and cooled zones
 			for ( ZonesHeatedIndex = 1; ZonesHeatedIndex <= AirToZoneNodeInfo( AirLoopNum ).NumZonesCooled; ++ZonesHeatedIndex ) {
 				CtrlZoneNum = AirToZoneNodeInfo( AirLoopNum ).CoolCtrlZoneNums( ZonesHeatedIndex );
 				ZoneInletNode = AirToZoneNodeInfo( AirLoopNum ).CoolZoneInletNodes( ZonesHeatedIndex );
@@ -7002,7 +7002,7 @@ namespace SetPointManager {
 					if ( ! DataPlant::verifyTwoNodeNumsOnSamePlantLoop( this->supplyNodeIndex, this->returnNodeIndex ) ) {
 						ShowSevereError( "Node problem for SetpointManager:ReturnTemperature:ChilledWater." );
 						ShowContinueError( "Return and Supply nodes were not found on the same plant loop.  Verify node names." );
-						ShowFatalError( "Simulation aborts due to setpoint node problem" );
+						ShowFatalError( "Simulation aborts due to setpoint node problem" );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -7039,7 +7039,7 @@ namespace SetPointManager {
 				ShowContinueError( "The manager is specified to look to the return node setpoint to find a target return temperature, but the node setpoint was invalid" );
 				ShowContinueError( "Verify that a separate sepoint manager is specified to set the setpoint on the return node named \"" + NodeID( this->returnNodeIndex ) + "\"" );
 				ShowContinueError( "Or change the target return temperature input type to constant or scheduled" );
-				ShowFatalError( "Missing reference setpoint" );
+				ShowFatalError( "Missing reference setpoint" );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -7108,7 +7108,7 @@ namespace SetPointManager {
 					if ( ! DataPlant::verifyTwoNodeNumsOnSamePlantLoop( this->supplyNodeIndex, this->returnNodeIndex ) ) {
 						ShowSevereError( "Node problem for SetpointManager:ReturnTemperature:HotWater." );
 						ShowContinueError( "Return and Supply nodes were not found on the same plant loop.  Verify node names." );
-						ShowFatalError( "Simulation aborts due to setpoint node problem" );
+						ShowFatalError( "Simulation aborts due to setpoint node problem" );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -7142,7 +7142,7 @@ namespace SetPointManager {
 				ShowContinueError( "The manager is specified to look to the return node setpoint to find a target return temperature, but the node setpoint was invalid" );
 				ShowContinueError( "Verify that a separate sepoint manager is specified to set the setpoint on the return node named \"" + NodeID( this->returnNodeIndex ) + "\"" );
 				ShowContinueError( "Or change the target return temperature input type to constant or scheduled" );
-				ShowFatalError( "Missing reference setpoint" );
+				ShowFatalError( "Missing reference setpoint" );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -8305,7 +8305,7 @@ namespace SetPointManager {
 		ErrorsFoundinTESSchSetup = false;
 		VerifySetPointManagers( ErrorsFoundinTESSchSetup );
 		if ( ErrorsFoundinTESSchSetup ) {
-			ShowFatalError( "Errors found in verification step of SetUpNewScheduledTESSetPtMgr.  Program terminates." );
+			ShowFatalError( "Errors found in verification step of SetUpNewScheduledTESSetPtMgr.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 		// Since all of the other setpoint managers not only been read and verified but also initialized, simulated, and updated,
 		// we must now also initialize, simulate, and update the current SchTESStPtMgr that was just added.  But the init and simulate

--- a/src/EnergyPlus/SimAirServingZones.cc
+++ b/src/EnergyPlus/SimAirServingZones.cc
@@ -1178,10 +1178,10 @@ namespace SimAirServingZones {
 
 					} else if ( componentType == "FAN:VARIABLEVOLUME" ) {
 						PrimaryAirSystem( AirSysNum ).Branch( BranchNum ).Comp( CompNum ).CompType_Num = Fan_Simple_VAV;
-					
+
 					} else if ( componentType == "FAN:SYSTEMMODEL") {
 						PrimaryAirSystem( AirSysNum ).Branch( BranchNum ).Comp( CompNum ).CompType_Num = Fan_System_Object;
-						//Construct fan object 
+						//Construct fan object
 						HVACFan::fanObjs.emplace_back( new HVACFan::FanSystem ( PrimaryAirSystem( AirSysNum ).Branch( BranchNum ).Comp( CompNum ).Name ) );
 						PrimaryAirSystem( AirSysNum ).Branch( BranchNum ).Comp( CompNum ).CompIndex = HVACFan::getFanObjectVectorIndex( PrimaryAirSystem( AirSysNum ).Branch( BranchNum ).Comp( CompNum ).Name ) + 1; // + 1 for shift from zero-based vector to 1-based compIndex
 						// cpw22Aug2010 Add Fan_ComponentModel type (new num=24)
@@ -1335,7 +1335,7 @@ namespace SimAirServingZones {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found retrieving input for " + CurrentModuleObject + '.' );
+			ShowFatalError( RoutineName + "Errors found retrieving input for " + CurrentModuleObject + '.' );  // LCOV_EXCL_LINE
 		}
 
 		for ( AirSysNum = 1; AirSysNum <= NumPrimaryAirSys; ++AirSysNum ) {
@@ -1892,7 +1892,7 @@ namespace SimAirServingZones {
 			TermUnitSizingNumsHeat.deallocate();
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Preceding errors cause termination" );
+				ShowFatalError( "Preceding errors cause termination" );  // LCOV_EXCL_LINE
 			}
 
 			for ( AirLoopNum = 1; AirLoopNum <= NumPrimaryAirSys; ++AirLoopNum ) {
@@ -2144,7 +2144,7 @@ namespace SimAirServingZones {
 				for ( InNum = 1; InNum <= PrimaryAirSystem( AirLoopNum ).NumInletBranches; ++InNum ) {
 					InBranchNum = PrimaryAirSystem( AirLoopNum ).InletBranchNum( InNum );
 					if ( InBranchNum == 0 ) {
-						ShowFatalError( "Missing Inlet Branch on Primary Air System=" + PrimaryAirSystem( AirLoopNum ).Name );
+						ShowFatalError( "Missing Inlet Branch on Primary Air System=" + PrimaryAirSystem( AirLoopNum ).Name );  // LCOV_EXCL_LINE
 					}
 					NodeNumIn = PrimaryAirSystem( AirLoopNum ).Branch( InBranchNum ).NodeNumIn;
 
@@ -2963,7 +2963,7 @@ namespace SimAirServingZones {
 			}
 			// if the fan is here, it can't (yet) really be cycling fan operation, set this ugly global in the event that there are dx coils involved but the fan should really run like constant volume and not cycle with compressor
 			DataHVACGlobals::OnOffFanPartLoadFraction = 1.0;
-			HVACFan::fanObjs[ CompIndex - 1 ]->simulate( _,_,_,_ ); // vector is 0 based, but CompIndex is 1 based so shift 
+			HVACFan::fanObjs[ CompIndex - 1 ]->simulate( _,_,_,_ ); // vector is 0 based, but CompIndex is 1 based so shift
 
 			// cpw22Aug2010 Add Fan:ComponentModel (new)
 		} else if ( SELECT_CASE_var == Fan_ComponentModel ) { // 'Fan:ComponentModel'
@@ -3508,7 +3508,7 @@ namespace SimAirServingZones {
 				ShowSevereError( "AirLoopHVAC " + PrimaryAirSystem( AirLoopNum ).Name + " has no air flow" );
 				ShowContinueError( "Check flow rate inputs for components in this air loop and," );
 				ShowContinueError( "if autosized, check Sizing:Zone and Sizing:System objects and related inputs." );
-				ShowFatalError( "Previous condition causes termination." );
+				ShowFatalError( "Previous condition causes termination." );  // LCOV_EXCL_LINE
 
 			}
 
@@ -3532,7 +3532,7 @@ namespace SimAirServingZones {
 			}
 		} // End of component loop
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -3662,7 +3662,7 @@ namespace SimAirServingZones {
 			}
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in Sizing:System input" );
+			ShowFatalError( "Errors found in Sizing:System input" );  // LCOV_EXCL_LINE
 		}
 
 		SysSizing.allocate( TotDesDays + TotRunDesPersDays, NumPrimaryAirSys );
@@ -4093,7 +4093,7 @@ namespace SimAirServingZones {
 					int TermUnitSizingIndex = AirToZoneNodeInfo( AirLoopNum ).TermUnitCoolSizingIndex( ZonesCooledNum );
 					if ( TermUnitSizingIndex == 0 ) {
 						ShowSevereError( "SetUpSysSizingArray: TermUnitSizingIndex = 0 for AirLoop=" + AirToZoneNodeInfo( AirLoopNum ).AirLoopName + ", Zone =" + Zone( AirToZoneNodeInfo( AirLoopNum ).CoolCtrlZoneNums( ZonesCooledNum ) ).Name );
-						ShowFatalError( "This is a defect. Please report this issue." );
+						ShowFatalError( "This is a defect. Please report this issue." );  // LCOV_EXCL_LINE
 					}
 					if ( SysSizNum > 0 ) {
 						if ( SysSizInput( SysSizNum ).SystemOAMethod == SOAM_ZoneSum ) { // ZoneSum Method
@@ -6546,7 +6546,7 @@ namespace SimAirServingZones {
 					}
 				} else if ( FinalSysSizing( AirLoopNum ).CoolingCapMethod == CapacityPerFloorArea ) {
 					TempSize = FinalSysSizing( AirLoopNum ).FlowPerCoolingCapacity * FinalSysSizing( AirLoopNum ).ScaledCoolingCapacity * FinalSysSizing( AirLoopNum ).FloorAreaOnAirLoopCooled;
-				} 
+				}
 				CalcSysSizing( AirLoopNum ).InpDesCoolAirFlow = TempSize;
 				FinalSysSizing( AirLoopNum ).InpDesCoolAirFlow = TempSize;
 			}}
@@ -6613,7 +6613,7 @@ namespace SimAirServingZones {
 					}
 				} else if ( FinalSysSizing( AirLoopNum ).HeatingCapMethod == CapacityPerFloorArea ) {
 					TempSize = FinalSysSizing( AirLoopNum ).FlowPerHeatingCapacity * FinalSysSizing( AirLoopNum ).ScaledHeatingCapacity * FinalSysSizing( AirLoopNum ).FloorAreaOnAirLoopCooled;
-				} 
+				}
 				CalcSysSizing( AirLoopNum ).InpDesHeatAirFlow = TempSize;
 				FinalSysSizing( AirLoopNum ).InpDesHeatAirFlow = TempSize;
 			}}
@@ -6643,7 +6643,7 @@ namespace SimAirServingZones {
 					FinalSysSizing( AirLoopNum ).HeatingTotalCapacity = 0.0; // autosized, set to zero initially
 				}
 			} else if ( SELECT_CASE_var == CapacityPerFloorArea ) {
-				// even for heating capacity we use cooled zones floor area ( *.FloorAreaOnAirLoopCooled ) served by the airloop 
+				// even for heating capacity we use cooled zones floor area ( *.FloorAreaOnAirLoopCooled ) served by the airloop
 				FinalSysSizing( AirLoopNum ).HeatingTotalCapacity = CalcSysSizing( AirLoopNum ).ScaledHeatingCapacity * FinalSysSizing( AirLoopNum ).FloorAreaOnAirLoopCooled;
 			} else if ( SELECT_CASE_var == FractionOfAutosizedHeatingCapacity ) {
 				FinalSysSizing( AirLoopNum ).FractionOfAutosizedHeatingCapacity = CalcSysSizing( AirLoopNum ).ScaledHeatingCapacity;
@@ -6865,7 +6865,7 @@ namespace SimAirServingZones {
 			ZoneOAFrac = 1.0 + Xs - FinalZoneSizing( CtrlZoneNum ).ZoneVentilationEff;
 			// reset AvailSAFlow (which in this case is minimum cooling supply air flow rate)
 			AvailSAFlow = Voz/ZoneOAFrac;
-			// save ZoneOAFrac 
+			// save ZoneOAFrac
 			FinalZoneSizing( CtrlZoneNum ).ZpzClgByZone = ZoneOAFrac;
 			// save new (increased) minimum flow rate
 			FinalZoneSizing( CtrlZoneNum ).DesCoolVolFlowMin = AvailSAFlow;

--- a/src/EnergyPlus/SimulationManager.cc
+++ b/src/EnergyPlus/SimulationManager.cc
@@ -373,7 +373,7 @@ namespace SimulationManager {
 		Available = true;
 
 		if ( InvalidBranchDefinitions ) {
-			ShowFatalError( "Preceding error(s) in Branch Input cause termination." );
+			ShowFatalError( "Preceding error(s) in Branch Input cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		DisplayString( "Initializing Simulation" );
@@ -436,7 +436,7 @@ namespace SimulationManager {
 			ProduceRDDMDD();
 
 			if ( TerminalError ) {
-				ShowFatalError( "Previous Conditions cause program termination." );
+				ShowFatalError( "Previous Conditions cause program termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -447,10 +447,10 @@ namespace SimulationManager {
 		}
 
 		GetInputForLifeCycleCost(); //must be prior to WriteTabularReports -- do here before big simulation stuff.
-		
+
 		// check for variable latitude/location/etc
 		WeatherManager::ReadVariableLocationOrientation();
-		
+
 		// if user requested HVAC Sizing Simulation, call HVAC sizing simulation manager
 		if ( DoHVACSizingSimulation ) {
 			ManageHVACSizingSimulation( ErrorsFound );
@@ -586,7 +586,7 @@ namespace SimulationManager {
 						//  After the first iteration of HeatBalance, all the 'input' has been gotten
 						if ( BeginFullSimFlag ) {
 							if ( GetNumRangeCheckErrorsFound() > 0 ) {
-								ShowFatalError( "Out of \"range\" values found in input" );
+								ShowFatalError( "Out of \"range\" values found in input" );  // LCOV_EXCL_LINE
 							}
 						}
 
@@ -671,7 +671,7 @@ namespace SimulationManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Error condition occurred.  Previous Severe Errors cause termination." );
+			ShowFatalError( "Error condition occurred.  Previous Severe Errors cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1043,7 +1043,7 @@ namespace SimulationManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found getting Project Input" );
+			ShowFatalError( "Errors found getting Project Input" );  // LCOV_EXCL_LINE
 		}
 
 		gio::write( OutputFileInits, fmtA ) << "! <Version>, Version ID";
@@ -1233,7 +1233,7 @@ namespace SimulationManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Program terminates due to preceding conditions." );
+			ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1338,7 +1338,7 @@ namespace SimulationManager {
 		StdOutputRecordCount = 0;
 		{ IOFlags flags; flags.ACTION( "write" ); flags.STATUS( "UNKNOWN" ); gio::open( OutputFileStandard, DataStringGlobals::outputEsoFileName, flags ); write_stat = flags.ios(); }
 		if ( write_stat != 0 ) {
-			ShowFatalError( "OpenOutputFiles: Could not open file "+DataStringGlobals::outputEsoFileName+" for output (write)." );
+			ShowFatalError( "OpenOutputFiles: Could not open file "+DataStringGlobals::outputEsoFileName+" for output (write)." );  // LCOV_EXCL_LINE
 		}
 		eso_stream = gio::out_stream( OutputFileStandard );
 		gio::write( OutputFileStandard, fmtA ) << "Program Version," + VerString;
@@ -1347,7 +1347,7 @@ namespace SimulationManager {
 		OutputFileInits = GetNewUnitNumber();
 		{ IOFlags flags; flags.ACTION( "write" ); flags.STATUS( "UNKNOWN" ); gio::open( OutputFileInits, DataStringGlobals::outputEioFileName, flags ); write_stat = flags.ios(); }
 		if ( write_stat != 0 ) {
-			ShowFatalError( "OpenOutputFiles: Could not open file "+DataStringGlobals::outputEioFileName+" for output (write)." );
+			ShowFatalError( "OpenOutputFiles: Could not open file "+DataStringGlobals::outputEioFileName+" for output (write)." );  // LCOV_EXCL_LINE
 		}
 		eio_stream = gio::out_stream( OutputFileInits );
 		gio::write( OutputFileInits, fmtA ) << "Program Version," + VerString;
@@ -1357,7 +1357,7 @@ namespace SimulationManager {
 		StdMeterRecordCount = 0;
 		{ IOFlags flags; flags.ACTION( "write" ); flags.STATUS( "UNKNOWN" ); gio::open( OutputFileMeters, DataStringGlobals::outputMtrFileName, flags ); write_stat = flags.ios(); }
 		if ( write_stat != 0 ) {
-			ShowFatalError( "OpenOutputFiles: Could not open file "+DataStringGlobals::outputMtrFileName+" for output (write)." );
+			ShowFatalError( "OpenOutputFiles: Could not open file "+DataStringGlobals::outputMtrFileName+" for output (write)." );  // LCOV_EXCL_LINE
 		}
 		mtr_stream = gio::out_stream( OutputFileMeters );
 		gio::write( OutputFileMeters, fmtA ) << "Program Version," + VerString;
@@ -1366,7 +1366,7 @@ namespace SimulationManager {
 		OutputFileBNDetails = GetNewUnitNumber();
 		{ IOFlags flags; flags.ACTION( "write" ); flags.STATUS( "UNKNOWN" ); gio::open( OutputFileBNDetails, DataStringGlobals::outputBndFileName, flags ); write_stat = flags.ios(); }
 		if ( write_stat != 0 ) {
-			ShowFatalError( "OpenOutputFiles: Could not open file "+DataStringGlobals::outputBndFileName+" for output (write)." );
+			ShowFatalError( "OpenOutputFiles: Could not open file "+DataStringGlobals::outputBndFileName+" for output (write)." );  // LCOV_EXCL_LINE
 		}
 		gio::write( OutputFileBNDetails, fmtA ) << "Program Version," + VerString;
 
@@ -1665,7 +1665,7 @@ namespace SimulationManager {
 			//  After the first iteration of HeatBalance, all the 'input' has been gotten
 			if ( BeginFullSimFlag ) {
 				if ( GetNumRangeCheckErrorsFound() > 0 ) {
-					ShowFatalError( "Out of \"range\" values found in input" );
+					ShowFatalError( "Out of \"range\" values found in input" );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -1704,7 +1704,7 @@ namespace SimulationManager {
 		}
 
 		if ( ! ErrorsFound ) SimCostEstimate(); // basically will get and check input
-		if ( ErrorsFound ) ShowFatalError( "Previous conditions cause program termination." );
+		if ( ErrorsFound ) ShowFatalError( "Previous conditions cause program termination." );  // LCOV_EXCL_LINE
 
 	}
 
@@ -2492,11 +2492,11 @@ namespace SimulationManager {
 		CheckCachedIPErrors();
 
 		if ( PreP_Fatal ) {
-			ShowFatalError( "Preprocessor condition(s) cause termination." );
+			ShowFatalError( "Preprocessor condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( OverallErrorFlag ) {
-			ShowFatalError( "IP: Errors occurred on processing IDF file. Preceding condition(s) cause termination." );
+			ShowFatalError( "IP: Errors occurred on processing IDF file. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		CompactObjectsCheck(); // Check to see if Compact Objects (CompactHVAC, etc) are in input file.
@@ -2506,7 +2506,7 @@ namespace SimulationManager {
 
 		if ( NumOutOfRangeErrorsFound + NumBlankReqFieldFound + NumMiscErrorsFound > 0 ) {
 			ShowSevereError( "IP: Out of \"range\" values and/or blank required fields found in input" );
-			ShowFatalError( "IP: Errors occurred on processing IDF file. Preceding condition(s) cause termination." );
+			ShowFatalError( "IP: Errors occurred on processing IDF file. Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		if ( GetNumSectionsFound( "DISPLAYALLWARNINGS" ) > 0 ) {

--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -287,17 +287,17 @@ namespace SingleDuct {
 		if ( CompIndex == 0 ) {
 			SysNum = FindItemInList( CompName, Sys, &SysDesignParams::SysName );
 			if ( SysNum == 0 ) {
-				ShowFatalError( "SimulateSingleDuct: System not found=" + CompName );
+				ShowFatalError( "SimulateSingleDuct: System not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = SysNum;
 		} else {
 			SysNum = CompIndex;
 			if ( SysNum > NumSys || SysNum < 1 ) {
-				ShowFatalError( "SimulateSingleDuct: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of Systems=" + TrimSigDigits( NumSys ) + ", System name=" + CompName );
+				ShowFatalError( "SimulateSingleDuct: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", Number of Systems=" + TrimSigDigits( NumSys ) + ", System name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( SysNum ) ) {
 				if ( CompName != Sys( SysNum ).SysName ) {
-					ShowFatalError( "SimulateSingleDuct: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", System name=" + CompName + ", stored System Name for that index=" + Sys( SysNum ).SysName );
+					ShowFatalError( "SimulateSingleDuct: Invalid CompIndex passed=" + TrimSigDigits( CompIndex ) + ", System name=" + CompName + ", stored System Name for that index=" + Sys( SysNum ).SysName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( SysNum ) = false;
 			}
@@ -1644,7 +1644,7 @@ namespace SingleDuct {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1737,7 +1737,7 @@ namespace SingleDuct {
 
 				if ( errFlag ) {
 					ShowContinueError( "Reference Unit=\"" + Sys( SysNum ).SysName + "\", type=" + Sys( SysNum ).SysType );
-					ShowFatalError( "InitSys: Program terminated for previous conditions." );
+					ShowFatalError( "InitSys: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 
 				Sys( SysNum ).ReheatCoilOutletNode = PlantLoop( Sys( SysNum ).HWLoopNum ).LoopSide( Sys( SysNum ).HWLoopSide ).Branch( Sys( SysNum ).HWBranchIndex ).Comp( Sys( SysNum ).HWCompIndex ).NodeNumOut;
@@ -2020,7 +2020,7 @@ namespace SingleDuct {
 		if ( ( CurZoneEqNum > 0 ) && ( CurTermUnitSizingNum > 0 ) ) {
 			if ( ! IsAutoSize && ! ZoneSizingRunDone ) { // simulation continue
 				if ( Sys( SysNum ).MaxAirVolFlowRate > 0.0 ) {
-					ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "User-Specified Maximum Air Flow Rate [m3/s]", 
+					ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "User-Specified Maximum Air Flow Rate [m3/s]",
 						Sys( SysNum ).MaxAirVolFlowRate );
 				}
 			} else { // Autosize or hard-size with sizing run
@@ -2038,7 +2038,7 @@ namespace SingleDuct {
 				} else { // Hard-size with sizing data
 					if ( Sys( SysNum ).MaxAirVolFlowRate > 0.0 && MaxAirVolFlowRateDes > 0.0 ) {
 						MaxAirVolFlowRateUser = Sys( SysNum ).MaxAirVolFlowRate;
-						ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Maximum Air Flow Rate [m3/s]", 
+						ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Maximum Air Flow Rate [m3/s]",
 							MaxAirVolFlowRateDes, "User-Specified Maximum Air Flow Rate [m3/s]", MaxAirVolFlowRateUser );
 						if ( DisplayExtraWarnings ) {
 							if ( ( std::abs( MaxAirVolFlowRateDes - MaxAirVolFlowRateUser ) / MaxAirVolFlowRateUser ) > AutoVsHardSizingThreshold ) {
@@ -2124,7 +2124,7 @@ namespace SingleDuct {
 			} else {
 				// report out hard (user set) value and issue warning if appropriate
 				MinAirFlowFracUser = Sys( SysNum ).ZoneMinAirFrac;
-				ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Constant Minimum Air Flow Fraction", MinAirFlowFracDes, 
+				ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Constant Minimum Air Flow Fraction", MinAirFlowFracDes,
 					"User-Specified Constant Minimum Air Flow Fraction", MinAirFlowFracUser );
 				if ( DisplayExtraWarnings ) {
 					if ( ( std::abs( MinAirFlowFracDes - MinAirFlowFracUser ) / MinAirFlowFracUser) > AutoVsHardSizingThreshold ) {
@@ -2178,7 +2178,7 @@ namespace SingleDuct {
 			else {
 				// report out hard (user set) value and issue warning if appropriate
 				FixedMinAirUser = Sys( SysNum ).ZoneFixedMinAir;
-				ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Fixed Minimum Air Flow Rate [m3/s]", FixedMinAirDes, 
+				ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Fixed Minimum Air Flow Rate [m3/s]", FixedMinAirDes,
 					"User-Specified Fixed Minimum Air Flow Rate [m3/s]", FixedMinAirUser );
 				if ( DisplayExtraWarnings ) {
 					if ( ( std::abs( FixedMinAirDes - FixedMinAirUser ) / FixedMinAirUser ) > AutoVsHardSizingThreshold ) {
@@ -2263,7 +2263,7 @@ namespace SingleDuct {
 				ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Maximum Flow Fraction during Reheat []",
 					MaxAirVolFractionDuringReheatDes, "User-Specified Maximum Flow Fraction during Reheat []", MaxAirVolFractionDuringReheatUser );
 				if ( Sys( SysNum ).ZoneFloorArea > 0.0 ) {
-					ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, 
+					ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName,
 						"Design Size Maximum Flow per Zone Floor Area during Reheat [m3/s-m2]",
 						MaxAirVolFlowRateDuringReheatDes / Sys( SysNum ).ZoneFloorArea );
 				}
@@ -2400,7 +2400,7 @@ namespace SingleDuct {
 					}
 				}
 			}
-		
+
 			if ( TermUnitSizing( CurTermUnitSizingNum ).AirVolFlow > SmallAirVolFlow ) {
 				if ( Sys( SysNum ).DamperHeatingAction == ReverseActionWithLimits ) {
 					TermUnitSizing( CurTermUnitSizingNum ).ReheatAirFlowMult = min( Sys( SysNum ).MaxAirVolFlowRateDuringReheat, Sys( SysNum ).MaxAirVolFlowRate ) / TermUnitSizing( CurTermUnitSizingNum ).AirVolFlow;
@@ -2476,7 +2476,7 @@ namespace SingleDuct {
 						ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Maximum Reheat Water Flow Rate [m3/s]", MaxReheatWaterVolFlowDes );
 						ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Reheat Coil Sizing Air Volume Flow Rate [m3/s]", TermUnitSizing( CurTermUnitSizingNum ).AirVolFlow );
 						ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Reheat Coil Sizing Inlet Air Temperature [C]", TermUnitFinalZoneSizing( CurTermUnitSizingNum ).DesHeatCoilInTempTU );
-						ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Reheat Coil Sizing Inlet Air Humidity Ratio [kgWater/kgDryAir]", TermUnitFinalZoneSizing( CurTermUnitSizingNum ).DesHeatCoilInHumRatTU );						
+						ReportSizingOutput( Sys( SysNum ).SysType, Sys( SysNum ).SysName, "Design Size Reheat Coil Sizing Inlet Air Humidity Ratio [kgWater/kgDryAir]", TermUnitFinalZoneSizing( CurTermUnitSizingNum ).DesHeatCoilInHumRatTU );
 					} else { // Hard-size with sizing data
 						if ( Sys( SysNum ).MaxReheatWaterVolFlow > 0.0 && MaxReheatWaterVolFlowDes > 0.0 ) {
 							MaxReheatWaterVolFlowUser = Sys( SysNum ).MaxReheatWaterVolFlow;
@@ -2598,7 +2598,7 @@ namespace SingleDuct {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -3008,7 +3008,7 @@ namespace SingleDuct {
 				// If something else is there that is not a reheat coil or a blank then give the error message
 
 			} else {
-				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );
+				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );  // LCOV_EXCL_LINE
 			}}
 
 			//the COIL is OFF the properties are calculated for this special case.
@@ -3039,7 +3039,7 @@ namespace SingleDuct {
 				// If something else is that is not a reheat coil or a blank then give the error message
 
 			} else {
-				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );
+				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );  // LCOV_EXCL_LINE
 			}}
 
 		}
@@ -3409,7 +3409,7 @@ namespace SingleDuct {
 				// If something else is there that is not a reheat coil then give the error message below.
 
 			} else {
-				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );
+				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );  // LCOV_EXCL_LINE
 			}}
 
 			//the COIL is OFF the properties are calculated for this special case.
@@ -3442,7 +3442,7 @@ namespace SingleDuct {
 				// If something else is there that is not a reheat coil then give the error message
 
 			} else {
-				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );
+				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );  // LCOV_EXCL_LINE
 			}}
 
 		}
@@ -3850,7 +3850,7 @@ namespace SingleDuct {
 					CalcVAVVS( SysNum, FirstHVACIteration, ZoneNodeNum, HCType, 0.0, QTotLoad, FanType, MassFlow, FanOp, QDelivered );
 				}
 			} else {
-				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );
+				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );  // LCOV_EXCL_LINE
 			}
 
 		} else {
@@ -4003,7 +4003,7 @@ namespace SingleDuct {
 				// Simulate reheat coil for the VAV system
 				SimulateHeatingCoilComponents( Sys( SysNum ).ReheatName, FirstHVACIteration, QZnReq, Sys( SysNum ).ReheatComp_Index );
 			} else {
-				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );
+				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );  // LCOV_EXCL_LINE
 			}}
 
 			//the COIL is OFF the properties are calculated for this special case.
@@ -4032,7 +4032,7 @@ namespace SingleDuct {
 				// Simulate reheat coil for the Const Volume system
 				SimulateHeatingCoilComponents( Sys( SysNum ).ReheatName, FirstHVACIteration, 0.0, Sys( SysNum ).ReheatComp_Index );
 			} else {
-				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );
+				ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );  // LCOV_EXCL_LINE
 			}}
 
 		}
@@ -4156,7 +4156,7 @@ namespace SingleDuct {
 		} else if ( SELECT_CASE_var == HCoilType_Gas ) { // COIL:GAS:HEATING
 			SimulateHeatingCoilComponents( Sys( SysNum ).ReheatName, FirstHVACIteration, HCoilReq, Sys( SysNum ).ReheatComp_Index );
 		} else {
-			ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );
+			ShowFatalError( "Invalid Reheat Component=" + Sys( SysNum ).ReheatComp );  // LCOV_EXCL_LINE
 		}}
 
 		LoadMet = AirMassFlow * CpAirZn * ( Node( HCOutNode ).Temp - Node( ZoneNode ).Temp );
@@ -4721,7 +4721,7 @@ namespace SingleDuct {
 			SysNum = FindItemInList( SysName, SysATMixer );
 			SysIndex = SysNum;
 			if ( SysNum == 0 ) {
-				ShowFatalError( "Object " + SysName + " not found" );
+				ShowFatalError( "Object " + SysName + " not found" );  // LCOV_EXCL_LINE
 			}
 		} else {
 			SysNum = SysIndex;
@@ -4829,7 +4829,7 @@ namespace SingleDuct {
 			if ( cAlphaArgs( 2 ) == "ZONEHVAC:WATERTOAIRHEATPUMP" ) {
 				SysATMixer( ATMixerNum ).ZoneHVACUnitType = 1;
 			} else if ( cAlphaArgs( 2 ) == "ZONEHVAC:FOURPIPEFANCOIL" ) {
-				SysATMixer( ATMixerNum ).ZoneHVACUnitType = 2;			
+				SysATMixer( ATMixerNum ).ZoneHVACUnitType = 2;
 			} else if ( cAlphaArgs( 2 ) == "ZONEHVAC:PACKAGEDTERMINALAIRCONDITIONER" ) {
 				SysATMixer( ATMixerNum ).ZoneHVACUnitType = 3;
 			} else if ( cAlphaArgs( 2 ) == "ZONEHVAC:PACKAGEDTERMINALHEATPUMP" ) {
@@ -4851,18 +4851,18 @@ namespace SingleDuct {
 			SysATMixer( ATMixerNum ).PriInNode = GetOnlySingleNode( cAlphaArgs( 5 ), ErrorsFound, cCurrentModuleObject, cAlphaArgs( 1 ), NodeType_Air, NodeConnectionType_Inlet, 1, ObjectIsNotParent, cAlphaFieldNames( 5 ) );
 			SysATMixer( ATMixerNum ).SecInNode = GetOnlySingleNode( cAlphaArgs( 6 ), ErrorsFound, cCurrentModuleObject, cAlphaArgs( 1 ), NodeType_Air, NodeConnectionType_Inlet, 1, ObjectIsNotParent, cAlphaFieldNames( 6 ) );
 
-			if ( lAlphaFieldBlanks( 8 ) ) { 
+			if ( lAlphaFieldBlanks( 8 ) ) {
 				SysATMixer( ATMixerNum ).NoOAFlowInputFromUser = true;
-			} else { 
-				SysATMixer( ATMixerNum ).OARequirementsPtr = InputProcessor::FindItemInList( cAlphaArgs( 8 ), DataSizing::OARequirements ); 
-				if ( SysATMixer( ATMixerNum ).OARequirementsPtr == 0 ) { 
-					ShowSevereError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", invalid data." ); 
-					ShowContinueError( "..invalid " + cAlphaFieldNames( 8 ) + "=\"" + cAlphaArgs( 8 ) + "\"." ); 
-					ErrorsFound = true; 
-				} else { 
-					SysATMixer( ATMixerNum ).NoOAFlowInputFromUser = false; 
-				} 
-			} 
+			} else {
+				SysATMixer( ATMixerNum ).OARequirementsPtr = InputProcessor::FindItemInList( cAlphaArgs( 8 ), DataSizing::OARequirements );
+				if ( SysATMixer( ATMixerNum ).OARequirementsPtr == 0 ) {
+					ShowSevereError( RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs( 1 ) + "\", invalid data." );
+					ShowContinueError( "..invalid " + cAlphaFieldNames( 8 ) + "=\"" + cAlphaArgs( 8 ) + "\"." );
+					ErrorsFound = true;
+				} else {
+					SysATMixer( ATMixerNum ).NoOAFlowInputFromUser = false;
+				}
+			}
 
 			if ( lAlphaFieldBlanks( 9 ) ) {
 				SysATMixer( ATMixerNum ).OAPerPersonMode = DataZoneEquipment::PerPersonDCVByCurrentLevel;
@@ -4915,14 +4915,14 @@ namespace SingleDuct {
 							if ( SysATMixer( ATMixerNum ).SecInNode == ZoneEquipConfig( CtrlZone ).ExhaustNode( NodeNum ) ) {
 								ZoneNodeNotFound = false;
 								AirDistUnit( SysATMixer( ATMixerNum ).ADUNum ).ZoneEqNum = CtrlZone;
-								SysATMixer( ATMixerNum ).ZoneEqNum = CtrlZone; 
-								SysATMixer( ATMixerNum ).ZoneNum = ZoneEquipConfig( CtrlZone ).ActualZoneNum; 
+								SysATMixer( ATMixerNum ).ZoneEqNum = CtrlZone;
+								SysATMixer( ATMixerNum ).ZoneNum = ZoneEquipConfig( CtrlZone ).ActualZoneNum;
 								// Must wait until InitATMixer to fill other zone equip config data because ultimate zone inlet node is not known yet for inlet side mixers
-								if ( !SysATMixer( ATMixerNum ).NoOAFlowInputFromUser ) { 																						 
-									bool UseOccSchFlag = false; 
-									bool UseMinOASchFlag = false; 
-									SysATMixer( ATMixerNum ).DesignPrimaryAirVolRate = DataZoneEquipment::CalcDesignSpecificationOutdoorAir( SysATMixer( ATMixerNum ).OARequirementsPtr, SysATMixer( ATMixerNum ).ZoneNum, UseOccSchFlag, UseMinOASchFlag ); 
-								} 
+								if ( !SysATMixer( ATMixerNum ).NoOAFlowInputFromUser ) {
+									bool UseOccSchFlag = false;
+									bool UseMinOASchFlag = false;
+									SysATMixer( ATMixerNum ).DesignPrimaryAirVolRate = DataZoneEquipment::CalcDesignSpecificationOutdoorAir( SysATMixer( ATMixerNum ).OARequirementsPtr, SysATMixer( ATMixerNum ).ZoneNum, UseOccSchFlag, UseMinOASchFlag );
+								}
 								goto ControlledZoneLoop_exit;
 							}
 						}
@@ -4933,7 +4933,7 @@ namespace SingleDuct {
 						ShowContinueError( "..Zone exhaust node name is specified in ZoneHVAC:EquipmentConnections object." );
 						ShowContinueError( "..Inlet Side CONNECTED Air Terminal Mixer inlet node name = " + NodeID( SysATMixer( ATMixerNum ).SecInNode ) );
 						ErrorsFound = true;
-					}				
+					}
 				}
 
 				if ( SysATMixer( ATMixerNum ).MixerType == ATMixer_SupplySide ) {
@@ -4944,8 +4944,8 @@ namespace SingleDuct {
 							if ( SysATMixer( ATMixerNum ).MixedAirOutNode == ZoneEquipConfig( CtrlZone ).InletNode( NodeNum ) ) {
 								ZoneNodeNotFound = false;
 								AirDistUnit( SysATMixer( ATMixerNum ).ADUNum ).ZoneEqNum = CtrlZone;
-								SysATMixer( ATMixerNum ).ZoneEqNum = CtrlZone; 
-								SysATMixer( ATMixerNum ).ZoneNum = ZoneEquipConfig( CtrlZone ).ActualZoneNum; 
+								SysATMixer( ATMixerNum ).ZoneEqNum = CtrlZone;
+								SysATMixer( ATMixerNum ).ZoneNum = ZoneEquipConfig( CtrlZone ).ActualZoneNum;
 								// Wait until InitATMixer to fill other zone equip config data
 
 								if ( !SysATMixer( ATMixerNum ).NoOAFlowInputFromUser ) {
@@ -4993,7 +4993,7 @@ namespace SingleDuct {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );
+			ShowFatalError( RoutineName + "Errors found in input.  Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -5265,7 +5265,7 @@ namespace SingleDuct {
 			ATMixerSecNode = SysATMixer( ATMixerIndex ).SecInNode;
 			ATMixerOutNode = SysATMixer( ATMixerIndex ).MixedAirOutNode;
 			ATMixerType = SysATMixer( ATMixerIndex ).MixerType;
-			if ( ATMixerType == ATMixer_InletSide ) { 
+			if ( ATMixerType == ATMixer_InletSide ) {
 				SysATMixer( ATMixerIndex ).ZoneInletNode = ZoneEquipOutletNode;
 			} else {
 				SysATMixer( ATMixerIndex ).ZoneInletNode = ATMixerOutNode;

--- a/src/EnergyPlus/SizingAnalysisObjects.cc
+++ b/src/EnergyPlus/SizingAnalysisObjects.cc
@@ -544,7 +544,7 @@ namespace EnergyPlus {
 		}
 
 		//step 3 calculate mdot from max load and delta T
-		if ( ( ! CheckTimeStampForNull( NewFoundMaxDemandTimeStamp ) && ( NewFoundMaxDemandTimeStamp.runningAvgDataValue > 0.0 ) ) && 
+		if ( ( ! CheckTimeStampForNull( NewFoundMaxDemandTimeStamp ) && ( NewFoundMaxDemandTimeStamp.runningAvgDataValue > 0.0 ) ) &&
 			( ( specificHeatForSizing * PlantSizData( plantSizingIndex ).DeltaT ) > 0.0 ) )  {
 				peakLoadCalculatedMassFlow = NewFoundMaxDemandTimeStamp.runningAvgDataValue /
 											( specificHeatForSizing * PlantSizData( plantSizingIndex ).DeltaT );

--- a/src/EnergyPlus/SizingManager.cc
+++ b/src/EnergyPlus/SizingManager.cc
@@ -243,7 +243,7 @@ namespace SizingManager {
 			if ( ( NumSysSizInput > 0 && NumZoneSizingInput == 0 ) || ( ! DoZoneSizing && DoSystemSizing && NumSysSizInput > 0 ) ) {
 				ShowSevereError( RoutineName + "Requested System Sizing but did not request Zone Sizing." );
 				ShowContinueError( "System Sizing cannot be done without Zone Sizing" );
-				ShowFatalError( "Program terminates for preceding conditions." );
+				ShowFatalError( "Program terminates for preceding conditions." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -279,17 +279,17 @@ namespace SizingManager {
 			if ( SizingFileColSep == CharComma ) {
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputFileZoneSizing, DataStringGlobals::outputZszCsvFileName, flags ); write_stat = flags.ios(); }
 				if ( write_stat != 0 ) {
-					ShowFatalError( RoutineName + "Could not open file "+ DataStringGlobals::outputZszCsvFileName +" for output (write)." );
+					ShowFatalError( RoutineName + "Could not open file "+ DataStringGlobals::outputZszCsvFileName +" for output (write)." );  // LCOV_EXCL_LINE
 				}
 			} else if ( SizingFileColSep == CharTab ) {
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputFileZoneSizing, DataStringGlobals::outputZszTabFileName, flags ); write_stat = flags.ios(); }
 				if ( write_stat != 0 ) {
-					ShowFatalError( RoutineName + "Could not open file "+DataStringGlobals::outputZszTabFileName+" for output (write)." );
+					ShowFatalError( RoutineName + "Could not open file "+DataStringGlobals::outputZszTabFileName+" for output (write)." );  // LCOV_EXCL_LINE
 				}
 			} else {
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputFileZoneSizing, DataStringGlobals::outputZszTxtFileName, flags ); write_stat = flags.ios(); }
 				if ( write_stat != 0 ) {
-					ShowFatalError( RoutineName + "Could not open file "+ DataStringGlobals::outputZszTxtFileName +" for output (write)." );
+					ShowFatalError( RoutineName + "Could not open file "+ DataStringGlobals::outputZszTxtFileName +" for output (write)." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -422,7 +422,7 @@ namespace SizingManager {
 								//  After the first iteration of HeatBalance, all the "input" has been gotten
 								if ( BeginSimFlag ) {
 									if ( GetNumRangeCheckErrorsFound() > 0 ) {
-										ShowFatalError( RoutineName + "Out of \"range\" values found in input" );
+										ShowFatalError( RoutineName + "Out of \"range\" values found in input" );  // LCOV_EXCL_LINE
 									}
 								}
 
@@ -496,17 +496,17 @@ namespace SizingManager {
 			if ( SizingFileColSep == CharComma ) {
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputFileSysSizing, DataStringGlobals::outputSszCsvFileName, flags ); write_stat = flags.ios(); }
 				if ( write_stat != 0 ) {
-					ShowFatalError( RoutineName + "Could not open file "+ DataStringGlobals::outputSszCsvFileName +" for output (write)." );
+					ShowFatalError( RoutineName + "Could not open file "+ DataStringGlobals::outputSszCsvFileName +" for output (write)." );  // LCOV_EXCL_LINE
 				}
 			} else if ( SizingFileColSep == CharTab ) {
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputFileSysSizing, DataStringGlobals::outputSszTabFileName, flags ); write_stat = flags.ios(); }
 				if ( write_stat != 0 ) {
-					ShowFatalError( RoutineName + "Could not open file "+ DataStringGlobals::outputSszTabFileName +" for output (write)." );
+					ShowFatalError( RoutineName + "Could not open file "+ DataStringGlobals::outputSszTabFileName +" for output (write)." );  // LCOV_EXCL_LINE
 				}
 			} else {
 				{ IOFlags flags; flags.ACTION( "write" ); gio::open( OutputFileSysSizing, DataStringGlobals::outputSszTxtFileName, flags ); write_stat = flags.ios(); }
 				if ( write_stat != 0 ) {
-					ShowFatalError( RoutineName + "Could not open file "+DataStringGlobals::outputSszTxtFileName+ " for output (write)." );
+					ShowFatalError( RoutineName + "Could not open file "+DataStringGlobals::outputSszTxtFileName+ " for output (write)." );  // LCOV_EXCL_LINE
 				}
 			}
 			SimAir = true;
@@ -515,7 +515,7 @@ namespace SizingManager {
 			ManageZoneEquipment( true, SimZoneEquip, SimAir );
 			ManageAirLoops( true, SimAir, SimZoneEquip );
 			if ( GetNumRangeCheckErrorsFound() > 0 ) {
-				ShowFatalError( RoutineName + "Out of \"range\" values found in input" );
+				ShowFatalError( RoutineName + "Out of \"range\" values found in input" );  // LCOV_EXCL_LINE
 			}
 
 			ResetEnvironmentCounter();
@@ -764,7 +764,7 @@ namespace SizingManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Program terminates due to preceding conditions." );
+			ShowFatalError( "Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -873,7 +873,7 @@ namespace SizingManager {
 			lNumericBlanks.deallocate();
 
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+				ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 
 		}
@@ -1198,7 +1198,7 @@ namespace SizingManager {
 			lNumericBlanks.deallocate();
 
 			if ( ErrorsFound ) {
-				ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+				ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 			}
 
 		}
@@ -1277,7 +1277,7 @@ namespace SizingManager {
 			GlobalCoolSizingFactor = 1.0;
 			NumTimeStepsInAvg = NumOfTimeStepInHour;
 		} else {
-			ShowFatalError( cCurrentModuleObject + ": More than 1 occurence of this object; only 1 allowed" );
+			ShowFatalError( cCurrentModuleObject + ": More than 1 occurence of this object; only 1 allowed" );  // LCOV_EXCL_LINE
 		}
 
 		if ( NumTimeStepsInAvg < NumOfTimeStepInHour ) {
@@ -1906,7 +1906,7 @@ namespace SizingManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( cCurrentModuleObject + ": Errors found in getting input. Program terminates." );
+			ShowFatalError( cCurrentModuleObject + ": Errors found in getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2501,7 +2501,7 @@ namespace SizingManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( cCurrentModuleObject + ": Errors found in getting input. Program terminates." );
+			ShowFatalError( cCurrentModuleObject + ": Errors found in getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2647,7 +2647,7 @@ namespace SizingManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( cCurrentModuleObject + ": Errors found in getting input. Program terminates." );
+			ShowFatalError( cCurrentModuleObject + ": Errors found in getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -3483,7 +3483,7 @@ namespace SizingManager {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -3547,7 +3547,7 @@ namespace SizingManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -3555,7 +3555,7 @@ namespace SizingManager {
 
 	// Update the sizing for the entire facilty to gather values for reporting - Glazer January 2017
 	void
-	UpdateFacilitySizing( 
+	UpdateFacilitySizing(
 		int const CallIndicator
 	)
 	{

--- a/src/EnergyPlus/SolarCollectors.cc
+++ b/src/EnergyPlus/SolarCollectors.cc
@@ -189,17 +189,17 @@ namespace SolarCollectors {
 		if ( CompIndex == 0 ) {
 			CollectorNum = FindItemInList( CompName, Collector );
 			if ( CollectorNum == 0 ) {
-				ShowFatalError( "SimSolarCollector: Specified solar collector not Valid =" + CompName );
+				ShowFatalError( "SimSolarCollector: Specified solar collector not Valid =" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CollectorNum;
 		} else {
 			CollectorNum = CompIndex;
 			if ( CollectorNum > NumOfCollectors || CollectorNum < 1 ) {
-				ShowFatalError( "SimSolarCollector: Invalid CompIndex passed=" + TrimSigDigits( CollectorNum ) + ", Number of Units=" + TrimSigDigits( NumOfCollectors ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimSolarCollector: Invalid CompIndex passed=" + TrimSigDigits( CollectorNum ) + ", Number of Units=" + TrimSigDigits( NumOfCollectors ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( CollectorNum ) ) {
 				if ( CompName != Collector( CollectorNum ).Name ) {
-					ShowFatalError( "SimSolarCollector: Invalid CompIndex passed=" + TrimSigDigits( CollectorNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + Collector( CollectorNum ).Name );
+					ShowFatalError( "SimSolarCollector: Invalid CompIndex passed=" + TrimSigDigits( CollectorNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + Collector( CollectorNum ).Name );  // LCOV_EXCL_LINE
 
 				}
 				CheckEquipName( CollectorNum ) = false;
@@ -416,7 +416,7 @@ namespace SolarCollectors {
 				}
 			} // ParametersNum
 
-			if ( ErrorsFound ) ShowFatalError( "Errors in " + CurrentModuleParamObject + " input." );
+			if ( ErrorsFound ) ShowFatalError( "Errors in " + CurrentModuleParamObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 		if ( NumOfCollectors > 0 ) {
@@ -606,7 +606,7 @@ namespace SolarCollectors {
 
 			} // end of ParametersNum
 
-			if ( ErrorsFound ) ShowFatalError( "Errors in " + CurrentModuleParamObject + " input." );
+			if ( ErrorsFound ) ShowFatalError( "Errors in " + CurrentModuleParamObject + " input." );  // LCOV_EXCL_LINE
 
 			CurrentModuleObject = "SolarCollector:IntegralCollectorStorage";
 
@@ -746,7 +746,7 @@ namespace SolarCollectors {
 
 			} // ICSNum
 
-			if ( ErrorsFound ) ShowFatalError( "Errors in " + CurrentModuleObject + " input." );
+			if ( ErrorsFound ) ShowFatalError( "Errors in " + CurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 
 			if ( NumOfCollectors > 0 ) {
 				CheckEquipName.dimension( NumOfCollectors, true );
@@ -830,7 +830,7 @@ namespace SolarCollectors {
 				errFlag = false;
 				ScanPlantLoopsForObject( Collector( CollectorNum ).Name, Collector( CollectorNum ).TypeNum, Collector( CollectorNum ).WLoopNum, Collector( CollectorNum ).WLoopSideNum, Collector( CollectorNum ).WLoopBranchNum, Collector( CollectorNum ).WLoopCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitSolarCollector: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitSolarCollector: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				SetLoopIndexFlag( CollectorNum ) = false;
 			}
@@ -1244,7 +1244,7 @@ namespace SolarCollectors {
 				gio::write( String, fmtLD ) << IAM;
 				ShowContinueError( "Calculated Incident Angle Modifier =" + String );
 				ShowContinueError( "Expected Incident Angle Modifier should be approximately 1.5 or less." );
-				ShowFatalError( "Errors in SolarCollectorPerformance:FlatPlate input." );
+				ShowFatalError( "Errors in SolarCollectorPerformance:FlatPlate input." );  // LCOV_EXCL_LINE
 			}
 
 		} // not greater than cut off angle
@@ -1501,7 +1501,7 @@ namespace SolarCollectors {
 
 			} else { // this should never occur
 				ShowSevereError( "ICSCollectorAnalyticalSoluton: Unanticipated differential equation coefficient - report to EnergyPlus Development Team" );
-				ShowFatalError( "Program terminates due to above conditions." );
+				ShowFatalError( "Program terminates due to above conditions." );  // LCOV_EXCL_LINE
 			}
 		} else {
 			// In the absence of absorber plate thermal mass, only the collector water heat balance has a
@@ -2282,7 +2282,7 @@ namespace SolarCollectors {
 
 		if ( SurfacePtr == 0 ) {
 			// should be trapped already
-			ShowFatalError( "Invalid surface passed to GetExtVentedCavityIndex" );
+			ShowFatalError( "Invalid surface passed to GetExtVentedCavityIndex" );  // LCOV_EXCL_LINE
 		}
 
 		CavNum = 0;
@@ -2297,7 +2297,7 @@ namespace SolarCollectors {
 		}
 
 		if ( ! Found ) {
-			ShowFatalError( "Did not find surface in Exterior Vented Cavity description in GetExtVentedCavityIndex, Surface name = " + Surface( SurfacePtr ).Name );
+			ShowFatalError( "Did not find surface in Exterior Vented Cavity description in GetExtVentedCavityIndex, Surface name = " + Surface( SurfacePtr ).Name );  // LCOV_EXCL_LINE
 		} else {
 
 			VentCavIndex = CavNum;

--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -387,7 +387,7 @@ namespace SolarShading {
 
 			shd_stream.open( DataStringGlobals::outputShdFileName );
 			if ( ! shd_stream ) {
-				ShowFatalError( "InitSolarCalculations: Could not open file \"" + DataStringGlobals::outputShdFileName + "\" for output (write)." );
+				ShowFatalError( "InitSolarCalculations: Could not open file \"" + DataStringGlobals::outputShdFileName + "\" for output (write)." );  // LCOV_EXCL_LINE
 			}
 
 			if ( GetInputFlag ) {
@@ -1433,7 +1433,7 @@ namespace SolarShading {
 					ShowContinueError("This is a diagnostic error that should not be encountered under normal circumstances");
 					ShowContinueError( "Occurs on surface: " + Surface ( SurfNum ).Name );
 					ShowContinueError( "Current value = " + TrimSigDigits( CosIncAngBeamOnSurface ) + " ... should be within [-1, +1]" );
-					ShowFatalError( "Anisotropic solar calculation causes fatal error" );
+					ShowFatalError( "Anisotropic solar calculation causes fatal error" );  // LCOV_EXCL_LINE
 				}
 				CosIncAngBeamOnSurface = 1.0;
 			} else if ( CosIncAngBeamOnSurface < -1.0 ) {
@@ -1442,7 +1442,7 @@ namespace SolarShading {
 					ShowContinueError("This is a diagnostic error that should not be encountered under normal circumstances");
 					ShowContinueError( "Occurs on surface: " + Surface ( SurfNum ).Name );
 					ShowContinueError( "Current value = " + TrimSigDigits( CosIncAngBeamOnSurface ) + " ... should be within [-1, +1]" );
-					ShowFatalError( "Anisotropic solar calculation causes fatal error" );
+					ShowFatalError( "Anisotropic solar calculation causes fatal error" );  // LCOV_EXCL_LINE
 				}
 				CosIncAngBeamOnSurface = -1.0;
 			}
@@ -2484,7 +2484,7 @@ namespace SolarShading {
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 
 		if ( NS > 2 * MaxHCS ) {
-			ShowFatalError( "Solar Shading: HTrans: Too many Figures (>" + TrimSigDigits( MaxHCS ) + ')' );
+			ShowFatalError( "Solar Shading: HTrans: Too many Figures (>" + TrimSigDigits( MaxHCS ) + ')' );  // LCOV_EXCL_LINE
 		}
 
 		HCNV( NS ) = NumVertices;
@@ -2551,7 +2551,7 @@ namespace SolarShading {
 		// Locals
 
 		if ( NS > 2 * MaxHCS ) {
-			ShowFatalError( "Solar Shading: HTrans0: Too many Figures (>" + TrimSigDigits( MaxHCS ) + ')' );
+			ShowFatalError( "Solar Shading: HTrans0: Too many Figures (>" + TrimSigDigits( MaxHCS ) + ')' );  // LCOV_EXCL_LINE
 		}
 
 		HCNV( NS ) = NumVertices;
@@ -2598,7 +2598,7 @@ namespace SolarShading {
 		using General::TrimSigDigits;
 
 		if ( NS > 2 * MaxHCS ) {
-			ShowFatalError( "Solar Shading: HTrans1: Too many Figures (>" + TrimSigDigits( MaxHCS ) + ')' );
+			ShowFatalError( "Solar Shading: HTrans1: Too many Figures (>" + TrimSigDigits( MaxHCS ) + ')' );  // LCOV_EXCL_LINE
 		}
 
 		HCNV( NS ) = NumVertices;
@@ -3738,7 +3738,7 @@ namespace SolarShading {
 			}
 			CosIncAng( iTimeStep, iHour, SurfNum ) = CTHETA( SurfNum );
 		}
-		
+
 		if ( UseScheduledSunlitFrac ) {
 			for ( int SurfNum = 1; SurfNum <= TotSurfaces; ++SurfNum ) {
 				if ( Surface( SurfNum ).SchedExternalShadingFrac ) {
@@ -3747,7 +3747,7 @@ namespace SolarShading {
 				else {
 					SunlitFrac( iTimeStep, iHour, SurfNum ) = 1.0;
 				}
-			} 
+			}
 		} else {
 			SHADOW( iHour, iTimeStep ); // Determine sunlit areas and solar multipliers for all surfaces.
 			for ( int SurfNum = 1; SurfNum <= TotSurfaces; ++SurfNum ) {
@@ -8395,7 +8395,7 @@ namespace SolarShading {
 					SchedulePtr = SurfaceWindow( ISurf ).AirflowSchedulePtr;
 					ScheduleMult = GetCurrentScheduleValue( SchedulePtr );
 					if ( ScheduleMult < 0.0 || ScheduleMult > 1.0 ) {
-						ShowFatalError( "Airflow schedule has a value outside the range 0.0 to 1.0 for window=" + Surface( ISurf ).Name );
+						ShowFatalError( "Airflow schedule has a value outside the range 0.0 to 1.0 for window=" + Surface( ISurf ).Name );  // LCOV_EXCL_LINE
 					}
 					SurfaceWindow( ISurf ).AirflowThisTS = ScheduleMult * SurfaceWindow( ISurf ).MaxAirflow;
 				}

--- a/src/EnergyPlus/SplitterComponent.cc
+++ b/src/EnergyPlus/SplitterComponent.cc
@@ -187,17 +187,17 @@ namespace SplitterComponent {
 		if ( CompIndex == 0 ) {
 			SplitterNum = FindItemInList( CompName, SplitterCond, &SplitterConditions::SplitterName );
 			if ( SplitterNum == 0 ) {
-				ShowFatalError( "SimAirLoopSplitter: Splitter not found=" + CompName );
+				ShowFatalError( "SimAirLoopSplitter: Splitter not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = SplitterNum;
 		} else {
 			SplitterNum = CompIndex;
 			if ( SplitterNum > NumSplitters || SplitterNum < 1 ) {
-				ShowFatalError( "SimAirLoopSplitter: Invalid CompIndex passed=" + TrimSigDigits( SplitterNum ) + ", Number of Splitters=" + TrimSigDigits( NumSplitters ) + ", Splitter name=" + CompName );
+				ShowFatalError( "SimAirLoopSplitter: Invalid CompIndex passed=" + TrimSigDigits( SplitterNum ) + ", Number of Splitters=" + TrimSigDigits( NumSplitters ) + ", Splitter name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( SplitterNum ) ) {
 				if ( CompName != SplitterCond( SplitterNum ).SplitterName ) {
-					ShowFatalError( "SimAirLoopSplitter: Invalid CompIndex passed=" + TrimSigDigits( SplitterNum ) + ", Splitter name=" + CompName + ", stored Splitter Name for that index=" + SplitterCond( SplitterNum ).SplitterName );
+					ShowFatalError( "SimAirLoopSplitter: Invalid CompIndex passed=" + TrimSigDigits( SplitterNum ) + ", Splitter name=" + CompName + ", stored Splitter Name for that index=" + SplitterCond( SplitterNum ).SplitterName );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( SplitterNum ) = false;
 			}
@@ -367,7 +367,7 @@ namespace SplitterComponent {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input." );
+			ShowFatalError( RoutineName + "Errors found in getting input." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/SteamBaseboardRadiator.cc
+++ b/src/EnergyPlus/SteamBaseboardRadiator.cc
@@ -223,17 +223,17 @@ namespace SteamBaseboardRadiator {
 		if ( CompIndex == 0 ) {
 			BaseboardNum = FindItemInList( EquipName, SteamBaseboard, &SteamBaseboardParams::EquipID );
 			if ( BaseboardNum == 0 ) {
-				ShowFatalError( "SimSteamBaseboard: Unit not found=" + EquipName );
+				ShowFatalError( "SimSteamBaseboard: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BaseboardNum;
 		} else {
 			BaseboardNum = CompIndex;
 			if ( BaseboardNum > NumSteamBaseboards || BaseboardNum < 1 ) {
-				ShowFatalError( "SimSteamBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumSteamBaseboards ) + ", Entered Unit name=" + EquipName );
+				ShowFatalError( "SimSteamBaseboard:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of Units=" + TrimSigDigits( NumSteamBaseboards ) + ", Entered Unit name=" + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( BaseboardNum ) ) {
 				if ( EquipName != SteamBaseboard( BaseboardNum ).EquipID ) {
-					ShowFatalError( "SimSteamBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + SteamBaseboard( BaseboardNum ).EquipID );
+					ShowFatalError( "SimSteamBaseboard: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Unit name=" + EquipName + ", stored Unit Name for that index=" + SteamBaseboard( BaseboardNum ).EquipID );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( BaseboardNum ) = false;
 			}
@@ -264,7 +264,7 @@ namespace SteamBaseboardRadiator {
 				} else {
 					ShowSevereError( "SimSteamBaseboard: Errors in Baseboard=" + SteamBaseboard( BaseboardNum ).EquipID );
 					ShowContinueError( "Invalid or unimplemented equipment type=" + TrimSigDigits( SteamBaseboard( BaseboardNum ).EquipType ) );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 				}}
 
@@ -282,7 +282,7 @@ namespace SteamBaseboardRadiator {
 			ReportSteamBaseboard( BaseboardNum );
 
 		} else {
-			ShowFatalError( "SimSteamBaseboard: Unit not found=" + EquipName );
+			ShowFatalError( "SimSteamBaseboard: Unit not found=" + EquipName );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -607,7 +607,7 @@ namespace SteamBaseboardRadiator {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + cCMO_BBRadiator_Steam + "Errors found getting input. Program terminates." );
+			ShowFatalError( RoutineName + cCMO_BBRadiator_Steam + "Errors found getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		// Setup Report variables for the Coils
@@ -722,7 +722,7 @@ namespace SteamBaseboardRadiator {
 				ScanPlantLoopsForObject( SteamBaseboard( BaseboardNum ).EquipID, SteamBaseboard( BaseboardNum ).EquipType, SteamBaseboard( BaseboardNum ).LoopNum, SteamBaseboard( BaseboardNum ).LoopSideNum, SteamBaseboard( BaseboardNum ).BranchNum, SteamBaseboard( BaseboardNum ).CompNum, _, _, _, _, _, errFlag );
 				SetLoopIndexFlag( BaseboardNum ) = false;
 				if ( errFlag ) {
-					ShowFatalError( "InitSteamBaseboard: Program terminated for previous conditions." );
+					ShowFatalError( "InitSteamBaseboard: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -867,7 +867,7 @@ namespace SteamBaseboardRadiator {
 		if ( PltSizSteamNum > 0 ) {
 
 			DataScalableCapSizingON = false;
-			
+
 			if ( CurZoneEqNum > 0 ) {
 
 				if ( SteamBaseboard( BaseboardNum ).SteamVolFlowRateMax == AutoSize ) {
@@ -969,7 +969,7 @@ namespace SteamBaseboardRadiator {
 		RegisterPlantCompDesignFlow( SteamBaseboard( BaseboardNum ).SteamInletNode, SteamBaseboard( BaseboardNum ).SteamVolFlowRateMax );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1304,7 +1304,7 @@ namespace SteamBaseboardRadiator {
 						ShowContinueError( "Occurs in " + cCMO_BBRadiator_Steam + " = " + SteamBaseboard( BaseboardNum ).EquipID );
 						ShowContinueError( "Radiation intensity = " + RoundSigDigits( ThisSurfIntensity, 2 ) + " [W/m2]" );
 						ShowContinueError( "Assign a larger surface area or more surfaces in " + cCMO_BBRadiator_Steam );
-						ShowFatalError( "DistributeBBSteamRadGains:  excessive thermal radiation heat flux intensity detected" );
+						ShowFatalError( "DistributeBBSteamRadGains:  excessive thermal radiation heat flux intensity detected" );  // LCOV_EXCL_LINE
 					}
 				} else { // small surface
 					ShowSevereError( "DistributeBBSteamRadGains:  surface not large enough to receive thermal radiation heat flux" );
@@ -1312,7 +1312,7 @@ namespace SteamBaseboardRadiator {
 					ShowContinueError( "Surface area = " + RoundSigDigits( Surface( SurfNum ).Area, 3 ) + " [m2]" );
 					ShowContinueError( "Occurs in " + cCMO_BBRadiator_Steam + " = " + SteamBaseboard( BaseboardNum ).EquipID );
 					ShowContinueError( "Assign a larger surface area or more surfaces in " + cCMO_BBRadiator_Steam );
-					ShowFatalError( "DistributeBBSteamRadGains:  surface not large enough to receive thermal radiation heat flux" );
+					ShowFatalError( "DistributeBBSteamRadGains:  surface not large enough to receive thermal radiation heat flux" );  // LCOV_EXCL_LINE
 
 				}
 			}
@@ -1491,20 +1491,20 @@ namespace SteamBaseboardRadiator {
 		if ( CompIndex == 0 ) {
 			BaseboardNum = FindItemInList( BaseboardName, SteamBaseboard, &SteamBaseboardParams::EquipID );
 			if ( BaseboardNum == 0 ) {
-				ShowFatalError( "UpdateSteamBaseboardPlantConnection: Specified baseboard not valid =" + BaseboardName );
+				ShowFatalError( "UpdateSteamBaseboardPlantConnection: Specified baseboard not valid =" + BaseboardName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = BaseboardNum;
 		} else {
 			BaseboardNum = CompIndex;
 			if ( BaseboardNum > NumSteamBaseboards || BaseboardNum < 1 ) {
-				ShowFatalError( "UpdateSteamBaseboardPlantConnection:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of baseboards=" + TrimSigDigits( NumSteamBaseboards ) + ", Entered baseboard name=" + BaseboardName );
+				ShowFatalError( "UpdateSteamBaseboardPlantConnection:  Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", Number of baseboards=" + TrimSigDigits( NumSteamBaseboards ) + ", Entered baseboard name=" + BaseboardName );  // LCOV_EXCL_LINE
 			}
 			if ( KickOffSimulation ) {
 				if ( BaseboardName != SteamBaseboard( BaseboardNum ).EquipID ) {
-					ShowFatalError( "UpdateSteamBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + SteamBaseboard( BaseboardNum ).EquipID );
+					ShowFatalError( "UpdateSteamBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + SteamBaseboard( BaseboardNum ).EquipID );  // LCOV_EXCL_LINE
 				}
 				if ( BaseboardTypeNum != TypeOf_Baseboard_Rad_Conv_Steam ) {
-					ShowFatalError( "UpdateSteamBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + ccSimPlantEquipTypes( BaseboardTypeNum ) );
+					ShowFatalError( "UpdateSteamBaseboardPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( BaseboardNum ) + ", baseboard name=" + BaseboardName + ", stored baseboard Name for that index=" + ccSimPlantEquipTypes( BaseboardTypeNum ) );  // LCOV_EXCL_LINE
 				}
 			}
 		}

--- a/src/EnergyPlus/SteamCoils.cc
+++ b/src/EnergyPlus/SteamCoils.cc
@@ -218,17 +218,17 @@ namespace SteamCoils {
 		if ( CompIndex == 0 ) {
 			CoilNum = FindItemInList( CompName, SteamCoil );
 			if ( CoilNum == 0 ) {
-				ShowFatalError( "SimulateSteamCoilComponents: Coil not found=" + CompName );
+				ShowFatalError( "SimulateSteamCoilComponents: Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CoilNum;
 		} else {
 			CoilNum = CompIndex;
 			if ( CoilNum > NumSteamCoils || CoilNum < 1 ) {
-				ShowFatalError( "SimulateSteamCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Steam Coils=" + TrimSigDigits( NumSteamCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "SimulateSteamCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Steam Coils=" + TrimSigDigits( NumSteamCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( CoilNum ) ) {
 				if ( CompName != SteamCoil( CoilNum ).Name ) {
-					ShowFatalError( "SimulateSteamCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + SteamCoil( CoilNum ).Name );
+					ShowFatalError( "SimulateSteamCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + SteamCoil( CoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( CoilNum ) = false;
 			}
@@ -434,7 +434,7 @@ namespace SteamCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input." );
+			ShowFatalError( RoutineName + "Errors found in getting input." );  // LCOV_EXCL_LINE
 		}
 
 		AlphArray.deallocate();
@@ -517,7 +517,7 @@ namespace SteamCoils {
 			errFlag = false;
 			ScanPlantLoopsForObject( SteamCoil( CoilNum ).Name, SteamCoil( CoilNum ).Coil_PlantTypeNum, SteamCoil( CoilNum ).LoopNum, SteamCoil( CoilNum ).LoopSide, SteamCoil( CoilNum ).BranchNum, SteamCoil( CoilNum ).CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitSteamCoil: Program terminated for previous conditions." );
+				ShowFatalError( "InitSteamCoil: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 			}
 			MyPlantScanFlag( CoilNum ) = false;
 		}
@@ -880,7 +880,7 @@ namespace SteamCoils {
 		RegisterPlantCompDesignFlow( SteamCoil( CoilNum ).SteamInletNodeNum, SteamCoil( CoilNum ).MaxSteamVolFlowRate );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding Steam coil sizing errors cause program termination" );
+			ShowFatalError( "Preceding Steam coil sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -982,7 +982,7 @@ namespace SteamCoils {
 			//update the TempSetPoint
 			TempSetPoint -= SteamCoil( CoilNum ).FaultyCoilSATOffset;
 		}
-		
+
 		//  adjust mass flow rates for cycling fan cycling coil operation
 		if ( FanOpMode == CycFanCycCoil ) {
 			if ( PartLoadRatio > 0.0 ) {
@@ -1545,17 +1545,17 @@ namespace SteamCoils {
 		if ( CompIndex == 0 ) {
 			CoilNum = FindItemInList( CompName, SteamCoil );
 			if ( CoilNum == 0 ) {
-				ShowFatalError( "CheckSteamCoilSchedule: Coil not found=" + CompName );
+				ShowFatalError( "CheckSteamCoilSchedule: Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CoilNum;
 			Value = GetCurrentScheduleValue( SteamCoil( CoilNum ).SchedPtr ); // not scheduled?
 		} else {
 			CoilNum = CompIndex;
 			if ( CoilNum > NumSteamCoils || CoilNum < 1 ) {
-				ShowFatalError( "SimulateSteamCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Steam Coils=" + TrimSigDigits( NumSteamCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "SimulateSteamCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Steam Coils=" + TrimSigDigits( NumSteamCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CompName != SteamCoil( CoilNum ).Name ) {
-				ShowFatalError( "SimulateSteamCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + SteamCoil( CoilNum ).Name );
+				ShowFatalError( "SimulateSteamCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + SteamCoil( CoilNum ).Name );  // LCOV_EXCL_LINE
 			}
 			Value = GetCurrentScheduleValue( SteamCoil( CoilNum ).SchedPtr ); // not scheduled?
 		}
@@ -2459,7 +2459,7 @@ namespace SteamCoils {
 		int const CoilNum, // Number of hot water heating Coil
 		bool & ErrorsFound, // Set to true if certain errors found
 		Optional_bool DesiccantRegenerationCoil, // Flag that this coil is used as regeneration air heating coil
-		Optional_int DesiccantDehumIndex // Index for the desiccant dehum system where this caoil is used 
+		Optional_int DesiccantDehumIndex // Index for the desiccant dehum system where this caoil is used
 		) {
 
 		// FUNCTION INFORMATION:

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -1933,7 +1933,7 @@ namespace SurfaceGeometry {
 
 		if ( SurfError || ErrorsFound ) {
 			ErrorsFound = true;
-			ShowFatalError( RoutineName + "Errors discovered, program terminates." );
+			ShowFatalError( RoutineName + "Errors discovered, program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		int TotShadSurf = TotDetachedFixed + TotDetachedBldg + TotRectDetachedFixed + TotRectDetachedBldg + TotShdSubs + TotOverhangs + TotOverhangsProjection + TotFins + TotFinsProjection;
@@ -6005,7 +6005,7 @@ namespace SurfaceGeometry {
 		using ScheduleManager::GetScheduleIndex;
 		using NodeInputManager::GetOnlySingleNode;
 		using OutAirNodeManager::CheckOutAirNodeNumber;
-		
+
 		using DataSurfaces::TotSurfaces;
 		using DataSurfaces::Surface;
 		using DataSurfaces::TotSurfLocalEnv;
@@ -6116,7 +6116,7 @@ namespace SurfaceGeometry {
 		}
 		// Link surface properties to surface object
 		for ( SurfLoop = 1; SurfLoop <= TotSurfaces; ++SurfLoop ) {
-			for ( Loop = 1; Loop <= TotSurfLocalEnv; ++Loop ) {			
+			for ( Loop = 1; Loop <= TotSurfLocalEnv; ++Loop ) {
 				if ( SurfLocalEnvironment( Loop ).SurfPtr == SurfLoop ) {
 					if ( SurfLocalEnvironment( Loop ).OutdoorAirNodePtr != 0 ) {
 						Surface( SurfLoop ).HasLinkedOutAirNode = true;
@@ -7022,7 +7022,7 @@ namespace SurfaceGeometry {
 			TransformVertsByAspect( SurfNum, SurfaceTmp( SurfNum ).Sides );
 
 		} else {
-			ShowFatalError( RoutineName + "Called with less than 2 sides, Surface=" + SurfaceTmp( SurfNum ).Name );
+			ShowFatalError( RoutineName + "Called with less than 2 sides, Surface=" + SurfaceTmp( SurfNum ).Name );  // LCOV_EXCL_LINE
 		}
 
 		// Preliminary Height/Width
@@ -10341,7 +10341,7 @@ namespace SurfaceGeometry {
 				gio::write( ErrLineOut, ErrFmt ) << point.x << point.y << point.z;
 				ShowContinueError( ErrLineOut );
 			}
-			ShowFatalError( "CalcCoordinateTransformation: Program terminates due to preceding condition.", OutputFileStandard );
+			ShowFatalError( "CalcCoordinateTransformation: Program terminates due to preceding condition.", OutputFileStandard );  // LCOV_EXCL_LINE
 			return;
 		}
 
@@ -10562,7 +10562,7 @@ namespace SurfaceGeometry {
 			ConstrNum = Surface( SurfNum ).Construction;
 			// Fatal error if base construction has more than three glass layers
 			if ( Construct( ConstrNum ).TotGlassLayers > 3 ) {
-				ShowFatalError( "Window=" + Surface( SurfNum ).Name + " has more than 3 glass layers; a storm window cannot be applied." );
+				ShowFatalError( "Window=" + Surface( SurfNum ).Name + " has more than 3 glass layers; a storm window cannot be applied." );  // LCOV_EXCL_LINE
 			}
 			ConstrNumSh = Surface( SurfNum ).ShadedConstruction;
 			ConstrName = Construct( ConstrNum ).Name;
@@ -10590,7 +10590,7 @@ namespace SurfaceGeometry {
 					ShowContinueError( "Storm windows can only be applied to shaded constructions that:" );
 					ShowContinueError( "have an interior shade or blind and up to three glass layers, or" );
 					ShowContinueError( "have a between-glass shade or blind and two glass layers." );
-					ShowFatalError( "EnergyPlus is exiting due to reason stated above." );
+					ShowFatalError( "EnergyPlus is exiting due to reason stated above." );  // LCOV_EXCL_LINE
 				}
 			}
 

--- a/src/EnergyPlus/SurfaceGroundHeatExchanger.cc
+++ b/src/EnergyPlus/SurfaceGroundHeatExchanger.cc
@@ -202,7 +202,7 @@ namespace loc {
 			}
 		}
 		// If we didn't find it, fatal
-		ShowFatalError( "Surface Ground Heat Exchanger: Error getting inputs for pipe named: " + objectName );
+		ShowFatalError( "Surface Ground Heat Exchanger: Error getting inputs for pipe named: " + objectName );  // LCOV_EXCL_LINE
 		// Shut up the compiler
 		return nullptr;
 	}
@@ -380,7 +380,7 @@ namespace loc {
 
 		// final error check
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 		}
 
 		// Set up the output variables
@@ -481,7 +481,7 @@ namespace loc {
 			ScanPlantLoopsForObject( this->Name, TypeOf_GrndHtExchgSurface, this->LoopNum, this->LoopSideNum, this->BranchNum, this->CompNum, _, _, _, _, _, errFlag );
 
 			if ( errFlag ) {
-				ShowFatalError( "InitSurfaceGroundHeatExchanger: Program terminated due to previous condition(s)." );
+				ShowFatalError( "InitSurfaceGroundHeatExchanger: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 			}
 			rho = GetDensityGlycol( PlantLoop( this->LoopNum ).FluidName, constant_zero, PlantLoop( this->LoopNum ).FluidIndex, RoutineName );
 			this->DesignMassFlowRate = Pi / 4.0 * pow_2( this->TubeDiameter ) * DesignVelocity * rho * this->TubeCircuits;

--- a/src/EnergyPlus/SwimmingPool.cc
+++ b/src/EnergyPlus/SwimmingPool.cc
@@ -540,7 +540,7 @@ namespace SwimmingPool {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in swimming pool input. Preceding conditions cause termination." );
+			ShowFatalError( RoutineName + "Errors found in swimming pool input. Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Set up the output variables for swimming pools
@@ -655,7 +655,7 @@ namespace SwimmingPool {
 		}
 
 		InitSwimmingPoolPlantLoopIndex( PoolNum, MyPlantScanFlagPool( PoolNum ) );
-		
+
 		if ( BeginEnvrnFlag && MyEnvrnFlagGeneral ) {
 			ZeroSourceSumHATsurf = 0.0;
 			QPoolSrcAvg = 0.0;
@@ -809,13 +809,13 @@ namespace SwimmingPool {
 
 		bool errFlag;
 		static std::string const RoutineName( "InitSwimmingPoolPlantLoopIndex" );
-		
+
 		if ( MyPlantScanFlagPool && allocated( PlantLoop ) ) {
 			errFlag = false;
 			if ( Pool( PoolNum ).WaterInletNode > 0 ) {
 				ScanPlantLoopsForObject( Pool( PoolNum ).Name, TypeOf_SwimmingPool_Indoor, Pool( PoolNum ).HWLoopNum, Pool( PoolNum ).HWLoopSide, Pool( PoolNum ).HWBranchNum, Pool( PoolNum ).HWCompNum, _, _, _, Pool( PoolNum ).WaterInletNode, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( RoutineName + ": Program terminated due to previous condition(s)." );
+					ShowFatalError( RoutineName + ": Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 			}
 			MyPlantScanFlagPool = false;
@@ -824,8 +824,8 @@ namespace SwimmingPool {
 		}
 
 	}
-	
-	
+
+
 	void
 	CalcSwimmingPool(
 		int const PoolNum // number of the swimming pool
@@ -1007,18 +1007,18 @@ namespace SwimmingPool {
 		using DataEnvironment::OutBaroPress;
 		using DataConversions::CFA;
 		using DataConversions::CFMF;
-		
+
 		static std::string const RoutineName( "CalcSwimmingPoolEvap" );
 		static Real64 const CFinHg( 0.00029613 ); // Multiple pressure in Pa by this constant to get inches of Hg
 
 		Real64 PSatPool;
 		Real64 PParAir;
-		
+
 		// Evaporation calculation:
 		// Evaporation Rate (lb/h) = 0.1 * Area (ft2) * Activity Factor * (Psat,pool - Ppar,air) (in Hg)
 		// So evaporation rate, area, and pressures have to be converted to standard E+ units (kg/s, m2, and Pa, respectively)
 		// Evaporation Rate per Area = Evaporation Rate * Heat of Vaporization / Area of Surface
-		
+
 		PSatPool = PsyPsatFnTemp( Pool( PoolNum ).PoolWaterTemp, RoutineName );
 		PParAir = PsyPsatFnTemp( MAT, RoutineName ) * PsyRhFnTdbWPb( MAT, HumRat, OutBaroPress );
 		if ( PSatPool < PParAir ) PSatPool = PParAir;
@@ -1027,7 +1027,7 @@ namespace SwimmingPool {
 		EvapRate = ( 0.1 * ( Surface( SurfNum ).Area / CFA ) * Pool( PoolNum ).CurActivityFactor * ( ( PSatPool - PParAir ) * CFinHg ) ) * CFMF * Pool( PoolNum ).CurCoverEvapFac;
 
 	}
-	
+
 	void
 	UpdateSwimmingPool(
 		int const PoolNum // number of the swimming pool

--- a/src/EnergyPlus/SystemAvailabilityManager.cc
+++ b/src/EnergyPlus/SystemAvailabilityManager.cc
@@ -1244,7 +1244,7 @@ namespace SystemAvailabilityManager {
 		lNumericFieldBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1370,7 +1370,7 @@ namespace SystemAvailabilityManager {
 		lNumericFieldBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetSysAvailManagerListInputs: Program terminates due to preceding conditions." );
+			ShowFatalError( "GetSysAvailManagerListInputs: Program terminates due to preceding conditions." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1852,7 +1852,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcSchedSysAvailMgr( SysAvailNum, AvailStatus );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:Scheduled not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:Scheduled not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_ScheduledOn ) { // 'AvailabilityManager:ScheduledOn'
@@ -1862,7 +1862,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcSchedOnSysAvailMgr( SysAvailNum, AvailStatus );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:ScheduledOn not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:ScheduledOn not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_ScheduledOff ) { // 'AvailabilityManager:ScheduledOff'
@@ -1872,7 +1872,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcSchedOffSysAvailMgr( SysAvailNum, AvailStatus );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:ScheduledOff not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:ScheduledOff not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_NightCycle ) { // 'AvailabilityManager:NightCycle'
@@ -1882,7 +1882,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcNCycSysAvailMgr( SysAvailNum, PriAirSysNum, AvailStatus, ZoneEquipType, CompNum );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:NightCycle not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:NightCycle not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_OptimumStart ) { // 'AvailabilityManager:OptimumStart'
@@ -1892,7 +1892,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcOptStartSysAvailMgr( SysAvailNum, PriAirSysNum, AvailStatus, ZoneEquipType, CompNum );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:OptimumStart not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:OptimumStart not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_NightVent ) { // 'AvailabilityManager:NightVentilation'
@@ -1902,7 +1902,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcNVentSysAvailMgr( SysAvailNum, PriAirSysNum, AvailStatus, ZoneEquipType );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:NightVentilation not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:NightVentilation not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_DiffThermo ) { // 'AvailabilityManager:DifferentialThermostat'
@@ -1912,7 +1912,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcDiffTSysAvailMgr( SysAvailNum, PreviousStatus, AvailStatus );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:DifferentialThermostat not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:DifferentialThermostat not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_HiTempTOff ) { // 'AvailabilityManager:HighTemperatureTurnOff'
@@ -1922,7 +1922,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcHiTurnOffSysAvailMgr( SysAvailNum, AvailStatus );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:HighTemperatureTurnOff not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:HighTemperatureTurnOff not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_HiTempTOn ) { // 'AvailabilityManager:HighTemperatureTurnOn'
@@ -1932,7 +1932,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcHiTurnOnSysAvailMgr( SysAvailNum, AvailStatus );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:HighTemperatureTurnOn not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:HighTemperatureTurnOn not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_LoTempTOff ) { // 'AvailabilityManager:LowTemperatureTurnOff'
@@ -1942,7 +1942,7 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcLoTurnOffSysAvailMgr( SysAvailNum, AvailStatus );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:LowTemperatureTurnOff not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:LowTemperatureTurnOff not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == SysAvailMgr_LoTempTOn ) { // 'AvailabilityManager:LowTemperatureTurnOn'
@@ -1952,13 +1952,13 @@ namespace SystemAvailabilityManager {
 			if ( SysAvailNum > 0 ) {
 				CalcLoTurnOnSysAvailMgr( SysAvailNum, AvailStatus );
 			} else {
-				ShowFatalError( "SimSysAvailManager: AvailabilityManager:LowTemperatureTurnOn not found: " + SysAvailName );
+				ShowFatalError( "SimSysAvailManager: AvailabilityManager:LowTemperatureTurnOn not found: " + SysAvailName );  // LCOV_EXCL_LINE
 			}
 
 		} else {
 			ShowSevereError( "AvailabilityManager Type not found: " + TrimSigDigits( SysAvailType ) );
 			ShowContinueError( "Occurs in Manager=" + SysAvailName );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -2165,7 +2165,7 @@ namespace SystemAvailabilityManager {
 		int ZoneNum;
 		Real64 TempTol;
 		static Array1D_bool ZoneCompNCControlType;
-		int CyclingRunTimeControlType; 
+		int CyclingRunTimeControlType;
 
 		// reset start/stop times at beginning of each day during warmup to prevent non-convergence due to rotating start times
 		if ( WarmupFlag && BeginDayFlag ) {
@@ -2411,11 +2411,11 @@ namespace SystemAvailabilityManager {
 
 			if ( ( tstatType == SingleCoolingSetPoint ) ||  ( tstatType == SingleHeatCoolSetPoint) ){
 				if ( DataHeatBalFanSys::TempTstatAir( ZoneNum ) > DataHeatBalFanSys::TempZoneThermostatSetPoint( ZoneNum ) + TempTolerance ) {
-					return true; // return on the first zone found 
+					return true; // return on the first zone found
 				}
 			} else if ( tstatType == DualSetPointWithDeadBand ){
 				if ( DataHeatBalFanSys::TempTstatAir( ZoneNum ) > DataHeatBalFanSys::ZoneThermostatSetPointHi( ZoneNum ) + TempTolerance ) {
-					return true; // return on the first zone found 
+					return true; // return on the first zone found
 				}
 			}}
 		}
@@ -2436,11 +2436,11 @@ namespace SystemAvailabilityManager {
 
 			if ( ( tstatType == SingleHeatingSetPoint ) ||  ( tstatType == SingleHeatCoolSetPoint) ){
 				if ( DataHeatBalFanSys::TempTstatAir( ZoneNum ) < DataHeatBalFanSys::TempZoneThermostatSetPoint( ZoneNum ) - TempTolerance ) {
-					return true; // return on the first zone found 
+					return true; // return on the first zone found
 				}
 			} else if ( tstatType == DualSetPointWithDeadBand ){
 				if ( DataHeatBalFanSys::TempTstatAir( ZoneNum ) < DataHeatBalFanSys::ZoneThermostatSetPointLo( ZoneNum ) - TempTolerance ) {
-					return true; // return on the first zone found 
+					return true; // return on the first zone found
 				}
 			}}
 		}
@@ -4562,7 +4562,7 @@ namespace SystemAvailabilityManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 		// Set up output variables
@@ -4741,7 +4741,7 @@ namespace SystemAvailabilityManager {
 			}
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Errors found in getting AvailabilityManager:* inputs" );
+				ShowFatalError( "Errors found in getting AvailabilityManager:* inputs" );  // LCOV_EXCL_LINE
 			}
 
 			MyOneTimeFlag = false;
@@ -5035,7 +5035,7 @@ namespace SystemAvailabilityManager {
 				}
 			} else {
 				ShowSevereError( cValidSysAvailManagerTypes( HybridVentSysAvailMgrData( SysAvailNum ).MgrType ) + ": incorrect Control Type: " + HybridVentSysAvailMgrData( SysAvailNum ).AirLoopName );
-				ShowFatalError( "Errors found in getting " + cValidSysAvailManagerTypes( HybridVentSysAvailMgrData( SysAvailNum ).MgrType ) + " Control mode value" );
+				ShowFatalError( "Errors found in getting " + cValidSysAvailManagerTypes( HybridVentSysAvailMgrData( SysAvailNum ).MgrType ) + " Control mode value" );  // LCOV_EXCL_LINE
 
 			}}
 
@@ -5138,7 +5138,7 @@ namespace SystemAvailabilityManager {
 		HybridVentSysAvailVentCtrl( SysAvailNum ) = HybridVentSysAvailMgrData( SysAvailNum ).VentilationCtrl;
 		if ( HybridVentSysAvailVentCtrl( SysAvailNum ) < 0 ) {
 			// Fatal error
-			ShowFatalError( "Hybrid ventilation control: the ventilation control status is beyond the range. Please check input of control mode schedule" );
+			ShowFatalError( "Hybrid ventilation control: the ventilation control status is beyond the range. Please check input of control mode schedule" );  // LCOV_EXCL_LINE
 		}
 
 		if ( HybridVentSysAvailMgrData( SysAvailNum ).HybridVentMgrConnectedToAirLoop ) {

--- a/src/EnergyPlus/SystemReports.cc
+++ b/src/EnergyPlus/SystemReports.cc
@@ -4229,7 +4229,7 @@ namespace SystemReports {
 
 				} else {
 
-					ShowFatalError( "ReportMaxVentilationLoads: Developer must either create accounting for OA or include in final else if to do nothing" );
+					ShowFatalError( "ReportMaxVentilationLoads: Developer must either create accounting for OA or include in final else if to do nothing" );  // LCOV_EXCL_LINE
 
 				}}
 

--- a/src/EnergyPlus/ThermalChimney.cc
+++ b/src/EnergyPlus/ThermalChimney.cc
@@ -457,7 +457,7 @@ namespace ThermalChimney {
 		} // IF (TotThermalChimney > 1) THEN
 
 		if ( ErrorsFound ) {
-			ShowFatalError( cCurrentModuleObject + " Errors found in input.  Preceding condition(s) cause termination." );
+			ShowFatalError( cCurrentModuleObject + " Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/ThermalComfort.cc
+++ b/src/EnergyPlus/ThermalComfort.cc
@@ -1933,7 +1933,7 @@ namespace ThermalComfort {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetAngleFactorList: Program terminated due to preceding errors." );
+			ShowFatalError( "GetAngleFactorList: Program terminated due to preceding errors." );  // LCOV_EXCL_LINE
 		}
 
 		for ( Item = 1; Item <= TotPeople; ++Item ) {
@@ -1952,7 +1952,7 @@ namespace ThermalComfort {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetAngleFactorList: Program terminated due to preceding errors." );
+			ShowFatalError( "GetAngleFactorList: Program terminated due to preceding errors." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2659,7 +2659,7 @@ namespace ThermalComfort {
 				statFile = GetNewUnitNumber();
 				{ IOFlags flags; flags.ACTION( "READ" ); gio::open( statFile, DataStringGlobals::inStatFileName, flags ); readStat = flags.ios(); }
 				if ( readStat != 0 ) {
-					ShowFatalError( "CalcThermalComfortAdaptiveASH55: Could not open file "+DataStringGlobals::inStatFileName+" for input (read)." );
+					ShowFatalError( "CalcThermalComfortAdaptiveASH55: Could not open file "+DataStringGlobals::inStatFileName+" for input (read)." );  // LCOV_EXCL_LINE
 				}
 				while ( readStat == 0 ) {
 					{ IOFlags flags; gio::read( statFile, fmtA, flags ) >> lineIn; readStat = flags.ios(); }
@@ -2680,7 +2680,7 @@ namespace ThermalComfort {
 				epwFile = GetNewUnitNumber();
 				{ IOFlags flags; flags.ACTION( "READ" ); gio::open( epwFile, DataStringGlobals::inputWeatherFileName, flags ); readStat = flags.ios(); }
 				if ( readStat != 0 ) {
-					ShowFatalError( "CalcThermalComfortAdaptiveASH55: Could not open file " + DataStringGlobals::inputWeatherFileName+ " for input (read)." );
+					ShowFatalError( "CalcThermalComfortAdaptiveASH55: Could not open file " + DataStringGlobals::inputWeatherFileName+ " for input (read)." );  // LCOV_EXCL_LINE
 				}
 				for ( i = 1; i <= 9; ++i ) { // Headers
 					{ IOFlags flags; gio::read( epwFile, fmtA, flags ); readStat = flags.ios(); }
@@ -2910,7 +2910,7 @@ namespace ThermalComfort {
 				epwFile = GetNewUnitNumber();
 				{ IOFlags flags; flags.ACTION( "READ" ); gio::open( epwFile, DataStringGlobals::inputWeatherFileName, flags ); readStat = flags.ios(); }
 				if ( readStat != 0 ) {
-					ShowFatalError( "CalcThermalComfortAdaptiveCEN15251: Could not open file "+DataStringGlobals::inputWeatherFileName+" for input (read)." );
+					ShowFatalError( "CalcThermalComfortAdaptiveCEN15251: Could not open file "+DataStringGlobals::inputWeatherFileName+" for input (read)." );  // LCOV_EXCL_LINE
 				}
 				for ( i = 1; i <= 9; ++i ) { // Headers
 					{ IOFlags flags; gio::read( epwFile, fmtA, flags ); readStat = flags.ios(); }

--- a/src/EnergyPlus/TranspiredCollector.cc
+++ b/src/EnergyPlus/TranspiredCollector.cc
@@ -202,17 +202,17 @@ namespace TranspiredCollector {
 		if ( CompIndex == 0 ) {
 			UTSCNum = FindItemInList( CompName, UTSC );
 			if ( UTSCNum == 0 ) {
-				ShowFatalError( "Transpired Collector not found=" + CompName );
+				ShowFatalError( "Transpired Collector not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = UTSCNum;
 		} else {
 			UTSCNum = CompIndex;
 			if ( UTSCNum > NumUTSC || UTSCNum < 1 ) {
-				ShowFatalError( "SimTranspiredCollector: Invalid CompIndex passed=" + TrimSigDigits( UTSCNum ) + ", Number of Transpired Collectors=" + TrimSigDigits( NumUTSC ) + ", UTSC name=" + CompName );
+				ShowFatalError( "SimTranspiredCollector: Invalid CompIndex passed=" + TrimSigDigits( UTSCNum ) + ", Number of Transpired Collectors=" + TrimSigDigits( NumUTSC ) + ", UTSC name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( UTSCNum ) ) {
 				if ( CompName != UTSC( UTSCNum ).Name ) {
-					ShowFatalError( "SimTranspiredCollector: Invalid CompIndex passed=" + TrimSigDigits( UTSCNum ) + ", Transpired Collector name=" + CompName + ", stored Transpired Collector Name for that index=" + UTSC( UTSCNum ).Name );
+					ShowFatalError( "SimTranspiredCollector: Invalid CompIndex passed=" + TrimSigDigits( UTSCNum ) + ", Transpired Collector name=" + CompName + ", stored Transpired Collector Name for that index=" + UTSC( UTSCNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( UTSCNum ) = false;
 			}
@@ -646,7 +646,7 @@ namespace TranspiredCollector {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetTranspiredCollectorInput: Errors found in input" );
+			ShowFatalError( "GetTranspiredCollectorInput: Errors found in input" );  // LCOV_EXCL_LINE
 		}
 
 		Alphas.deallocate();
@@ -766,7 +766,7 @@ namespace TranspiredCollector {
 		if ( ! BeginEnvrnFlag ) {
 			MyEnvrnFlag( UTSCNum ) = true;
 		}
-		
+
 		// determine average ambient temperature
 		Real64 const surfaceArea( sum_sub( Surface, &SurfaceData::Area, UTSC( UTSCNum ).SurfPtrs ) );
 		if ( !DataEnvironment::IsRain ) {
@@ -1392,7 +1392,7 @@ namespace TranspiredCollector {
 		}
 
 		if ( SurfacePtr == 0 ) {
-			ShowFatalError( "Invalid surface passed to GetTranspiredCollectorIndex, Surface name = " + Surface( SurfacePtr ).Name );
+			ShowFatalError( "Invalid surface passed to GetTranspiredCollectorIndex, Surface name = " + Surface( SurfacePtr ).Name );  // LCOV_EXCL_LINE
 		}
 
 		UTSCNum = 0;
@@ -1407,7 +1407,7 @@ namespace TranspiredCollector {
 		}
 
 		if ( ! Found ) {
-			ShowFatalError( "Did not find surface in UTSC description in GetTranspiredCollectorIndex, Surface name = " + Surface( SurfacePtr ).Name );
+			ShowFatalError( "Did not find surface in UTSC description in GetTranspiredCollectorIndex, Surface name = " + Surface( SurfacePtr ).Name );  // LCOV_EXCL_LINE
 		} else {
 
 			UTSCIndex = UTSCNum;

--- a/src/EnergyPlus/UFADManager.cc
+++ b/src/EnergyPlus/UFADManager.cc
@@ -435,7 +435,7 @@ namespace UFADManager {
 				ZoneUCSDUI( UINum ).E_Kc = 0.0;
 			} else {
 				if ( ZoneUCSDUI( UINum ).A_Kc == AutoCalculate || ZoneUCSDUI( UINum ).B_Kc == AutoCalculate || ZoneUCSDUI( UINum ).C_Kc == AutoCalculate || ZoneUCSDUI( UINum ).D_Kc == AutoCalculate || ZoneUCSDUI( UINum ).E_Kc == AutoCalculate ) {
-					ShowFatalError( "For RoomAirSettings:UnderFloorAirDistributionInterior for Zone " + ZoneUCSDUI( UINum ).ZoneName + ", input for Coefficients A - E must be specified when Floor Diffuser Type = Custom." );
+					ShowFatalError( "For RoomAirSettings:UnderFloorAirDistributionInterior for Zone " + ZoneUCSDUI( UINum ).ZoneName + ", input for Coefficients A - E must be specified when Floor Diffuser Type = Custom." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( ZoneUCSDUI( UINum ).PowerPerPlume == AutoCalculate ) {
@@ -587,7 +587,7 @@ namespace UFADManager {
 				ZoneUCSDUE( UINum ).E_Kc = 0.0014;
 			} else {
 				if ( ZoneUCSDUE( UINum ).A_Kc == AutoCalculate || ZoneUCSDUE( UINum ).B_Kc == AutoCalculate || ZoneUCSDUE( UINum ).C_Kc == AutoCalculate || ZoneUCSDUE( UINum ).D_Kc == AutoCalculate || ZoneUCSDUE( UINum ).E_Kc == AutoCalculate ) {
-					ShowFatalError( "For RoomAirSettings:UnderFloorAirDistributionExterior for Zone " + ZoneUCSDUE( UINum ).ZoneName + ", input for Coefficients A - E must be specified when Floor Diffuser Type = Custom." );
+					ShowFatalError( "For RoomAirSettings:UnderFloorAirDistributionExterior for Zone " + ZoneUCSDUE( UINum ).ZoneName + ", input for Coefficients A - E must be specified when Floor Diffuser Type = Custom." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( ZoneUCSDUE( UINum ).PowerPerPlume == AutoCalculate ) {
@@ -753,7 +753,7 @@ namespace UFADManager {
 					ShowContinueError( "Zone=\"" + Zone( Surface( SurfNum ).Zone ).Name + "\", Surface=\"" + Surface( SurfNum ).Name + "\"." );
 					ShowContinueError( "ZInfSurf=[" + RoundSigDigits( ZInfSurf, 4 ) + "], LayH=[" + RoundSigDigits( LayH, 4 ) + "]." );
 					ShowContinueError( "ZSupSurf=[" + RoundSigDigits( ZSupSurf, 4 ) + "], LayH=[" + RoundSigDigits( LayH, 4 ) + "]." );
-					ShowFatalError( "...Previous condition causes termination." );
+					ShowFatalError( "...Previous condition causes termination." );  // LCOV_EXCL_LINE
 				}
 
 				// The Wall surface is partially in upper and partially in lower subzone
@@ -1325,7 +1325,7 @@ namespace UFADManager {
 			} else if ( HeightComfort >= HeightUpSubzoneAve && HeightComfort <= CeilingHeight ) {
 				TCMF( ZoneNum ) = ZTMX( ZoneNum );
 			} else {
-				ShowFatalError( "UFAD comfort height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );
+				ShowFatalError( "UFAD comfort height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -1341,7 +1341,7 @@ namespace UFADManager {
 			} else if ( HeightThermostat >= HeightUpSubzoneAve && HeightThermostat <= CeilingHeight ) {
 				TempTstatAir( ZoneNum ) = ZTMX( ZoneNum );
 			} else {
-				ShowFatalError( "Underfloor air distribution thermostat height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );
+				ShowFatalError( "Underfloor air distribution thermostat height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -1644,8 +1644,8 @@ namespace UFADManager {
 				if ( ZoneUCSDUE( UINum ).ShadeDown ) {
 					GainsFrac -= 0.2;
 				}
-				AIRRATOC( ZoneNum ) = Zone( ZoneNum ).Volume * ( HeightTransition( ZoneNum ) - min( HeightTransition( ZoneNum ), 0.2 ) ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATOC( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATOC( ZoneNum ) ) / ( TimeStepSys * SecInHour ); 
-				AIRRATMX( ZoneNum ) = Zone( ZoneNum ).Volume * ( CeilingHeight - HeightTransition( ZoneNum ) ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATMX( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATMX( ZoneNum ) ) / ( TimeStepSys * SecInHour ); 
+				AIRRATOC( ZoneNum ) = Zone( ZoneNum ).Volume * ( HeightTransition( ZoneNum ) - min( HeightTransition( ZoneNum ), 0.2 ) ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATOC( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATOC( ZoneNum ) ) / ( TimeStepSys * SecInHour );
+				AIRRATMX( ZoneNum ) = Zone( ZoneNum ).Volume * ( CeilingHeight - HeightTransition( ZoneNum ) ) / CeilingHeight * Zone( ZoneNum ).ZoneVolCapMultpSens * PsyRhoAirFnPbTdbW( OutBaroPress, MATMX( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), MATMX( ZoneNum ) ) / ( TimeStepSys * SecInHour );
 
 				if ( UseZoneTimeStepHistory ) {
 					ZTM3OC( ZoneNum ) = XM3TOC( ZoneNum );
@@ -1783,7 +1783,7 @@ namespace UFADManager {
 			} else if ( HeightComfort >= HeightUpSubzoneAve && HeightComfort <= CeilingHeight ) {
 				TCMF( ZoneNum ) = ZTMX( ZoneNum );
 			} else {
-				ShowFatalError( "UFAD comfort height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );
+				ShowFatalError( "UFAD comfort height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -1799,7 +1799,7 @@ namespace UFADManager {
 			} else if ( HeightThermostat >= HeightUpSubzoneAve && HeightThermostat <= CeilingHeight ) {
 				TempTstatAir( ZoneNum ) = ZTMX( ZoneNum );
 			} else {
-				ShowFatalError( "Underfloor air distribution thermostat height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );
+				ShowFatalError( "Underfloor air distribution thermostat height is above ceiling or below floor in Zone: " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/EnergyPlus/UnitHeater.cc
+++ b/src/EnergyPlus/UnitHeater.cc
@@ -238,17 +238,17 @@ namespace UnitHeater {
 		if ( CompIndex == 0 ) {
 			UnitHeatNum = FindItemInList( CompName, UnitHeat );
 			if ( UnitHeatNum == 0 ) {
-				ShowFatalError( "SimUnitHeater: Unit not found=" + CompName );
+				ShowFatalError( "SimUnitHeater: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = UnitHeatNum;
 		} else {
 			UnitHeatNum = CompIndex;
 			if ( UnitHeatNum > NumOfUnitHeats || UnitHeatNum < 1 ) {
-				ShowFatalError( "SimUnitHeater:  Invalid CompIndex passed=" + TrimSigDigits( UnitHeatNum ) + ", Number of Units=" + TrimSigDigits( NumOfUnitHeats ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimUnitHeater:  Invalid CompIndex passed=" + TrimSigDigits( UnitHeatNum ) + ", Number of Units=" + TrimSigDigits( NumOfUnitHeats ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( UnitHeatNum ) ) {
 				if ( CompName != UnitHeat( UnitHeatNum ).Name ) {
-					ShowFatalError( "SimUnitHeater: Invalid CompIndex passed=" + TrimSigDigits( UnitHeatNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + UnitHeat( UnitHeatNum ).Name );
+					ShowFatalError( "SimUnitHeater: Invalid CompIndex passed=" + TrimSigDigits( UnitHeatNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + UnitHeat( UnitHeatNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( UnitHeatNum ) = false;
 			}
@@ -641,7 +641,7 @@ namespace UnitHeater {
 		lAlphaBlanks.deallocate();
 		lNumericBlanks.deallocate();
 
-		if ( ErrorsFound ) ShowFatalError( RoutineName + "Errors found in input" );
+		if ( ErrorsFound ) ShowFatalError( RoutineName + "Errors found in input" );  // LCOV_EXCL_LINE
 
 		// Setup Report variables for the Unit Heaters, CurrentModuleObject='ZoneHVAC:UnitHeater'
 		for ( UnitHeatNum = 1; UnitHeatNum <= NumOfUnitHeats; ++UnitHeatNum ) {
@@ -749,7 +749,7 @@ namespace UnitHeater {
 				ScanPlantLoopsForObject( UnitHeat( UnitHeatNum ).HCoilName, UnitHeat( UnitHeatNum ).HCoil_PlantTypeNum, UnitHeat( UnitHeatNum ).HWLoopNum, UnitHeat( UnitHeatNum ).HWLoopSide, UnitHeat( UnitHeatNum ).HWBranchNum, UnitHeat( UnitHeatNum ).HWCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
 					ShowContinueError( "Reference Unit=\"" + UnitHeat( UnitHeatNum ).Name + "\", type=ZoneHVAC:UnitHeater" );
-					ShowFatalError( "InitUnitHeater: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitUnitHeater: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 
 				UnitHeat( UnitHeatNum ).HotCoilOutNodeNum = PlantLoop( UnitHeat( UnitHeatNum ).HWLoopNum ).LoopSide( UnitHeat( UnitHeatNum ).HWLoopSide ).Branch( UnitHeat( UnitHeatNum ).HWBranchNum ).Comp( UnitHeat( UnitHeatNum ).HWCompNum ).NodeNumOut;
@@ -1236,7 +1236,7 @@ namespace UnitHeater {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/UnitVentilator.cc
+++ b/src/EnergyPlus/UnitVentilator.cc
@@ -248,17 +248,17 @@ namespace UnitVentilator {
 		if ( CompIndex == 0 ) {
 			UnitVentNum = FindItemInList( CompName, UnitVent );
 			if ( UnitVentNum == 0 ) {
-				ShowFatalError( "SimUnitVentilator: Unit not found=" + CompName );
+				ShowFatalError( "SimUnitVentilator: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = UnitVentNum;
 		} else {
 			UnitVentNum = CompIndex;
 			if ( UnitVentNum > NumOfUnitVents || UnitVentNum < 1 ) {
-				ShowFatalError( "SimUnitVentilator:  Invalid CompIndex passed=" + TrimSigDigits( UnitVentNum ) + ", Number of Units=" + TrimSigDigits( NumOfUnitVents ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimUnitVentilator:  Invalid CompIndex passed=" + TrimSigDigits( UnitVentNum ) + ", Number of Units=" + TrimSigDigits( NumOfUnitVents ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( UnitVentNum ) ) {
 				if ( CompName != UnitVent( UnitVentNum ).Name ) {
-					ShowFatalError( "SimUnitVentilator: Invalid CompIndex passed=" + TrimSigDigits( UnitVentNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + UnitVent( UnitVentNum ).Name );
+					ShowFatalError( "SimUnitVentilator: Invalid CompIndex passed=" + TrimSigDigits( UnitVentNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + UnitVent( UnitVentNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( UnitVentNum ) = false;
 			}
@@ -499,7 +499,7 @@ namespace UnitVentilator {
 			if ( !UnitVent( UnitVentNum ).ATMixerExists ) {
 				UnitVent( UnitVentNum ).AirInNode = GetOnlySingleNode( Alphas( 6 ), ErrorsFound, CurrentModuleObject, Alphas( 1 ), NodeType_Air, NodeConnectionType_Inlet, 1, ObjectIsParent );
 				UnitVent( UnitVentNum ).AirInNode = GetOnlySingleNode( Alphas( 6 ), ErrorsFound, CurrentModuleObject + "-OA MIXER", Alphas( 1 ), NodeType_Air, NodeConnectionType_Inlet, 1, ObjectIsNotParent );
-			} else { 
+			} else {
 				UnitVent( UnitVentNum ).AirInNode = GetOnlySingleNode( Alphas( 6 ), ErrorsFound, CurrentModuleObject, Alphas( 1 ), NodeType_Air, NodeConnectionType_Inlet, 1, ObjectIsParent );
 			}
 			UnitVent( UnitVentNum ).AirOutNode = GetOnlySingleNode( Alphas( 7 ), ErrorsFound, CurrentModuleObject, Alphas( 1 ), NodeType_Air, NodeConnectionType_Outlet, 1, ObjectIsParent );
@@ -1002,7 +1002,7 @@ namespace UnitVentilator {
 		lAlphaBlanks.deallocate();
 		lNumericBlanks.deallocate();
 
-		if ( ErrorsFound ) ShowFatalError( RoutineName + "Errors found in input." );
+		if ( ErrorsFound ) ShowFatalError( RoutineName + "Errors found in input." );  // LCOV_EXCL_LINE
 
 		// Setup Report variables for the Unit Ventilators, CurrentModuleObject='ZoneHVAC:UnitVentilator'
 		for ( UnitVentNum = 1; UnitVentNum <= NumOfUnitVents; ++UnitVentNum ) {
@@ -1132,7 +1132,7 @@ namespace UnitVentilator {
 				ScanPlantLoopsForObject( UnitVent( UnitVentNum ).HCoilName, UnitVent( UnitVentNum ).HCoil_PlantTypeNum, UnitVent( UnitVentNum ).HWLoopNum, UnitVent( UnitVentNum ).HWLoopSide, UnitVent( UnitVentNum ).HWBranchNum, UnitVent( UnitVentNum ).HWCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
 					ShowContinueError( "Reference Unit=\"" + UnitVent( UnitVentNum ).Name + "\", type=ZoneHVAC:UnitVentilator" );
-					ShowFatalError( "InitUnitVentilator: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitUnitVentilator: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 
 				UnitVent( UnitVentNum ).HotCoilOutNodeNum = PlantLoop( UnitVent( UnitVentNum ).HWLoopNum ).LoopSide( UnitVent( UnitVentNum ).HWLoopSide ).Branch( UnitVent( UnitVentNum ).HWBranchNum ).Comp( UnitVent( UnitVentNum ).HWCompNum ).NodeNumOut;
@@ -1142,12 +1142,12 @@ namespace UnitVentilator {
 				ScanPlantLoopsForObject( UnitVent( UnitVentNum ).CCoilPlantName, UnitVent( UnitVentNum ).CCoil_PlantTypeNum, UnitVent( UnitVentNum ).CWLoopNum, UnitVent( UnitVentNum ).CWLoopSide, UnitVent( UnitVentNum ).CWBranchNum, UnitVent( UnitVentNum ).CWCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
 					ShowContinueError( "Reference Unit=\"" + UnitVent( UnitVentNum ).Name + "\", type=ZoneHVAC:UnitVentilator" );
-					ShowFatalError( "InitUnitVentilator: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitUnitVentilator: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 
 				UnitVent( UnitVentNum ).ColdCoilOutNodeNum = PlantLoop( UnitVent( UnitVentNum ).CWLoopNum ).LoopSide( UnitVent( UnitVentNum ).CWLoopSide ).Branch( UnitVent( UnitVentNum ).CWBranchNum ).Comp( UnitVent( UnitVentNum ).CWCompNum ).NodeNumOut;
 			} else {
-				if ( UnitVent( UnitVentNum ).CCoilPresent ) ShowFatalError( "InitUnitVentilator: Unit=" + UnitVent( UnitVentNum ).Name + ", invalid cooling coil type. Program terminated." );
+				if ( UnitVent( UnitVentNum ).CCoilPresent ) ShowFatalError( "InitUnitVentilator: Unit=" + UnitVent( UnitVentNum ).Name + ", invalid cooling coil type. Program terminated." );  // LCOV_EXCL_LINE
 			}
 			MyPlantScanFlag( UnitVentNum ) = false;
 		} else if ( MyPlantScanFlag( UnitVentNum ) && ! AnyPlantInModel ) {
@@ -2108,7 +2108,7 @@ namespace UnitVentilator {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2240,7 +2240,7 @@ namespace UnitVentilator {
 			} else if ( SELECT_CASE_var1 == Heating_GasCoilType ) {
 				CheckHeatingCoilSchedule( "Coil:Heating:Fuel", UnitVent( UnitVentNum ).HCoilName, UnitVent( UnitVentNum ).HCoilSchedValue, UnitVent( UnitVentNum ).HCoil_Index );
 			} else {
-				//      CALL ShowFatalError('Illegal coil type='//TRIM(UnitVent(UnitVentNum)%HCoilType))
+				//      CALL ShowFatalError('Illegal coil type='//TRIM(UnitVent(UnitVentNum)%HCoilType))  // LCOV_EXCL_LINE
 			}}
 
 			{ auto const SELECT_CASE_var1( UnitVent( UnitVentNum ).CCoilType );
@@ -2252,7 +2252,7 @@ namespace UnitVentilator {
 			} else if ( SELECT_CASE_var1 == Cooling_CoilHXAssisted ) {
 				CheckHXAssistedCoolingCoilSchedule( "CoilSystem:Cooling:Water:HeatExchangerAssisted", UnitVent( UnitVentNum ).CCoilName, UnitVent( UnitVentNum ).CCoilSchedValue, UnitVent( UnitVentNum ).CCoil_Index );
 			} else {
-				//      CALL ShowFatalError('Illegal coil type='//TRIM(UnitVent(UnitVentNum)%CCoilType))
+				//      CALL ShowFatalError('Illegal coil type='//TRIM(UnitVent(UnitVentNum)%CCoilType))  // LCOV_EXCL_LINE
 			}}
 
 		} else if ( SELECT_CASE_var == HeatingOption ) {
@@ -2268,7 +2268,7 @@ namespace UnitVentilator {
 			} else if ( SELECT_CASE_var1 == Heating_GasCoilType ) {
 				CheckHeatingCoilSchedule( "Coil:Heating:Fuel", UnitVent( UnitVentNum ).HCoilName, UnitVent( UnitVentNum ).HCoilSchedValue, UnitVent( UnitVentNum ).HCoil_Index );
 			} else {
-				//      CALL ShowFatalError('Illegal coil type='//TRIM(UnitVent(UnitVentNum)%HCoilType))
+				//      CALL ShowFatalError('Illegal coil type='//TRIM(UnitVent(UnitVentNum)%HCoilType))  // LCOV_EXCL_LINE
 			}}
 
 		} else if ( SELECT_CASE_var == CoolingOption ) {
@@ -2282,7 +2282,7 @@ namespace UnitVentilator {
 			} else if ( SELECT_CASE_var1 == Cooling_CoilHXAssisted ) {
 				CheckHXAssistedCoolingCoilSchedule( "CoilSystem:Cooling:Water:HeatExchangerAssisted", UnitVent( UnitVentNum ).CCoilName, UnitVent( UnitVentNum ).CCoilSchedValue, UnitVent( UnitVentNum ).CCoil_Index );
 			} else {
-				//      CALL ShowFatalError('Illegal coil type='//TRIM(UnitVent(UnitVentNum)%CCoilType))
+				//      CALL ShowFatalError('Illegal coil type='//TRIM(UnitVent(UnitVentNum)%CCoilType))  // LCOV_EXCL_LINE
 
 			}}
 
@@ -2439,7 +2439,7 @@ namespace UnitVentilator {
 							}
 						} else {
 							// It should NEVER get to this point, but just in case...
-							ShowFatalError( "ZoneHVAC:UnitVentilator simulation control: illogical condition for " + UnitVent( UnitVentNum ).Name );
+							ShowFatalError( "ZoneHVAC:UnitVentilator simulation control: illogical condition for " + UnitVent( UnitVentNum ).Name );  // LCOV_EXCL_LINE
 						}
 
 					}}
@@ -2514,7 +2514,7 @@ namespace UnitVentilator {
 							}
 						} else {
 							// It should NEVER get to this point, but just in case...
-							ShowFatalError( "ZoneHVAC:UnitVentilator simulation control: illogical condition for " + UnitVent( UnitVentNum ).Name );
+							ShowFatalError( "ZoneHVAC:UnitVentilator simulation control: illogical condition for " + UnitVent( UnitVentNum ).Name );  // LCOV_EXCL_LINE
 						}
 
 					}}
@@ -2650,7 +2650,7 @@ namespace UnitVentilator {
 							}
 						} else {
 							// It should NEVER get to this point, but just in case...
-							ShowFatalError( "ZoneHVAC:UnitVentilator simulation control: illogical condition for " + UnitVent( UnitVentNum ).Name );
+							ShowFatalError( "ZoneHVAC:UnitVentilator simulation control: illogical condition for " + UnitVent( UnitVentNum ).Name );  // LCOV_EXCL_LINE
 						}
 
 					}}
@@ -2717,7 +2717,7 @@ namespace UnitVentilator {
 							}
 						} else {
 							// It should NEVER get to this point, but just in case...
-							ShowFatalError( "ZoneHVAC:UnitVentilator simulation control: illogical condition for " + UnitVent( UnitVentNum ).Name );
+							ShowFatalError( "ZoneHVAC:UnitVentilator simulation control: illogical condition for " + UnitVent( UnitVentNum ).Name );  // LCOV_EXCL_LINE
 						}
 
 					}}
@@ -2886,7 +2886,7 @@ namespace UnitVentilator {
 			} else {
 				SimUnitVentOAMixer( UnitVentNum, FanOpMode );
 			}
-			if ( UnitVent( UnitVentNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) { 
+			if ( UnitVent( UnitVentNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) {
 				Fans::SimulateFanComponents( UnitVent( UnitVentNum ).FanName, FirstHVACIteration, UnitVent( UnitVentNum ).Fan_Index, _, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
 			} else {
 				DataHVACGlobals::OnOffFanPartLoadFraction = 1.0; // used for cycling fan, set to 1.0 to be sure
@@ -2960,7 +2960,7 @@ namespace UnitVentilator {
 			} else {
 				SimUnitVentOAMixer( UnitVentNum, FanOpMode );
 			}
-			if ( UnitVent( UnitVentNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) { 
+			if ( UnitVent( UnitVentNum ).FanType_Num != DataHVACGlobals::FanType_SystemModelObject ) {
 				Fans::SimulateFanComponents( UnitVent( UnitVentNum ).FanName, FirstHVACIteration, UnitVent( UnitVentNum ).Fan_Index, _, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
 			} else {
 				HVACFan::fanObjs[ UnitVent( UnitVentNum ).Fan_Index ]->simulate( _, ZoneCompTurnFansOn, ZoneCompTurnFansOff, _ );

--- a/src/EnergyPlus/UserDefinedComponents.cc
+++ b/src/EnergyPlus/UserDefinedComponents.cc
@@ -206,17 +206,17 @@ namespace UserDefinedComponents {
 		if ( CompIndex == 0 ) {
 			CompNum = FindItemInList( EquipName, UserPlantComp );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimUserDefinedPlantComponent: User Defined Plant Component not found" );
+				ShowFatalError( "SimUserDefinedPlantComponent: User Defined Plant Component not found" );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CompNum;
 		} else {
 			CompNum = CompIndex;
 			if ( CompNum < 1 || CompNum > NumUserPlantComps ) {
-				ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumUserPlantComps ) + ", Entered Unit name = " + EquipName );
+				ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumUserPlantComps ) + ", Entered Unit name = " + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckUserPlantCompName( CompNum ) ) {
 				if ( EquipName != UserPlantComp( CompNum ).Name ) {
-					ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + EquipName + ", stored unit name for that index=" + UserPlantComp( CompNum ).Name );
+					ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + EquipName + ", stored unit name for that index=" + UserPlantComp( CompNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckUserPlantCompName( CompNum ) = false;
 			}
@@ -246,7 +246,7 @@ namespace UserDefinedComponents {
 
 			} else {
 				// throw warning
-				ShowFatalError( "SimUserDefinedPlantComponent: did not find where called from loop number called from =" + TrimSigDigits( LoopNum ) + " , loop side called from =" + TrimSigDigits( LoopSideNum ) );
+				ShowFatalError( "SimUserDefinedPlantComponent: did not find where called from loop number called from =" + TrimSigDigits( LoopNum ) + " , loop side called from =" + TrimSigDigits( LoopSideNum ) );  // LCOV_EXCL_LINE
 			}
 			return;
 		}
@@ -334,17 +334,17 @@ namespace UserDefinedComponents {
 		if ( CompIndex == 0 ) {
 			CompNum = FindItemInList( EquipName, UserCoil );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimUserDefinedPlantComponent: User Defined Coil not found" );
+				ShowFatalError( "SimUserDefinedPlantComponent: User Defined Coil not found" );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CompNum;
 		} else {
 			CompNum = CompIndex;
 			if ( CompNum < 1 || CompNum > NumUserCoils ) {
-				ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumUserCoils ) + ", Entered Unit name = " + EquipName );
+				ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumUserCoils ) + ", Entered Unit name = " + EquipName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckUserCoilName( CompNum ) ) {
 				if ( EquipName != UserCoil( CompNum ).Name ) {
-					ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + EquipName + ", stored unit name for that index=" + UserCoil( CompNum ).Name );
+					ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + EquipName + ", stored unit name for that index=" + UserCoil( CompNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckUserCoilName( CompNum ) = false;
 			}
@@ -453,17 +453,17 @@ namespace UserDefinedComponents {
 		if ( CompIndex == 0 ) {
 			CompNum = FindItemInList( CompName, UserZoneAirHVAC );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimUserDefinedPlantComponent: User Defined Coil not found" );
+				ShowFatalError( "SimUserDefinedPlantComponent: User Defined Coil not found" );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CompNum;
 		} else {
 			CompNum = CompIndex;
 			if ( CompNum < 1 || CompNum > NumUserZoneAir ) {
-				ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumUserZoneAir ) + ", Entered Unit name = " + CompName );
+				ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumUserZoneAir ) + ", Entered Unit name = " + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckUserZoneAirName( CompNum ) ) {
 				if ( CompName != UserZoneAirHVAC( CompNum ).Name ) {
-					ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored unit name for that index=" + UserZoneAirHVAC( CompNum ).Name );
+					ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored unit name for that index=" + UserZoneAirHVAC( CompNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckUserZoneAirName( CompNum ) = false;
 			}
@@ -565,17 +565,17 @@ namespace UserDefinedComponents {
 		if ( CompIndex == 0 ) {
 			CompNum = FindItemInList( CompName, UserAirTerminal );
 			if ( CompNum == 0 ) {
-				ShowFatalError( "SimUserDefinedPlantComponent: User Defined Coil not found" );
+				ShowFatalError( "SimUserDefinedPlantComponent: User Defined Coil not found" );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CompNum;
 		} else {
 			CompNum = CompIndex;
 			if ( CompNum < 1 || CompNum > NumUserAirTerminals ) {
-				ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumUserAirTerminals ) + ", Entered Unit name = " + CompName );
+				ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of units =" + TrimSigDigits( NumUserAirTerminals ) + ", Entered Unit name = " + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckUserAirTerminal( CompNum ) ) {
 				if ( CompName != UserAirTerminal( CompNum ).Name ) {
-					ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored unit name for that index=" + UserAirTerminal( CompNum ).Name );
+					ShowFatalError( "SimUserDefinedPlantComponent: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored unit name for that index=" + UserAirTerminal( CompNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckUserAirTerminal( CompNum ) = false;
 			}
@@ -889,7 +889,7 @@ namespace UserDefinedComponents {
 		} //NumUserPlantComps > 0
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetUserDefinedComponents: Errors found in processing " + cCurrentModuleObject + " input." );
+			ShowFatalError( "GetUserDefinedComponents: Errors found in processing " + cCurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 		cCurrentModuleObject = "Coil:UserDefined";
@@ -1042,7 +1042,7 @@ namespace UserDefinedComponents {
 		} //NumUserCoils > 0
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetUserDefinedComponents: Errors found in processing " + cCurrentModuleObject + " input." );
+			ShowFatalError( "GetUserDefinedComponents: Errors found in processing " + cCurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 		cCurrentModuleObject = "ZoneHVAC:ForcedAir:UserDefined";
@@ -1194,7 +1194,7 @@ namespace UserDefinedComponents {
 		} //NumUserZoneAir > 0
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetUserDefinedComponents: Errors found in processing " + cCurrentModuleObject + " input." );
+			ShowFatalError( "GetUserDefinedComponents: Errors found in processing " + cCurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 		cCurrentModuleObject = "AirTerminal:SingleDuct:UserDefined";
@@ -1382,7 +1382,7 @@ namespace UserDefinedComponents {
 		} //NumUserZoneAir > 0
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetUserDefinedComponents: Errors found in processing " + cCurrentModuleObject + " input." );
+			ShowFatalError( "GetUserDefinedComponents: Errors found in processing " + cCurrentModuleObject + " input." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1452,7 +1452,7 @@ namespace UserDefinedComponents {
 				errFlag = false;
 				ScanPlantLoopsForObject( UserPlantComp( CompNum ).Name, TypeOf_PlantComponentUserDefined, UserPlantComp( CompNum ).Loop( ConnectionNum ).LoopNum, UserPlantComp( CompNum ).Loop( ConnectionNum ).LoopSideNum, UserPlantComp( CompNum ).Loop( ConnectionNum ).BranchNum, UserPlantComp( CompNum ).Loop( ConnectionNum ).CompNum, _, _, _, UserPlantComp( CompNum ).Loop( ConnectionNum ).InletNodeNum );
 				if ( errFlag ) {
-					ShowFatalError( "InitPlantUserComponent: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitPlantUserComponent: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 
 				//set user input for flow priority
@@ -1538,7 +1538,7 @@ namespace UserDefinedComponents {
 				errFlag = false;
 				ScanPlantLoopsForObject( UserCoil( CompNum ).Name, TypeOf_CoilUserDefined, UserCoil( CompNum ).Loop.LoopNum, UserCoil( CompNum ).Loop.LoopSideNum, UserCoil( CompNum ).Loop.BranchNum, UserCoil( CompNum ).Loop.CompNum );
 				if ( errFlag ) {
-					ShowFatalError( "InitPlantUserComponent: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitPlantUserComponent: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				//set user input for flow priority
 				PlantLoop( UserCoil( CompNum ).Loop.LoopNum ).LoopSide( UserCoil( CompNum ).Loop.LoopSideNum ).Branch( UserCoil( CompNum ).Loop.BranchNum ).Comp( UserCoil( CompNum ).Loop.CompNum ).FlowPriority = UserCoil( CompNum ).Loop.FlowPriority;
@@ -1629,7 +1629,7 @@ namespace UserDefinedComponents {
 					errFlag = false;
 					ScanPlantLoopsForObject( UserZoneAirHVAC( CompNum ).Name, TypeOf_ZoneHVACAirUserDefined, UserZoneAirHVAC( CompNum ).Loop( Loop ).LoopNum, UserZoneAirHVAC( CompNum ).Loop( Loop ).LoopSideNum, UserZoneAirHVAC( CompNum ).Loop( Loop ).BranchNum, UserZoneAirHVAC( CompNum ).Loop( Loop ).CompNum, _, _, _, UserZoneAirHVAC( CompNum ).Loop( Loop ).InletNodeNum );
 					if ( errFlag ) {
-						ShowFatalError( "InitPlantUserComponent: Program terminated due to previous condition(s)." );
+						ShowFatalError( "InitPlantUserComponent: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 					}
 					//set user input for flow priority
 					PlantLoop( UserZoneAirHVAC( CompNum ).Loop( Loop ).LoopNum ).LoopSide( UserZoneAirHVAC( CompNum ).Loop( Loop ).LoopSideNum ).Branch( UserZoneAirHVAC( CompNum ).Loop( Loop ).BranchNum ).Comp( UserZoneAirHVAC( CompNum ).Loop( Loop ).CompNum ).FlowPriority = UserZoneAirHVAC( CompNum ).Loop( Loop ).FlowPriority;
@@ -1729,7 +1729,7 @@ namespace UserDefinedComponents {
 					errFlag = false;
 					ScanPlantLoopsForObject( UserAirTerminal( CompNum ).Name, TypeOf_AirTerminalUserDefined, UserAirTerminal( CompNum ).Loop( Loop ).LoopNum, UserAirTerminal( CompNum ).Loop( Loop ).LoopSideNum, UserAirTerminal( CompNum ).Loop( Loop ).BranchNum, UserAirTerminal( CompNum ).Loop( Loop ).CompNum, _, _, _, UserAirTerminal( CompNum ).Loop( Loop ).InletNodeNum );
 					if ( errFlag ) {
-						ShowFatalError( "InitPlantUserComponent: Program terminated due to previous condition(s)." );
+						ShowFatalError( "InitPlantUserComponent: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 					}
 					//set user input for flow priority
 					PlantLoop( UserAirTerminal( CompNum ).Loop( Loop ).LoopNum ).LoopSide( UserAirTerminal( CompNum ).Loop( Loop ).LoopSideNum ).Branch( UserAirTerminal( CompNum ).Loop( Loop ).BranchNum ).Comp( UserAirTerminal( CompNum ).Loop( Loop ).CompNum ).FlowPriority = UserAirTerminal( CompNum ).Loop( Loop ).FlowPriority;

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -810,7 +810,7 @@ env_var_on( std::string const & env_var_str )
 }
 
 void
-ShowFatalError(
+ShowFatalError(  // LCOV_EXCL_LINE
 	std::string const & ErrorMessage,
 	Optional_int OutUnit1,
 	Optional_int OutUnit2

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -450,16 +450,16 @@ namespace VariableSpeedCoils {
 		if ( CompIndex == 0 ) {
 			DXCoilNum = FindItemInList( CompName, VarSpeedCoil );
 			if ( DXCoilNum == 0 ) {
-				ShowFatalError( "WaterToAirHPVSWEquationFit not found=" + CompName );
+				ShowFatalError( "WaterToAirHPVSWEquationFit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = DXCoilNum;
 		} else {
 			DXCoilNum = CompIndex;
 			if ( DXCoilNum > NumVarSpeedCoils || DXCoilNum < 1 ) {
-				ShowFatalError( "SimVariableSpeedCoils: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Number of Water to Air HPs=" + TrimSigDigits( NumVarSpeedCoils ) + ", WaterToAir HP name=" + CompName );
+				ShowFatalError( "SimVariableSpeedCoils: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", Number of Water to Air HPs=" + TrimSigDigits( NumVarSpeedCoils ) + ", WaterToAir HP name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( !CompName.empty() && CompName != VarSpeedCoil( DXCoilNum ).Name ) {
-				ShowFatalError( "SimVariableSpeedCoils: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", WaterToAir HP name=" + CompName + ", stored WaterToAir HP Name for that index=" + VarSpeedCoil( DXCoilNum ).Name );
+				ShowFatalError( "SimVariableSpeedCoils: Invalid CompIndex passed=" + TrimSigDigits( DXCoilNum ) + ", WaterToAir HP name=" + CompName + ", stored WaterToAir HP Name for that index=" + VarSpeedCoil( DXCoilNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -492,7 +492,7 @@ namespace VariableSpeedCoils {
 			CalcVarSpeedHPWH( DXCoilNum, RuntimeFrac, PartLoadFrac, SpeedRatio, SpeedNum, CyclingScheme );
 			UpdateVarSpeedCoil( DXCoilNum );
 		} else {
-			ShowFatalError( "SimVariableSpeedCoils: WatertoAir heatpump not in either HEATING or COOLING mode" );
+			ShowFatalError( "SimVariableSpeedCoils: WatertoAir heatpump not in either HEATING or COOLING mode" );  // LCOV_EXCL_LINE
 		}
 
 		// two additional output variables
@@ -2498,7 +2498,7 @@ namespace VariableSpeedCoils {
 		NumArray.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found getting input. Program terminates." );
+			ShowFatalError( RoutineName + "Errors found getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		for ( DXCoilNum = 1; DXCoilNum <= NumVarSpeedCoils; ++DXCoilNum ) {
@@ -2646,7 +2646,7 @@ namespace VariableSpeedCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2757,7 +2757,7 @@ namespace VariableSpeedCoils {
 				errFlag = false;
 				ScanPlantLoopsForObject( VarSpeedCoil( DXCoilNum ).Name, VarSpeedCoil( DXCoilNum ).VSCoilTypeOfNum, VarSpeedCoil( DXCoilNum ).LoopNum, VarSpeedCoil( DXCoilNum ).LoopSide, VarSpeedCoil( DXCoilNum ).BranchNum, VarSpeedCoil( DXCoilNum ).CompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitVarSpeedCoil: Program terminated for previous conditions." );
+					ShowFatalError( "InitVarSpeedCoil: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 				}
 				MyPlantScanFlag( DXCoilNum ) = false;
 			}
@@ -2784,7 +2784,7 @@ namespace VariableSpeedCoils {
 						ErrorsFound = true;
 					}
 					if ( ErrorsFound ) {
-						ShowFatalError( "Preceding condition causes termination." );
+						ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 					}
 					// Check for valid range of (Rated Air Volume Flow Rate / Rated Total Capacity)
 					RatedVolFlowPerRatedTotCap = VarSpeedCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ) / VarSpeedCoil( DXCoilNum ).MSRatedTotCap( Mode );
@@ -3551,11 +3551,11 @@ namespace VariableSpeedCoils {
 			if ( VarSpeedCoil( DXCoilNum ).MSHPDesignSpecIndex > 0 && allocated( HVACUnitarySystem::DesignSpecMSHP ) ) {
 				if ( VarSpeedCoil( DXCoilNum ).CoolHeatType == "COOLING" ) {
 					if ( HVACUnitarySystem::DesignSpecMSHP( VarSpeedCoil( DXCoilNum ).MSHPDesignSpecIndex ).NumOfSpeedCooling != VarSpeedCoil( DXCoilNum ).NumOfSpeeds ) {
-						ShowFatalError( "COIL:" + VarSpeedCoil( DXCoilNum ).CoolHeatType + CurrentObjSubfix + " = " + VarSpeedCoil( DXCoilNum ).Name + " number of speeds not equal to number of speed specified in UnitarySystemPerformance:Multispeed object." );
+						ShowFatalError( "COIL:" + VarSpeedCoil( DXCoilNum ).CoolHeatType + CurrentObjSubfix + " = " + VarSpeedCoil( DXCoilNum ).Name + " number of speeds not equal to number of speed specified in UnitarySystemPerformance:Multispeed object." );  // LCOV_EXCL_LINE
 					}
 				} else {
 					if ( HVACUnitarySystem::DesignSpecMSHP( VarSpeedCoil( DXCoilNum ).MSHPDesignSpecIndex ).NumOfSpeedHeating != VarSpeedCoil( DXCoilNum ).NumOfSpeeds ) {
-						ShowFatalError( "COIL:" + VarSpeedCoil( DXCoilNum ).CoolHeatType + CurrentObjSubfix + " = " + VarSpeedCoil( DXCoilNum ).Name + " number of speeds not equal to number of speed specified in UnitarySystemPerformance:Multispeed object." );
+						ShowFatalError( "COIL:" + VarSpeedCoil( DXCoilNum ).CoolHeatType + CurrentObjSubfix + " = " + VarSpeedCoil( DXCoilNum ).Name + " number of speeds not equal to number of speed specified in UnitarySystemPerformance:Multispeed object." );  // LCOV_EXCL_LINE
 					}
 				}
 			}
@@ -3670,7 +3670,7 @@ namespace VariableSpeedCoils {
 				if ( VarSpeedCoil( DXCoilNum ).MSRatedWaterVolFlowRate( Mode ) > VarSpeedCoil( DXCoilNum ).MSRatedWaterVolFlowRate( Mode + 1 ) * 1.05 ) {
 					ShowWarningError( "SizeDXCoil: " + VarSpeedCoil( DXCoilNum ).VarSpeedCoilType + ' ' + VarSpeedCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Rated Air Flow Rate must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Rated Air Flow Rate." );
 					ShowContinueError( "Instead, " + RoundSigDigits( VarSpeedCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ), 2 ) + " > " + RoundSigDigits( VarSpeedCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode + 1 ), 2 ) );
-					ShowFatalError( "Preceding conditions cause termination." );
+					ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 				}
 			}
 		} else {
@@ -3739,7 +3739,7 @@ namespace VariableSpeedCoils {
 			if ( VarSpeedCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ) > VarSpeedCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode + 1 ) ) {
 				ShowWarningError( "SizeDXCoil: " + VarSpeedCoil( DXCoilNum ).VarSpeedCoilType + ' ' + VarSpeedCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Rated Air Flow Rate must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Rated Air Flow Rate." );
 				ShowContinueError( "Instead, " + RoundSigDigits( VarSpeedCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode ), 2 ) + " > " + RoundSigDigits( VarSpeedCoil( DXCoilNum ).MSRatedAirVolFlowRate( Mode + 1 ), 2 ) );
-				ShowFatalError( "Preceding conditions cause termination." );
+				ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -3748,7 +3748,7 @@ namespace VariableSpeedCoils {
 			if ( VarSpeedCoil( DXCoilNum ).MSRatedTotCap( Mode ) > VarSpeedCoil( DXCoilNum ).MSRatedTotCap( Mode + 1 ) ) {
 				ShowWarningError( "SizeDXCoil: " + VarSpeedCoil( DXCoilNum ).VarSpeedCoilType + ' ' + VarSpeedCoil( DXCoilNum ).Name + ", Speed " + TrimSigDigits( Mode ) + " Rated Total Cooling Capacity must be less than or equal to Speed " + TrimSigDigits( Mode + 1 ) + " Rated Total Cooling Capacity." );
 				ShowContinueError( "Instead, " + RoundSigDigits( VarSpeedCoil( DXCoilNum ).MSRatedTotCap( Mode ), 2 ) + " > " + RoundSigDigits( VarSpeedCoil( DXCoilNum ).MSRatedTotCap( Mode + 1 ), 2 ) );
-				ShowFatalError( "Preceding conditions cause termination." );
+				ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -4824,7 +4824,7 @@ namespace VariableSpeedCoils {
 			// calculate evaporator total cooling capacity
 			if ( VarSpeedCoil( DXCoilNum ).FanPowerIncludedInCOP ) {
 				if ( VarSpeedCoil( DXCoilNum ).CondPumpPowerInCOP ) {
-					//       make sure fan power is full load fan power, it isn't though,  
+					//       make sure fan power is full load fan power, it isn't though,
 					CompressorPower = OperatingHeatingPower - locFanElecPower / HPRTF
 						- VarSpeedCoil( DXCoilNum ).HPWHCondPumpElecNomPower;
 					if ( OperatingHeatingPower > 0.0 ) TankHeatingCOP = TotalTankHeatingCapacity / OperatingHeatingPower;
@@ -6687,7 +6687,7 @@ namespace VariableSpeedCoils {
 				}
 			}
 			ShowContinueErrorTimeStamp( "" );
-			ShowFatalError( "Check and revise the input data for this coil before rerunning the simulation." );
+			ShowFatalError( "Check and revise the input data for this coil before rerunning the simulation." );  // LCOV_EXCL_LINE
 		}
 		DeltaT = InletAirTemp - OutletAirTemp;
 		if ( DeltaT <= 0.0 ) {
@@ -6711,7 +6711,7 @@ namespace VariableSpeedCoils {
 				}
 			}
 			ShowContinueErrorTimeStamp( "" );
-			ShowFatalError( "Check and revise the input data for this coil before rerunning the simulation." );
+			ShowFatalError( "Check and revise the input data for this coil before rerunning the simulation." );  // LCOV_EXCL_LINE
 		}
 		// Calculate slope at given conditions
 		if ( DeltaT > 0.0 ) SlopeAtConds = DeltaHumRat / DeltaT;
@@ -6801,7 +6801,7 @@ namespace VariableSpeedCoils {
 
 		// Show fatal error for specific coil that caused a CBF error
 		if ( CBFErrors ) {
-			ShowFatalError( UnitType + " \"" + UnitName + "\" Errors found in calculating coil bypass factors" );
+			ShowFatalError( UnitType + " \"" + UnitName + "\" Errors found in calculating coil bypass factors" );  // LCOV_EXCL_LINE
 		}
 
 		return CBF;

--- a/src/EnergyPlus/VentilatedSlab.cc
+++ b/src/EnergyPlus/VentilatedSlab.cc
@@ -282,17 +282,17 @@ namespace VentilatedSlab {
 		if ( CompIndex == 0 ) {
 			Item = FindItemInList( CompName, VentSlab );
 			if ( Item == 0 ) {
-				ShowFatalError( "SimVentilatedSlab: system not found=" + CompName );
+				ShowFatalError( "SimVentilatedSlab: system not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = Item;
 		} else {
 			Item = CompIndex;
 			if ( Item > NumOfVentSlabs || Item < 1 ) {
-				ShowFatalError( "SimVentilatedSlab:  Invalid CompIndex passed=" + TrimSigDigits( Item ) + ", Number of Systems=" + TrimSigDigits( NumOfVentSlabs ) + ", Entered System name=" + CompName );
+				ShowFatalError( "SimVentilatedSlab:  Invalid CompIndex passed=" + TrimSigDigits( Item ) + ", Number of Systems=" + TrimSigDigits( NumOfVentSlabs ) + ", Entered System name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( Item ) ) {
 				if ( CompName != VentSlab( Item ).Name ) {
-					ShowFatalError( "SimVentilatedSlab: Invalid CompIndex passed=" + TrimSigDigits( Item ) + ", System name=" + CompName + ", stored System Name for that index=" + VentSlab( Item ).Name );
+					ShowFatalError( "SimVentilatedSlab: Invalid CompIndex passed=" + TrimSigDigits( Item ) + ", System name=" + CompName + ", stored System Name for that index=" + VentSlab( Item ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( Item ) = false;
 			}
@@ -1077,7 +1077,7 @@ namespace VentilatedSlab {
 		lAlphaBlanks.deallocate();
 		lNumericBlanks.deallocate();
 
-		if ( ErrorsFound ) ShowFatalError( CurrentModuleObject + " errors occurred in input.  Program terminates." );
+		if ( ErrorsFound ) ShowFatalError( CurrentModuleObject + " errors occurred in input.  Program terminates." );  // LCOV_EXCL_LINE
 
 		// Setup Report variables for the VENTILATED SLAB
 		for ( Item = 1; Item <= NumOfVentSlabs; ++Item ) {
@@ -1249,7 +1249,7 @@ namespace VentilatedSlab {
 				ScanPlantLoopsForObject( VentSlab( Item ).HCoilName, VentSlab( Item ).HCoil_PlantTypeNum, VentSlab( Item ).HWLoopNum, VentSlab( Item ).HWLoopSide, VentSlab( Item ).HWBranchNum, VentSlab( Item ).HWCompNum, _, _, _, _, _, errFlag );
 				if ( errFlag ) {
 					ShowContinueError( "Reference Unit=\"" + VentSlab( Item ).Name + "\", type=ZoneHVAC:VentilatedSlab" );
-					ShowFatalError( "InitVentilatedSlab: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitVentilatedSlab: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 
 				VentSlab( Item ).HotCoilOutNodeNum = PlantLoop( VentSlab( Item ).HWLoopNum ).LoopSide( VentSlab( Item ).HWLoopSide ).Branch( VentSlab( Item ).HWBranchNum ).Comp( VentSlab( Item ).HWCompNum ).NodeNumOut;
@@ -1260,11 +1260,11 @@ namespace VentilatedSlab {
 				ScanPlantLoopsForObject( VentSlab( Item ).CCoilPlantName, VentSlab( Item ).CCoil_PlantTypeNum, VentSlab( Item ).CWLoopNum, VentSlab( Item ).CWLoopSide, VentSlab( Item ).CWBranchNum, VentSlab( Item ).CWCompNum );
 				if ( errFlag ) {
 					ShowContinueError( "Reference Unit=\"" + VentSlab( Item ).Name + "\", type=ZoneHVAC:VentilatedSlab" );
-					ShowFatalError( "InitVentilatedSlab: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitVentilatedSlab: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				VentSlab( Item ).ColdCoilOutNodeNum = PlantLoop( VentSlab( Item ).CWLoopNum ).LoopSide( VentSlab( Item ).CWLoopSide ).Branch( VentSlab( Item ).CWBranchNum ).Comp( VentSlab( Item ).CWCompNum ).NodeNumOut;
 			} else {
-				if ( VentSlab( Item ).CCoilPresent ) ShowFatalError( "InitVentilatedSlab: Unit=" + VentSlab( Item ).Name + ", invalid cooling coil type. Program terminated." );
+				if ( VentSlab( Item ).CCoilPresent ) ShowFatalError( "InitVentilatedSlab: Unit=" + VentSlab( Item ).Name + ", invalid cooling coil type. Program terminated." );  // LCOV_EXCL_LINE
 			}
 			MyPlantScanFlag( Item ) = false;
 		} else if ( MyPlantScanFlag( Item ) && ! AnyPlantInModel ) {
@@ -2070,7 +2070,7 @@ namespace VentilatedSlab {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2311,7 +2311,7 @@ namespace VentilatedSlab {
 		} else { // Should never get here
 			SetPointTemp = 0.0; // Suppress uninitialized warning
 			ShowSevereError( "Illegal control type in low temperature radiant system: " + VentSlab( Item ).Name );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 		}}
 
 		// Load Check
@@ -2381,7 +2381,7 @@ namespace VentilatedSlab {
 				if ( SetPointTempHi < SetPointTempLo ) {
 					ShowSevereError( "Heating setpoint temperature mismatch in" + VentSlab( Item ).Name );
 					ShowContinueError( "High setpoint temperature is less than low setpoint temperature--check your schedule input" );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 				AirTempHi = GetCurrentScheduleValue( VentSlab( Item ).HotAirHiTempSchedPtr );
 				AirTempLo = GetCurrentScheduleValue( VentSlab( Item ).HotAirLoTempSchedPtr );
@@ -2389,7 +2389,7 @@ namespace VentilatedSlab {
 				if ( AirTempHi < AirTempLo ) {
 					ShowSevereError( "Heating Air temperature mismatch in" + VentSlab( Item ).Name );
 					ShowContinueError( "High Air temperature is less than low Air temperature--check your schedule input" );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 
 				if ( SetPointTemp >= SetPointTempHi ) {
@@ -2509,7 +2509,7 @@ namespace VentilatedSlab {
 							}
 						} else {
 							// It should NEVER get to this point, but just in case...
-							ShowFatalError( "Ventilated Slab simulation control: illogical condition for " + VentSlab( Item ).Name );
+							ShowFatalError( "Ventilated Slab simulation control: illogical condition for " + VentSlab( Item ).Name );  // LCOV_EXCL_LINE
 						}
 
 					}}
@@ -2572,7 +2572,7 @@ namespace VentilatedSlab {
 							}
 						} else {
 							// It should NEVER get to this point, but just in case...
-							ShowFatalError( "Ventilated Slab simulation control: illogical condition for " + VentSlab( Item ).Name );
+							ShowFatalError( "Ventilated Slab simulation control: illogical condition for " + VentSlab( Item ).Name );  // LCOV_EXCL_LINE
 						}
 
 					}}
@@ -2613,7 +2613,7 @@ namespace VentilatedSlab {
 				if ( SetPointTempHi < SetPointTempLo ) {
 					ShowSevereError( "Cooling setpoint temperature mismatch in" + VentSlab( Item ).Name );
 					ShowContinueError( "High setpoint temperature is less than low setpoint temperature--check your schedule input" );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 
 				AirTempHi = GetCurrentScheduleValue( VentSlab( Item ).ColdAirHiTempSchedPtr );
@@ -2621,7 +2621,7 @@ namespace VentilatedSlab {
 				if ( AirTempHi < AirTempLo ) {
 					ShowSevereError( "Cooling Air temperature mismatch in" + VentSlab( Item ).Name );
 					ShowContinueError( "High Air temperature is less than low Air temperature--check your schedule input" );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 
 				if ( SetPointTemp <= SetPointTempLo ) {
@@ -2735,7 +2735,7 @@ namespace VentilatedSlab {
 							}
 						} else {
 							// It should NEVER get to this point, but just in case...
-							ShowFatalError( cMO_VentilatedSlab + " simulation control: illogical condition for " + VentSlab( Item ).Name );
+							ShowFatalError( cMO_VentilatedSlab + " simulation control: illogical condition for " + VentSlab( Item ).Name );  // LCOV_EXCL_LINE
 						}
 
 					}}
@@ -2801,7 +2801,7 @@ namespace VentilatedSlab {
 							}
 						} else {
 							// It should NEVER get to this point, but just in case...
-							ShowFatalError( cMO_VentilatedSlab + " simulation control: illogical condition for " + VentSlab( Item ).Name );
+							ShowFatalError( cMO_VentilatedSlab + " simulation control: illogical condition for " + VentSlab( Item ).Name );  // LCOV_EXCL_LINE
 						}
 
 					}}

--- a/src/EnergyPlus/WaterCoils.cc
+++ b/src/EnergyPlus/WaterCoils.cc
@@ -300,17 +300,17 @@ namespace WaterCoils {
 		if ( CompIndex == 0 ) {
 			CoilNum = FindItemInList( CompName, WaterCoil );
 			if ( CoilNum == 0 ) {
-				ShowFatalError( "SimulateWaterCoilComponents: Coil not found=" + CompName );
+				ShowFatalError( "SimulateWaterCoilComponents: Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CoilNum;
 		} else {
 			CoilNum = CompIndex;
 			if ( CoilNum > NumWaterCoils || CoilNum < 1 ) {
-				ShowFatalError( "SimulateWaterCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Water Coils=" + TrimSigDigits( NumWaterCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "SimulateWaterCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Water Coils=" + TrimSigDigits( NumWaterCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( CoilNum ) ) {
 				if ( CompName != WaterCoil( CoilNum ).Name ) {
-					ShowFatalError( "SimulateWaterCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + WaterCoil( CoilNum ).Name );
+					ShowFatalError( "SimulateWaterCoilComponents: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + WaterCoil( CoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( CoilNum ) = false;
 			}
@@ -740,7 +740,7 @@ namespace WaterCoils {
 				WaterCoil( CoilNum ).UseDesignWaterDeltaTemp = true;
 			} else {
 				WaterCoil( CoilNum ).UseDesignWaterDeltaTemp = false;
-			}			
+			}
 
 			WaterCoil( CoilNum ).WaterInletNodeNum = GetOnlySingleNode( AlphArray( 3 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Water, NodeConnectionType_Inlet, 2, ObjectIsNotParent );
 			WaterCoil( CoilNum ).WaterOutletNodeNum = GetOnlySingleNode( AlphArray( 4 ), ErrorsFound, CurrentModuleObject, AlphArray( 1 ), NodeType_Water, NodeConnectionType_Outlet, 2, ObjectIsNotParent );
@@ -813,7 +813,7 @@ namespace WaterCoils {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting input." );
+			ShowFatalError( RoutineName + "Errors found in getting input." );  // LCOV_EXCL_LINE
 		}
 
 		AlphArray.deallocate();
@@ -986,7 +986,7 @@ namespace WaterCoils {
 			errFlag = false;
 			ScanPlantLoopsForObject( WaterCoil( CoilNum ).Name, WaterCoil( CoilNum ).WaterCoilType_Num, WaterCoil( CoilNum ).WaterLoopNum, WaterCoil( CoilNum ).WaterLoopSide, WaterCoil( CoilNum ).WaterLoopBranchNum, WaterCoil( CoilNum ).WaterLoopCompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitWaterCoil: Program terminated for previous conditions." );
+				ShowFatalError( "InitWaterCoil: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 			}
 			PlantLoopScanFlag( CoilNum ) = false;
 		}
@@ -1354,7 +1354,7 @@ namespace WaterCoils {
 				if ( SolFla == -1 ) {
 					ShowSevereError( "Calculation of cooling coil design UA failed for coil " + WaterCoil( CoilNum ).Name );
 					ShowContinueError( "  Iteration limit exceeded in calculating coil UA" );
-					// CALL ShowFatalError('Preceeding error causes program termination')
+					// CALL ShowFatalError('Preceeding error causes program termination')  // LCOV_EXCL_LINE
 					WaterCoil( CoilNum ).UACoilExternal = UA0 * 10.0;
 					WaterCoil( CoilNum ).UACoilInternal = WaterCoil( CoilNum ).UACoilExternal * 3.3;
 					WaterCoil( CoilNum ).UACoilTotal = 1.0 / ( 1.0 / WaterCoil( CoilNum ).UACoilExternal + 1.0 / WaterCoil( CoilNum ).UACoilInternal );
@@ -1366,7 +1366,7 @@ namespace WaterCoils {
 				} else if ( SolFla == -2 ) {
 					ShowSevereError( "Calculation of cooling coil design UA failed for coil " + WaterCoil( CoilNum ).Name );
 					ShowContinueError( "  Bad starting values for UA" );
-					// CALL ShowFatalError('Preceeding error causes program termination')
+					// CALL ShowFatalError('Preceeding error causes program termination')  // LCOV_EXCL_LINE
 					WaterCoil( CoilNum ).UACoilExternal = UA0 * 10.0;
 					WaterCoil( CoilNum ).UACoilInternal = WaterCoil( CoilNum ).UACoilExternal * 3.3;
 					WaterCoil( CoilNum ).UACoilTotal = 1.0 / ( 1.0 / WaterCoil( CoilNum ).UACoilExternal + 1.0 / WaterCoil( CoilNum ).UACoilInternal );
@@ -1690,7 +1690,7 @@ namespace WaterCoils {
 			PltSizCoolNum = MyPlantSizingIndex( "chilled water coil", WaterCoil( CoilNum ).Name, WaterCoil( CoilNum ).WaterInletNodeNum, WaterCoil( CoilNum ).WaterOutletNodeNum, LoopErrorsFound );
 		}
 
-		
+
 		if ( WaterCoil( CoilNum ).WaterCoilType == CoilType_Cooling ) { // 'Cooling'
 
 			if ( WaterCoil( CoilNum ).UseDesignWaterDeltaTemp ) {
@@ -1698,11 +1698,11 @@ namespace WaterCoils {
 			} else {
 				if ( PltSizCoolNum > 0 ) {
 					DataWaterCoilSizCoolDeltaT = PlantSizData( PltSizCoolNum ).DeltaT;
-				} 
+				}
 			}
 
 			if ( PltSizCoolNum > 0 ) {
-			
+
 				DataPltSizCoolNum = PltSizCoolNum;
 				DataWaterLoopNum = WaterCoil ( CoilNum ).WaterLoopNum;
 
@@ -1984,10 +1984,10 @@ namespace WaterCoils {
 				} else if ( CurSysNum > 0 ) {
 					if ( FinalSysSizing( CurSysNum ).HeatingCapMethod == CapacityPerFloorArea ) {
 						NomCapUserInp = true;
-					} else if ( FinalSysSizing( CurSysNum ).HeatingCapMethod == HeatingDesignCapacity && 
+					} else if ( FinalSysSizing( CurSysNum ).HeatingCapMethod == HeatingDesignCapacity &&
 						FinalSysSizing( CurSysNum ).HeatingTotalCapacity > 0.0 ) {
 						NomCapUserInp = true;
-					} 
+					}
 				} else {
 					NomCapUserInp = false;
 				}
@@ -2037,7 +2037,7 @@ namespace WaterCoils {
 				WaterCoil( CoilNum ).DesTotWaterCoilLoad = TempSize;
 				DataCapacityUsedForSizing = WaterCoil( CoilNum ).DesWaterHeatingCoilRate;
 
-				// We now have the design load if it was autosized. For the case of CoilPerfInpMeth == NomCap, calculate the air flow rate specified 
+				// We now have the design load if it was autosized. For the case of CoilPerfInpMeth == NomCap, calculate the air flow rate specified
 				// by the NomCap inputs. This overrides all previous values
 				if ( WaterCoil( CoilNum ).CoilPerfInpMeth == NomCap && NomCapUserInp ) {
 					WaterCoil( CoilNum ).InletAirMassFlowRate = WaterCoil( CoilNum ).DesTotWaterCoilLoad / ( CpAirStd*( WaterCoil( CoilNum ).DesOutletAirTemp -
@@ -2046,7 +2046,7 @@ namespace WaterCoils {
 					DataAirFlowUsedForSizing = WaterCoil( CoilNum ).DesAirVolFlowRate;
 					DataFlowUsedForSizing = WaterCoil( CoilNum ).DesAirVolFlowRate;
 				}
-				
+
 
 				FieldNum = 2; // N2 , \field Maximum Water Flow Rate
 				SizingString = WaterCoilNumericFields( CoilNum ).FieldNames( FieldNum ) + " [m3/s]";
@@ -2113,7 +2113,7 @@ namespace WaterCoils {
 					WaterCoil( CoilNum ).InletAirMassFlowRate = TempSize;
 				}
 
-				// zone and air loop coils use different design coil load calculations, air loop coils use air side capacity, 
+				// zone and air loop coils use different design coil load calculations, air loop coils use air side capacity,
 				// zone coils use water side capacity
 				DataDesInletAirTemp = WaterCoil ( CoilNum ).InletAirTemp; // used in error mesages
 				DataDesInletAirHumRat = WaterCoil ( CoilNum ).InletAirHumRat; // used in error mesages
@@ -2159,7 +2159,7 @@ namespace WaterCoils {
 					ShowContinueError( " Plant design loop exit temperature = " + TrimSigDigits( PlantSizData( DataPltSizHeatNum ).ExitTemp, 2 ) + " C" );
 					ShowContinueError( " Plant design loop exit temperature is low for design load and leaving air temperature anticipated." );
 					ShowContinueError( " Heating coil UA-value is sized using coil water inlet temperature = " + TrimSigDigits( DesCoilInletWaterTempUsed, 2 ) + " C" );
-					WaterCoil( DataCoilNum ).InletWaterTemp = DesCoilWaterInTempSaved; // reset the Design Coil Inlet Water Temperature 
+					WaterCoil( DataCoilNum ).InletWaterTemp = DesCoilWaterInTempSaved; // reset the Design Coil Inlet Water Temperature
 				}
 				WaterCoil( CoilNum ).UACoil = TempSize;
 				// if coil UA did not size due to one of these variables being 0, must set UACoilVariable to avoid crash later on
@@ -2170,7 +2170,7 @@ namespace WaterCoils {
 				}
 				WaterCoil( CoilNum ).UACoilVariable = TempSize;
 				WaterCoil( CoilNum ).DesWaterHeatingCoilRate = DataCapacityUsedForSizing;
-				WaterCoil( DataCoilNum ).InletWaterTemp = DesCoilWaterInTempSaved; // reset the Design Coil Inlet Water Temperature 
+				WaterCoil( DataCoilNum ).InletWaterTemp = DesCoilWaterInTempSaved; // reset the Design Coil Inlet Water Temperature
 
 				DataWaterLoopNum = 0; // reset all globals to 0 to ensure correct sizing for other child components
 				DataPltSizHeatNum = 0;
@@ -2206,7 +2206,7 @@ namespace WaterCoils {
 		}
 
 		if ( ErrorsFound || DataErrorsFound) {
-			ShowFatalError( "Preceding water coil sizing errors cause program termination" );
+			ShowFatalError( "Preceding water coil sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2322,7 +2322,7 @@ namespace WaterCoils {
 		if ( ( ( CapacitanceAir > 0.0 ) && ( CapacitanceWater > 0.0 ) ) && ( CalcMode == DesignCalc || MySizeFlag( CoilNum ) || MyUAAndFlowCalcFlag( CoilNum ) || GetCurrentScheduleValue( WaterCoil( CoilNum ).SchedPtr ) > 0.0 ) ) {
 
 			if ( UA <= 0.0 ) {
-				ShowFatalError( "UA is zero for COIL:Heating:Water " + WaterCoil( CoilNum ).Name );
+				ShowFatalError( "UA is zero for COIL:Heating:Water " + WaterCoil( CoilNum ).Name );  // LCOV_EXCL_LINE
 			}
 			NTU = UA / CapacitanceMin;
 			ETA = std::pow( NTU, 0.22 );
@@ -2572,7 +2572,7 @@ namespace WaterCoils {
 			AirVelocity = AirMassFlow * AirDensity / WaterCoil( CoilNum ).MinAirFlowArea;
 			ShowContinueError( "Air Face Velocity[m/s]=" + TrimSigDigits( AirVelocity, 6 ) );
 			ShowContinueError( "Approximate MassFlowRate limit for Face Area[kg/s]=" + TrimSigDigits( 2.5 * WaterCoil( CoilNum ).MinAirFlowArea / AirDensity, 6 ) );
-			ShowFatalError( "Coil:Cooling:Water:DetailedGeometry needs to be resized/autosized to handle capacity" );
+			ShowFatalError( "Coil:Cooling:Water:DetailedGeometry needs to be resized/autosized to handle capacity" );  // LCOV_EXCL_LINE
 		}
 
 		// If Coil is Scheduled ON then do the simulation
@@ -4977,17 +4977,17 @@ Label10: ;
 		if ( CompIndex == 0 ) {
 			CoilNum = FindItemInList( CompName, WaterCoil );
 			if ( CoilNum == 0 ) {
-				ShowFatalError( "CheckWaterCoilSchedule: Coil not found=" + CompName );
+				ShowFatalError( "CheckWaterCoilSchedule: Coil not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CoilNum;
 			Value = GetCurrentScheduleValue( WaterCoil( CoilNum ).SchedPtr ); // not scheduled?
 		} else {
 			CoilNum = CompIndex;
 			if ( CoilNum > NumWaterCoils || CoilNum < 1 ) {
-				ShowFatalError( "CheckWaterCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Heating Coils=" + TrimSigDigits( NumWaterCoils ) + ", Coil name=" + CompName );
+				ShowFatalError( "CheckWaterCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Heating Coils=" + TrimSigDigits( NumWaterCoils ) + ", Coil name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CompName != WaterCoil( CoilNum ).Name ) {
-				ShowFatalError( "CheckWaterCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + WaterCoil( CoilNum ).Name );
+				ShowFatalError( "CheckWaterCoilSchedule: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CompName + ", stored Coil Name for that index=" + WaterCoil( CoilNum ).Name );  // LCOV_EXCL_LINE
 			}
 			Value = GetCurrentScheduleValue( WaterCoil( CoilNum ).SchedPtr ); // not scheduled?
 		}
@@ -6096,20 +6096,20 @@ Label10: ;
 		if ( CompIndex == 0 ) {
 			CoilNum = FindItemInList( CoilName, WaterCoil );
 			if ( CoilNum == 0 ) {
-				ShowFatalError( "UpdateWaterToAirCoilPlantConnection: Specified Coil not one of Valid water coils=" + CoilName );
+				ShowFatalError( "UpdateWaterToAirCoilPlantConnection: Specified Coil not one of Valid water coils=" + CoilName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = CoilNum;
 		} else {
 			CoilNum = CompIndex;
 			if ( CoilNum > NumWaterCoils || CoilNum < 1 ) {
-				ShowFatalError( "UpdateWaterToAirCoilPlantConnection:  Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Coils=" + TrimSigDigits( NumWaterCoils ) + ", Entered Coil name=" + CoilName );
+				ShowFatalError( "UpdateWaterToAirCoilPlantConnection:  Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Number of Coils=" + TrimSigDigits( NumWaterCoils ) + ", Entered Coil name=" + CoilName );  // LCOV_EXCL_LINE
 			}
 			if ( KickOffSimulation ) {
 				if ( CoilName != WaterCoil( CoilNum ).Name ) {
-					ShowFatalError( "UpdateWaterToAirCoilPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CoilName + ", stored Coil Name for that index=" + WaterCoil( CoilNum ).Name );
+					ShowFatalError( "UpdateWaterToAirCoilPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CoilName + ", stored Coil Name for that index=" + WaterCoil( CoilNum ).Name );  // LCOV_EXCL_LINE
 				}
 				if ( CoilTypeNum != WaterCoil( CoilNum ).WaterCoilType_Num ) {
-					ShowFatalError( "UpdateWaterToAirCoilPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CoilName + ", stored Coil Name for that index=" + ccSimPlantEquipTypes( CoilTypeNum ) );
+					ShowFatalError( "UpdateWaterToAirCoilPlantConnection: Invalid CompIndex passed=" + TrimSigDigits( CoilNum ) + ", Coil name=" + CoilName + ", stored Coil Name for that index=" + ccSimPlantEquipTypes( CoilTypeNum ) );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -6227,7 +6227,7 @@ Label10: ;
 		int const CoilNum, // Number of hot water heating Coil
 		bool & ErrorsFound, // Set to true if certain errors found
 		Optional_bool DesiccantRegenerationCoil, // Flag that this coil is used as regeneration air heating coil
-		Optional_int DesiccantDehumIndex // Index for the desiccant dehum system where this caoil is used 
+		Optional_int DesiccantDehumIndex // Index for the desiccant dehum system where this caoil is used
 		) {
 
 		// FUNCTION INFORMATION:
@@ -6269,19 +6269,19 @@ Label10: ;
 		int const FanOpMode, // fan operating mode
 		Real64 const PartLoadRatio, // part-load ratio of heating coil
 		Real64 const UAMax, // maximum UA-Value = design heating capacity
-		Real64 & DesCoilInletWaterTempUsed // estimated coil design inlet water temperature 
+		Real64 & DesCoilInletWaterTempUsed // estimated coil design inlet water temperature
 	)
 	{
 		// SUBROUTINE INFORMATION:
 
 		// PURPOSE OF THIS SUBROUTINE:
-		// returns estimated coil inlet water temperature given UA value for assumed 
+		// returns estimated coil inlet water temperature given UA value for assumed
 		// maximum effectiveness value for heating coil
 
 		// METHODOLOGY EMPLOYED:
-		// applies energy balance around the water coil and estimates coil water inlet temperature 
+		// applies energy balance around the water coil and estimates coil water inlet temperature
 		// assuming coil effectiveness of 0.8
-		
+
 		// REFERENCES:
 		// na
 
@@ -6322,7 +6322,7 @@ Label10: ;
 		Real64 Effec;
 		Real64 Cp;
 
-		UA = UAMax; 
+		UA = UAMax;
 		DesCoilInletWaterTempUsed = DesCoilHWInletTempMin;
 		TempAirIn = WaterCoil( CoilNum ).InletAirTemp;
 		Win = WaterCoil( CoilNum ).InletAirHumRat;
@@ -6378,11 +6378,11 @@ Label10: ;
 				Effec = 1.0 - E2;
 			}
 			TempAirOut = TempAirIn + Effec * CapacitanceMin * ( TempWaterIn - TempAirIn ) / CapacitanceAir;
-			// this formulation assumes coil effectiveness of 0.80 to increase the estimated coil water inlet temperatures 
+			// this formulation assumes coil effectiveness of 0.80 to increase the estimated coil water inlet temperatures
 			DesCoilInletWaterTempUsed = CapacitanceAir * ( TempAirOut - TempAirIn ) / ( CapacitanceMin * EffectivnessMaxAssumed ) + TempAirIn;
 			// water coil should not be sized at coil water inlet temperature lower than 46.0C (for convergence problem in Regulafalsi)
 			DesCoilInletWaterTempUsed = max( DesCoilInletWaterTempUsed, DesCoilHWInletTempMin );
-		} 
+		}
 	}
 
 	// End of Coil Utility subroutines

--- a/src/EnergyPlus/WaterManager.cc
+++ b/src/EnergyPlus/WaterManager.cc
@@ -798,7 +798,7 @@ namespace WaterManager {
 			lNumericFieldBlanks.deallocate();
 
 			if ( ErrorsFound ) {
-				ShowFatalError( "Errors found in processing input for water manager objects" );
+				ShowFatalError( "Errors found in processing input for water manager objects" );  // LCOV_EXCL_LINE
 			}
 			// <SetupOutputVariables here...>, CurrentModuleObject='WaterUse:Storage'
 			for ( Item = 1; Item <= NumWaterStorageTanks; ++Item ) {
@@ -1186,7 +1186,7 @@ namespace WaterManager {
 			WaterStorage( TankNum ).Twater = GetCurrentScheduleValue( WaterStorage( TankNum ).TempSchedID );
 			WaterStorage( TankNum ).TouterSkin = WaterStorage( TankNum ).Twater;
 		} else if ( SELECT_CASE_var == TankZoneThermalCoupled ) {
-			ShowFatalError( "WaterUse:Storage (Water Storage Tank) zone thermal model incomplete" );
+			ShowFatalError( "WaterUse:Storage (Water Storage Tank) zone thermal model incomplete" );  // LCOV_EXCL_LINE
 		}}
 
 		//set supply avail data from overflows in Receiving tank

--- a/src/EnergyPlus/WaterThermalTanks.cc
+++ b/src/EnergyPlus/WaterThermalTanks.cc
@@ -463,17 +463,17 @@ namespace WaterThermalTanks {
 			if ( CompIndex == 0 ) {
 				CompNum = FindItem( CompName, WaterThermalTank );
 				if ( CompNum == 0 ) {
-					ShowFatalError( "SimWaterThermalTank:  Unit not found=" + CompName );
+					ShowFatalError( "SimWaterThermalTank:  Unit not found=" + CompName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = CompNum;
 			} else {
 				CompNum = CompIndex;
 				if ( CompNum > NumWaterThermalTank || CompNum < 1 ) {
-					ShowFatalError( "SimWaterThermalTank:  Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of Units=" + TrimSigDigits( NumWaterThermalTank ) + ", Entered Unit name=" + CompName );
+					ShowFatalError( "SimWaterThermalTank:  Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of Units=" + TrimSigDigits( NumWaterThermalTank ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 				}
 				if ( CheckWTTEquipName( CompNum ) ) {
 					if ( CompName != WaterThermalTank( CompNum ).Name ) {
-						ShowFatalError( "SimWaterThermalTank: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + WaterThermalTank( CompNum ).Name );
+						ShowFatalError( "SimWaterThermalTank: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + WaterThermalTank( CompNum ).Name );  // LCOV_EXCL_LINE
 					}
 					CheckWTTEquipName( CompNum ) = false;
 				}
@@ -482,17 +482,17 @@ namespace WaterThermalTanks {
 			if ( CompIndex == 0 ) {
 				CompNum = FindItem( CompName, HPWaterHeater );
 				if ( CompNum == 0 ) {
-					ShowFatalError( "SimWaterThermalTank:  Unit not found=" + CompName );
+					ShowFatalError( "SimWaterThermalTank:  Unit not found=" + CompName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = CompNum;
 			} else {
 				CompNum = CompIndex;
 				if ( CompNum > NumWaterThermalTank || CompNum < 1 ) {
-					ShowFatalError( "SimWaterThermalTank:  Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of Units=" + TrimSigDigits( NumHeatPumpWaterHeater ) + ", Entered Unit name=" + CompName );
+					ShowFatalError( "SimWaterThermalTank:  Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Number of Units=" + TrimSigDigits( NumHeatPumpWaterHeater ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 				}
 				if ( CheckHPWHEquipName( CompNum ) ) {
 					if ( CompName != HPWaterHeater( CompNum ).Name ) {
-						ShowFatalError( "SimWaterThermalTank: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + HPWaterHeater( CompNum ).Name );
+						ShowFatalError( "SimWaterThermalTank: Invalid CompIndex passed=" + TrimSigDigits( CompNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + HPWaterHeater( CompNum ).Name );  // LCOV_EXCL_LINE
 					}
 					CheckHPWHEquipName( CompNum ) = false;
 				}
@@ -696,7 +696,7 @@ namespace WaterThermalTanks {
 		} else {
 			ShowSevereError( "SimWaterThermalTank: Invalid Water Thermal Tank Equipment Type=" + TrimSigDigits( CompType ) );
 			ShowContinueError( "Occurs in Water Thermal Tank Equipment named = " + CompName );
-			ShowFatalError( "Preceding condition causes termination." );
+			ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -751,7 +751,7 @@ namespace WaterThermalTanks {
 			TestNum = WaterHeaterNum;
 			SimWaterThermalTank( WaterThermalTank( WaterHeaterNum ).TypeNum, WaterThermalTank( WaterHeaterNum ).Name, TestNum, LocalRunFlag, LocalInitLoopEquip, MyLoad, MinCap, MaxCap, OptCap, FirstHVACIteration );
 			if ( TestNum != WaterHeaterNum ) {
-				ShowFatalError( "SimulateWaterHeaterStandAlone: Input WaterHeater Num [" + TrimSigDigits( WaterHeaterNum ) + "] does not match returned WaterHeater Num[" + TrimSigDigits( TestNum ) + "] Name=\"" + WaterThermalTank( WaterHeaterNum ).Name + "\"." );
+				ShowFatalError( "SimulateWaterHeaterStandAlone: Input WaterHeater Num [" + TrimSigDigits( WaterHeaterNum ) + "] does not match returned WaterHeater Num[" + TrimSigDigits( TestNum ) + "] Name=\"" + WaterThermalTank( WaterHeaterNum ).Name + "\"." );  // LCOV_EXCL_LINE
 			}
 
 			// HPWHs with inlet air from a zone and not connected to a plant loop are simulated through a CALL from ZoneEquipmentManager.
@@ -775,7 +775,7 @@ namespace WaterThermalTanks {
 				TestNum = WaterHeaterNum;
 				SimWaterThermalTank( WaterThermalTank( WaterHeaterNum ).TypeNum, WaterThermalTank( WaterHeaterNum ).Name, TestNum, LocalRunFlag, LocalInitLoopEquip, MyLoad, MinCap, MaxCap, OptCap, FirstHVACIteration );
 				if ( TestNum != WaterHeaterNum ) {
-					ShowFatalError( "SimulateWaterHeaterStandAlone: Input WaterHeater Num [" + TrimSigDigits( WaterHeaterNum ) + "] does not match returned WaterHeater Num[" + TrimSigDigits( TestNum ) + "] Name=\"" + WaterThermalTank( WaterHeaterNum ).Name + "\"." );
+					ShowFatalError( "SimulateWaterHeaterStandAlone: Input WaterHeater Num [" + TrimSigDigits( WaterHeaterNum ) + "] does not match returned WaterHeater Num[" + TrimSigDigits( TestNum ) + "] Name=\"" + WaterThermalTank( WaterHeaterNum ).Name + "\"." );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -831,13 +831,13 @@ namespace WaterThermalTanks {
 		if ( CompIndex == 0 ) {
 			HeatPumpNum = FindItemInList( CompName, HPWaterHeater );
 			if ( HeatPumpNum == 0 ) {
-				ShowFatalError( "SimHeatPumpWaterHeater: Unit not found=" + CompName );
+				ShowFatalError( "SimHeatPumpWaterHeater: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = HeatPumpNum;
 		} else {
 			HeatPumpNum = CompIndex;
 			if ( HeatPumpNum > NumHeatPumpWaterHeater || HeatPumpNum < 1 ) {
-				ShowFatalError( "SimHeatPumpWaterHeater:  Invalid CompIndex passed=" + TrimSigDigits( HeatPumpNum ) + ", Number of Units=" + TrimSigDigits( NumHeatPumpWaterHeater ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimHeatPumpWaterHeater:  Invalid CompIndex passed=" + TrimSigDigits( HeatPumpNum ) + ", Number of Units=" + TrimSigDigits( NumHeatPumpWaterHeater ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -977,7 +977,7 @@ namespace WaterThermalTanks {
 		GetWaterThermalTankInputData( ErrorsFound );
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting thermal storage input. Preceding condition(s) causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting thermal storage input. Preceding condition(s) causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		return ErrorsFound;
@@ -1477,7 +1477,7 @@ namespace WaterThermalTanks {
 				}
 
 				if ( ErrorsFound ) {
-					ShowFatalError( "Errors found in getting " + cCurrentModuleObject + " input. Preceding condition causes termination." );
+					ShowFatalError( "Errors found in getting " + cCurrentModuleObject + " input. Preceding condition causes termination." );  // LCOV_EXCL_LINE
 				}
 
 			}
@@ -1903,7 +1903,7 @@ namespace WaterThermalTanks {
 						}
 
 					}
-					// issue #5630, set fan info in coils. 
+					// issue #5630, set fan info in coils.
 					if ( bIsVScoil == true ) {
 						VariableSpeedCoils::setVarSpeedHPWHFanTypeNum( HPWH.DXCoilNum, HPWH.FanType_Num );
 						VariableSpeedCoils::setVarSpeedHPWHFanIndex( HPWH.DXCoilNum, HPWH.FanNum );
@@ -5123,7 +5123,7 @@ namespace WaterThermalTanks {
 				errFlag = false;
 				ScanPlantLoopsForObject( WaterThermalTank( WaterThermalTankNum ).Name, WaterThermalTank( WaterThermalTankNum ).TypeNum, WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopNum, WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopSide, WaterThermalTank( WaterThermalTankNum ).UseSidePlantBranchNum, WaterThermalTank( WaterThermalTankNum ).UseSidePlantCompNum, _, _, _, UseInletNode, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				rho = GetDensityGlycol( PlantLoop( WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopNum ).FluidName, DataGlobals::InitConvTemp, PlantLoop( WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopNum ).FluidIndex, GetWaterThermalTankInput );
 				WaterThermalTank( WaterThermalTankNum ).PlantUseMassFlowRateMax = WaterThermalTank( WaterThermalTankNum ).UseDesignVolFlowRate * rho;
@@ -5131,7 +5131,7 @@ namespace WaterThermalTanks {
 				WaterThermalTank( WaterThermalTankNum ).UseSidePlantSizNum = PlantLoop( WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopNum ).PlantSizNum;
 				if ( ( WaterThermalTank( WaterThermalTankNum ).UseDesignVolFlowRateWasAutoSized ) && ( WaterThermalTank( WaterThermalTankNum ).UseSidePlantSizNum == 0 ) ) {
 					ShowSevereError( "InitWaterThermalTank: Did not find Sizing:Plant object for use side of plant thermal tank = " + WaterThermalTank( WaterThermalTankNum ).Name );
-					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( ( UseInletNode > 0 ) && ( WaterThermalTank( WaterThermalTankNum ).HeatPumpNum > 0 ) ) {
@@ -5140,7 +5140,7 @@ namespace WaterThermalTanks {
 				errFlag = false;
 				ScanPlantLoopsForObject( HPWaterHeater( WaterThermalTank( WaterThermalTankNum ).HeatPumpNum ).Name, HPWaterHeater( WaterThermalTank( WaterThermalTankNum ).HeatPumpNum ).TypeNum, WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopNum, WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopSide, WaterThermalTank( WaterThermalTankNum ).UseSidePlantBranchNum, WaterThermalTank( WaterThermalTankNum ).UseSidePlantCompNum, _, _, _, UseInletNode, _, errFlag );
 				if ( errFlag ) {
-					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				rho = GetDensityGlycol( PlantLoop( WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopNum ).FluidName, DataGlobals::InitConvTemp, PlantLoop( WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopNum ).FluidIndex, GetWaterThermalTankInput );
 				WaterThermalTank( WaterThermalTankNum ).PlantUseMassFlowRateMax = WaterThermalTank( WaterThermalTankNum ).UseDesignVolFlowRate * rho;
@@ -5148,7 +5148,7 @@ namespace WaterThermalTanks {
 				WaterThermalTank( WaterThermalTankNum ).UseSidePlantSizNum = PlantLoop( WaterThermalTank( WaterThermalTankNum ).UseSidePlantLoopNum ).PlantSizNum;
 				if ( ( WaterThermalTank( WaterThermalTankNum ).UseDesignVolFlowRateWasAutoSized ) && ( WaterThermalTank( WaterThermalTankNum ).UseSidePlantSizNum == 0 ) ) {
 					ShowSevereError( "InitWaterThermalTank: Did not find Sizing:Plant object for use side of plant thermal tank = " + WaterThermalTank( WaterThermalTankNum ).Name );
-					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( ( SourceInletNode > 0 ) && ( WaterThermalTank( WaterThermalTankNum ).DesuperheaterNum == 0 ) && ( WaterThermalTank( WaterThermalTankNum ).HeatPumpNum == 0 ) ) {
@@ -5159,14 +5159,14 @@ namespace WaterThermalTanks {
 				}
 
 				if ( errFlag ) {
-					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 				rho = GetDensityGlycol( PlantLoop( WaterThermalTank( WaterThermalTankNum ).SourceSidePlantLoopNum ).FluidName, DataGlobals::InitConvTemp, PlantLoop( WaterThermalTank( WaterThermalTankNum ).SourceSidePlantLoopNum ).FluidIndex, GetWaterThermalTankInput );
 				WaterThermalTank( WaterThermalTankNum ).PlantSourceMassFlowRateMax = WaterThermalTank( WaterThermalTankNum ).SourceDesignVolFlowRate * rho;
 				WaterThermalTank( WaterThermalTankNum ).SourceSidePlantSizNum = PlantLoop( WaterThermalTank( WaterThermalTankNum ).SourceSidePlantLoopNum ).PlantSizNum;
 				if ( ( WaterThermalTank( WaterThermalTankNum ).SourceDesignVolFlowRateWasAutoSized ) && ( WaterThermalTank( WaterThermalTankNum ).SourceSidePlantSizNum == 0 ) ) {
 					ShowSevereError( "InitWaterThermalTank: Did not find Sizing:Plant object for source side of plant thermal tank = " + WaterThermalTank( WaterThermalTankNum ).Name );
-					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );
+					ShowFatalError( "InitWaterThermalTank: Program terminated due to previous condition(s)." );  // LCOV_EXCL_LINE
 				}
 			}
 			if ( ( ( SourceInletNode > 0 ) && ( WaterThermalTank( WaterThermalTankNum ).DesuperheaterNum > 0 ) ) || ( WaterThermalTank( WaterThermalTankNum ).HeatPumpNum > 0 ) ) {
@@ -5212,7 +5212,7 @@ namespace WaterThermalTanks {
 							ShowContinueError( "Nominal tank change over rate = " + RoundSigDigits( TankChangeRateScale, 2 ) + " [s]" );
 							ShowContinueError( "Change over rate is too fast, increase tank volume, decrease connection flow rates or use mixed tank model" );
 
-							ShowFatalError( "InitWaterThermalTank: Simulation halted because of sizing problem in stratified tank model." );
+							ShowFatalError( "InitWaterThermalTank: Simulation halted because of sizing problem in stratified tank model." );  // LCOV_EXCL_LINE
 						}
 					}
 				}
@@ -5671,9 +5671,9 @@ namespace WaterThermalTanks {
 				} else if ( HPWaterHeater( HPNum ).FanType_Num == DataHVACGlobals::FanType_SimpleOnOff ) {
 					GetFanVolFlow( HPWaterHeater( HPNum ).FanNum, FanVolFlow );
 				}
-				
+
 				if ( FanVolFlow  < HPWaterHeater( HPNum ).HPWHAirVolFlowRate( HPWaterHeater( HPNum ).NumofSpeed ) ) { // but this is the not the scaled mas flow
-				//if ( FanVolFlow  < HPWaterHeater( HPNum ).HPWHAirVolFlowRate( HPWaterHeater( HPNum ).NumofSpeed ) ) { 
+				//if ( FanVolFlow  < HPWaterHeater( HPNum ).HPWHAirVolFlowRate( HPWaterHeater( HPNum ).NumofSpeed ) ) {
 
 					ShowWarningError( "InitWaterThermalTank: -air flow rate = " + TrimSigDigits(FanVolFlow, 7) +
 						" in fan object " " is less than the MSHP system air flow rate" " when waterheating is required("
@@ -7629,7 +7629,7 @@ namespace WaterThermalTanks {
 
 			//   should never get here, case is checked in GetWaterThermalTankInput
 		} else {
-			ShowFatalError( "Coil:WaterHeating:Desuperheater = " + WaterHeaterDesuperheater( DesuperheaterNum ).Name + ":  invalid water heater tank type and name entered = " + WaterHeaterDesuperheater( DesuperheaterNum ).TankType + ", " + WaterHeaterDesuperheater( DesuperheaterNum ).TankName );
+			ShowFatalError( "Coil:WaterHeating:Desuperheater = " + WaterHeaterDesuperheater( DesuperheaterNum ).Name + ":  invalid water heater tank type and name entered = " + WaterHeaterDesuperheater( DesuperheaterNum ).TankType + ", " + WaterHeaterDesuperheater( DesuperheaterNum ).TankName );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -8767,7 +8767,7 @@ namespace WaterThermalTanks {
 		Node( FanInNode ).MassFlowRateMaxAvail = MdotAir;
 		Node( FanInNode ).MassFlowRateMax = MdotAir;
 		if ( ! ( HPWaterHeater( HPNum ).FanType_Num == DataHVACGlobals::FanType_SystemModelObject ) ) {
-			Fans::Fan( HPWaterHeater( HPNum ).FanNum ).MassFlowRateMaxAvail = MdotAir; 
+			Fans::Fan( HPWaterHeater( HPNum ).FanNum ).MassFlowRateMaxAvail = MdotAir;
 		} // system fan will use the inlet node max avail.
 
 		MdotAirSav = MdotAir;
@@ -9415,7 +9415,7 @@ namespace WaterThermalTanks {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding water heater input errors cause program termination" );
+			ShowFatalError( "Preceding water heater input errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -9606,7 +9606,7 @@ namespace WaterThermalTanks {
 		} // connected to plant
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -10059,7 +10059,7 @@ namespace WaterThermalTanks {
 					}
 					tmpMaxCapacity = ( WaterThermalTank( WaterThermalTankNum ).Volume * rho * Cp * ( Tfinish - Tstart ) ) / ( WaterThermalTank( WaterThermalTankNum ).Sizing.RecoveryTime * SecInHour ); // m3 | kg/m3 | J/Kg/K | K | seconds
 				} else {
-					ShowFatalError( "SizeTankForSupplySide: Tank=\"" + WaterThermalTank( WaterThermalTankNum ).Name + "\", requested sizing for max capacity but entered Recovery Time is zero." );
+					ShowFatalError( "SizeTankForSupplySide: Tank=\"" + WaterThermalTank( WaterThermalTankNum ).Name + "\", requested sizing for max capacity but entered Recovery Time is zero." );  // LCOV_EXCL_LINE
 				}
 			}
 
@@ -10353,7 +10353,7 @@ namespace WaterThermalTanks {
 		} // connected to plant
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Preceding sizing errors cause program termination" );
+			ShowFatalError( "Preceding sizing errors cause program termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -10443,7 +10443,7 @@ namespace WaterThermalTanks {
 
 						tmpMaxCapacity = ( WaterThermalTank( WaterThermalTankNum ).Volume * rho * Cp * ( Tfinish - Tstart ) ) / ( WaterThermalTank( WaterThermalTankNum ).Sizing.RecoveryTime * SecInHour ); // m3 | kg/m3 | J/Kg/K | K | seconds
 					} else {
-						ShowFatalError( "SizeStandAloneWaterHeater: Tank=\"" + WaterThermalTank( WaterThermalTankNum ).Name + "\", requested sizing for max capacity but entered Recovery Time is zero." );
+						ShowFatalError( "SizeStandAloneWaterHeater: Tank=\"" + WaterThermalTank( WaterThermalTankNum ).Name + "\", requested sizing for max capacity but entered Recovery Time is zero." );  // LCOV_EXCL_LINE
 					}
 					WaterThermalTank( WaterThermalTankNum ).MaxCapacity = tmpMaxCapacity;
 					ReportSizingOutput( WaterThermalTank( WaterThermalTankNum ).Type, WaterThermalTank( WaterThermalTankNum ).Name, "Maximum Heater Capacity [W]", WaterThermalTank( WaterThermalTankNum ).MaxCapacity );

--- a/src/EnergyPlus/WaterToAirHeatPump.cc
+++ b/src/EnergyPlus/WaterToAirHeatPump.cc
@@ -220,17 +220,17 @@ namespace WaterToAirHeatPump {
 		if ( CompIndex == 0 ) {
 			HPNum = FindItemInList( CompName, WatertoAirHP );
 			if ( HPNum == 0 ) {
-				ShowFatalError( "WaterToAir HP not found=" + CompName );
+				ShowFatalError( "WaterToAir HP not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = HPNum;
 		} else {
 			HPNum = CompIndex;
 			if ( HPNum > NumWatertoAirHPs || HPNum < 1 ) {
-				ShowFatalError( "SimWatertoAirHP: Invalid CompIndex passed=" + TrimSigDigits( HPNum ) + ", Number of Water to Air HPs=" + TrimSigDigits( NumWatertoAirHPs ) + ", WaterToAir HP name=" + CompName );
+				ShowFatalError( "SimWatertoAirHP: Invalid CompIndex passed=" + TrimSigDigits( HPNum ) + ", Number of Water to Air HPs=" + TrimSigDigits( NumWatertoAirHPs ) + ", WaterToAir HP name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( HPNum ) ) {
 				if ( ! CompName.empty() && CompName != WatertoAirHP( HPNum ).Name ) {
-					ShowFatalError( "SimWatertoAirHP: Invalid CompIndex passed=" + TrimSigDigits( HPNum ) + ", WaterToAir HP name=" + CompName + ", stored WaterToAir HP Name for that index=" + WatertoAirHP( HPNum ).Name );
+					ShowFatalError( "SimWatertoAirHP: Invalid CompIndex passed=" + TrimSigDigits( HPNum ) + ", WaterToAir HP name=" + CompName + ", stored WaterToAir HP Name for that index=" + WatertoAirHP( HPNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( HPNum ) = false;
 			}
@@ -250,7 +250,7 @@ namespace WaterToAirHeatPump {
 			UpdateWatertoAirHP( HPNum );
 
 		} else {
-			ShowFatalError( "SimWatertoAirHP: AirtoAir heatpump not in either HEATING or COOLING" );
+			ShowFatalError( "SimWatertoAirHP: AirtoAir heatpump not in either HEATING or COOLING" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -566,7 +566,7 @@ namespace WaterToAirHeatPump {
 		NumArray.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found getting input. Program terminates." );
+			ShowFatalError( RoutineName + "Errors found getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		for ( HPNum = 1; HPNum <= NumWatertoAirHPs; ++HPNum ) {
@@ -726,7 +726,7 @@ namespace WaterToAirHeatPump {
 			}
 
 			if ( errFlag ) {
-				ShowFatalError( "InitWatertoAirHP: Program terminated for previous conditions." );
+				ShowFatalError( "InitWatertoAirHP: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 			}
 
 			MyPlantScanFlag( HPNum ) = false;

--- a/src/EnergyPlus/WaterToAirHeatPumpSimple.cc
+++ b/src/EnergyPlus/WaterToAirHeatPumpSimple.cc
@@ -261,16 +261,16 @@ namespace WaterToAirHeatPumpSimple {
 		if ( CompIndex == 0 ) {
 			HPNum = FindItemInList( CompName, SimpleWatertoAirHP );
 			if ( HPNum == 0 ) {
-				ShowFatalError( "WaterToAirHPSimple not found=" + CompName );
+				ShowFatalError( "WaterToAirHPSimple not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = HPNum;
 		} else {
 			HPNum = CompIndex;
 			if ( HPNum > NumWatertoAirHPs || HPNum < 1 ) {
-				ShowFatalError( "SimWatertoAirHPSimple: Invalid CompIndex passed=" + TrimSigDigits( HPNum ) + ", Number of Water to Air HPs=" + TrimSigDigits( NumWatertoAirHPs ) + ", WaterToAir HP name=" + CompName );
+				ShowFatalError( "SimWatertoAirHPSimple: Invalid CompIndex passed=" + TrimSigDigits( HPNum ) + ", Number of Water to Air HPs=" + TrimSigDigits( NumWatertoAirHPs ) + ", WaterToAir HP name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( ! CompName.empty() && CompName != SimpleWatertoAirHP( HPNum ).Name ) {
-				ShowFatalError( "SimWatertoAirHPSimple: Invalid CompIndex passed=" + TrimSigDigits( HPNum ) + ", WaterToAir HP name=" + CompName + ", stored WaterToAir HP Name for that index=" + SimpleWatertoAirHP( HPNum ).Name );
+				ShowFatalError( "SimWatertoAirHPSimple: Invalid CompIndex passed=" + TrimSigDigits( HPNum ) + ", WaterToAir HP name=" + CompName + ", stored WaterToAir HP Name for that index=" + SimpleWatertoAirHP( HPNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -291,7 +291,7 @@ namespace WaterToAirHeatPumpSimple {
 			CalcHPHeatingSimple( HPNum, CyclingScheme, RuntimeFrac, SensLoad, CompOp, PartLoadRatio, OnOffAirFlowRatio );
 			UpdateSimpleWatertoAirHP( HPNum );
 		} else {
-			ShowFatalError( "SimWatertoAirHPSimple: WatertoAir heatpump not in either HEATING or COOLING mode" );
+			ShowFatalError( "SimWatertoAirHPSimple: WatertoAir heatpump not in either HEATING or COOLING mode" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -540,7 +540,7 @@ namespace WaterToAirHeatPumpSimple {
 		NumArray.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found getting input. Program terminates." );
+			ShowFatalError( RoutineName + "Errors found getting input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 
 		for ( HPNum = 1; HPNum <= NumWatertoAirHPs; ++HPNum ) {
@@ -671,7 +671,7 @@ namespace WaterToAirHeatPumpSimple {
 			errFlag = false;
 			ScanPlantLoopsForObject( SimpleWatertoAirHP( HPNum ).Name, SimpleWatertoAirHP( HPNum ).WAHPPlantTypeOfNum, SimpleWatertoAirHP( HPNum ).LoopNum, SimpleWatertoAirHP( HPNum ).LoopSide, SimpleWatertoAirHP( HPNum ).BranchNum, SimpleWatertoAirHP( HPNum ).CompNum, _, _, _, _, _, errFlag );
 			if ( errFlag ) {
-				ShowFatalError( "InitSimpleWatertoAirHP: Program terminated for previous conditions." );
+				ShowFatalError( "InitSimpleWatertoAirHP: Program terminated for previous conditions." );  // LCOV_EXCL_LINE
 			}
 			MyPlantScanFlag( HPNum ) = false;
 		}

--- a/src/EnergyPlus/WaterUse.cc
+++ b/src/EnergyPlus/WaterUse.cc
@@ -286,17 +286,17 @@ namespace WaterUse {
 		if ( CompIndex == 0 ) {
 			WaterConnNum = FindItemInList( CompName, WaterConnections );
 			if ( WaterConnNum == 0 ) {
-				ShowFatalError( "SimulateWaterUseConnection: Unit not found=" + CompName );
+				ShowFatalError( "SimulateWaterUseConnection: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = WaterConnNum;
 		} else {
 			WaterConnNum = CompIndex;
 			if ( WaterConnNum > NumWaterConnections || WaterConnNum < 1 ) {
-				ShowFatalError( "SimulateWaterUseConnection: Invalid CompIndex passed=" + TrimSigDigits( WaterConnNum ) + ", Number of Units=" + TrimSigDigits( NumWaterConnections ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimulateWaterUseConnection: Invalid CompIndex passed=" + TrimSigDigits( WaterConnNum ) + ", Number of Units=" + TrimSigDigits( NumWaterConnections ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( WaterConnNum ) ) {
 				if ( CompName != WaterConnections( WaterConnNum ).Name ) {
-					ShowFatalError( "SimulateWaterUseConnection: Invalid CompIndex passed=" + TrimSigDigits( WaterConnNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + WaterConnections( WaterConnNum ).Name );
+					ShowFatalError( "SimulateWaterUseConnection: Invalid CompIndex passed=" + TrimSigDigits( WaterConnNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + WaterConnections( WaterConnNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( WaterConnNum ) = false;
 			}
@@ -504,7 +504,7 @@ namespace WaterUse {
 
 			} // WaterEquipNum
 
-			if ( ErrorsFound ) ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			if ( ErrorsFound ) ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 
 		}
 
@@ -626,7 +626,7 @@ namespace WaterUse {
 
 			} // WaterConnNum
 
-			if ( ErrorsFound ) ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );
+			if ( ErrorsFound ) ShowFatalError( "Errors found in processing input for " + cCurrentModuleObject );  // LCOV_EXCL_LINE
 
 			if ( NumWaterConnections > 0 ) {
 				CheckEquipName.allocate( NumWaterConnections );
@@ -1020,7 +1020,7 @@ namespace WaterUse {
 				errFlag = false;
 				ScanPlantLoopsForObject( WaterConnections( WaterConnNum ).Name, TypeOf_WaterUseConnection, WaterConnections( WaterConnNum ).PlantLoopNum, WaterConnections( WaterConnNum ).PlantLoopSide, WaterConnections( WaterConnNum ).PlantLoopBranchNum, WaterConnections( WaterConnNum ).PlantLoopCompNum, _, _, _, _, _, errFlag ); //DSU | DSU | DSU | DSU | DSU | DSU | DSU
 				if ( errFlag ) { //DSU
-					ShowFatalError( "InitConnections: Program terminated due to previous condition(s)." ); //DSU
+					ShowFatalError( "InitConnections: Program terminated due to previous condition(s)." ); //DSU  // LCOV_EXCL_LINE
 				} //DSU
 				SetLoopIndexFlag( WaterConnNum ) = false; //DSU
 			} //DSU

--- a/src/EnergyPlus/WeatherManager.cc
+++ b/src/EnergyPlus/WeatherManager.cc
@@ -350,7 +350,7 @@ namespace WeatherManager {
 	static gio::Fmt fmtAN( "(A,$)" );
 
 	std::vector< UnderwaterBoundary > underwaterBoundaries;
-	
+
 	// MODULE SUBROUTINES:
 
 	// Functions
@@ -606,15 +606,15 @@ namespace WeatherManager {
 		int Num = InputProcessor::GetNumObjectsFound( DataIPShortCuts::cCurrentModuleObject );
 		for ( int i = 1; i <= Num; i++ ) {
 			InputProcessor::GetObjectItem(
-				DataIPShortCuts::cCurrentModuleObject, i, 
-				DataIPShortCuts::cAlphaArgs, 
-				NumAlpha, 
-				DataIPShortCuts::rNumericArgs, 
-				NumNumber, 
-				IOStat, 
-				DataIPShortCuts::lNumericFieldBlanks, 
-				DataIPShortCuts::lAlphaFieldBlanks, 
-				DataIPShortCuts::cAlphaFieldNames, 
+				DataIPShortCuts::cCurrentModuleObject, i,
+				DataIPShortCuts::cAlphaArgs,
+				NumAlpha,
+				DataIPShortCuts::rNumericArgs,
+				NumNumber,
+				IOStat,
+				DataIPShortCuts::lNumericFieldBlanks,
+				DataIPShortCuts::lAlphaFieldBlanks,
+				DataIPShortCuts::cAlphaFieldNames,
 				DataIPShortCuts::cNumericFieldNames
 			);
 			underwaterBoundaries.push_back( UnderwaterBoundary() );
@@ -643,7 +643,7 @@ namespace WeatherManager {
 			if ( errorsFound ) break;
 		}
 		if ( errorsFound ) {
-			ShowFatalError( "Previous input problems cause program termination" );
+			ShowFatalError( "Previous input problems cause program termination" );  // LCOV_EXCL_LINE
 		}
 		return ( Num > 0 );
 	}
@@ -698,15 +698,15 @@ namespace WeatherManager {
 		int NumAlpha = 0, NumNumber = 0, IOStat = 0;
 		DataIPShortCuts::cCurrentModuleObject = "Site:VariableLocation";
 		if ( InputProcessor::GetNumObjectsFound( DataIPShortCuts::cCurrentModuleObject ) == 0 ) return;
-		InputProcessor::GetObjectItem( DataIPShortCuts::cCurrentModuleObject, 1, 
-			DataIPShortCuts::cAlphaArgs, 
-			NumAlpha, 
-			DataIPShortCuts::rNumericArgs, 
-			NumNumber, 
-			IOStat, 
-			DataIPShortCuts::lNumericFieldBlanks, 
-			DataIPShortCuts::lAlphaFieldBlanks, 
-			DataIPShortCuts::cAlphaFieldNames, 
+		InputProcessor::GetObjectItem( DataIPShortCuts::cCurrentModuleObject, 1,
+			DataIPShortCuts::cAlphaArgs,
+			NumAlpha,
+			DataIPShortCuts::rNumericArgs,
+			NumNumber,
+			IOStat,
+			DataIPShortCuts::lNumericFieldBlanks,
+			DataIPShortCuts::lAlphaFieldBlanks,
+			DataIPShortCuts::cAlphaFieldNames,
 			DataIPShortCuts::cNumericFieldNames
 		);
 		DataEnvironment::varyingLocationSchedIndexLat = ScheduleManager::GetScheduleIndex( DataIPShortCuts::cAlphaArgs( 1 ) );
@@ -1095,7 +1095,7 @@ namespace WeatherManager {
 							} else {
 								ShowContinueError( "Multiple Weather Data Periods 1st (Start=" + StDate + ",End=" + EnDate + ')' );
 							}
-							ShowFatalError( RoutineName + "Program terminates due to preceding condition." );
+							ShowFatalError( RoutineName + "Program terminates due to preceding condition." );  // LCOV_EXCL_LINE
 						}
 
 						// Following builds Environment start/end for ASHRAE 55 warnings
@@ -1821,7 +1821,7 @@ namespace WeatherManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Program terminates due to preceding condition(s)." );
+			ShowFatalError( RoutineName + "Program terminates due to preceding condition(s)." );  // LCOV_EXCL_LINE
 		}
 
 		if ( present( DSTActStMon ) ) {
@@ -1953,7 +1953,7 @@ namespace WeatherManager {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Program terminates due to preceding condition(s)." );
+			ShowFatalError( RoutineName + "Program terminates due to preceding condition(s)." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -2426,7 +2426,7 @@ namespace WeatherManager {
 		// Determine if Sun is up or down, set Solar Cosine values for time step.
 		DetermineSunUpDown( SOLCOS );
 		if ( SunIsUp && SolarAltitudeAngle < 0.0 ) {
-			ShowFatalError( "SetCurrentWeather: At " + CurMnDyHr + " Sun is Up but Solar Altitude Angle is < 0.0" );
+			ShowFatalError( "SetCurrentWeather: At " + CurMnDyHr + " Sun is Up but Solar Altitude Angle is < 0.0" );  // LCOV_EXCL_LINE
 		}
 
 		OutDryBulbTemp = TodayOutDryBulbTemp( TimeStep, HourOfDay );
@@ -2806,7 +2806,7 @@ namespace WeatherManager {
 					BadRecord = RoundSigDigits( WYear ) + '/' + RoundSigDigits( WMonth ) + '/' + RoundSigDigits( WDay ) + BlankString + RoundSigDigits( WHour ) + ':' + RoundSigDigits( WMinute );
 					gio::write( ErrOut, fmtLD ) << ReadStatus;
 					strip( ErrOut );
-					ShowFatalError( "Error occurred on EPW while searching for first day, stopped at " + BadRecord + " IO Error=" + RoundSigDigits( ReadStatus ), OutputFileStandard );
+					ShowFatalError( "Error occurred on EPW while searching for first day, stopped at " + BadRecord + " IO Error=" + RoundSigDigits( ReadStatus ), OutputFileStandard );  // LCOV_EXCL_LINE
 				}
 				if ( CurDayOfWeek <= 7 ) {
 					CurDayOfWeek = mod( CurDayOfWeek, 7 ) + 1;
@@ -2844,7 +2844,7 @@ namespace WeatherManager {
 						if ( ReadStatus != 0 ) {
 							gio::read( WeatherDataLine, fmtLD ) >> WYear >> WMonth >> WDay >> WHour >> WMinute;
 							BadRecord = RoundSigDigits( WYear ) + '/' + RoundSigDigits( WMonth ) + '/' + RoundSigDigits( WDay ) + BlankString + RoundSigDigits( WHour ) + ':' + RoundSigDigits( WMinute );
-							ShowFatalError( "Error occurred on EPW while searching for first day, stopped at " + BadRecord + " IO Error=" + RoundSigDigits( ReadStatus ), OutputFileStandard );
+							ShowFatalError( "Error occurred on EPW while searching for first day, stopped at " + BadRecord + " IO Error=" + RoundSigDigits( ReadStatus ), OutputFileStandard );  // LCOV_EXCL_LINE
 						}
 					}
 					for ( Item = 1; Item <= 23 * NumIntervalsPerHour; ++Item ) {
@@ -2852,7 +2852,7 @@ namespace WeatherManager {
 						if ( ReadStatus != 0 ) {
 							gio::read( WeatherDataLine, fmtLD ) >> WYear >> WMonth >> WDay >> WHour >> WMinute;
 							BadRecord = RoundSigDigits( WYear ) + '/' + RoundSigDigits( WMonth ) + '/' + RoundSigDigits( WDay ) + BlankString + RoundSigDigits( WHour ) + ':' + RoundSigDigits( WMinute );
-							ShowFatalError( "Error occurred on EPW while searching for first day, stopped at " + BadRecord + " IO Error=" + RoundSigDigits( ReadStatus ), OutputFileStandard );
+							ShowFatalError( "Error occurred on EPW while searching for first day, stopped at " + BadRecord + " IO Error=" + RoundSigDigits( ReadStatus ), OutputFileStandard );  // LCOV_EXCL_LINE
 						}
 					}
 				}
@@ -2928,17 +2928,17 @@ namespace WeatherManager {
 								InterpretWeatherDataLine( WeatherDataLine, ErrorFound, WYear, WMonth, WDay, WHour, WMinute, DryBulb, DewPoint, RelHum, AtmPress, ETHoriz, ETDirect, IRHoriz, GLBHoriz, DirectRad, DiffuseRad, GLBHorizIllum, DirectNrmIllum, DiffuseHorizIllum, ZenLum, WindDir, WindSpeed, TotalSkyCover, OpaqueSkyCover, Visibility, CeilHeight, PresWeathObs, PresWeathConds, PrecipWater, AerosolOptDepth, SnowDepth, DaysSinceLastSnow, Albedo, LiquidPrecip );
 							} else {
 								BadRecord = RoundSigDigits( WYear ) + '/' + RoundSigDigits( WMonth ) + '/' + RoundSigDigits( WDay ) + BlankString + RoundSigDigits( WHour ) + ':' + RoundSigDigits( WMinute );
-								ShowFatalError( "End-of-File encountered after " + BadRecord + ", starting from first day of Weather File would not be \"next day\"" );
+								ShowFatalError( "End-of-File encountered after " + BadRecord + ", starting from first day of Weather File would not be \"next day\"" );  // LCOV_EXCL_LINE
 							}
 						} else {
 							BadRecord = RoundSigDigits( WYear ) + '/' + RoundSigDigits( WMonth ) + '/' + RoundSigDigits( WDay ) + BlankString + RoundSigDigits( WHour ) + ':' + RoundSigDigits( WMinute );
-							ShowFatalError( "Unexpected error condition in middle of reading EPW file, stopped at " + BadRecord, OutputFileStandard );
+							ShowFatalError( "Unexpected error condition in middle of reading EPW file, stopped at " + BadRecord, OutputFileStandard );  // LCOV_EXCL_LINE
 						}
 					}
 
 					if ( Hour != WHour ) {
 						BadRecord = RoundSigDigits( WYear ) + '/' + RoundSigDigits( WMonth ) + '/' + RoundSigDigits( WDay ) + BlankString + RoundSigDigits( WHour ) + ':' + RoundSigDigits( WMinute );
-						ShowFatalError( "Unexpected error condition in middle of reading EPW file, " + BadRecord, OutputFileStandard );
+						ShowFatalError( "Unexpected error condition in middle of reading EPW file, " + BadRecord, OutputFileStandard );  // LCOV_EXCL_LINE
 					}
 
 					//         Set possible missing values
@@ -3552,7 +3552,7 @@ namespace WeatherManager {
 
 		if ( DateInError ) {
 			ShowSevereError( "Reading Weather Data Line, Invalid Date, Year=" + RoundSigDigits( WYear ) + ", Month=" + RoundSigDigits( WMonth ) + ", Day=" + RoundSigDigits( WDay ) );
-			ShowFatalError( "Program terminates due to previous condition." );
+			ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 		}
 
 		Pos = index( Line, ',' ); // WYear
@@ -3700,28 +3700,28 @@ namespace WeatherManager {
 Label900: ;
 		ShowSevereError( "Invalid Date info in Weather Line" );
 		ShowContinueError( "Entire Data Line=" + SaveLine );
-		ShowFatalError( "Error in Reading Weather Data" );
+		ShowFatalError( "Error in Reading Weather Data" );  // LCOV_EXCL_LINE
 
 Label901: ;
 		gio::write( DateError, "(I4,'/',I2,'/',I2,' Hour#=',I2,' Min#=',I2)" ) << WYear << WMonth << WDay << WHour << WMinute;
 		ShowSevereError( "Invalid Weather Line at date=" + DateError );
 		ShowContinueError( "Full Data Line=" + SaveLine );
 		ShowContinueError( "Remainder of line=" + Line );
-		ShowFatalError( "Error in Reading Weather Data" );
+		ShowFatalError( "Error in Reading Weather Data" );  // LCOV_EXCL_LINE
 
 Label902: ;
 		gio::write( DateError, "(I4,'/',I2,'/',I2,' Hour#=',I2,' Min#=',I2)" ) << WYear << WMonth << WDay << WHour << WMinute;
 		ShowSevereError( "Invalid Weather Line (no commas) at date=" + DateError );
 		ShowContinueError( "Full Data Line=" + SaveLine );
 		ShowContinueError( "Remainder of line=" + Line );
-		ShowFatalError( "Error in Reading Weather Data" );
+		ShowFatalError( "Error in Reading Weather Data" );  // LCOV_EXCL_LINE
 
 //Label903: ;
 //		gio::write( DateError, "(I4,'/',I2,'/',I2,' Hour#=',I2,' Min#=',I2)" ) << WYear << WMonth << WDay << WHour << WMinute;
 //		ShowSevereError( "Invalid Weather Line at date=" + DateError );
 //		ShowContinueError( "Full Data Line=" + SaveLine );
 //		ShowContinueError( "Partial line read; Remainder of line=" + Line );
-//		ShowFatalError( "Error in Reading Weather Data" );
+//		ShowFatalError( "Error in Reading Weather Data" );  // LCOV_EXCL_LINE
 
 	}
 
@@ -4862,13 +4862,13 @@ Label902: ;
 Label9997: ;
 		ShowSevereError( "OpenWeatherFile: EPW Weather File appears to be a Unicode or binary file.", OutputFileStandard );
 		ShowContinueError( "...This file cannot be read by this program. Please save as PC or Unix file and try again" );
-		ShowFatalError( "Program terminates due to previous condition." );
+		ShowFatalError( "Program terminates due to previous condition." );  // LCOV_EXCL_LINE
 
 Label9998: ;
-		ShowFatalError( "OpenWeatherFile: Unexpected End-of-File on EPW Weather file, while reading header information, looking for header=" + Header( HdLine ), OutputFileStandard );
+		ShowFatalError( "OpenWeatherFile: Unexpected End-of-File on EPW Weather file, while reading header information, looking for header=" + Header( HdLine ), OutputFileStandard );  // LCOV_EXCL_LINE
 
 Label9999: ;
-		ShowFatalError( "OpenWeatherFile: Could not OPEN EPW Weather File", OutputFileStandard );
+		ShowFatalError( "OpenWeatherFile: Could not OPEN EPW Weather File", OutputFileStandard );  // LCOV_EXCL_LINE
 
 	}
 
@@ -5100,7 +5100,7 @@ Label9999: ;
 		// the simulation must be terminated
 
 		if ( LocationError ) {
-			ShowFatalError( "Due to previous error condition, simulation terminated" );
+			ShowFatalError( "Due to previous error condition, simulation terminated" );  // LCOV_EXCL_LINE
 		}
 
 		if ( TimeZoneNumber <= 12.00 ) {
@@ -5234,7 +5234,7 @@ Label9999: ;
 
 		AssignReportNumber( EnvironmentReportNbr );
 		if ( EnvironmentReportNbr != 1 ) { //  problem
-			ShowFatalError( "ReportOutputFileHeaders: Assigned report number for Environment title is not 1.  Contact Support." );
+			ShowFatalError( "ReportOutputFileHeaders: Assigned report number for Environment title is not 1.  Contact Support." );  // LCOV_EXCL_LINE
 		}
 		gio::write( EnvironmentReportChr, IntFmt ) << EnvironmentReportNbr;
 		strip( EnvironmentReportChr );
@@ -5479,7 +5479,7 @@ Label9999: ;
 		SPSiteScheduleUnits.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "GetWeatherInput: Above errors cause termination" );
+			ShowFatalError( "GetWeatherInput: Above errors cause termination" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -8255,7 +8255,7 @@ Label9999: ;
 		if ( ( Pos == std::string::npos ) && ( ! has_prefixi( HeaderString, "COMMENTS" ) ) ) {
 			ShowSevereError( "Invalid Header line in in.epw -- no commas" );
 			ShowContinueError( "Line=" + Line );
-			ShowFatalError( "Previous conditions cause termination." );
+			ShowFatalError( "Previous conditions cause termination." );  // LCOV_EXCL_LINE
 		}
 		if ( Pos != std::string::npos ) Line.erase( 0, Pos + 1 );
 
@@ -8871,7 +8871,7 @@ Label9999: ;
 			}
 
 		} else {
-			ShowFatalError( "Invalid EPW Header designation found=" + HeaderString );
+			ShowFatalError( "Invalid EPW Header designation found=" + HeaderString );  // LCOV_EXCL_LINE
 
 		}}
 
@@ -8996,7 +8996,7 @@ Label9999: ;
 		return;
 
 Label9998: ;
-		ShowFatalError( "Unexpected End-of-File on EPW Weather file, while reading header information, looking for header=" + Header, OutputFileStandard );
+		ShowFatalError( "Unexpected End-of-File on EPW Weather file, while reading header information, looking for header=" + Header, OutputFileStandard );  // LCOV_EXCL_LINE
 
 	}
 

--- a/src/EnergyPlus/WindTurbine.cc
+++ b/src/EnergyPlus/WindTurbine.cc
@@ -187,16 +187,16 @@ namespace WindTurbine {
 		if ( GeneratorIndex == 0 ) {
 			WindTurbineNum = FindItemInList( GeneratorName, WindTurbineSys );
 			if ( WindTurbineNum == 0 ) {
-				ShowFatalError( "SimWindTurbine: Specified Generator not one of Valid Wind Turbine Generators " + GeneratorName );
+				ShowFatalError( "SimWindTurbine: Specified Generator not one of Valid Wind Turbine Generators " + GeneratorName );  // LCOV_EXCL_LINE
 			}
 			GeneratorIndex = WindTurbineNum;
 		} else {
 			WindTurbineNum = GeneratorIndex;
 			if ( WindTurbineNum > NumWindTurbines || WindTurbineNum < 1 ) {
-				ShowFatalError( "SimWindTurbine: Invalid GeneratorIndex passed=" + TrimSigDigits( WindTurbineNum ) + ", Number of Wind Turbine Generators=" + TrimSigDigits( NumWindTurbines ) + ", Generator name=" + GeneratorName );
+				ShowFatalError( "SimWindTurbine: Invalid GeneratorIndex passed=" + TrimSigDigits( WindTurbineNum ) + ", Number of Wind Turbine Generators=" + TrimSigDigits( NumWindTurbines ) + ", Generator name=" + GeneratorName );  // LCOV_EXCL_LINE
 			}
 			if ( GeneratorName != WindTurbineSys( WindTurbineNum ).Name ) {
-				ShowFatalError( "SimMWindTurbine: Invalid GeneratorIndex passed=" + TrimSigDigits( WindTurbineNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + WindTurbineSys( WindTurbineNum ).Name );
+				ShowFatalError( "SimMWindTurbine: Invalid GeneratorIndex passed=" + TrimSigDigits( WindTurbineNum ) + ", Generator name=" + GeneratorName + ", stored Generator Name for that index=" + WindTurbineSys( WindTurbineNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -589,7 +589,7 @@ namespace WindTurbine {
 		lAlphaBlanks.deallocate();
 		lNumericBlanks.deallocate();
 
-		if ( ErrorsFound ) ShowFatalError( CurrentModuleObject + " errors occurred in input.  Program terminates." );
+		if ( ErrorsFound ) ShowFatalError( CurrentModuleObject + " errors occurred in input.  Program terminates." );  // LCOV_EXCL_LINE
 
 		for ( WindTurbineNum = 1; WindTurbineNum <= NumWindTurbines; ++WindTurbineNum ) {
 			SetupOutputVariable( "Generator Produced Electric Power", OutputProcessor::Unit::W, WindTurbineSys( WindTurbineNum ).Power, "System", "Average", WindTurbineSys( WindTurbineNum ).Name );
@@ -674,7 +674,7 @@ namespace WindTurbine {
 				ReadStatus = 0;
 				{ IOFlags flags; flags.ACTION( "READ" ); gio::open( statFile, DataStringGlobals::inStatFileName, flags ); ReadStatus = flags.ios(); }
 				if ( ReadStatus != 0 ) {
-					ShowFatalError( "InitWindTurbine: Could not open file "+DataStringGlobals::inStatFileName+" for input (read)." );
+					ShowFatalError( "InitWindTurbine: Could not open file "+DataStringGlobals::inStatFileName+" for input (read)." );  // LCOV_EXCL_LINE
 				}
 				while ( ReadStatus == 0 ) { //end of file
 					{ IOFlags flags; gio::read( statFile, fmtA, flags ) >> lineIn; ReadStatus = flags.ios(); }

--- a/src/EnergyPlus/WindowAC.cc
+++ b/src/EnergyPlus/WindowAC.cc
@@ -254,17 +254,17 @@ namespace WindowAC {
 		if ( CompIndex == 0 ) {
 			WindACNum = FindItemInList( CompName, WindAC );
 			if ( WindACNum == 0 ) {
-				ShowFatalError( "SimWindowAC: Unit not found=" + CompName );
+				ShowFatalError( "SimWindowAC: Unit not found=" + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = WindACNum;
 		} else {
 			WindACNum = CompIndex;
 			if ( WindACNum > NumWindAC || WindACNum < 1 ) {
-				ShowFatalError( "SimWindowAC:  Invalid CompIndex passed=" + TrimSigDigits( WindACNum ) + ", Number of Units=" + TrimSigDigits( NumWindAC ) + ", Entered Unit name=" + CompName );
+				ShowFatalError( "SimWindowAC:  Invalid CompIndex passed=" + TrimSigDigits( WindACNum ) + ", Number of Units=" + TrimSigDigits( NumWindAC ) + ", Entered Unit name=" + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( WindACNum ) ) {
 				if ( CompName != WindAC( WindACNum ).Name ) {
-					ShowFatalError( "SimWindowAC: Invalid CompIndex passed=" + TrimSigDigits( WindACNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + WindAC( WindACNum ).Name );
+					ShowFatalError( "SimWindowAC: Invalid CompIndex passed=" + TrimSigDigits( WindACNum ) + ", Unit name=" + CompName + ", stored Unit Name for that index=" + WindAC( WindACNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( WindACNum ) = false;
 			}
@@ -685,7 +685,7 @@ namespace WindowAC {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition causes termination." );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " input.  Preceding condition causes termination." );  // LCOV_EXCL_LINE
 		}
 
 		for ( WindACNum = 1; WindACNum <= NumWindAC; ++WindACNum ) {
@@ -1079,7 +1079,7 @@ namespace WindowAC {
 		}
 
 		DataScalableCapSizingON = false;
-		
+
 	}
 
 	void
@@ -1371,7 +1371,7 @@ namespace WindowAC {
 			Real64 OnOffAirFlowRatio( 1.0 ); // ratio of compressor on flow to average flow over time step
 
 			VariableSpeedCoils::SimVariableSpeedCoils( WindAC( WindACNum ).DXCoilName, WindAC( WindACNum ).DXCoilIndex, WindAC( WindACNum ).OpMode, MaxONOFFCyclesperHour, HPTimeConstant, FanDelayTime, 1.0, PartLoadFrac, WindAC( WindACNum ).DXCoilNumOfSpeeds, 1.0, QZnReq, QLatReq, OnOffAirFlowRatio );
-		
+
 		} else {
 			SimDXCoil( WindAC( WindACNum ).DXCoilName, On, FirstHVACIteration, WindAC( WindACNum ).DXCoilIndex, WindAC( WindACNum ).OpMode, PartLoadFrac );
 		}

--- a/src/EnergyPlus/WindowComplexManager.cc
+++ b/src/EnergyPlus/WindowComplexManager.cc
@@ -309,7 +309,7 @@ namespace WindowComplexManager {
 				}
 			}
 			if ( WindowStateList( NumStates, NumComplexWind ).IncBasisIndx <= 0 ) {
-				ShowFatalError( "Complex Window Init: Window Basis not in BasisList." );
+				ShowFatalError( "Complex Window Init: Window Basis not in BasisList." );  // LCOV_EXCL_LINE
 			}
 		}
 		//  Should now have a WindowList with NumComplexWind entries containing all the complex fenestrations
@@ -1366,7 +1366,7 @@ namespace WindowComplexManager {
 				for ( I = 2; I <= NThetas; ++I ) {
 					Thetas( I ) = Construct( IConst ).BSDFInput.BasisMat( 1, I ) * DegToRadians;
 					NPhis( I ) = std::floor( Construct( IConst ).BSDFInput.BasisMat( 2, I ) + 0.001 );
-					if ( NPhis( I ) <= 0 ) ShowFatalError( "WindowComplexManager: incorrect input, no. phis must be positive." );
+					if ( NPhis( I ) <= 0 ) ShowFatalError( "WindowComplexManager: incorrect input, no. phis must be positive." );  // LCOV_EXCL_LINE
 					NumElem += NPhis( I );
 				}
 				MaxNPhis = maxval( NPhis( {1,NThetas} ) );
@@ -1375,7 +1375,7 @@ namespace WindowComplexManager {
 				Basis.Phis = 0.0; // Initialize so undefined elements will contain zero
 				Basis.BasisIndex = 0; //Initialize so undefined elements will contain zero
 				if ( NumElem != Construct( IConst ).BSDFInput.NBasis ) { //Constructed Basis must match property matrices
-					ShowFatalError( "WindowComplexManager: Constructed basis length does not match property matrices." );
+					ShowFatalError( "WindowComplexManager: Constructed basis length does not match property matrices." );  // LCOV_EXCL_LINE
 				}
 				Basis.Thetas = Thetas;
 				Basis.NPhis = NPhis;
@@ -1439,7 +1439,7 @@ namespace WindowComplexManager {
 				Basis.Phis = 0.0; // Initialize so undefined elements will contain zero
 				Basis.BasisIndex = 0; //Initialize so undefined elements will contain zero
 				if ( NumElem != Construct( IConst ).BSDFInput.NBasis ) { //Constructed Basis must match property matrices
-					ShowFatalError( "WindowComplexManager: Constructed basis length does not match property matrices." );
+					ShowFatalError( "WindowComplexManager: Constructed basis length does not match property matrices." );  // LCOV_EXCL_LINE
 				}
 				Basis.Thetas = Thetas;
 				Basis.NPhis = NPhis;
@@ -1486,7 +1486,7 @@ namespace WindowComplexManager {
 				}
 			} // BST
 		} else { // BTW
-			ShowFatalError( "WindowComplexManager: Non-Window6 basis type not yet implemented." );
+			ShowFatalError( "WindowComplexManager: Non-Window6 basis type not yet implemented." );  // LCOV_EXCL_LINE
 		} // BTW
 		Thetas.deallocate();
 		NPhis.deallocate();
@@ -1563,7 +1563,7 @@ namespace WindowComplexManager {
 		} else {
 			//Non-WINDOW6 Type Basis
 			//Currently not implemented
-			ShowFatalError( "WindowComplexManager: Custom basis type not yet implemented." );
+			ShowFatalError( "WindowComplexManager: Custom basis type not yet implemented." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -3355,7 +3355,7 @@ namespace WindowComplexManager {
 				//            END DO ! ZoneEquipConfigNum
 				// check whether this zone is a controlled zone or not
 				if ( ! Zone( ZoneNum ).IsControlled ) {
-					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );
+					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 					return;
 				}
 				// determine supply air conditions
@@ -3397,7 +3397,7 @@ namespace WindowComplexManager {
 					ZoneEquipConfigNum = ZoneNum;
 					// check whether this zone is a controlled zone or not
 					if ( ! Zone( ZoneNum ).IsControlled ) {
-						ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );
+						ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 						return;
 					}
 					// determine supply air conditions
@@ -3442,7 +3442,7 @@ namespace WindowComplexManager {
 						}
 						if ( SurroundingSurfsProperty( SrdSurfsNum ).SkyViewFactor != -1 ) {
 							Surface( SurfNum ).ViewFactorGroundIR = SurroundingSurfsProperty( SrdSurfsNum ).GroundViewFactor;
-						}					
+						}
 						for ( SrdSurfNum = 1; SrdSurfNum <= SurroundingSurfsProperty( SrdSurfsNum ).TotSurroundingSurface; SrdSurfNum++ ) {
 							SrdSurfViewFac = SurroundingSurfsProperty( SrdSurfsNum ).SurroundingSurfs( SrdSurfNum ).ViewFactor;
 							SrdSurfTempAbs = GetCurrentScheduleValue( SurroundingSurfsProperty( SrdSurfsNum ).SurroundingSurfs( SrdSurfNum ).TempSchNum ) + KelvinConv;
@@ -3624,7 +3624,7 @@ namespace WindowComplexManager {
 				ShowContinueError( "   - WindowMaterial:Glazing" );
 				ShowContinueError( "   - WindowMaterial:ComplexShade" );
 				ShowContinueError( "   - WindowMaterial:Gap" );
-				ShowFatalError( "halting because of error in layer definition for Construction:ComplexFenestrationState" );
+				ShowFatalError( "halting because of error in layer definition for Construction:ComplexFenestrationState" );  // LCOV_EXCL_LINE
 			}
 
 		} // End of loop over glass, gap and blind/shade layers in a window construction
@@ -3737,7 +3737,7 @@ namespace WindowComplexManager {
 				ShowContinueError( "surface name = " + Surface( SurfNum ).Name );
 			}
 			ShowContinueError( "construction name = " + Construct( ConstrNum ).Name );
-			ShowFatalError( "halting because of error in tarcog" );
+			ShowFatalError( "halting because of error in tarcog" );  // LCOV_EXCL_LINE
 		} else if ( CalcCondition == winterCondition ) {
 			NominalU( ConstrNum ) = ufactor;
 		} else if ( CalcCondition == summerCondition ) {

--- a/src/EnergyPlus/WindowEquivalentLayer.cc
+++ b/src/EnergyPlus/WindowEquivalentLayer.cc
@@ -964,7 +964,7 @@ namespace WindowEquivalentLayer {
 						}
 						if ( SurroundingSurfsProperty( SrdSurfsNum ).SkyViewFactor != -1 ) {
 							Surface( SurfNum ).ViewFactorGroundIR = SurroundingSurfsProperty( SrdSurfsNum ).GroundViewFactor;
-						}					
+						}
 						for ( SrdSurfNum = 1; SrdSurfNum <= SurroundingSurfsProperty( SrdSurfsNum ).TotSurroundingSurface; SrdSurfNum++ ) {
 							SrdSurfViewFac = SurroundingSurfsProperty( SrdSurfsNum ).SurroundingSurfs( SrdSurfNum ).ViewFactor;
 							SrdSurfTempAbs = GetCurrentScheduleValue( SurroundingSurfsProperty( SrdSurfsNum ).SurroundingSurfs( SrdSurfNum ).TempSchNum ) + KelvinConv;
@@ -8276,7 +8276,7 @@ namespace WindowEquivalentLayer {
 
 		// TODO handle vert blind cases etc
 		// the slat normal points along the profile angle to block the beam solar
-		VB_CriticalSlatAngle = 90.0 - OMEGA_DEG; // 
+		VB_CriticalSlatAngle = 90.0 - OMEGA_DEG; //
 
 		return VB_CriticalSlatAngle;
 	}
@@ -9020,7 +9020,7 @@ namespace WindowEquivalentLayer {
 			}
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Program terminates for preceding reason(s)." );
+			ShowFatalError( RoutineName + "Program terminates for preceding reason(s)." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/WindowManager.cc
+++ b/src/EnergyPlus/WindowManager.cc
@@ -844,7 +844,7 @@ namespace WindowManager {
 			if ( TotalIPhi > MaxNumOfIncidentAngles ) {
 				ShowSevereError( "WindowManage::InitGlassOpticalCalculations = " + Construct( ConstrNum ).Name + ", Invalid maximum value of common incidet angles = " + TrimSigDigits( TotalIPhi ) + "." );
 				ShowContinueError( "The maximum number of incident angles for each construct is " + TrimSigDigits( MaxNumOfIncidentAngles ) + ". Please rearrange the dataset." );
-				ShowFatalError( "Errors found getting inputs. Previous error(s) cause program termination." );
+				ShowFatalError( "Errors found getting inputs. Previous error(s) cause program termination." );  // LCOV_EXCL_LINE
 			}
 
 			for ( IGlass = 1; IGlass <= NGlass; ++IGlass ) {
@@ -2502,7 +2502,7 @@ namespace WindowManager {
 				//            END DO ! ZoneEquipConfigNum
 				// check whether this zone is a controlled zone or not
 				if ( ! Zone( ZoneNum ).IsControlled ) {
-					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );
+					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 					return;
 				}
 				// determine supply air conditions
@@ -2623,7 +2623,7 @@ namespace WindowManager {
 							if ( Material( ShadeLayPtr ).Group == WindowBlind ) {
 								ShowSevereError( "CalcWindowHeatBalance: ShadeFlag indicates Shade but Blind=\"" + Material( ShadeLayPtr ).Name + "\" is being used." );
 								ShowContinueError( "This is most likely a fault of the EMS values for shading control." );
-								ShowFatalError( "Preceding condition terminates program." );
+								ShowFatalError( "Preceding condition terminates program." );  // LCOV_EXCL_LINE
 							}
 						}
 						thick( TotGlassLay + 1 ) = Material( ShadeLayPtr ).Thickness;
@@ -2644,7 +2644,7 @@ namespace WindowManager {
 							if ( Material( ShadeLayPtr ).Group == Shade || Material( ShadeLayPtr ).Group == Screen ) {
 								ShowSevereError( "CalcWindowHeatBalance: ShadeFlag indicates Blind but Shade/Screen=\"" + Material( ShadeLayPtr ).Name + "\" is being used." );
 								ShowContinueError( "This is most likely a fault of the EMS values for shading control." );
-								ShowFatalError( "Preceding condition terminates program." );
+								ShowFatalError( "Preceding condition terminates program." );  // LCOV_EXCL_LINE
 							}
 						}
 						// Blind on
@@ -2716,7 +2716,7 @@ namespace WindowManager {
 					ZoneEquipConfigNum = ZoneNumAdj;
 					// check whether this zone is a controlled zone or not
 					if ( ! Zone( ZoneNumAdj ).IsControlled ) {
-						ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );
+						ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 						return;
 					}
 					// determine supply air conditions
@@ -2765,7 +2765,7 @@ namespace WindowManager {
 						}
 						if ( SurroundingSurfsProperty( SrdSurfsNum ).SkyViewFactor != -1 ) {
 							surface.ViewFactorGroundIR = SurroundingSurfsProperty( SrdSurfsNum ).GroundViewFactor;
-						}					
+						}
 						for ( SrdSurfNum = 1; SrdSurfNum <= SurroundingSurfsProperty( SrdSurfsNum ).TotSurroundingSurface; SrdSurfNum++ ) {
 							SrdSurfViewFac = SurroundingSurfsProperty( SrdSurfsNum ).SurroundingSurfs( SrdSurfNum ).ViewFactor;
 							SrdSurfTempAbs = GetCurrentScheduleValue( SurroundingSurfsProperty( SrdSurfsNum ).SurroundingSurfs( SrdSurfNum ).TempSchNum ) + KelvinConv;
@@ -3642,7 +3642,7 @@ namespace WindowManager {
 				}
 
 			} else {
-				ShowFatalError( "SolveForWindowTemperatures: Invalid number of Glass Layers=" + TrimSigDigits( ngllayer ) + ", up to 4 allowed." );
+				ShowFatalError( "SolveForWindowTemperatures: Invalid number of Glass Layers=" + TrimSigDigits( ngllayer ) + ", up to 4 allowed." );  // LCOV_EXCL_LINE
 			}}
 
 			LUdecomposition( Aface, nglfacep, indx, d ); // Note that these routines change Aface;
@@ -3798,7 +3798,7 @@ namespace WindowManager {
 
 			}
 
-			ShowFatalError( "Program halted because of convergence error in SolveForWindowTemperatures for window " + Surface( SurfNum ).Name );
+			ShowFatalError( "Program halted because of convergence error in SolveForWindowTemperatures for window " + Surface( SurfNum ).Name );  // LCOV_EXCL_LINE
 
 		}
 
@@ -4571,7 +4571,7 @@ namespace WindowManager {
 			for ( j = 1; j <= n; ++j ) {
 				if ( std::abs( ajac( j, i ) ) > aamax ) aamax = std::abs( ajac( j, i ) );
 			}
-			if ( aamax == 0.0 ) ShowFatalError( "Singular matrix in LUdecomposition, window calculations" );
+			if ( aamax == 0.0 ) ShowFatalError( "Singular matrix in LUdecomposition, window calculations" );  // LCOV_EXCL_LINE
 			vv( i ) = 1.0 / aamax;
 		}
 		for ( j = 1; j <= n; ++j ) {
@@ -7279,7 +7279,7 @@ namespace WindowManager {
 		// No convergence after MaxIterations; and/or error tolerance
 		if ( errtemp >= 10 * errtemptol ) {
 			// Fatal error: didn't converge
-			ShowFatalError( "Convergence error in WindowTempsForNominalCond for construction " + Construct( ConstrNum ).Name );
+			ShowFatalError( "Convergence error in WindowTempsForNominalCond for construction " + Construct( ConstrNum ).Name );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -8889,7 +8889,7 @@ Label99999: ;
 			}
 
 			if ( aamax == 0.0 ) {
-				ShowFatalError( "Singular matrix in LUDCMP, window calculations" );
+				ShowFatalError( "Singular matrix in LUDCMP, window calculations" );  // LCOV_EXCL_LINE
 			}
 			VV( i ) = 1.0 / aamax; // Was commented out prior to 10/5/01, which caused overflows
 			// in this routine in rare cases
@@ -9202,7 +9202,7 @@ Label99999: ;
 		rNumericArgs.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in processing input for user-defined solar/visible spectrum" );
+			ShowFatalError( "Errors found in processing input for user-defined solar/visible spectrum" );  // LCOV_EXCL_LINE
 		}
 
 		RunMeOnceFlag = true;

--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
@@ -207,16 +207,16 @@ namespace ZoneAirLoopEquipmentManager {
 		if ( CompIndex == 0 ) {
 			AirDistUnitNum = FindItemInList( ZoneAirLoopEquipName, AirDistUnit );
 			if ( AirDistUnitNum == 0 ) {
-				ShowFatalError( "ManageZoneAirLoopEquipment: Unit not found=" + ZoneAirLoopEquipName );
+				ShowFatalError( "ManageZoneAirLoopEquipment: Unit not found=" + ZoneAirLoopEquipName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = AirDistUnitNum;
 		} else {
 			AirDistUnitNum = CompIndex;
 			if ( AirDistUnitNum > NumAirDistUnits || AirDistUnitNum < 1 ) {
-				ShowFatalError( "ManageZoneAirLoopEquipment:  Invalid CompIndex passed=" + TrimSigDigits( AirDistUnitNum ) + ", Number of Units=" + TrimSigDigits( NumAirDistUnits ) + ", Entered Unit name=" + ZoneAirLoopEquipName );
+				ShowFatalError( "ManageZoneAirLoopEquipment:  Invalid CompIndex passed=" + TrimSigDigits( AirDistUnitNum ) + ", Number of Units=" + TrimSigDigits( NumAirDistUnits ) + ", Entered Unit name=" + ZoneAirLoopEquipName );  // LCOV_EXCL_LINE
 			}
 			if ( ZoneAirLoopEquipName != AirDistUnit( AirDistUnitNum ).Name ) {
-				ShowFatalError( "ManageZoneAirLoopEquipment: Invalid CompIndex passed=" + TrimSigDigits( AirDistUnitNum ) + ", Unit name=" + ZoneAirLoopEquipName + ", stored Unit Name for that index=" + AirDistUnit( AirDistUnitNum ).Name );
+				ShowFatalError( "ManageZoneAirLoopEquipment: Invalid CompIndex passed=" + TrimSigDigits( AirDistUnitNum ) + ", Unit name=" + ZoneAirLoopEquipName + ", stored Unit Name for that index=" + AirDistUnit( AirDistUnitNum ).Name );  // LCOV_EXCL_LINE
 			}
 		}
 		DataSizing::CurTermUnitSizingNum = AirDistUnit( AirDistUnitNum ).TermUnitSizingNum;
@@ -456,7 +456,7 @@ namespace ZoneAirLoopEquipmentManager {
 				} else if ( SameString( AirDistUnit( AirDistUnitNum ).EquipType( AirDistCompUnitNum ), "AirTerminal:SingleDuct:UserDefined" ) ) {
 					AirDistUnit( AirDistUnitNum ).EquipType_Num( AirDistCompUnitNum ) = SingleDuctUserDefined;
 				}
-				else if ( SameString( AirDistUnit( AirDistUnitNum ).EquipType( AirDistCompUnitNum ), "AirTerminal:SingleDuct:Mixer" ) ) {					
+				else if ( SameString( AirDistUnit( AirDistUnitNum ).EquipType( AirDistCompUnitNum ), "AirTerminal:SingleDuct:Mixer" ) ) {
 					AirDistUnit( AirDistUnitNum ).EquipType_Num( AirDistCompUnitNum ) = SingleDuctATMixer;
 					if ( AirDistUnit( AirDistUnitNum ).UpStreamLeak || AirDistUnit( AirDistUnitNum ).DownStreamLeak ) {
 						ShowSevereError( "Error found in " + CurrentModuleObject + " = " + AirDistUnit( AirDistUnitNum ).Name );
@@ -498,7 +498,7 @@ namespace ZoneAirLoopEquipmentManager {
 			}
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " Input" );
+			ShowFatalError( RoutineName + "Errors found in getting " + CurrentModuleObject + " Input" );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -707,7 +707,7 @@ namespace ZoneAirLoopEquipmentManager {
 			} else {
 				ShowSevereError( "Error found in ZoneHVAC:AirDistributionUnit=" + AirDistUnit( AirDistUnitNum ).Name );
 				ShowContinueError( "Invalid Component=" + AirDistUnit( AirDistUnitNum ).EquipType( AirDistCompNum ) );
-				ShowFatalError( "Preceding condition causes termination." );
+				ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 			}}
 

--- a/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
@@ -899,7 +899,7 @@ namespace ZoneContaminantPredictorCorrector {
 		AlphaName.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors getting Zone Contaminant Sources and Sinks input data.  Preceding condition(s) cause termination." );
+			ShowFatalError( "Errors getting Zone Contaminant Sources and Sinks input data.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1111,7 +1111,7 @@ namespace ZoneContaminantPredictorCorrector {
 		} // ContControlledZoneNum
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors getting Zone Contaminant Control input data.  Preceding condition(s) cause termination." );
+			ShowFatalError( "Errors getting Zone Contaminant Control input data.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
@@ -1370,7 +1370,7 @@ namespace ZoneContaminantPredictorCorrector {
 			}
 			MyConfigOneTimeFlag = false;
 			if ( ErrorsFound ) {
-				ShowFatalError( "ZoneControl:ContaminantController: Program terminates for preceding reason(s)." );
+				ShowFatalError( "ZoneControl:ContaminantController: Program terminates for preceding reason(s)." );  // LCOV_EXCL_LINE
 			}
 		}
 
@@ -1667,7 +1667,7 @@ namespace ZoneContaminantPredictorCorrector {
 						B = CO2Gain + ( ( OAMFL( ZoneNum ) + VAMFL( ZoneNum ) + EAMFL( ZoneNum ) + CTMFL( ZoneNum ) ) * OutdoorCO2 ) + MixingMassFlowCO2( ZoneNum );
 						A = OAMFL( ZoneNum ) + VAMFL( ZoneNum ) + EAMFL( ZoneNum ) + CTMFL( ZoneNum ) + MixingMassFlowZone( ZoneNum );
 					}
-					C = RhoAir * Zone( ZoneNum ).Volume * Zone( ZoneNum ).ZoneVolCapMultpCO2 / SysTimeStepInSeconds; 
+					C = RhoAir * Zone( ZoneNum ).Volume * Zone( ZoneNum ).ZoneVolCapMultpCO2 / SysTimeStepInSeconds;
 
 					// Use a 3rd Order derivative to predict zone moisture addition or removal and
 					// smooth the changes using the zone air capacitance.  Positive values of CO2 Load means that
@@ -1749,7 +1749,7 @@ namespace ZoneContaminantPredictorCorrector {
 						B = GCGain + ( ( OAMFL( ZoneNum ) + VAMFL( ZoneNum ) + EAMFL( ZoneNum ) + CTMFL( ZoneNum ) ) * OutdoorGC ) + MixingMassFlowGC( ZoneNum );
 						A = OAMFL( ZoneNum ) + VAMFL( ZoneNum ) + EAMFL( ZoneNum ) + CTMFL( ZoneNum ) + MixingMassFlowZone( ZoneNum );
 					}
-					C = RhoAir * Zone( ZoneNum ).Volume * Zone( ZoneNum ).ZoneVolCapMultpGenContam / SysTimeStepInSeconds; 
+					C = RhoAir * Zone( ZoneNum ).Volume * Zone( ZoneNum ).ZoneVolCapMultpGenContam / SysTimeStepInSeconds;
 
 					// Use a 3rd Order derivative to predict zone moisture addition or removal and
 					// smooth the changes using the zone air capacitance.  Positive values of GC Load means that
@@ -2242,7 +2242,7 @@ namespace ZoneContaminantPredictorCorrector {
 						B = CO2Gain + ( AirflowNetworkExchangeData( ZoneNum ).SumMHrCO + AirflowNetworkExchangeData( ZoneNum ).SumMMHrCO ) + CO2MassFlowRate;
 						A = ZoneMassFlowRate + AirflowNetworkExchangeData( ZoneNum ).SumMHr + AirflowNetworkExchangeData( ZoneNum ).SumMMHr;
 					}
-					C = RhoAir * Zone( ZoneNum ).Volume * Zone( ZoneNum ).ZoneVolCapMultpCO2 / SysTimeStepInSeconds; 
+					C = RhoAir * Zone( ZoneNum ).Volume * Zone( ZoneNum ).ZoneVolCapMultpCO2 / SysTimeStepInSeconds;
 				}
 			} else if ( ZoneMassFlowRate <= 0.0 ) {
 				if ( Contaminant.CO2Simulation ) {

--- a/src/EnergyPlus/ZoneDehumidifier.cc
+++ b/src/EnergyPlus/ZoneDehumidifier.cc
@@ -224,17 +224,17 @@ namespace ZoneDehumidifier {
 		if ( CompIndex == 0 ) {
 			ZoneDehumidNum = FindItemInList( CompName, ZoneDehumid );
 			if ( ZoneDehumidNum == 0 ) {
-				ShowFatalError( "SimZoneDehumidifier: Unit not found= " + CompName );
+				ShowFatalError( "SimZoneDehumidifier: Unit not found= " + CompName );  // LCOV_EXCL_LINE
 			}
 			CompIndex = ZoneDehumidNum;
 		} else {
 			ZoneDehumidNum = CompIndex;
 			if ( ZoneDehumidNum > NumDehumidifiers || ZoneDehumidNum < 1 ) {
-				ShowFatalError( "SimZoneDehumidifier:  Invalid CompIndex passed= " + TrimSigDigits( ZoneDehumidNum ) + ", Number of Units= " + TrimSigDigits( NumDehumidifiers ) + ", Entered Unit name= " + CompName );
+				ShowFatalError( "SimZoneDehumidifier:  Invalid CompIndex passed= " + TrimSigDigits( ZoneDehumidNum ) + ", Number of Units= " + TrimSigDigits( NumDehumidifiers ) + ", Entered Unit name= " + CompName );  // LCOV_EXCL_LINE
 			}
 			if ( CheckEquipName( ZoneDehumidNum ) ) {
 				if ( CompName != ZoneDehumid( ZoneDehumidNum ).Name ) {
-					ShowFatalError( "SimZoneDehumidifier: Invalid CompIndex passed=" + TrimSigDigits( ZoneDehumidNum ) + ", Unit name= " + CompName + ", stored Unit Name for that index= " + ZoneDehumid( ZoneDehumidNum ).Name );
+					ShowFatalError( "SimZoneDehumidifier: Invalid CompIndex passed=" + TrimSigDigits( ZoneDehumidNum ) + ", Unit name= " + CompName + ", stored Unit Name for that index= " + ZoneDehumid( ZoneDehumidNum ).Name );  // LCOV_EXCL_LINE
 				}
 				CheckEquipName( ZoneDehumidNum ) = false;
 			}
@@ -521,7 +521,7 @@ namespace ZoneDehumidifier {
 		lNumericBlanks.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + ':' + CurrentModuleObject + ": Errors found in input." );
+			ShowFatalError( RoutineName + ':' + CurrentModuleObject + ": Errors found in input." );  // LCOV_EXCL_LINE
 		}
 
 		for ( ZoneDehumidIndex = 1; ZoneDehumidIndex <= NumDehumidifiers; ++ZoneDehumidIndex ) {

--- a/src/EnergyPlus/ZoneEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneEquipmentManager.cc
@@ -676,7 +676,7 @@ namespace ZoneEquipmentManager {
 				else {
 					ShowSevereError( RoutineName + ": to account for the effect a Dedicated Outside Air System on zone equipment sizing" );
 					ShowContinueError( "there must be at least one zone air inlet node" );
-					ShowFatalError( "Previous severe error causes abort " );
+					ShowFatalError( "Previous severe error causes abort " );  // LCOV_EXCL_LINE
 				}
 				// set the DOAS mass flow rate and supply temperature and humidity ratio
 				HR90H = PsyWFnTdbRhPb( CalcZoneSizing( CurOverallSimDay, ControlledZoneNum ).DOASHighSetpoint, 0.9, StdBaroPress );
@@ -918,7 +918,7 @@ namespace ZoneEquipmentManager {
 			}
 		}
 		else {
-			ShowFatalError( RoutineName + ":illegal DOAS design control strategy" );
+			ShowFatalError( RoutineName + ":illegal DOAS design control strategy" );  // LCOV_EXCL_LINE
 		}
 	}
 
@@ -1026,7 +1026,7 @@ namespace ZoneEquipmentManager {
 			}
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( "SetUpZoneSizingArrays: Errors found in Sizing:Zone input" );
+			ShowFatalError( "SetUpZoneSizingArrays: Errors found in Sizing:Zone input" );  // LCOV_EXCL_LINE
 		}
 
 		// Put Auto Sizing of Sizing:Zone inputs here!
@@ -2777,7 +2777,7 @@ namespace ZoneEquipmentManager {
 						// issue 6006, heating coils sizing to 0 when no heating load in zone
 						if ( ZoneSizing( DDNumF, CtrlZoneNum ).DesCoolSetPtSeq.empty() ) {
 							ShowSevereError( RoutineName + ":  Thermostat cooling set point temperatures are not initialized for Zone = " + FinalZoneSizing( CtrlZoneNum ).ZoneName );
-							ShowFatalError( "Please send your input file to the EnergyPlus support/development team for further investigation." );
+							ShowFatalError( "Please send your input file to the EnergyPlus support/development team for further investigation." );  // LCOV_EXCL_LINE
 						} else {
 							FinalZoneSizing( CtrlZoneNum ).ZoneTempAtCoolPeak = *std::min_element( ZoneSizing( DDNumF, CtrlZoneNum ).DesCoolSetPtSeq.begin(), ZoneSizing( DDNumF, CtrlZoneNum ).DesCoolSetPtSeq.end() );
 						}
@@ -2907,7 +2907,7 @@ namespace ZoneEquipmentManager {
 						// issue 6006, heating coils sizing to 0 when no heating load in zone
 						if ( ZoneSizing( DDNumF, CtrlZoneNum ).DesHeatSetPtSeq.empty() ) {
 							ShowSevereError( RoutineName + ":  Thermostat heating set point temperatures not initialized for Zone = " + FinalZoneSizing( CtrlZoneNum ).ZoneName );
-							ShowFatalError( "Please send your input file to the EnergyPlus support/development team for further investigation." );
+							ShowFatalError( "Please send your input file to the EnergyPlus support/development team for further investigation." );  // LCOV_EXCL_LINE
 						} else {
 							FinalZoneSizing( CtrlZoneNum ).ZoneTempAtHeatPeak = *std::max_element( ZoneSizing( DDNumF, CtrlZoneNum ).DesHeatSetPtSeq.begin(), ZoneSizing( DDNumF, CtrlZoneNum ).DesHeatSetPtSeq.end() );
 							FinalZoneSizing( CtrlZoneNum ).OutTempAtHeatPeak = *std::min_element( ZoneSizing( DDNumF, CtrlZoneNum ).HeatOutTempSeq.begin(), ZoneSizing( DDNumF, CtrlZoneNum ).HeatOutTempSeq.end() );
@@ -2929,12 +2929,12 @@ namespace ZoneEquipmentManager {
 
 				// set the zone minimum cooling supply air flow rate. This will be used for autosizing VAV terminal unit
 				// minimum flow rates
-				FinalZoneSizing( CtrlZoneNum ).DesCoolVolFlowMin = max( FinalZoneSizing( CtrlZoneNum ).DesCoolMinAirFlow, 
-					FinalZoneSizing( CtrlZoneNum ).DesCoolMinAirFlow2, 
+				FinalZoneSizing( CtrlZoneNum ).DesCoolVolFlowMin = max( FinalZoneSizing( CtrlZoneNum ).DesCoolMinAirFlow,
+					FinalZoneSizing( CtrlZoneNum ).DesCoolMinAirFlow2,
 					FinalZoneSizing( CtrlZoneNum ).DesCoolVolFlow * FinalZoneSizing( CtrlZoneNum ).DesCoolMinAirFlowFrac );
 				// set the zone maximum heating supply air flow rate. This will be used for autosizing VAV terminal unit
 				// max heating flow rates
-				FinalZoneSizing( CtrlZoneNum ).DesHeatVolFlowMax = max( FinalZoneSizing( CtrlZoneNum ).DesHeatMaxAirFlow, 
+				FinalZoneSizing( CtrlZoneNum ).DesHeatVolFlowMax = max( FinalZoneSizing( CtrlZoneNum ).DesHeatMaxAirFlow,
 					FinalZoneSizing( CtrlZoneNum ).DesHeatMaxAirFlow2, max( FinalZoneSizing( CtrlZoneNum ).DesCoolVolFlow, FinalZoneSizing( CtrlZoneNum ).DesHeatVolFlow ) *
 					FinalZoneSizing( CtrlZoneNum ).DesHeatMaxAirFlowFrac );
 				// Determine the design cooling supply air temperature if the supply air temperature difference is specified by user.
@@ -3091,7 +3091,7 @@ namespace ZoneEquipmentManager {
 				} else {
 					ShowSevereError( "Error found in Supply Air Path=" + SupplyAirPath( SupplyAirPathNum ).Name );
 					ShowContinueError( "Invalid Supply Air Path Component=" + SupplyAirPath( SupplyAirPathNum ).ComponentType( CompNum ) );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 				}}
 			}
@@ -3286,10 +3286,10 @@ namespace ZoneEquipmentManager {
 
 				} else if ( SELECT_CASE_var == CoolingPanel_Num ) { // 'ZoneHVAC:CoolingPanel:RadiantConvective:Water'
 					SimCoolingPanel( PrioritySimOrder( EquipTypeNum ).EquipName, ActualZoneNum, ControlledZoneNum, FirstHVACIteration, SysOutputProvided, ZoneEquipList( CurZoneEqNum ).EquipIndex( EquipPtr ) );
-					
+
 					NonAirSystemResponse( ActualZoneNum ) += SysOutputProvided;
 					LatOutputProvided = 0.0; // This cooling panel does not add/remove any latent heat
-					
+
 				} else if ( SELECT_CASE_var == HiTempRadiant_Num ) { // 'ZoneHVAC:HighTemperatureRadiant'
 					SimHighTempRadiantSystem( PrioritySimOrder( EquipTypeNum ).EquipName, FirstHVACIteration, SysOutputProvided, ZoneEquipList( CurZoneEqNum ).EquipIndex( EquipPtr ) );
 					LatOutputProvided = 0.0; // This baseboard currently sends its latent heat gain directly to predictor/corrector
@@ -3416,7 +3416,7 @@ namespace ZoneEquipmentManager {
 				} else {
 					ShowSevereError( "Error found in Supply Air Path=" + SupplyAirPath( SupplyAirPathNum ).Name );
 					ShowContinueError( "Invalid Supply Air Path Component=" + SupplyAirPath( SupplyAirPathNum ).ComponentType( CompNum ) );
-					ShowFatalError( "Preceding condition causes termination." );
+					ShowFatalError( "Preceding condition causes termination." );  // LCOV_EXCL_LINE
 
 				}}
 			}
@@ -3444,7 +3444,7 @@ namespace ZoneEquipmentManager {
 				}
 			}
 			if ( ErrorFlag ) {
-				ShowFatalError( "Preceding condition causes termination" );
+				ShowFatalError( "Preceding condition causes termination" );  // LCOV_EXCL_LINE
 			}
 			MyOneTimeFlag = false;
 		}
@@ -3946,7 +3946,7 @@ namespace ZoneEquipmentManager {
 	//							Node( RetNode ).MassFlowRate = ;
 							}
 						}
-					
+
 					}
 				}
 
@@ -4620,7 +4620,7 @@ namespace ZoneEquipmentManager {
 			}
 			else {
 				HumRatExt = OutHumRat;
-				EnthalpyExt = OutEnthalpy;					
+				EnthalpyExt = OutEnthalpy;
 			}
 			AirDensity = PsyRhoAirFnPbTdbW( OutBaroPress, TempExt, HumRatExt );
 			CpAir = PsyCpAirFnWTdb( HumRatExt, TempExt );
@@ -5195,7 +5195,7 @@ namespace ZoneEquipmentManager {
 			WindSpeedExt = Zone( NZ ).WindSpeed;
 
 			// Use air node information linked to the zone if defined
-			
+
 			if ( Zone( NZ ).HasLinkedOutAirNode ) {
 				HumRatExt = Node( Zone( NZ ).LinkedOutAirNode ).HumRat;
 				}
@@ -5540,7 +5540,7 @@ namespace ZoneEquipmentManager {
 
 		// REFERENCES:
 		// See IO Ref for suggested values
-		
+
 		// Using/Aliasing
 
 		// FUNCTION ARGUMENT DEFINITIONS:
@@ -5612,7 +5612,7 @@ namespace ZoneEquipmentManager {
 			}
 		}
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors found in DOAS sizing input. Program terminates." );
+			ShowFatalError( "Errors found in DOAS sizing input. Program terminates." );  // LCOV_EXCL_LINE
 		}
 	}
 
@@ -5659,7 +5659,7 @@ namespace ZoneEquipmentManager {
 
 		// BSLLC Start
 		// if ( sqlite ) {
-		// 	sqlite->addSQLiteZoneSizingRecord( ZoneName, LoadType, CalcDesLoad, UserDesLoad, CalcDesFlow, UserDesFlow, DesDayName, PeakHrMin, 
+		// 	sqlite->addSQLiteZoneSizingRecord( ZoneName, LoadType, CalcDesLoad, UserDesLoad, CalcDesFlow, UserDesFlow, DesDayName, PeakHrMin,
 		// 		PeakTemp, PeakHumRat, MinOAVolFlow, DOASHeatAddRate );
 		// }
 		// BSLLC Finish

--- a/src/EnergyPlus/ZonePlenum.cc
+++ b/src/EnergyPlus/ZonePlenum.cc
@@ -211,17 +211,17 @@ namespace ZonePlenum {
 			if ( CompIndex == 0 ) {
 				ZonePlenumNum = FindItemInList( CompName, ZoneRetPlenCond, &ZoneReturnPlenumConditions::ZonePlenumName );
 				if ( ZonePlenumNum == 0 ) {
-					ShowFatalError( "SimAirZonePlenum: AirLoopHVAC:ReturnPlenum not found=" + CompName );
+					ShowFatalError( "SimAirZonePlenum: AirLoopHVAC:ReturnPlenum not found=" + CompName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = ZonePlenumNum;
 			} else {
 				ZonePlenumNum = CompIndex;
 				if ( ZonePlenumNum > NumZoneReturnPlenums || ZonePlenumNum < 1 ) {
-					ShowFatalError( "SimAirZonePlenum: Invalid CompIndex passed=" + TrimSigDigits( ZonePlenumNum ) + ", Number of AirLoopHVAC:ReturnPlenum=" + TrimSigDigits( NumZoneReturnPlenums ) + ", AirLoopHVAC:ReturnPlenum name=" + CompName );
+					ShowFatalError( "SimAirZonePlenum: Invalid CompIndex passed=" + TrimSigDigits( ZonePlenumNum ) + ", Number of AirLoopHVAC:ReturnPlenum=" + TrimSigDigits( NumZoneReturnPlenums ) + ", AirLoopHVAC:ReturnPlenum name=" + CompName );  // LCOV_EXCL_LINE
 				}
 				if ( CheckRetEquipName( ZonePlenumNum ) ) {
 					if ( CompName != ZoneRetPlenCond( ZonePlenumNum ).ZonePlenumName ) {
-						ShowFatalError( "SimAirZonePlenum: Invalid CompIndex passed=" + TrimSigDigits( ZonePlenumNum ) + ", AirLoopHVAC:ReturnPlenum name=" + CompName + ", stored AirLoopHVAC:ReturnPlenum Name for that index=" + ZoneRetPlenCond( ZonePlenumNum ).ZonePlenumName );
+						ShowFatalError( "SimAirZonePlenum: Invalid CompIndex passed=" + TrimSigDigits( ZonePlenumNum ) + ", AirLoopHVAC:ReturnPlenum name=" + CompName + ", stored AirLoopHVAC:ReturnPlenum Name for that index=" + ZoneRetPlenCond( ZonePlenumNum ).ZonePlenumName );  // LCOV_EXCL_LINE
 					}
 					CheckRetEquipName( ZonePlenumNum ) = false;
 				}
@@ -240,17 +240,17 @@ namespace ZonePlenum {
 			if ( CompIndex == 0 ) {
 				ZonePlenumNum = FindItemInList( CompName, ZoneSupPlenCond, &ZoneSupplyPlenumConditions::ZonePlenumName );
 				if ( ZonePlenumNum == 0 ) {
-					ShowFatalError( "SimAirZonePlenum: AirLoopHVAC:SupplyPlenum not found=" + CompName );
+					ShowFatalError( "SimAirZonePlenum: AirLoopHVAC:SupplyPlenum not found=" + CompName );  // LCOV_EXCL_LINE
 				}
 				CompIndex = ZonePlenumNum;
 			} else {
 				ZonePlenumNum = CompIndex;
 				if ( ZonePlenumNum > NumZoneSupplyPlenums || ZonePlenumNum < 1 ) {
-					ShowFatalError( "SimAirZonePlenum: Invalid CompIndex passed=" + TrimSigDigits( ZonePlenumNum ) + ", Number of AirLoopHVAC:SupplyPlenum=" + TrimSigDigits( NumZoneReturnPlenums ) + ", AirLoopHVAC:SupplyPlenum name=" + CompName );
+					ShowFatalError( "SimAirZonePlenum: Invalid CompIndex passed=" + TrimSigDigits( ZonePlenumNum ) + ", Number of AirLoopHVAC:SupplyPlenum=" + TrimSigDigits( NumZoneReturnPlenums ) + ", AirLoopHVAC:SupplyPlenum name=" + CompName );  // LCOV_EXCL_LINE
 				}
 				if ( CheckSupEquipName( ZonePlenumNum ) ) {
 					if ( CompName != ZoneSupPlenCond( ZonePlenumNum ).ZonePlenumName ) {
-						ShowFatalError( "SimAirZonePlenum: Invalid CompIndex passed=" + TrimSigDigits( ZonePlenumNum ) + ", AirLoopHVAC:SupplyPlenum name=" + CompName + ", stored AirLoopHVAC:SupplyPlenum Name for that index=" + ZoneSupPlenCond( ZonePlenumNum ).ZonePlenumName );
+						ShowFatalError( "SimAirZonePlenum: Invalid CompIndex passed=" + TrimSigDigits( ZonePlenumNum ) + ", AirLoopHVAC:SupplyPlenum name=" + CompName + ", stored AirLoopHVAC:SupplyPlenum Name for that index=" + ZoneSupPlenCond( ZonePlenumNum ).ZonePlenumName );  // LCOV_EXCL_LINE
 					}
 					CheckSupEquipName( ZonePlenumNum ) = false;
 				}
@@ -267,7 +267,7 @@ namespace ZonePlenum {
 		} else {
 			ShowSevereError( "SimAirZonePlenum: Errors in Plenum=" + CompName );
 			ShowContinueError( "ZonePlenum: Unhandled plenum type found:" + TrimSigDigits( iCompType ) );
-			ShowFatalError( "Preceding conditions cause termination." );
+			ShowFatalError( "Preceding conditions cause termination." );  // LCOV_EXCL_LINE
 
 		}
 
@@ -637,7 +637,7 @@ namespace ZonePlenum {
 		NodeNums.deallocate();
 
 		if ( ErrorsFound ) {
-			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );
+			ShowFatalError( RoutineName + "Errors found in input.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -178,7 +178,7 @@ namespace ZoneTempPredictorCorrector {
 	int const CEN15251_UPPER_I( 6 );
 	int const CEN15251_UPPER_II( 7 );
 	int const CEN15251_UPPER_III( 8 );
-	
+
 	int const SglHeatSetPoint( 1 );
 	int const SglCoolSetPoint( 2 );
 	int const SglHCSetPoint( 3 );
@@ -1531,7 +1531,7 @@ namespace ZoneTempPredictorCorrector {
 
 		// Get the Hybrid Model setting inputs
 		GetHybridModelZone();
-		
+
 		// Default multiplier values
 		Real64 ZoneVolCapMultpSens = 1.0;
 		Real64 ZoneVolCapMultpMoist = 1.0;
@@ -1551,7 +1551,7 @@ namespace ZoneTempPredictorCorrector {
 			}
 
 		} else {
-		
+
 			// Allow user to specify ZoneCapacitanceMultiplier:ResearchSpecial at zone level
 			// Added by S. Lee and R. Zhang in Oct. 2016.
 			// Assign the user inputted multipliers to specified zones
@@ -1565,7 +1565,7 @@ namespace ZoneTempPredictorCorrector {
 					ZoneVolCapMultpCO2 = rNumericArgs( 3 );
 					ZoneVolCapMultpGenContam = rNumericArgs( 4 );
 				} else {
-				// multiplier values for the specified zone 
+				// multiplier values for the specified zone
 					int ZoneNum = 0;
 					ZLItem = 0;
 					Item1 = FindItemInList( cAlphaArgs( 2 ), Zone );
@@ -1593,7 +1593,7 @@ namespace ZoneTempPredictorCorrector {
 					}
 				}
 			}
-			
+
 			// Assign default multiplier values to all the other zones
 			for( int ZoneNum = 1; ZoneNum <= NumOfZones; ZoneNum++ ){
 				if( ! Zone( ZoneNum ).FlagCustomizedZoneCap ){
@@ -1605,7 +1605,7 @@ namespace ZoneTempPredictorCorrector {
 			}
 
 			// Calculate the average multiplier value from all zones
-			{				
+			{
 				Real64 ZoneVolCapMultpSens_temp = 0.0;
 				Real64 ZoneVolCapMultpMoist_temp = 0.0;
 				Real64 ZoneVolCapMultpCO2_temp = 0.0;
@@ -1774,7 +1774,7 @@ namespace ZoneTempPredictorCorrector {
 										Array1D< Real64 > runningAverageASH( NumDaysInYear, 0.0 );
 										Array1D< Real64 > runningAverageCEN( NumDaysInYear, 0.0 );
 										CalculateMonthlyRunningAverageDryBulb( runningAverageASH, runningAverageCEN );
-										CalculateAdaptiveComfortSetPointSchl( runningAverageASH, runningAverageCEN ); 
+										CalculateAdaptiveComfortSetPointSchl( runningAverageASH, runningAverageCEN );
 									}
 								}
 							}
@@ -2109,15 +2109,15 @@ namespace ZoneTempPredictorCorrector {
 		} // NumStageControlledZones > 0
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "Errors getting Zone Control input data.  Preceding condition(s) cause termination." );
+			ShowFatalError( "Errors getting Zone Control input data.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 		}
 
 	}
 
 	void CalculateMonthlyRunningAverageDryBulb(
 		Array1D< Real64 > & runningAverageASH,
-		Array1D< Real64 > & runningAverageCEN		
-	) 
+		Array1D< Real64 > & runningAverageCEN
+	)
 	{
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Xuan Luo
@@ -2172,7 +2172,7 @@ namespace ZoneTempPredictorCorrector {
 			epwFile = GetNewUnitNumber();
 			{ IOFlags flags; flags.ACTION( "READ" ); gio::open( epwFile, DataStringGlobals::inputWeatherFileName, flags ); readStat = flags.ios(); }
 			if ( readStat != 0 ) {
-				ShowFatalError( "CalcThermalComfortAdaptive: Could not open file " + DataStringGlobals::inputWeatherFileName + " for input (read)." );
+				ShowFatalError( "CalcThermalComfortAdaptive: Could not open file " + DataStringGlobals::inputWeatherFileName + " for input (read)." );  // LCOV_EXCL_LINE
 			}
 			for ( i = 1; i <= 9; ++i ) { // Headers
 				{ IOFlags flags; gio::read( epwFile, fmtA, flags ); readStat = flags.ios(); }
@@ -2243,15 +2243,15 @@ namespace ZoneTempPredictorCorrector {
 			}
 		}
 		else {
-			ShowFatalError( "CalcThermalComfortAdaptive: Could not open file " + DataStringGlobals::inputWeatherFileName + " for input (read)." );
+			ShowFatalError( "CalcThermalComfortAdaptive: Could not open file " + DataStringGlobals::inputWeatherFileName + " for input (read)." );  // LCOV_EXCL_LINE
 		}
-		
+
 	}
 
 	void CalculateAdaptiveComfortSetPointSchl(
 		Array1D< Real64 > const & runningAverageASH,
 		Array1D< Real64 > const & runningAverageCEN
-	) 
+	)
 	{
 		// SUBROUTINE INFORMATION:
 		//       AUTHOR         Xuan Luo
@@ -2277,7 +2277,7 @@ namespace ZoneTempPredictorCorrector {
 		for ( size_t i = 1; i <= DesDayInput.size(); i++ ) {
 			// Summer design day
 			if ( DesDayInput( i ).DayType == summerDesignDayTypeIndex ) {
-				GrossApproxAvgDryBulbDesignDay = ( DesDayInput( i ).MaxDryBulb + ( DesDayInput( i ).MaxDryBulb - DesDayInput( i ).DailyDBRange ) ) / 2.0;				
+				GrossApproxAvgDryBulbDesignDay = ( DesDayInput( i ).MaxDryBulb + ( DesDayInput( i ).MaxDryBulb - DesDayInput( i ).DailyDBRange ) ) / 2.0;
 				if ( GrossApproxAvgDryBulbDesignDay > 10 && GrossApproxAvgDryBulbDesignDay < 33.5 ) {
 					AdapComfortSetPointSummerDesDay( 1 ) = 0.31 * GrossApproxAvgDryBulbDesignDay + 17.8;
 					AdapComfortSetPointSummerDesDay( 2 ) = 0.31 * GrossApproxAvgDryBulbDesignDay + 20.3;
@@ -2707,7 +2707,7 @@ namespace ZoneTempPredictorCorrector {
 		}
 
 		if ( ErrorsFound ) {
-			ShowFatalError( "InitZoneAirSetpoints - program terminates due to previous condition." );
+			ShowFatalError( "InitZoneAirSetpoints - program terminates due to previous condition." );  // LCOV_EXCL_LINE
 		}
 
 		if ( ZoneEquipInputsFilled ) {
@@ -3122,7 +3122,7 @@ namespace ZoneTempPredictorCorrector {
 				SchedTypeIndex = TempControlledZone( RelativeZoneNum ).ControlTypeSchIndx( SchedNameIndex );
 
 				SetPointTempSchedIndex = SetPointSingleHeating( SchedTypeIndex ).TempSchedIndex;
-				TempZoneThermostatSetPoint( ActualZoneNum ) = GetCurrentScheduleValue( SetPointTempSchedIndex );			
+				TempZoneThermostatSetPoint( ActualZoneNum ) = GetCurrentScheduleValue( SetPointTempSchedIndex );
 				AdjustAirSetPointsforOpTempCntrl( RelativeZoneNum, ActualZoneNum, TempZoneThermostatSetPoint( ActualZoneNum ) );
 				ZoneThermostatSetPointLo( ActualZoneNum ) = TempZoneThermostatSetPoint( ActualZoneNum );
 				//        ZoneThermostatSetPointHi(ActualZoneNum) = TempZoneThermostatSetPoint(ActualZoneNum)
@@ -3142,7 +3142,7 @@ namespace ZoneTempPredictorCorrector {
 					AdjustOperativeSetPointsforAdapComfort( RelativeZoneNum, TempZoneThermostatSetPoint( ActualZoneNum ) );
 					AdapComfortCoolingSetPoint( ActualZoneNum ) = TempZoneThermostatSetPoint ( ActualZoneNum );
 				}
-				
+
 
 				AdjustAirSetPointsforOpTempCntrl( RelativeZoneNum, ActualZoneNum, TempZoneThermostatSetPoint( ActualZoneNum ) );
 				ZoneThermostatSetPointHi( ActualZoneNum ) = TempZoneThermostatSetPoint( ActualZoneNum );
@@ -3164,7 +3164,7 @@ namespace ZoneTempPredictorCorrector {
 				if ( ( TempControlledZone( RelativeZoneNum ).AdaptiveComfortTempControl ) ) {
 					AdjustOperativeSetPointsforAdapComfort( RelativeZoneNum, TempZoneThermostatSetPoint( ActualZoneNum ) );
 					AdapComfortCoolingSetPoint( ActualZoneNum ) = TempZoneThermostatSetPoint( ActualZoneNum );
-				}				
+				}
 
 				AdjustAirSetPointsforOpTempCntrl( RelativeZoneNum, ActualZoneNum, TempZoneThermostatSetPoint( ActualZoneNum ) );
 
@@ -3414,7 +3414,7 @@ namespace ZoneTempPredictorCorrector {
 				ShowContinueError( "Zone TempDepZnLd=" + RoundSigDigits( TempDepZnLd( ZoneNum ), 2 ) );
 				ShowContinueError( "Zone TempIndZnLd=" + RoundSigDigits( TempIndZnLd( ZoneNum ), 2 ) );
 				ShowContinueError( "Zone ThermostatSetPoint=" + RoundSigDigits( TempZoneThermostatSetPoint( ZoneNum ), 2 ) );
-				ShowFatalError( "Program terminates due to above conditions." );
+				ShowFatalError( "Program terminates due to above conditions." );  // LCOV_EXCL_LINE
 			}
 
 			if ( LoadToHeatingSetPoint > 0.0 && LoadToCoolingSetPoint > 0.0 ) {
@@ -3436,7 +3436,7 @@ namespace ZoneTempPredictorCorrector {
 				ShowContinueError( "Zone TempDepZnLd=" + RoundSigDigits( TempDepZnLd( ZoneNum ), 2 ) );
 				ShowContinueError( "Zone TempIndZnLd=" + RoundSigDigits( TempIndZnLd( ZoneNum ), 2 ) );
 				ShowContinueError( "Zone ThermostatSetPoint=" + RoundSigDigits( TempZoneThermostatSetPoint( ZoneNum ), 2 ) );
-				ShowFatalError( "Program terminates due to above conditions." );
+				ShowFatalError( "Program terminates due to above conditions." );  // LCOV_EXCL_LINE
 			}
 
 		} else if ( SELECT_CASE_var == DualSetPointWithDeadBand ) {
@@ -3476,7 +3476,7 @@ namespace ZoneTempPredictorCorrector {
 				ShowContinueError( "Zone TempIndZnLd=" + RoundSigDigits( TempIndZnLd( ZoneNum ), 2 ) );
 				ShowContinueError( "Zone Heating ThermostatSetPoint=" + RoundSigDigits( ZoneThermostatSetPointLo( ZoneNum ), 2 ) );
 				ShowContinueError( "Zone Cooling ThermostatSetPoint=" + RoundSigDigits( ZoneThermostatSetPointHi( ZoneNum ), 2 ) );
-				ShowFatalError( "Program terminates due to above conditions." );
+				ShowFatalError( "Program terminates due to above conditions." );  // LCOV_EXCL_LINE
 			}
 			if ( LoadToHeatingSetPoint > 0.0 && LoadToCoolingSetPoint > 0.0 ) {
 				ZoneSysEnergyDemand( ZoneNum ).TotalOutputRequired = LoadToHeatingSetPoint;
@@ -3503,7 +3503,7 @@ namespace ZoneTempPredictorCorrector {
 				ShowContinueError( "Zone TempIndZnLd=" + RoundSigDigits( TempIndZnLd( ZoneNum ), 2 ) );
 				ShowContinueError( "Zone ThermostatSetPoint=" + RoundSigDigits( TempZoneThermostatSetPoint( ZoneNum ), 2 ) );
 
-				ShowFatalError( "Program terminates due to above conditions." );
+				ShowFatalError( "Program terminates due to above conditions." );  // LCOV_EXCL_LINE
 			}
 
 		}}
@@ -3719,7 +3719,7 @@ namespace ZoneTempPredictorCorrector {
 							// The FaultsThermostatOffset specified in the FaultHumidistatOffset is not found
 							if ( ! IsThermostatFound ) {
 								ShowSevereError( "FaultModel:HumidistatOffset = \"" + FaultsHumidistatOffset( iFault ).Name + "\" invalid Reference Humidistat Offset Name = \"" + FaultsHumidistatOffset( iFault ).FaultyThermostatName + "\" not found." );
-								ShowFatalError( "Errors getting FaultModel input data.  Preceding condition(s) cause termination." );
+								ShowFatalError( "Errors getting FaultModel input data.  Preceding condition(s) cause termination." );  // LCOV_EXCL_LINE
 							}
 
 							if ( offsetThermostat != 0.0 ) {
@@ -3898,7 +3898,7 @@ namespace ZoneTempPredictorCorrector {
 					ShowContinueError( "LoadToHumidifySetPoint=" + RoundSigDigits( LoadToHumidifySetPoint, 5 ) + ", LoadToDehumidifySetPoint=" + RoundSigDigits( LoadToDehumidifySetPoint, 5 ) );
 					ShowContinueError( "Zone RH Humidifying Set-point=" + RoundSigDigits( ZoneRHHumidifyingSetPoint, 1 ) );
 					ShowContinueError( "Zone RH Dehumidifying Set-point=" + RoundSigDigits( ZoneRHDehumidifyingSetPoint, 2 ) );
-					ShowFatalError( "Program terminates due to above conditions." );
+					ShowFatalError( "Program terminates due to above conditions." );  // LCOV_EXCL_LINE
 				}
 			}
 		}
@@ -3991,7 +3991,7 @@ namespace ZoneTempPredictorCorrector {
 		static Real64 TempDepCoef( 0.0 ); // Formerly CoefSumha, coef in zone temp equation with dimensions of h*A
 		static Real64 TempIndCoef( 0.0 ); // Formerly CoefSumhat, coef in zone temp equation with dimensions of h*A(T1
 		static Real64 AirCap( 0.0 ); // Formerly CoefAirrat, coef in zone temp eqn with dim of "air power capacity"
-		static Real64 AirCapHM(0.0); // Air power capacity for hybrid modeling 
+		static Real64 AirCapHM(0.0); // Air power capacity for hybrid modeling
 		static Real64 SNLoad( 0.0 ); // Sensible load calculated for zone in watts and then loaded in report variables
 		static int ZoneNum( 0 );
 		static int ZoneNodeNum( 0 ); // System node number for air flow through zone either by system or as a plenum
@@ -4236,11 +4236,11 @@ namespace ZoneTempPredictorCorrector {
 							MCPIHM = 0.0;
 						}
 						else {
-							MCPIHM = ( AA - Zone( ZoneNum ).ZoneMeasuredTemperature * BB ) / ( Zone( ZoneNum ).ZoneMeasuredTemperature - a ); // MCPIHM calculation using Use3rdOrder method 
+							MCPIHM = ( AA - Zone( ZoneNum ).ZoneMeasuredTemperature * BB ) / ( Zone( ZoneNum ).ZoneMeasuredTemperature - a ); // MCPIHM calculation using Use3rdOrder method
 						}
 
 						InfilVolumeOADensityHM = ( MCPIHM / CpAir / AirDensity ) * TimeStepZone * SecInHour;
-						
+
 						if ( abs( Zone( ZoneNum ).ZoneMeasuredTemperature - Zone( ZoneNum ).OutDryBulbTemp ) > 5.0 && abs( ZT( ZoneNum ) - PreviousMeasuredZT1( ZoneNum ) ) < 0.1 ) {// Filter
 							InfilOAACHHM = InfilVolumeOADensityHM / ( TimeStepZone * Zone( ZoneNum ).Volume );
 							InfilOAACHHM = max( 0.0, min( 10.0, InfilOAACHHM ) );  // ACH max 10, min 0
@@ -4281,16 +4281,16 @@ namespace ZoneTempPredictorCorrector {
 						if ( abs( ZT( ZoneNum ) - PreviousMeasuredZT1( ZoneNum ) ) > 0.05 ){ // Filter
 							MultpHM = AirCapHM / ( Zone( ZoneNum ).Volume * PsyRhoAirFnPbTdbW( OutBaroPress, ZT( ZoneNum ), ZoneAirHumRat( ZoneNum ) ) * PsyCpAirFnWTdb( ZoneAirHumRat( ZoneNum ), ZT( ZoneNum ) ) ) * ( TimeStepZone * SecInHour ); // Inverse equation
 							if ( ( MultpHM < 1.0 ) || ( MultpHM > 30.0 ) ){ // Temperature capacity multiplier greater than 1 and less than 30
-								MultpHM = 1.0; // Default value 1.0 
+								MultpHM = 1.0; // Default value 1.0
 							}
 						}
 						else {
-							MultpHM = 1.0; // Default value 1.0 
+							MultpHM = 1.0; // Default value 1.0
 						}
 
 						// For timestep output
 						Zone(ZoneNum).ZoneVolCapMultpSensHM = MultpHM;
-						
+
 						// Calculate the average multiplier of the zone for the whole running period
 						{
 							// count for hybrid model calculations
@@ -4298,8 +4298,8 @@ namespace ZoneTempPredictorCorrector {
 								Zone( ZoneNum ).ZoneVolCapMultpSensHMSum += MultpHM;
 								Zone( ZoneNum ).ZoneVolCapMultpSensHMCountSum++;
 							}
-							
-							// Calculate and store the multiplier average at the end of HM simulations 
+
+							// Calculate and store the multiplier average at the end of HM simulations
 							if ( DayOfYear == HybridModelZone( ZoneNum ).HybridEndDayOfYear && EndDayFlag ){
 								HMMultiplierAverage = Zone( ZoneNum ).ZoneVolCapMultpSensHMSum / Zone( ZoneNum ).ZoneVolCapMultpSensHMCountSum;
 								Zone( ZoneNum ).ZoneVolCapMultpSensHMAverage = HMMultiplierAverage;
@@ -4314,7 +4314,7 @@ namespace ZoneTempPredictorCorrector {
 				PreviousMeasuredZT1( ZoneNum ) = ZT( ZoneNum );
 
 			} // Hybrid model end
-			
+
 			MAT( ZoneNum ) = ZT( ZoneNum );
 
 			// Determine sensible load heating/cooling rate and energy
@@ -5244,7 +5244,7 @@ namespace ZoneTempPredictorCorrector {
 			} else if ( SELECT_CASE_var == ZoneSupplyAirTemp ) {
 				// check whether this zone is a controlled zone or not
 				if ( ! ControlledZoneAirFlag ) {
-					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );
+					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 					return;
 				}
 				// determine supply air temperature as a weighted average of the inlet temperatures.
@@ -5516,7 +5516,7 @@ namespace ZoneTempPredictorCorrector {
 			} else if ( SELECT_CASE_var == ZoneSupplyAirTemp ) {
 				// check whether this zone is a controlled zone or not
 				if ( ! ControlledZoneAirFlag ) {
-					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );
+					ShowFatalError( "Zones must be controlled for Ceiling-Diffuser Convection model. No system serves zone " + Zone( ZoneNum ).Name );  // LCOV_EXCL_LINE
 					return;
 				}
 				// determine supply air temperature as a weighted average of the inlet temperatures.
@@ -5848,7 +5848,7 @@ namespace ZoneTempPredictorCorrector {
 		using DataEnvironment::DayOfYear;
 		using WeatherManager::DesDayInput;
 		using WeatherManager::Envrn;
-		using WeatherManager::Environment;		
+		using WeatherManager::Environment;
 
 		// SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 		int originZoneAirSetPoint = ZoneAirSetPoint;
@@ -5858,7 +5858,7 @@ namespace ZoneTempPredictorCorrector {
 		// adjust zone operative setpoint
 		if ( !( TempControlledZone( TempControlledZoneID ).AdaptiveComfortTempControl ) ) return; // do nothing to setpoint
 		if ( ( Environment( Envrn ).KindOfEnvrn != ksDesignDay ) && ( Environment( Envrn ).KindOfEnvrn != ksHVACSizeDesignDay ) ) {
-			// Adjust run period cooling set point 
+			// Adjust run period cooling set point
 			switch ( AdaptiveComfortModelTypeIndex ) {
 				case ASH55_CENTRAL:
 					ZoneAirSetPoint = AdapComfortDailySetPointSchedule.ThermalComfortAdaptiveASH55_Central( DayOfYear );
@@ -5868,7 +5868,7 @@ namespace ZoneTempPredictorCorrector {
 					break;
 				case ASH55_UPPER_80:
 					ZoneAirSetPoint = AdapComfortDailySetPointSchedule.ThermalComfortAdaptiveASH55_Upper_80( DayOfYear );
-					break;				
+					break;
 				case CEN15251_CENTRAL:
 					ZoneAirSetPoint = AdapComfortDailySetPointSchedule.ThermalComfortAdaptiveCEN15251_Central(DayOfYear);
 					break;
@@ -6693,7 +6693,7 @@ namespace ZoneTempPredictorCorrector {
 		int const firstTimeStep = 1;
 		int weekSchIndexSelect = ScheduleManager::Schedule( scheduleIndex ).WeekSchedulePointer( jdateSelect );
 		int daySchIndexSelect = ScheduleManager::WeekSchedule( weekSchIndexSelect ).DaySchedulePointer( dayOfWeek );
-		Real64 valueAtSelectTime = ScheduleManager::DaySchedule( daySchIndexSelect ).TSValue( firstTimeStep, hourSelect ); 
+		Real64 valueAtSelectTime = ScheduleManager::DaySchedule( daySchIndexSelect ).TSValue( firstTimeStep, hourSelect );
 		int countOfSame = 0;
 
 		// count the number of times with that same value


### PR DESCRIPTION
This is a "what if" scenario.  We don't actively add unit/integration test support for the fatal error code paths.  There are probably a bunch in the code that really are "unreachable" assuming the IDD validation guards it.  I've long wanted to evaluate how much actual, meaningful code our tests are covering with the fatals in place.  I'll probably do a couple steps:
 - Just the ShowFatalError code lines
 - Also ShowSevereError code lines - since these _should_ result in fatal errors (no severe warnings, right?)
 - Then finally, try to match up the ShowContinueError lines that occur just before a ShowFatalError call.

It could certainly be that this doesn't ever get merged in, no problem.  However, it could be valuable.  If we can show that our integration test coverage is up in the 90%s once we ignore the fatal error paths, then it would be easy to target new integration tests to get it up to 100% of the meaningful code.  Which would be super cool.