### PR TITLE
Fix crash when zero heat or cool load with AirLoopComponentLoadSummary report

### DIFF
--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -11856,7 +11856,11 @@ namespace OutputReportTabular {
 			// set the peak day and time for each zone used by the airloops
 			for ( int iAirLoop = 1; iAirLoop <= NumPrimaryAirSys; ++iAirLoop ) {
 				coolDesSelected = SysSizPeakDDNum( iAirLoop ).TotCoolPeakDD;
-				timeCoolMax = SysSizPeakDDNum( iAirLoop ).TimeStepAtTotCoolPk( coolDesSelected );
+				if ( coolDesSelected != 0 ) {
+					timeCoolMax = SysSizPeakDDNum( iAirLoop ).TimeStepAtTotCoolPk( coolDesSelected );
+				} else {
+					timeCoolMax = 0;
+				}
 				int NumZonesCooled = AirToZoneNodeInfo( iAirLoop ).NumZonesCooled;
 				for ( int ZonesCooledNum = 1; ZonesCooledNum <= NumZonesCooled; ++ZonesCooledNum ) { // loop over cooled zones
 					int CtrlZoneNum = AirToZoneNodeInfo( iAirLoop ).CoolCtrlZoneNums( ZonesCooledNum );
@@ -11865,7 +11869,11 @@ namespace OutputReportTabular {
 					AirLoopZonesCoolCompLoadTables( CtrlZoneNum ).timeStepMax = timeCoolMax;
 				}
 				heatDesSelected = SysSizPeakDDNum( iAirLoop ).HeatPeakDD;
-				timeHeatMax = SysSizPeakDDNum( iAirLoop ).TimeStepAtHeatPk( heatDesSelected );
+				if ( heatDesSelected != 0 ) {
+					timeHeatMax = SysSizPeakDDNum( iAirLoop ).TimeStepAtHeatPk( heatDesSelected );
+				} else {
+					timeHeatMax = 0;
+				}
 				int NumZonesHeated = AirToZoneNodeInfo( iAirLoop ).NumZonesHeated;
 				for ( int ZonesHeatedNum = 1; ZonesHeatedNum <= NumZonesHeated; ++ZonesHeatedNum ) { // loop over cooled zones
 					int CtrlZoneNum = AirToZoneNodeInfo( iAirLoop ).HeatCtrlZoneNums( ZonesHeatedNum );
@@ -11881,7 +11889,11 @@ namespace OutputReportTabular {
 						int airLoopNum = ZoneEquipConfig(iZone).AirLoopNum;
 						zoneToAirLoopCool( iZone ) = airLoopNum;
 						coolDesSelected = SysSizPeakDDNum( airLoopNum ).TotCoolPeakDD;
-						timeCoolMax = SysSizPeakDDNum( airLoopNum ).TimeStepAtTotCoolPk( coolDesSelected );
+						if ( coolDesSelected != 0 ) {
+							timeCoolMax = SysSizPeakDDNum( airLoopNum ).TimeStepAtTotCoolPk( coolDesSelected );
+						} else {
+							timeCoolMax = 0;
+						}
 						AirLoopZonesCoolCompLoadTables( iZone ).desDayNum = coolDesSelected;
 						AirLoopZonesCoolCompLoadTables( iZone ).timeStepMax = timeCoolMax;
 					}
@@ -11891,7 +11903,11 @@ namespace OutputReportTabular {
 						int airLoopNum = ZoneEquipConfig( iZone ).AirLoopNum;
 						zoneToAirLoopHeat( iZone ) = airLoopNum;
 						heatDesSelected = SysSizPeakDDNum( airLoopNum ).HeatPeakDD;
-						timeHeatMax = SysSizPeakDDNum( airLoopNum ).TimeStepAtHeatPk( heatDesSelected );
+						if ( heatDesSelected != 0 ) {
+							timeHeatMax = SysSizPeakDDNum( airLoopNum ).TimeStepAtHeatPk( heatDesSelected );
+						} else {
+							timeHeatMax = 0;
+						}
 						AirLoopZonesHeatCompLoadTables( iZone ).desDayNum = heatDesSelected;
 						AirLoopZonesHeatCompLoadTables( iZone ).timeStepMax = timeHeatMax;
 					}

--- a/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
+++ b/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
@@ -55,6 +55,7 @@
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array1D.hh>
 // EnergyPlus Headers
+#include <EnergyPlus/DataAirLoop.hh>
 #include <EnergyPlus/DataGlobals.hh>
 #include <EnergyPlus/DataGlobalConstants.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
@@ -6516,5 +6517,39 @@ TEST( OutputReportTabularTest, CreateListOfZonesForAirLoop_test )
 
 }
 
+TEST_F( SQLiteFixture, OutputReportTabular_WriteLoadComponentSummaryTables_AirLoop_ZeroDesignDay )
+{
+	sqlite_test->sqliteBegin();
+	sqlite_test->createSQLiteSimulationsRecord( 1, "EnergyPlus Version", "Current Time" );
+	EnergyPlus::sqlite = std::move( sqlite_test );
+
+	DataHVACGlobals::NumPrimaryAirSys = 1;
+	SysSizPeakDDNum.allocate( DataHVACGlobals::NumPrimaryAirSys );
+	DataSizing::FinalSysSizing.allocate( DataHVACGlobals::NumPrimaryAirSys );
+	DataSizing::CalcSysSizing.allocate( DataHVACGlobals::NumPrimaryAirSys );
+	int numDesDays = 2;
+	DataAirLoop::AirToZoneNodeInfo.allocate( DataHVACGlobals::NumPrimaryAirSys );
+	DataGlobals::NumOfZones = 0;
+	displayAirLoopComponentLoadSummary = true;
+	CompLoadReportIsReq = true;
+	SysSizPeakDDNum( DataHVACGlobals::NumPrimaryAirSys ).TimeStepAtTotCoolPk.allocate( numDesDays );
+
+	SysSizPeakDDNum( DataHVACGlobals::NumPrimaryAirSys ).TotCoolPeakDD = 0; //set to zero to indicate no design day chosen
+	SysSizPeakDDNum( DataHVACGlobals::NumPrimaryAirSys ).HeatPeakDD = 0;    //set to zero to indicate no design day chosen
+
+	WriteLoadComponentSummaryTables();
+
+	sqlite_test = std::move( EnergyPlus::sqlite );
+
+	auto tabularData = queryResult( "SELECT * FROM TabularData;", "TabularData" );
+	auto strings = queryResult( "SELECT * FROM Strings;", "Strings" );
+	auto stringTypes = queryResult( "SELECT * FROM StringTypes;", "StringTypes" );
+	sqlite_test->sqliteCommit();
+
+	EXPECT_EQ( 460ul, tabularData.size() ); 
+	EXPECT_EQ( 76ul, strings.size() );
+	EXPECT_EQ( "AirLoop Component Load Summary", strings[0][2]); // just make sure that the output table was generated and did not crash
+
+}
 
 


### PR DESCRIPTION
Fixed crash when zero heating or zero cooling load in the AirLoopComponentLoadSummary report. This was due to no cooling and heating design day being selected since no cooling or heating load respectively. This caused a reference to an array based on the design day to fail.

Addresses #6307 

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
