### PR TITLE
Fix DOASMixer primary flow problem and add error trap

### DIFF
--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -5067,7 +5067,9 @@ namespace SingleDuct {
 				Node( this->PriInNode ).MassFlowRate = max( Node( this->PriInNode ).MassFlowRate, Node( this->PriInNode ).MassFlowRateMin );
 			}
 		}
-
+		if ( this->MixerType == ATMixer_InletSide ) {
+				Node( this->PriInNode ).MassFlowRate = min( Node( this->PriInNode ).MassFlowRate, Node( this->MixedAirOutNode ).MassFlowRate );
+		}
 	}
 
 	void
@@ -5136,6 +5138,11 @@ namespace SingleDuct {
 			MixedAirMassFlowRate = Node( SysATMixer( SysNum ).MixedAirOutNode ).MassFlowRate;
 			SecAirMassFlowRate = max( MixedAirMassFlowRate - PriMassFlowRate, 0.0 );
 			Node( SysATMixer( SysNum ).SecInNode ).MassFlowRate = SecAirMassFlowRate;
+			if ( abs( PriMassFlowRate + SecAirMassFlowRate - MixedAirMassFlowRate ) > SmallMassFlow ) {
+				ShowSevereError( "CalcATMixer: Invalid mass flow rates in AirTerminal:SingleDuct:Mixer=" + SysATMixer( SysNum ).Name );
+				ShowContinueErrorTimeStamp( "Primary mass flow rate=" + General::RoundSigDigits( PriMassFlowRate, 6 ) + "Secondary mass flow rate=" + General::RoundSigDigits( SecAirMassFlowRate, 6 ) + "Mixed mass flow rate=" + General::RoundSigDigits( MixedAirMassFlowRate, 6 ) );
+				ShowFatalError( "Simulation terminates." );
+			}
 		}
 		// now calculate the mixed (outlet) conditions
 		if ( MixedAirMassFlowRate > 0.0 ) {

--- a/tst/EnergyPlus/unit/SingleDuct.unit.cc
+++ b/tst/EnergyPlus/unit/SingleDuct.unit.cc
@@ -2546,3 +2546,85 @@ TEST_F( EnergyPlusFixture, TerminalUnitMixerInitTest ) {
 	DataHeatBalance::ZoneIntGain.deallocate( );
 
 }
+TEST_F( EnergyPlusFixture, TerminalUnitMixerInitTest2 ) {
+
+	// Address #6205
+	// Address #6241
+
+	using SingleDuct::SysATMixer;
+	int ATMixerNum = 1;
+	SingleDuct::NumATMixers = 1;
+	DataHeatBalance::TotPeople = 1;
+
+	SysATMixer.allocate( ATMixerNum );
+	DataZoneEquipment::ZoneEquipConfig.allocate( 1 );
+	DataAirLoop::AirLoopFlow.allocate( 1 );
+	DataLoopNode::Node.allocate( 3 );
+	DataSizing::OARequirements.allocate( 1 );
+	Zone.allocate( 1 );
+	DataHeatBalance::ZoneIntGain.allocate( 1 );
+
+	SysATMixer( ATMixerNum ).SecInNode = 1;
+	SysATMixer( ATMixerNum ).PriInNode = 2;
+	SysATMixer( ATMixerNum ).MixedAirOutNode = 3;
+	SysATMixer( ATMixerNum ).AirLoopNum = 1;
+	SysATMixer( ATMixerNum ).ZoneNum = 1;
+	SysATMixer( ATMixerNum ).ZoneEqNum = 1;
+	SysATMixer( ATMixerNum ).NoOAFlowInputFromUser = false;
+	SysATMixer( ATMixerNum ).OARequirementsPtr = 1;
+
+	DataZoneEquipment::ZoneEquipConfig( 1 ).AirLoopNum = 1;
+
+	DataAirLoop::AirLoopFlow( 1 ).OAFrac = 1.0;
+
+	Zone( 1 ).FloorArea = 10.0;
+	OARequirements( 1 ).OAFlowMethod = OAFlowSum;
+	OARequirements( 1 ).OAFlowPerZone = 0.5;
+	OARequirements( 1 ).OAFlowPerPerson = 0.0;
+	OARequirements( 1 ).OAFlowPerArea = 0.0;
+	OARequirements( 1 ).OAFlowACH = 0.0;
+
+	DataLoopNode::Node( 2 ).Press = 101325.0;
+	DataLoopNode::Node( 2 ).Temp = 23.0;
+	DataLoopNode::Node( 2 ).HumRat = 0.001;
+
+	DataHeatBalance::ZoneIntGain( 1 ).NOFOCC = 5.0;
+
+	DataEnvironment::StdRhoAir = 1.0;
+	SysATMixer( 1 ).MassFlowRateMaxAvail = 1.0;
+	// No airloop data exists, so skip these parts of the init
+	SysATMixer( 1 ).OneTimeInitFlag = false;
+	SysATMixer( 1 ).OneTimeInitFlag2 = false;
+	// Current occupancy
+	SysATMixer( 1 ).OAPerPersonMode = 1;
+
+	// InletSideMixer, Mixed air outlet mass flow > OA requirement, expect primary flow to equal OA requirement
+	SysATMixer( 1 ).MixerType = DataHVACGlobals::ATMixer_InletSide;
+	DataLoopNode::Node( SysATMixer( 1 ).MixedAirOutNode ).MassFlowRate = 1.0;
+	SysATMixer( 1 ).InitATMixer( true );
+	EXPECT_NEAR( DataLoopNode::Node( SysATMixer( 1 ).PriInNode ).MassFlowRate, 0.5, 0.0001 );
+
+	// InletSideMixer, Mixed air outlet mass flow < OA requirement, expect primary flow to equal mixed air flow
+	DataLoopNode::Node( SysATMixer( 1 ).MixedAirOutNode ).MassFlowRate = 0.10;
+	SysATMixer( 1 ).InitATMixer( true );
+	EXPECT_NEAR( DataLoopNode::Node( SysATMixer( 1 ).PriInNode ).MassFlowRate, 0.10, 0.0001 );
+
+	// SupplySideMixer, Mixed air outlet mass flow > OA requirement, expect primary flow to equal OA requirement
+	SysATMixer( 1 ).MixerType = DataHVACGlobals::ATMixer_SupplySide;
+	DataLoopNode::Node( SysATMixer( 1 ).MixedAirOutNode ).MassFlowRate = 1.0;
+	SysATMixer( 1 ).InitATMixer( true );
+	EXPECT_NEAR( DataLoopNode::Node( SysATMixer( 1 ).PriInNode ).MassFlowRate, 0.5, 0.0001 );
+
+	// SupplySideMixer, Mixed air outlet mass flow < OA requirement, expect primary flow to equal OA requirement
+	DataLoopNode::Node( SysATMixer( 1 ).MixedAirOutNode ).MassFlowRate = 0.10;
+	SysATMixer( 1 ).InitATMixer( true );
+	EXPECT_NEAR( DataLoopNode::Node( SysATMixer( 1 ).PriInNode ).MassFlowRate, 0.5, 0.0001 );
+	SysATMixer.deallocate( );
+	DataZoneEquipment::ZoneEquipConfig.deallocate( );
+	DataAirLoop::AirLoopFlow.deallocate( );
+	DataLoopNode::Node.deallocate( );
+	DataSizing::OARequirements.deallocate( );
+	Zone.deallocate( );
+	DataHeatBalance::ZoneIntGain.deallocate( );
+
+}


### PR DESCRIPTION
Pull request overview
---------------------
Addresses #6332 by limiting the DOAS mixer primary air flow to be no greater than the mixed air outlet mass flow rate which is set by the zone equipment.  This fixes a problem introduced by earlier DOAS mixer changes for v8.8 ( #6223 and #6252), so this doesn't need to be published.

**Question to reviewers:** Do you think the new fatal error is a good idea or should it just be a one-time warning?  If it happens, the user probably can't do anything to fix it.  Or maybe it should be a debug assert instead?

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
