### PR TITLE
EMPD model moisture sorption curve slope equation is incorrrect

### DIFF
--- a/doc/engineering-reference/src/surface-heat-balance-manager-processes/effective-moisture-penetration-depth-empd.tex
+++ b/doc/engineering-reference/src/surface-heat-balance-manager-processes/effective-moisture-penetration-depth-empd.tex
@@ -97,7 +97,7 @@ R_{MT,2} = \frac {d_{EMPD,1} + d_{EMPD,2}} {2 \bar R_{water} T \delta_{perm} }
 These moisture fluxes are used to update the moisture content (or equivalent RH, \(\phi\) of each layer:
 
 \begin{equation}
-\phi_{1}(t) = \phi_{1}(t-\delta t) - \frac { (j_{zone} + j_{2}) \cdot TimeStep} {\rho_{matl} d_{EMPD,2} \frac {du}{d\phi}}
+\phi_{1}(t) = \phi_{1}(t-\delta t) - \frac { (j_{zone} + j_{2}) \cdot TimeStep} {\rho_{matl} d_{EMPD,1} \frac {du}{d\phi}}
 \end{equation}
 
 \begin{equation}
@@ -115,11 +115,11 @@ $\frac {du}{d\phi}$ = slope of moisture curve (change in moisture content / chan
 The equivalent RH and equivalent vapor density are related with:
 
 \begin{equation}
-\rho_{v,1} = \frac {\phi_{1} P_{sat}(T)} {\bar R_{water}}
+\rho_{v,1} = \frac {\phi_{1} P_{sat}(T)} {\bar R_{water} T}
 \end{equation}
 
 \begin{equation}
-\rho_{v,2} = \frac {\phi_{2} P_{sat}(T)} {\bar R_{water}}
+\rho_{v,2} = \frac {\phi_{2} P_{sat}(T)} {\bar R_{water} T}
 \end{equation}
 
 The zone flux is used, along with the area of the particular surface, to update the zone humidity ratio, as discussed in \ref{moisture-predictor-corrector}.
@@ -139,7 +139,7 @@ For further information on the EMPD model, see References below.
   A  &= \text{surface area} \RB{m^{2}} \\
   d &= \text{penetration depth} \RB{m} \\
   j &= \text{water mass flux} \RB{\frac{kg}{m^{2} \cdot s}} \\
-  \bar R_{water} &= \text{universal gas constant for water,} \; 452.61 \RB{\frac{J}{kg \cdot K}}   \\
+  \bar R_{water} &= \text{universal gas constant for water,} \; 461.52 \RB{\frac{J}{kg \cdot K}}   \\
   R_{MT} &= \text{Mass transfer resistance} \RB{s/m} \\
   T &= \text{temperature} \RB{K} \\
   u &= \text{moisture content} \RB{\frac{kg}{kg}}

--- a/src/EnergyPlus/MoistureBalanceEMPDManager.cc
+++ b/src/EnergyPlus/MoistureBalanceEMPDManager.cc
@@ -558,7 +558,7 @@ namespace MoistureBalanceEMPDManager {
 
         // Calculate slope of moisture sorption curve at current RH. [kg/kg-RH]
         dU_dRH = material.MoistACoeff * material.MoistBCoeff * pow(RHaver, material.MoistBCoeff - 1) +
-                 material.MoistCCoeff * material.MoistCCoeff * material.MoistDCoeff * pow(RHaver, material.MoistDCoeff - 1);
+                 material.MoistCCoeff * material.MoistDCoeff * pow(RHaver, material.MoistDCoeff - 1);
 
         // Convert vapor density and temperature of zone air to RH
         RHZone = rho_vapor_air_in * 461.52 * (TempZone + KelvinConv) * std::exp(-23.7093 + 4111.0 / ((TempZone + KelvinConv) - 35.45));


### PR DESCRIPTION
Issue #6634 

Pull request overview
---------------------
EMPD model du_dRH calculation equation has duplicate "material.MoistCCoeff" term. This is defect. Removed the duplicate coefficient and also corrected equations in engineering reference. There are two EMPD model example files (1ZoneUncontrolledFourAlgorithms.idf and EMPD5ZoneWaterCooled_HighRHControl.idf) that affected by this fix.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [x] Unit Test(s)
 - [x] Documentation changes in place
 - [x] Changed docs build successfully

