### PR TITLE
Set multiple CO2 controllers correctly

### DIFF
--- a/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
@@ -156,6 +156,8 @@ namespace ZoneContaminantPredictorCorrector {
         TotGCBLDiff = 0;
         TotGCDVS = 0;
         TotGCDRS = 0;
+        Contaminant.CO2Simulation = false;
+        Contaminant.GenericContamSimulation = false;
     }
 
     void ManageZoneContaminanUpdates(int const UpdateType, // Can be iGetZoneSetPoints, iPredictStep, iCorrectStep

--- a/tst/EnergyPlus/unit/ZoneContaminantPredictorCorrector.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneContaminantPredictorCorrector.unit.cc
@@ -390,3 +390,220 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_CorrectZoneContamina
     DataContaminantBalance::Contaminant.CO2Simulation = false;
     DataContaminantBalance::Contaminant.GenericContamSimulation = false;
 }
+
+TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneCO2ControlTest)
+{
+
+    ShortenTimeStepSys = false;
+    UseZoneTimeStepHistory = false;
+
+    ZoneAirHumRat.allocate(3);
+    ZT.allocate(3);
+    MixingMassFlowZone.allocate(3);
+
+    DataGlobals::NumOfZones = 3;
+    DataContaminantBalance::Contaminant.CO2Simulation = true;
+ 
+    DataContaminantBalance::AZ.allocate(3);
+    DataContaminantBalance::BZ.allocate(3);
+    DataContaminantBalance::CZ.allocate(3);
+
+    DataContaminantBalance::CO2ZoneTimeMinus1Temp.allocate(3);
+    DataContaminantBalance::CO2ZoneTimeMinus2Temp.allocate(3);
+    DataContaminantBalance::CO2ZoneTimeMinus3Temp.allocate(3);
+    DataContaminantBalance::DSCO2ZoneTimeMinus1.allocate(3);
+    DataContaminantBalance::DSCO2ZoneTimeMinus2.allocate(3);
+    DataContaminantBalance::DSCO2ZoneTimeMinus3.allocate(3);
+    DataContaminantBalance::GCZoneTimeMinus1Temp.allocate(3);
+    DataContaminantBalance::GCZoneTimeMinus2Temp.allocate(3);
+    DataContaminantBalance::GCZoneTimeMinus3Temp.allocate(3);
+    DataContaminantBalance::DSGCZoneTimeMinus1.allocate(3);
+    DataContaminantBalance::DSGCZoneTimeMinus2.allocate(3);
+    DataContaminantBalance::DSGCZoneTimeMinus3.allocate(3);
+
+    DataContaminantBalance::MixingMassFlowCO2.allocate(3);
+    DataContaminantBalance::MixingMassFlowGC.allocate(3);
+    DataContaminantBalance::ZoneAirCO2Temp.allocate(3);
+    DataContaminantBalance::ZoneCO21.allocate(3);
+    DataContaminantBalance::ZoneAirCO2.allocate(3);
+    DataContaminantBalance::ZoneAirGCTemp.allocate(3);
+
+    DataContaminantBalance::ZoneCO2SetPoint.allocate(3);
+    DataContaminantBalance::CO2PredictedRate.allocate(3);
+
+    DataContaminantBalance::ZoneAirDensityCO.allocate(3);
+    DataContaminantBalance::ZoneCO2Gain.allocate(3);
+    DataContaminantBalance::ZoneGCGain.allocate(3);
+    DataContaminantBalance::ZoneCO2Gain(1) = 0.0001;
+    DataContaminantBalance::ZoneCO2Gain(2) = 0.0002;
+    DataContaminantBalance::ZoneCO2Gain(3) = 0.0003;
+    DataContaminantBalance::MixingMassFlowCO2(1) = 0.0;
+    DataContaminantBalance::MixingMassFlowCO2(2) = 0.0;
+    DataContaminantBalance::MixingMassFlowCO2(3) = 0.0;
+
+    DataContaminantBalance::DSCO2ZoneTimeMinus1(1) = 200.0;
+    DataContaminantBalance::DSCO2ZoneTimeMinus2(1) = 200.0;
+    DataContaminantBalance::DSCO2ZoneTimeMinus3(1) = 200.0;
+    DataContaminantBalance::DSCO2ZoneTimeMinus1(2) = 200.0;
+    DataContaminantBalance::DSCO2ZoneTimeMinus2(2) = 200.0;
+    DataContaminantBalance::DSCO2ZoneTimeMinus3(2) = 200.0;
+    DataContaminantBalance::DSCO2ZoneTimeMinus1(3) = 200.0;
+    DataContaminantBalance::DSCO2ZoneTimeMinus2(3) = 200.0;
+    DataContaminantBalance::DSCO2ZoneTimeMinus3(3) = 200.0;
+    DataContaminantBalance::OutdoorCO2 = 400.0;
+    DataContaminantBalance::ZoneCO21(1) = DataContaminantBalance::OutdoorCO2;
+    DataContaminantBalance::ZoneCO21(2) = DataContaminantBalance::OutdoorCO2;
+    DataContaminantBalance::ZoneCO21(3) = DataContaminantBalance::OutdoorCO2;
+    DataContaminantBalance::ZoneCO2SetPoint(1) = 450.0;
+    DataContaminantBalance::ZoneCO2SetPoint(2) = 500.0;
+    DataContaminantBalance::ZoneCO2SetPoint(3) = 550.0;
+    DataContaminantBalance::ZoneAirCO2(1) = DataContaminantBalance::ZoneCO21(1);
+    DataContaminantBalance::ZoneAirCO2(2) = DataContaminantBalance::ZoneCO21(2);
+    DataContaminantBalance::ZoneAirCO2(3) = DataContaminantBalance::ZoneCO21(3);
+
+    Real64 PriorTimeStep;
+
+    TimeStepSys = 15.0 / 60.0; // System timestep in hours
+    PriorTimeStep = TimeStepSys;
+
+    ZoneEquipConfig.allocate(3);
+    ZoneEquipConfig(1).ZoneName = "Zone 1";
+    ZoneEquipConfig(1).ActualZoneNum = 1;
+
+    ZoneEquipConfig(1).NumInletNodes = 2;
+    ZoneEquipConfig(1).InletNode.allocate(2);
+    ZoneEquipConfig(1).InletNode(1) = 1;
+    ZoneEquipConfig(1).InletNode(2) = 2;
+    ZoneEquipConfig(1).NumExhaustNodes = 1;
+    ZoneEquipConfig(1).ExhaustNode.allocate(1);
+    ZoneEquipConfig(1).ExhaustNode(1) = 3;
+    ZoneEquipConfig(1).NumReturnNodes = 1;
+    ZoneEquipConfig(1).ReturnNode.allocate(1);
+    ZoneEquipConfig(1).ReturnNode(1) = 4;
+
+    ZoneEquipConfig(2).ZoneName = "Zone 2";
+    ZoneEquipConfig(2).ActualZoneNum = 2;
+
+    ZoneEquipConfig(2).NumInletNodes = 1;
+    ZoneEquipConfig(2).InletNode.allocate(1);
+    ZoneEquipConfig(2).InletNode(1) = 6;
+    ZoneEquipConfig(2).NumExhaustNodes = 0;
+    ZoneEquipConfig(2).NumReturnNodes = 1;
+    ZoneEquipConfig(2).ReturnNode.allocate(1);
+    ZoneEquipConfig(2).ReturnNode(1) = 7;
+
+    ZoneEquipConfig(3).ZoneName = "Zone 3";
+    ZoneEquipConfig(3).ActualZoneNum = 3;
+
+    ZoneEquipConfig(3).NumInletNodes = 1;
+    ZoneEquipConfig(3).InletNode.allocate(1);
+    ZoneEquipConfig(3).InletNode(1) = 8;
+    ZoneEquipConfig(3).NumExhaustNodes = 0;
+    ZoneEquipConfig(3).NumReturnNodes = 1;
+    ZoneEquipConfig(3).ReturnNode.allocate(1);
+    ZoneEquipConfig(3).ReturnNode(1) = 9;
+
+    Node.allocate(10);
+
+    Zone.allocate(3);
+    Zone(1).Name = ZoneEquipConfig(1).ZoneName;
+    Zone(1).ZoneEqNum = 1;
+    ZoneEqSizing.allocate(3);
+    CurZoneEqNum = 1;
+    Zone(1).Multiplier = 1.0;
+    Zone(1).Volume = 1000.0;
+    Zone(1).SystemZoneNodeNumber = 5;
+    Zone(1).ZoneVolCapMultpMoist = 1.0;
+    Zone(2).Name = ZoneEquipConfig(2).ZoneName;
+    Zone(2).ZoneEqNum = 1;
+    Zone(2).Multiplier = 1.0;
+    Zone(2).Volume = 1000.0;
+    Zone(2).SystemZoneNodeNumber = 5;
+    Zone(2).ZoneVolCapMultpMoist = 1.0;
+    Zone(3).Name = ZoneEquipConfig(3).ZoneName;
+    Zone(3).ZoneEqNum = 1;
+    Zone(3).Multiplier = 1.0;
+    Zone(3).Volume = 1000.0;
+    Zone(3).SystemZoneNodeNumber = 5;
+    Zone(3).ZoneVolCapMultpMoist = 1.0;
+
+    OutBaroPress = 101325.0;
+
+    NumZoneReturnPlenums = 0;
+    NumZoneSupplyPlenums = 0;
+
+    OAMFL.allocate(3);
+    VAMFL.allocate(3);
+    EAMFL.allocate(3);
+    CTMFL.allocate(3);
+    MDotOA.allocate(3);
+    MDotOA = 0.001;
+    ScheduleManager::Schedule.allocate(1);
+
+    ScheduleManager::Schedule(1).CurrentValue = 1.0;
+
+    SimulateAirflowNetwork = 0;
+
+    ZoneAirSolutionAlgo = UseEulerMethod;
+
+    Node(1).MassFlowRate = 0.01; // Zone inlet node 1
+    Node(1).HumRat = 0.008;
+    Node(2).MassFlowRate = 0.02; // Zone inlet node 2
+    Node(2).HumRat = 0.008;
+    ZoneEquipConfig(1).ZoneExhBalanced = 0.0;
+    Node(3).MassFlowRate = 0.00; // Zone exhaust node 1
+    ZoneEquipConfig(1).ZoneExh = Node(3).MassFlowRate;
+    Node(3).HumRat = 0.008;
+    Node(4).MassFlowRate = 0.03; // Zone return node
+    Node(4).HumRat = 0.000;
+    Node(5).HumRat = 0.000;
+    OAMFL(1) = 0.0;
+    VAMFL(1) = 0.0;
+    EAMFL(1) = 0.0;
+    CTMFL(1) = 0.0;
+    OAMFL(2) = 0.0;
+    VAMFL(2) = 0.0;
+    EAMFL(2) = 0.0;
+    CTMFL(2) = 0.0;
+    OAMFL(3) = 0.0;
+    VAMFL(3) = 0.0;
+    EAMFL(3) = 0.0;
+    CTMFL(3) = 0.0;
+    ZoneAirHumRat(1) = 0.008;
+    ZT(1) = 24.0;
+    ZoneAirHumRat(2) = 0.008;
+    ZT(2) = 23.5;
+    ZoneAirHumRat(3) = 0.008;
+    ZT(3) = 24.5;
+    MixingMassFlowZone = 0.0;
+
+    Node(6).MassFlowRate = 0.01; 
+    Node(7).MassFlowRate = 0.01;
+    Node(8).MassFlowRate = 0.01;
+    Node(9).MassFlowRate = 0.01;
+
+
+    DataContaminantBalance::CO2PredictedRate.allocate(3);
+    DataContaminantBalance::ZoneSysContDemand.allocate(3);
+    DataContaminantBalance::NumContControlledZones = 3;
+
+    DataContaminantBalance::ContaminantControlledZone.allocate(3);
+
+    DataContaminantBalance::ContaminantControlledZone(1).AvaiSchedPtr = 1;
+    DataContaminantBalance::ContaminantControlledZone(1).ActualZoneNum = 1;
+    DataContaminantBalance::ContaminantControlledZone(1).NumOfZones = 1;
+    DataContaminantBalance::ContaminantControlledZone(2).AvaiSchedPtr = 1;
+    DataContaminantBalance::ContaminantControlledZone(2).ActualZoneNum = 2;
+    DataContaminantBalance::ContaminantControlledZone(2).NumOfZones = 1;
+    DataContaminantBalance::ContaminantControlledZone(3).AvaiSchedPtr = 1;
+    DataContaminantBalance::ContaminantControlledZone(3).ActualZoneNum = 3;
+    DataContaminantBalance::ContaminantControlledZone(3).NumOfZones = 1;
+
+    PredictZoneContaminants(ShortenTimeStepSys, UseZoneTimeStepHistory, PriorTimeStep);
+    EXPECT_NEAR(1.0416921806, DataContaminantBalance::CO2PredictedRate(1), 0.00001);
+    EXPECT_NEAR(1.0434496257, DataContaminantBalance::CO2PredictedRate(2), 0.00001);
+    EXPECT_NEAR(1.0399406399, DataContaminantBalance::CO2PredictedRate(3), 0.00001);
+
+    DataContaminantBalance::Contaminant.CO2Simulation = false;
+    DataContaminantBalance::Contaminant.GenericContamSimulation = false;
+}

--- a/tst/EnergyPlus/unit/ZoneContaminantPredictorCorrector.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneContaminantPredictorCorrector.unit.cc
@@ -604,6 +604,4 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneCO2ControlT
     EXPECT_NEAR(1.0434496257, DataContaminantBalance::CO2PredictedRate(2), 0.00001);
     EXPECT_NEAR(1.0399406399, DataContaminantBalance::CO2PredictedRate(3), 0.00001);
 
-    DataContaminantBalance::Contaminant.CO2Simulation = false;
-    DataContaminantBalance::Contaminant.GenericContamSimulation = false;
 }


### PR DESCRIPTION
Pull request overview
---------------------
The fix set multiple CO2 controllers correctly and predict required OA rates based on its own setpoint.  
### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
