### PR TITLE
Minimum OA dry bulb is not properly processed

### DIFF
--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -2633,6 +2633,11 @@ namespace DXCoils {
             DXCoil(DXCoilNum).RatedSHR2 = Numbers(7);
             DXCoil(DXCoilNum).RatedCOP2 = Numbers(8);
             DXCoil(DXCoilNum).RatedAirVolFlowRate2 = Numbers(9);
+            if (lNumericBlanks(10)) {
+                DXCoil(DXCoilNum).MinOATCompressor = -25.0;
+            } else {
+                DXCoil(DXCoilNum).MinOATCompressor = Numbers(10);
+            }
 
             DXCoil(DXCoilNum).CCapFTemp2 = GetCurveIndex(Alphas(10)); // convert curve name to number
             if (DXCoil(DXCoilNum).CCapFTemp2 == 0) {

--- a/tst/EnergyPlus/unit/DXCoils.unit.cc
+++ b/tst/EnergyPlus/unit/DXCoils.unit.cc
@@ -1951,4 +1951,116 @@ TEST_F(EnergyPlusFixture, CoilHeatingDXSingleSpeed_MinOADBTempCompOperLimit)
     ASSERT_EQ("HEATING COIL SINGLESPEED", DXCoil(1).Name); // Heating Coil Single Speed
     ASSERT_EQ(-30.0, DXCoil(1).MinOATCompressor);          // removed the minimum limit of -20.0C
 }
+
+TEST_F(EnergyPlusFixture, CoilCoolingDXTwoSpeed_MinOADBTempCompOperLimit)
+{
+
+    // tests minimum limits of Minimum Outdoor Drybulb Temperature for Compressor Operation #6507
+
+    std::string const idf_objects = delimited_string({
+
+        "  Version,8.9;",
+
+        "  Schedule:Compact,",
+        "    FanAvailSched,           !- Name",
+        "    Fraction,                !- Schedule Type Limits Name",
+        "    Through: 12/31,          !- Field 1",
+        "    For: AllDays,            !- Field 2",
+        "    Until: 24:00,1.0;        !- Field 3",
+
+        "  Curve:Biquadratic,",
+        "    WindACCoolCapFT,         !- Name",
+        "    0.942587793,             !- Coefficient1 Constant",
+        "  0.009543347,             !- Coefficient2 x",
+        "  0.000683770,             !- Coefficient3 x**2",
+        "  -0.011042676,            !- Coefficient4 y",
+        "  0.000005249,             !- Coefficient5 y**2",
+        "  -0.000009720,            !- Coefficient6 x*y",
+        "  12.77778,                !- Minimum Value of x",
+        "  23.88889,                !- Maximum Value of x",
+        "  23.88889,                !- Minimum Value of y",
+        "  46.11111,                !- Maximum Value of y",
+        "  ,                        !- Minimum Curve Output",
+        "  ,                        !- Maximum Curve Output",
+        "  Temperature,             !- Input Unit Type for X",
+        "  Temperature,             !- Input Unit Type for Y",
+        "  Dimensionless;           !- Output Unit Type",
+
+        "  Curve:Cubic,",
+        "    RATED - CCAP - FFLOW,          !- Name",
+        "    0.84,                    !- Coefficient1 Constant",
+        "    0.16,                    !- Coefficient2 x",
+        "    0.0,                     !- Coefficient3 x**2",
+        "    0.0,                     !- Coefficient4 x**3",
+        "    0.5,                     !- Minimum Value of x",
+        "    1.5;                     !- Maximum Value of x",
+
+        "  Curve:Biquadratic,",
+        "    WindACEIRFT,         !- Name",
+        "    0.942587793,             !- Coefficient1 Constant",
+        "  0.009543347,             !- Coefficient2 x",
+        "  0.000683770,             !- Coefficient3 x**2",
+        "  -0.011042676,            !- Coefficient4 y",
+        "  0.000005249,             !- Coefficient5 y**2",
+        "  -0.000009720,            !- Coefficient6 x*y",
+        "  12.77778,                !- Minimum Value of x",
+        "  23.88889,                !- Maximum Value of x",
+        "  23.88889,                !- Minimum Value of y",
+        "  46.11111,                !- Maximum Value of y",
+        "  ,                        !- Minimum Curve Output",
+        "  ,                        !- Maximum Curve Output",
+        "  Temperature,             !- Input Unit Type for X",
+        "  Temperature,             !- Input Unit Type for Y",
+        "  Dimensionless;           !- Output Unit Type",
+
+        "  Curve:Quadratic,",
+        "    RATED - CEIR - FFLOW,          !- Name",
+        "    1.3824,                  !- Coefficient1 Constant",
+        "    -0.4336,                 !- Coefficient2 x",
+        "    0.0512,                  !- Coefficient3 x**2",
+        "    0.0,                     !- Minimum Value of x",
+        "    1.0;                     !- Maximum Value of x",
+
+        "  Curve:Quadratic,",
+        "    WindACPLFFPLR,         !- Name",
+        "    0.75,                    !- Coefficient1 Constant",
+        "    0.25,                    !- Coefficient2 x",
+        "    0.0,                     !- Coefficient3 x**2",
+        "    0.0,                     !- Minimum Value of x",
+        "    1.0;                     !- Maximum Value of x",
+
+        "  Coil:Cooling:DX:TwoSpeed,",
+        "    Main Cooling Coil 1,     !- Name",
+        "    FanAvailSched,   !- Availability Schedule Name",
+        "    autosize,                !- High Speed Gross Rated Total Cooling Capacity{ W }",
+        "    0.8,                     !- High Speed Rated Sensible Heat Ratio",
+        "    3.0,                     !- High Speed Gross Rated Cooling COP{ W / W }",
+        "    autosize,                !- High Speed Rated Air Flow Rate{ m3 / s }",
+        "    ,                        !- Unit Internal Static Air Pressure{ Pa }",
+        "    Mixed Air Node 1,        !- Air Inlet Node Name",
+        "    Main Cooling Coil 1 Outlet Node,  !- Air Outlet Node Name",
+        "    WindACCoolCapFT,         !- Total Cooling Capacity Function of Temperature Curve Name",
+        "    RATED - CCAP - FFLOW,        !- Total Cooling Capacity Function of Flow Fraction Curve Name",
+        "    WindACEIRFT,             !- Energy Input Ratio Function of Temperature Curve Name",
+        "    RATED - CEIR - FFLOW,        !- Energy Input Ratio Function of Flow Fraction Curve Name",
+        "    WindACPLFFPLR,           !- Part Load Fraction Correlation Curve Name",
+        "    autosize,                !- Low Speed Gross Rated Total Cooling Capacity{ W }",
+        "    0.8,                     !- Low Speed Gross Rated Sensible Heat Ratio",
+        "    4.2,                     !- Low Speed Gross Rated Cooling COP{ W / W }",
+        "    autosize,                !- Low Speed Rated Air Flow Rate{ m3 / s }",
+        "    WindACCoolCapFT,         !- Low Speed Total Cooling Capacity Function of Temperature Curve Name",
+        "    WindACEIRFT,             !- Low Speed Energy Input Ratio Function of Temperature Curve Name",
+        "    ;  !- Condenser Air Inlet Node Name",
+
+        });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+
+    ProcessScheduleInput();
+    GetDXCoils();
+
+    ASSERT_EQ("MAIN COOLING COIL 1", DXCoil(1).Name); // Cooling Coil Two Speed
+    ASSERT_EQ(-25.0, DXCoil(1).MinOATCompressor);          // use default value at -25C
+}
+
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------
For Coil:Cooling:DX:TwoSpeed, the input value of the Minimum Outdoor Dry-Bulb Temperature for Compressor Operation (N10) field is now assigned into a member variable. The AC operation works properly using a test file. Previously this input was ignored. Addresses #6507.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
