### PR TITLE
Fix up PCM unit test problem

### DIFF
--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
@@ -158,6 +158,7 @@
 #include <EnergyPlus/OutputReportTabularAnnual.hh>
 #include <EnergyPlus/OutsideEnergySources.hh>
 #include <EnergyPlus/PackagedTerminalHeatPump.hh>
+#include <EnergyPlus/PhaseChangeModeling/HysteresisModel.hh>
 #include <EnergyPlus/Pipes.hh>
 #include <EnergyPlus/PlantCondLoopOperation.hh>
 #include <EnergyPlus/PlantChillers.hh>
@@ -353,6 +354,7 @@ namespace EnergyPlus {
 		HVACUnitarySystem::clear_state();
 		HVACVariableRefrigerantFlow::clear_state();
 		HybridModel::clear_state();
+		HysteresisPhaseChange::clear_state();
 		InputProcessor::clear_state();
 		IntegratedHeatPump::clear_state();
 		InternalHeatGains::clear_state();

--- a/tst/EnergyPlus/unit/HeatBalFiniteDiffManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalFiniteDiffManager.unit.cc
@@ -228,6 +228,11 @@ namespace EnergyPlus {
 		EXPECT_NEAR( 10187.3, newSpecificHeat, 0.1 );
 		EXPECT_NEAR( 2250, newDensity, 0.1 );
 		EXPECT_NEAR( 1.65, newThermalConductivity, 0.1 );
+		
+		// deallocate
+		SurfaceFD.deallocate();
+		
+
 	}
 
 }


### PR DESCRIPTION
@mjwitte Could you test this out on your setup where you were seeing the failing test?  I believe the main problem was that the PCM `clear_state` function was written but never actually added to the `EnergyPlusFixture` class.  I also added a deallocation to be thorough.