### PR TITLE
VRF using Fan:SystemModel fan shows full air flow rate when system is scheduled off or no load is present

### DIFF
--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
@@ -6354,7 +6354,7 @@ namespace HVACVariableRefrigerantFlow {
 				if ( OnOffAirFlowRatio > 0.0 ) {
 					HVACFan::fanObjs[ VRFTU( VRFTUNum ).FanIndex ]->simulate( 1.0/OnOffAirFlowRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff,_);
 				} else {
-					HVACFan::fanObjs[ VRFTU( VRFTUNum ).FanIndex ]->simulate( 1.0, ZoneCompTurnFansOn, ZoneCompTurnFansOff,_);
+					HVACFan::fanObjs[ VRFTU( VRFTUNum ).FanIndex ]->simulate( PartLoadRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff,_);
 				}
 			} else {
 				Fans::SimulateFanComponents( "", FirstHVACIteration, VRFTU( VRFTUNum ).FanIndex, FanSpeedRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff );
@@ -6391,7 +6391,7 @@ namespace HVACVariableRefrigerantFlow {
 				if ( OnOffAirFlowRatio > 0.0 ) {
 					HVACFan::fanObjs[ VRFTU( VRFTUNum ).FanIndex ]->simulate( 1.0/OnOffAirFlowRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff,_);
 				} else {
-					HVACFan::fanObjs[ VRFTU( VRFTUNum ).FanIndex ]->simulate( 1.0, ZoneCompTurnFansOn, ZoneCompTurnFansOff,_);
+					HVACFan::fanObjs[ VRFTU( VRFTUNum ).FanIndex ]->simulate( PartLoadRatio, ZoneCompTurnFansOn, ZoneCompTurnFansOff,_ );
 				}
 				
 			} else {

--- a/tst/EnergyPlus/unit/HVACVariableRefrigerantFlow.unit.cc
+++ b/tst/EnergyPlus/unit/HVACVariableRefrigerantFlow.unit.cc
@@ -1920,6 +1920,7 @@ namespace EnergyPlus {
 			EXPECT_NEAR( 5110, OUEvapHeatExtract, 1 );
 			EXPECT_NEAR( 1500, CompSpdActual, 1 );
 			EXPECT_NEAR( 2080, Ncomp, 1 );
+			EXPECT_EQ( Node( VRFTU( 1 ).VRFTUInletNodeNum ).MassFlowRate, 0.0 );
 		}
 
 	}


### PR DESCRIPTION
Pull request overview
---------------------
When a Fan:SystemModel object is used in VRF and the system is either off or within the Tstat deadband, the fan operates at full air flow rate. This change corrects #6336.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
