### PR TITLE
Fix a typo that was making E+ crash on some OpenStudio-resources

### DIFF
--- a/src/EnergyPlus/RefrigeratedCase.cc
+++ b/src/EnergyPlus/RefrigeratedCase.cc
@@ -5096,7 +5096,7 @@ namespace RefrigeratedCase {
 				GetObjectItem( CurrentModuleObject, TransRefrigSysNum, Alphas, NumAlphas, Numbers, NumNumbers, IOStatus, lNumericBlanks, lAlphaBlanks, cAlphaFieldNames, cNumericFieldNames );
 				IsNotOK = false;
 				IsBlank = false;
-				VerifyName( Alphas( 1 ), TransSystem, RefrigSysNum - 1, IsNotOK, IsBlank, CurrentModuleObject + " Name" );
+				VerifyName( Alphas( 1 ), TransSystem, TransRefrigSysNum - 1, IsNotOK, IsBlank, CurrentModuleObject + " Name" );
 				if ( IsNotOK ) {
 					ShowSevereError( RoutineName + CurrentModuleObject + ", has an invalid or undefined " + cAlphaFieldNames( 1 ) + "=\"" + Alphas( 1 ) + "\"." );
 					if ( IsBlank ) Alphas( 1 ) = "xxxxx";


### PR DESCRIPTION
Pull request overview
---------------------

Running regression tests [here](https://github.com/NREL/OpenStudio-resources/blob/develop/model/simulationtests/refrigeration_system.rb) and  [here](https://github.com/NREL/OpenStudio-resources/blob/develop/model/simulationtests/refrigeration_system.osm) for OpenStudio, E+ was crashing (see backtrace below) on this line:

https://github.com/jmarrec/EnergyPlus/blob/develop/src/EnergyPlus/RefrigeratedCase.cc#L5099

This is just because it isn't the right int that's passed (a typo / copy-paste error)

### Work Checklist

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces


---- 

Bracktrace:

```
(lldb) 
Process 4203 stopped
* thread #1, name = 'energyplus', stop reason = step in
    frame #0: libenergyplusapi.so.8.8.0`ObjexxFCL::Array<EnergyPlus::RefrigeratedCase::TransRefrigSystemData>::operator[](this=0x00007ffff7db0860, i=1) const at Array.hh:1220
   1217		T const &
   1218		operator []( size_type const i ) const
   1219		{
-> 1220			assert( ( i < size_ ) || ( size_ == npos ) );
   1221			return data_[ i ];
   1222		}
   1223	
(lldb) 
Process 4203 stopped
* thread #1, name = 'energyplus', stop reason = step in
    frame #0: libc.so.6`__GI___assert_fail(assertion="( i < size_ ) || ( size_ == npos )", file="/home/julien/Software/Others/EnergyPlus/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh", line=1220, function="const T& ObjexxFCL::Array< <template-parameter-1-1> >::operator[](ObjexxFCL::BArray::size_type) const [with T = EnergyPlus::RefrigeratedCase::TransRefrigSystemData; ObjexxFCL::BArray::size_type = long unsigned int]") at assert.c:101
(lldb) 
Process 4203 stopped
* thread #1, name = 'energyplus', stop reason = step in
    frame #0: libc.so.6`__GI___assert_fail(assertion="( i < size_ ) || ( size_ == npos )", file="/home/julien/Software/Others/EnergyPlus/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh", line=1220, function="const T& ObjexxFCL::Array< <template-parameter-1-1> >::operator[](ObjexxFCL::BArray::size_type) const [with T = EnergyPlus::RefrigeratedCase::TransRefrigSystemData; ObjexxFCL::BArray::size_type = long unsigned int]") at assert.c:100
(lldb) bt
* thread #1, name = 'energyplus', stop reason = step in
  * frame #0: libc.so.6`__GI___assert_fail(assertion="( i < size_ ) || ( size_ == npos )", file="/home/julien/Software/Others/EnergyPlus/third_party/ObjexxFCL/src/ObjexxFCL/Array.hh", line=1220, function="const T& ObjexxFCL::Array< <template-parameter-1-1> >::operator[](ObjexxFCL::BArray::size_type) const [with T = EnergyPlus::RefrigeratedCase::TransRefrigSystemData; ObjexxFCL::BArray::size_type = long unsigned int]") at assert.c:100
    frame #1: libenergyplusapi.so.8.8.0`ObjexxFCL::Array<EnergyPlus::RefrigeratedCase::TransRefrigSystemData>::operator[](this=0x00007ffff7db0860, i=1) const at Array.hh:1220
    frame #2: libenergyplusapi.so.8.8.0`int EnergyPlus::InputProcessor::FindItemInList<ObjexxFCL::Array1D<EnergyPlus::RefrigeratedCase::TransRefrigSystemData>, void>(String="��", ListOfItems=0x00007ffff7db0860, NumItems=5) at InputProcessor.hh:564
    frame #3: libenergyplusapi.so.8.8.0`int EnergyPlus::InputProcessor::FindItem<ObjexxFCL::Array1D<EnergyPlus::RefrigeratedCase::TransRefrigSystemData>, void>(String="РW\x01"..., ListOfItems=0x00007ffff7db0860, NumItems=5) at InputProcessor.hh:792
    frame #4: libenergyplusapi.so.8.8.0`void EnergyPlus::InputProcessor::VerifyName<ObjexxFCL::Array1D<EnergyPlus::RefrigeratedCase::TransRefrigSystemData>, void>(NameToVerify="РW\x01", NamesList=0x00007ffff7db0860, NumOfNames=5, ErrorFound=0x00007ffff7db109c, IsBlank=0x00007ffff7db109d, StringToDisplay="p\xaaW\x01"...) at InputProcessor.hh:973
    frame #5: libenergyplusapi.so.8.8.0`EnergyPlus::RefrigeratedCase::GetRefrigerationInput() at RefrigeratedCase.cc:5099
    frame #6: libenergyplusapi.so.8.8.0`EnergyPlus::RefrigeratedCase::CheckRefrigerationInput() at RefrigeratedCase.cc:12001
    frame #7: libenergyplusapi.so.8.8.0`EnergyPlus::WaterThermalTanks::GetWaterThermalTankInputData(ErrorsFound=0x00007ffff7dc0900) at WaterThermalTanks.cc:1162
    frame #8: libenergyplusapi.so.8.8.0`EnergyPlus::WaterThermalTanks::GetWaterThermalTankInput() at WaterThermalTanks.cc:978
    frame #9: libenergyplusapi.so.8.8.0`EnergyPlus::WaterThermalTanks::CalcWaterThermalTankZoneGains() at WaterThermalTanks.cc:910
    frame #10: libenergyplusapi.so.8.8.0`EnergyPlus::InternalHeatGains::InitInternalHeatGains() at InternalHeatGains.cc:3693
    frame #11: libenergyplusapi.so.8.8.0`EnergyPlus::InternalHeatGains::ManageInternalHeatGains(InitOnly=ObjexxFCL::Optional_bool_const @ 0x00007fffffffbf50) at InternalHeatGains.cc:212
    frame #12: libenergyplusapi.so.8.8.0`EnergyPlus::HeatBalanceSurfaceManager::InitSurfaceHeatBalance() at HeatBalanceSurfaceManager.cc:739
    frame #13: libenergyplusapi.so.8.8.0`EnergyPlus::HeatBalanceSurfaceManager::ManageSurfaceHeatBalance() at HeatBalanceSurfaceManager.cc:272
    frame #14: libenergyplusapi.so.8.8.0`EnergyPlus::HeatBalanceManager::ManageHeatBalance() at HeatBalanceManager.cc:363
    frame #15: libenergyplusapi.so.8.8.0`EnergyPlus::SizingManager::SetupZoneSizing(ErrorsFound=0x00007ffff7d6bf8d) at SizingManager.cc:2739
    frame #16: libenergyplusapi.so.8.8.0`EnergyPlus::SizingManager::ManageSizing() at SizingManager.cc:301
    frame #17: libenergyplusapi.so.8.8.0`EnergyPlus::SimulationManager::ManageSimulation() at SimulationManager.cc:362
    frame #18: libenergyplusapi.so.8.8.0`EnergyPlusPgm(filepath="\x10����) at EnergyPlusPgm.cc:442
    frame #19: energyplus`main(argc=3, argv=0x00007fffffffe528) at main.cc:58
    frame #20: libc.so.6`__libc_start_main(main=(energyplus`main at main.cc:54), argc=3, argv=0x00007fffffffe528, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffe518) at libc-start.c:291
    frame #21: 0x00000000004014a9 energyplus`_start + 41
(lldb) exit
```