### PR TITLE
Use C++latest to get fallthrough

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -21,6 +21,7 @@ IF ( MSVC AND NOT ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" ) ) # Visual C++
     # Configuration Properties ->Debugging -> Environment, use drop-down list to choose <Edit> and type _NO_DEBUG_HEAP=1 then click OK
 
     # COMPILER FLAGS
+    ADD_CXX_DEFINITIONS("/std:c++latest")
     ADD_CXX_DEFINITIONS("/nologo")
     ADD_CXX_DEFINITIONS("/EHsc")
     ADD_CXX_DEFINITIONS("/MP") # Enables multi-processor compilation of source within a single project

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -21,7 +21,6 @@ IF ( MSVC AND NOT ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" ) ) # Visual C++
     # Configuration Properties ->Debugging -> Environment, use drop-down list to choose <Edit> and type _NO_DEBUG_HEAP=1 then click OK
 
     # COMPILER FLAGS
-    ADD_CXX_DEFINITIONS("/std:c++latest")
     ADD_CXX_DEFINITIONS("/nologo")
     ADD_CXX_DEFINITIONS("/EHsc")
     ADD_CXX_DEFINITIONS("/MP") # Enables multi-processor compilation of source within a single project

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -1823,7 +1823,7 @@ namespace General {
 							return zero_string;
 						}
 					}
-					[[fallthrough]];
+					// [[fallthrough]];
 				default:
 					return InputString.substr( 0, InputString.find_last_not_of( '0' ) + 1 );
 				}
@@ -1868,7 +1868,7 @@ namespace General {
 							break;
 						}
 					}
-					[[fallthrough]];
+					// [[fallthrough]];
 				default:
 					InputString.erase( pos + 1 );
 				}

--- a/src/EnergyPlus/PierceSurface.hh
+++ b/src/EnergyPlus/PierceSurface.hh
@@ -141,27 +141,27 @@ PierceSurface_Convex(
 		if ( es[ 7 ].cross( h2d - vs[ 7 ] ) < 0.0 ) {
 			return;
 		}
-		[[fallthrough]];
+		// [[fallthrough]];
 	case 7:
 		if ( es[ 6 ].cross( h2d - vs[ 6 ] ) < 0.0 ) {
 			return; 
 		}
-		[[fallthrough]];
+		// [[fallthrough]];
 	case 6:
 		if ( es[ 5 ].cross( h2d - vs[ 5 ] ) < 0.0 ) {
 			return; 
 		}
-		[[fallthrough]];
+		// [[fallthrough]];
 	case 5:
 		if ( es[ 4 ].cross( h2d - vs[ 4 ] ) < 0.0 ) {
 			return; 
 		}
-		[[fallthrough]];
+		// [[fallthrough]];
 	case 4:
 		if ( es[ 3 ].cross( h2d - vs[ 3 ] ) < 0.0 ) {
 			return; 
 		}
-		[[fallthrough]];
+		// [[fallthrough]];
 	case 3:
 		if ( es[ 2 ].cross( h2d - vs[ 2 ] ) < 0.0 ) {
 			return;

--- a/src/EnergyPlus/PlantPipingSystemsManager.cc
+++ b/src/EnergyPlus/PlantPipingSystemsManager.cc
@@ -3945,7 +3945,7 @@ namespace PlantPipingSystemsManager {
 						break;
 					case CellType::Unknown:
 						cellType = CellType::GeneralField;
-						[[fallthrough]];
+						// [[fallthrough]];
 					default:
 						++TotNumCells;
 					}


### PR DESCRIPTION
Pull request overview
---------------------
Adding the [[fallthrough]] attribute cleaned up some compiler warnings with some compilers, but Windows decided to (?sometimes?) complain about it.  CI seems happy with it, but other developers are seeing errors.  This PR adds a c++latest compiler flag declaration that fixes the issue.
 