### PR TITLE
Eliminate fallthrough warnings on new GCC

### DIFF
--- a/src/EnergyPlus/EnergyPlus.hh
+++ b/src/EnergyPlus/EnergyPlus.hh
@@ -59,6 +59,13 @@
 // UNUSED( foo );
 #define EP_UNUSED( expr )
 
+// macro to suppress fallthrough warnings on switch statements
+#ifdef __GNUC__
+  #define ATTR_FALLTHROUGH __attribute__((fallthrough))
+#else
+  #define ATTR_FALLTHROUGH
+#endif
+
 // ObjexxFCL
 namespace ObjexxFCL {
 namespace fmt {

--- a/src/EnergyPlus/EnergyPlus.hh
+++ b/src/EnergyPlus/EnergyPlus.hh
@@ -59,13 +59,6 @@
 // UNUSED( foo );
 #define EP_UNUSED( expr )
 
-// macro to suppress fallthrough warnings on switch statements
-#ifdef __GNUC__
-  #define ATTR_FALLTHROUGH __attribute__((fallthrough))
-#else
-  #define ATTR_FALLTHROUGH
-#endif
-
 // ObjexxFCL
 namespace ObjexxFCL {
 namespace fmt {

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -1823,7 +1823,7 @@ namespace General {
 							return zero_string;
 						}
 					}
-					ATTR_FALLTHROUGH;
+					// fallthrough
 				default:
 					return InputString.substr( 0, InputString.find_last_not_of( '0' ) + 1 );
 				}
@@ -1868,7 +1868,7 @@ namespace General {
 							break;
 						}
 					}
-					ATTR_FALLTHROUGH;
+					// fallthrough
 				default:
 					InputString.erase( pos + 1 );
 				}
@@ -2521,7 +2521,7 @@ namespace General {
 
 	}
 
-	// returns the Julian date for the first, second, etc. day of week for a given month 
+	// returns the Julian date for the first, second, etc. day of week for a given month
 	int
 	nthDayOfWeekOfMonth(
 		int const & dayOfWeek, // day of week (Sunday=1, Monday=2, ...)

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -1823,7 +1823,7 @@ namespace General {
 							return zero_string;
 						}
 					}
-					// [[fallthrough]];
+					ATTR_FALLTHROUGH;
 				default:
 					return InputString.substr( 0, InputString.find_last_not_of( '0' ) + 1 );
 				}
@@ -1868,7 +1868,7 @@ namespace General {
 							break;
 						}
 					}
-					// [[fallthrough]];
+					ATTR_FALLTHROUGH;
 				default:
 					InputString.erase( pos + 1 );
 				}

--- a/src/EnergyPlus/PierceSurface.hh
+++ b/src/EnergyPlus/PierceSurface.hh
@@ -141,27 +141,27 @@ PierceSurface_Convex(
 		if ( es[ 7 ].cross( h2d - vs[ 7 ] ) < 0.0 ) {
 			return;
 		}
-		// [[fallthrough]];
+		ATTR_FALLTHROUGH;
 	case 7:
 		if ( es[ 6 ].cross( h2d - vs[ 6 ] ) < 0.0 ) {
 			return; 
 		}
-		// [[fallthrough]];
+		ATTR_FALLTHROUGH;
 	case 6:
 		if ( es[ 5 ].cross( h2d - vs[ 5 ] ) < 0.0 ) {
 			return; 
 		}
-		// [[fallthrough]];
+		ATTR_FALLTHROUGH;
 	case 5:
 		if ( es[ 4 ].cross( h2d - vs[ 4 ] ) < 0.0 ) {
 			return; 
 		}
-		// [[fallthrough]];
+		ATTR_FALLTHROUGH;
 	case 4:
 		if ( es[ 3 ].cross( h2d - vs[ 3 ] ) < 0.0 ) {
 			return; 
 		}
-		// [[fallthrough]];
+		ATTR_FALLTHROUGH;
 	case 3:
 		if ( es[ 2 ].cross( h2d - vs[ 2 ] ) < 0.0 ) {
 			return;

--- a/src/EnergyPlus/PierceSurface.hh
+++ b/src/EnergyPlus/PierceSurface.hh
@@ -141,27 +141,27 @@ PierceSurface_Convex(
 		if ( es[ 7 ].cross( h2d - vs[ 7 ] ) < 0.0 ) {
 			return;
 		}
-		ATTR_FALLTHROUGH;
+		// fallthrough
 	case 7:
 		if ( es[ 6 ].cross( h2d - vs[ 6 ] ) < 0.0 ) {
-			return; 
+			return;
 		}
-		ATTR_FALLTHROUGH;
+		// fallthrough
 	case 6:
 		if ( es[ 5 ].cross( h2d - vs[ 5 ] ) < 0.0 ) {
-			return; 
+			return;
 		}
-		ATTR_FALLTHROUGH;
+		// fallthrough
 	case 5:
 		if ( es[ 4 ].cross( h2d - vs[ 4 ] ) < 0.0 ) {
-			return; 
+			return;
 		}
-		ATTR_FALLTHROUGH;
+		// fallthrough
 	case 4:
 		if ( es[ 3 ].cross( h2d - vs[ 3 ] ) < 0.0 ) {
-			return; 
+			return;
 		}
-		ATTR_FALLTHROUGH;
+		// fallthrough
 	case 3:
 		if ( es[ 2 ].cross( h2d - vs[ 2 ] ) < 0.0 ) {
 			return;

--- a/src/EnergyPlus/PlantPipingSystemsManager.cc
+++ b/src/EnergyPlus/PlantPipingSystemsManager.cc
@@ -3855,7 +3855,7 @@ namespace PlantPipingSystemsManager {
 						break;
 					case CellType::Unknown:
 						cellType = CellType::GeneralField;
-						ATTR_FALLTHROUGH;
+						// fallthrough
 					default:
 						++TotNumCells;
 					}

--- a/src/EnergyPlus/PlantPipingSystemsManager.cc
+++ b/src/EnergyPlus/PlantPipingSystemsManager.cc
@@ -3855,7 +3855,7 @@ namespace PlantPipingSystemsManager {
 						break;
 					case CellType::Unknown:
 						cellType = CellType::GeneralField;
-						// [[fallthrough]];
+						ATTR_FALLTHROUGH;
 					default:
 						++TotNumCells;
 					}


### PR DESCRIPTION
Pull request overview
---------------------
Trying another approach to get rid of the switch block fallthrough warnings on new GCC.  This should be more robust on different versions and platforms because I protect it in a #define for GCC only.

