### PR TITLE
Output Variable Parser Fix

### DIFF
--- a/src/EnergyPlus/IntegratedHeatPump.cc
+++ b/src/EnergyPlus/IntegratedHeatPump.cc
@@ -876,7 +876,7 @@ namespace IntegratedHeatPump {
             // set up output variables, not reported in the individual coil models
 
             //				TODO: Figure out how to get enum class to work with SetupOutputVariable
-            //				SetupOutputVariable( "Operation Mode []",
+            //				Setup Output Variable( "Operation Mode []",
             //				                     static_cast< int >( IntegratedHeatPumps( DXCoilNum ).CurMode ),
             //				                     "System", "Average",
             //				                     IntegratedHeatPumps( DXCoilNum ).Name );

--- a/src/EnergyPlus/WeatherManager.cc
+++ b/src/EnergyPlus/WeatherManager.cc
@@ -830,7 +830,7 @@ namespace WeatherManager {
 
             ReportOutputFileHeaders(); // Write the output file header information
 
-            // SetupOutputVariables, CurrentModuleObject='All Simulations'
+            // Setup Output Variables, CurrentModuleObject='All Simulations'
 
             SetupOutputVariable("Site Outdoor Air Drybulb Temperature", OutputProcessor::Unit::C, OutDryBulbTemp, "Zone", "Average", "Environment");
             SetupOutputVariable("Site Outdoor Air Dewpoint Temperature", OutputProcessor::Unit::C, OutDewPointTemp, "Zone", "Average", "Environment");


### PR DESCRIPTION
Pull request overview
---------------------
With the style change after 8.9.0, the script that parses the SetupOutputVariable calls no longer functioned well.  I modified it to match by regex instead of line-by-line parsing.  It works really well now.  I didn't take the time to have the regex ignore commented SetupOutputVariable calls, so instead, I first check for any commented ones and warn the developer about it, then I go find all of them.  I am open to improving that if someone has the burning desire to make the regex match more robust.

To test this fix, just make a tag of it and see if CI is successful at packaging.  Currently it [fails](http://nrel.github.io/EnergyPlusBuildResults/EnergyPlus-v8.9.0-PlusStyle-i386-Windows-7-VisualStudio-14.html#package).