### PR TITLE
Include zone equipment in night cycle manager warmup reset and fix crash when no airloops present

### DIFF
--- a/src/EnergyPlus/SystemAvailabilityManager.cc
+++ b/src/EnergyPlus/SystemAvailabilityManager.cc
@@ -2168,13 +2168,13 @@ namespace SystemAvailabilityManager {
 		static Array1D_bool ZoneCompNCControlType;
 		int CyclingRunTimeControlType; 
 
-		// reset start/stop times at beginning of each day during warmup to prevent non-convergence due to rotating start times
-		if ( WarmupFlag && BeginDayFlag ) {
-			PriAirSysAvailMgr( PriAirSysNum ).StartTime = SimTimeSteps;
-			PriAirSysAvailMgr( PriAirSysNum ).StopTime = SimTimeSteps;
-		}
-
 		if ( present( ZoneEquipType ) ) {
+			if ( WarmupFlag && BeginDayFlag ) {
+				// reset start/stop times at beginning of each day during warmup to prevent non-convergence due to rotating start times
+				ZoneComp( ZoneEquipType ).ZoneCompAvailMgrs( CompNum ).StartTime = SimTimeSteps;
+				ZoneComp( ZoneEquipType ).ZoneCompAvailMgrs( CompNum ).StopTime = SimTimeSteps;
+			}
+
 			StartTime = ZoneComp( ZoneEquipType ).ZoneCompAvailMgrs( CompNum ).StartTime;
 			StopTime = ZoneComp( ZoneEquipType ).ZoneCompAvailMgrs( CompNum ).StopTime;
 			if (CalcNCycSysAvailMgr_OneTimeFlag) {
@@ -2182,6 +2182,12 @@ namespace SystemAvailabilityManager {
 				CalcNCycSysAvailMgr_OneTimeFlag = false;
 			}
 		} else {
+			if ( WarmupFlag && BeginDayFlag ) {
+				// reset start/stop times at beginning of each day during warmup to prevent non-convergence due to rotating start times
+				PriAirSysAvailMgr( PriAirSysNum ).StartTime = SimTimeSteps;
+				PriAirSysAvailMgr( PriAirSysNum ).StopTime = SimTimeSteps;
+			}
+
 			StartTime = PriAirSysAvailMgr( PriAirSysNum ).StartTime;
 			StopTime = PriAirSysAvailMgr( PriAirSysNum ).StopTime;
 		}

--- a/tst/EnergyPlus/unit/SystemAvailabilityManager.unit.cc
+++ b/tst/EnergyPlus/unit/SystemAvailabilityManager.unit.cc
@@ -659,6 +659,16 @@ TEST_F( EnergyPlusFixture, SysAvailManager_NightCycleZone_CalcNCycSysAvailMgr )
 	SystemAvailabilityManager::CalcNCycSysAvailMgr( SysAvailNum, PriAirSysNum, AvailStatus, ZoneEquipType, CompNum );
 	// check that the system is no action mode, zone air temp is outside T tolerance limits of 0.05, 25.04 < 25.0 + 0.05
 	EXPECT_EQ( DataHVACGlobals::NoAction, SystemAvailabilityManager::NCycSysAvailMgrData( 1 ).AvailStatus );
+
+	// Test cycle time reset at beginning of day during warmup
+	DataGlobals::WarmupFlag = true;
+	DataGlobals::BeginDayFlag = true;
+	DataGlobals::SimTimeSteps = 96;
+	SystemAvailabilityManager::CalcNCycSysAvailMgr( SysAvailNum, PriAirSysNum, AvailStatus, ZoneEquipType, CompNum );
+	EXPECT_EQ( DataHVACGlobals::NoAction, SystemAvailabilityManager::NCycSysAvailMgrData( 1 ).AvailStatus );
+	EXPECT_EQ( DataGlobals::SimTimeSteps, DataHVACGlobals::ZoneComp( 1 ).ZoneCompAvailMgrs( 1 ).StartTime );
+	EXPECT_EQ( DataGlobals::SimTimeSteps, DataHVACGlobals::ZoneComp( 1 ).ZoneCompAvailMgrs( 1 ).StopTime );
+
 }
 
 TEST_F( EnergyPlusFixture, SysAvailManager_NightCycleSys_CalcNCycSysAvailMgr )
@@ -786,5 +796,15 @@ TEST_F( EnergyPlusFixture, SysAvailManager_NightCycleSys_CalcNCycSysAvailMgr )
 	SystemAvailabilityManager::CalcNCycSysAvailMgr( SysAvailNum, PriAirSysNum, AvailStatus );
 	// Check that the system is no action mode, zone air temp is within T tolerance limits of 0.05, 25.04 < 25.0 + 0.05
 	EXPECT_EQ( DataHVACGlobals::NoAction, SystemAvailabilityManager::NCycSysAvailMgrData( 1 ).AvailStatus );
+
+	// Test cycle time reset at beginning of day during warmup
+	DataGlobals::WarmupFlag = true;
+	DataGlobals::BeginDayFlag = true;
+	DataGlobals::SimTimeSteps = 96;
+	SystemAvailabilityManager::CalcNCycSysAvailMgr( SysAvailNum, PriAirSysNum, AvailStatus );
+	EXPECT_EQ( DataHVACGlobals::NoAction, SystemAvailabilityManager::NCycSysAvailMgrData( 1 ).AvailStatus );
+	EXPECT_EQ( DataGlobals::SimTimeSteps, DataAirLoop::PriAirSysAvailMgr( PriAirSysNum ).StartTime );
+	EXPECT_EQ( DataGlobals::SimTimeSteps, DataAirLoop::PriAirSysAvailMgr( PriAirSysNum ).StopTime );
+
 }
 


### PR DESCRIPTION
Pull request overview
---------------------
Addresses #6370.  
A reset for night cycle start-stop times during warmup was added in #6285, but did not allow for the difference between availability manager data when applied to zone equipment vs air loops.  This resulted in an array bounds crash for simulations which applied the night cycle manager only to zone equipment (and possibly other combinations). This may result in small changes in warmup results when the night cycle manager is used for zone equipment.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
