### PR TITLE
Fix time-stepping and exposed perimeter logic for Kiva foundations

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -16586,7 +16586,7 @@ SurfaceProperty:ExposedFoundationPerimeter,
   N1 , \field Total Exposed Perimeter
        \type real
        \units m
-       \minimum> 0.0
+       \minimum 0.0
   N2 , \field Exposed Perimeter Fraction
        \type real
        \units dimensionless

--- a/src/EnergyPlus/HeatBalanceKivaManager.cc
+++ b/src/EnergyPlus/HeatBalanceKivaManager.cc
@@ -1067,7 +1067,7 @@ void KivaManager::calcKivaInstances()
 	for ( auto& kv : kivaInstances ) {
 		auto& grnd = kv.ground;
 		kv.setBoundaryConditions();
-		grnd.calculate( kv.bcs,DataGlobals::MinutesPerTimeStep*60. );
+		grnd.calculate( kv.bcs, timestep);
 		grnd.calculateSurfaceAverages();
 		kv.reportKivaSurfaces();
 		if ( DataEnvironment::Month == 1 && DataEnvironment::DayOfMonth == 1 && DataGlobals::HourOfDay == 1 && DataGlobals::TimeStep == 1 ) {

--- a/src/EnergyPlus/HeatBalanceKivaManager.hh
+++ b/src/EnergyPlus/HeatBalanceKivaManager.hh
@@ -143,6 +143,7 @@ public:
 	FoundationKiva defaultFoundation;
 	std::vector<FoundationKiva> foundationInputs;
 	std::vector<KivaInstanceMap> kivaInstances;
+	Real64 timestep;
 
 
 

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -6006,7 +6006,7 @@ namespace SurfaceGeometry {
 		using ScheduleManager::GetScheduleIndex;
 		using NodeInputManager::GetOnlySingleNode;
 		using OutAirNodeManager::CheckOutAirNodeNumber;
-		
+
 		using DataSurfaces::TotSurfaces;
 		using DataSurfaces::Surface;
 		using DataSurfaces::TotSurfLocalEnv;
@@ -6117,7 +6117,7 @@ namespace SurfaceGeometry {
 		}
 		// Link surface properties to surface object
 		for ( SurfLoop = 1; SurfLoop <= TotSurfaces; ++SurfLoop ) {
-			for ( Loop = 1; Loop <= TotSurfLocalEnv; ++Loop ) {			
+			for ( Loop = 1; Loop <= TotSurfLocalEnv; ++Loop ) {
 				if ( SurfLocalEnvironment( Loop ).SurfPtr == SurfLoop ) {
 					if ( SurfLocalEnvironment( Loop ).OutdoorAirNodePtr != 0 ) {
 						Surface( SurfLoop ).HasLinkedOutAirNode = true;
@@ -8063,8 +8063,10 @@ namespace SurfaceGeometry {
 			if ( !lAlphaFieldBlanks( alpF ) ) {
 				if (SameString(cAlphaArgs( alpF ), "Hourly")) {
 					kivaManager.settings.timestepType = HeatBalanceKivaManager::KivaManager::Settings::HOURLY;
+					kivaManager.timestep = 3600.; // seconds
 				} else /* if (SameString(cAlphaArgs( alpF ), "Timestep")) */ {
 					kivaManager.settings.timestepType = HeatBalanceKivaManager::KivaManager::Settings::TIMESTEP;
+					kivaManager.timestep = DataGlobals::MinutesPerTimeStep*60.;
 				}
 			} alpF++;
 


### PR DESCRIPTION
Work completed under the Big Ladder Software Contribution License Agreement.

Pull request overview
---------------------
This addresses four issues related to Kiva. The first three issues occur when modeling Kiva foundations with exposed perimeter fraction less than 1.0:
1. Unnecessary limitation on total exposed perimeter input (can now equal zero).
1. Applies the correct weighting of exposed perimeter fraction to each wall section when multiple sections exist.
1. Use the individual wall constructions in each Kiva instance (previously just used the footing wall construction defined in the Foundation:Kiva object).

Some diffs are expected for files with basements/crawlspaces where the wall construction was different than the footing construction.

The final issue is related to the time-stepping in Kiva being locked into the zone timestep even when the kiva was being evaluated hourly. Now when evaluated hourly (as is the default) the ground will have a greater thermal mass effect. Big diffs are expected for all files where the [Simulation Timestep](http://bigladdersoftware.com/epx/docs/8-8/input-output-reference/group-advanced-surface-concepts.html#field-simulation-timestep) is set to "Hourly" or allowed to default.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
