### PR TITLE
Remove extra space at end of readvars header

### DIFF
--- a/doc/input-output-reference/src/output/using-readvarseso.tex
+++ b/doc/input-output-reference/src/output/using-readvarseso.tex
@@ -4,9 +4,11 @@
 
 The ReadVarsESO program is distributed with EnergyPlus as a simple approach to converting the standard output files (\textbf{eplusout.eso, eplusout.mtr}) into files that can be put directly into a spreadsheet program and then used to create graphs or do other statistical operations. ReadVarsESO can read the complex output files and sort the data into time-based form, it is a very quick application but does not have a lot of features.~ Note that all the \textbf{Output:Meter} and \textbf{Output:Meter:Cumulative} objects are included on the \textbf{eplusout.eso} file as well as the \textbf{eplusout.mtr} file.~ You can choose the \textbf{Output:Meter:MeterFileOnly} or \textbf{Output:Meter:Cumulative:MeterFileOnly} objects if you do not want a particular meter to show up on the \textbf{eplusout.eso} file. If you wish to see only the metered outputs, the \textbf{eplusout.mtr} file will typically be a lot smaller than the \textbf{eplusout.eso} file.
 
-The ReadVarsESO program has a very simple set of inputs. By default, you will get all the variables listed in the Output:Variable (\textbf{eplusout.eso}) or Output:Meter (\textbf{eplusout.mtr}) objects into the appropriate output files. The outputs from ReadVarsESO are limited to 255 variables (Microsoft Excel™ limit). You can tailor how many variables to list by specifying variables for the ReadVarsESO runs.
+The ReadVarsESO program has a very simple set of inputs. By default, you will get all the variables listed in the Output:Variable (\textbf{eplusout.eso}) or Output:Meter (\textbf{eplusout.mtr}) objects into the appropriate output files, and the outputs will be limited to 255 variables (a legacy Microsoft Excel™ limit). You can tailor how many variables to list by specifying variables for the ReadVarsESO runs.
 
 You can override the 255 variable limit by specifying an argument on the command line (\textbf{EP-Launch} has a special option for this). You use ``unlimited'' or ``nolimit'' on the command line to get as many variables into your output file as desired. Again, this will be limited either by the number of variables in the \textbf{eplusout.eso} or \textbf{eplusout.mtr} files or the contents of the ``rvi'' file. If you want to use this option, you must include two arguments to the command line of the ReadVars program -- 1) the ``rvi'' file and 2) the ``unlimited'' argument.
+
+By default, ReadVarsESO also included a trailing space on the header line, which can result in parsing difficulties, since the last variable will essentially have a blank character at the end.  In EnergyPlus 9.0, a new command line option (fixheader) was added to ReadVarsESO to allow eliminating this extra padding.  Just like with the variable limit command line argument, to use this one, you must first include an argument for the rvi file, which is a required first positional argument.  If you aren't using an rvi file, just include blank quotes to indicate no rvi use while satisfying the ReadVarsESO argument requirements.
 
 % table 41
 \begin{longtable}[c]{p{1.5in}p{4.5in}}
@@ -24,6 +26,7 @@ Option & Description \tabularnewline
 
 < filename > & To use any of these options, you must include a file name (“rvi” file) as the first argument. \tabularnewline
 Unlimited (or Nolimit) & Variables of any number will be produced on the output file. \tabularnewline
+FixHeader & The CSV header line will not have a trailing space on the line, to ease with parsing variable information \tabularnewline
 Timestep & Only variables with reported frequency “timestep” (or detailed) will be produced on the output file. \tabularnewline
 Hourly & Only variables with reported frequency “hourly”~ will be produced on the output file. \tabularnewline
 Daily & Only variables with reported frequency “daily”~ will be produced on the output file. \tabularnewline

--- a/src/ReadVars/ReadVarsESO.f90
+++ b/src/ReadVars/ReadVarsESO.f90
@@ -978,7 +978,7 @@
       write(auditunit,*) 'line 904 variable =',tracknum(ij),' not found'
     endif
   enddo
-  write(csvunit,inoutformat) ' ' !  final..trim(outline)
+  write(csvunit,inoutformat)     !  final..trim(outline)
   read(esounit,inoutformat) line ! first environment line
   curdate=blank
   curmonday=blank
@@ -1368,24 +1368,24 @@
     stop
 
 906 write(*,*) 'Output file='//trim(outputfilename)
-    write(*,*) 'error occured during processing.'
+    write(*,*) 'error occurred during processing.'
     write(*,*) 'Apparent line in error (1st 50 characters):'
     write(*,*) trim(line(1:50))
     write(*,*) 'ReadVarsESO program terminated.'
     write(auditunit,*) 'Output file='//trim(outputfilename)
-    write(auditunit,*) 'error occured during processing.'
+    write(auditunit,*) 'error occurred during processing.'
     write(auditunit,*) 'Apparent line in error (1st 50 characters):'
     write(auditunit,*) trim(line(1:50))
     write(auditunit,*) 'ReadVarsESO program terminated.'
     stop
 
 907 write(*,*) 'Output file='//trim(outputfilename)
-    write(*,*) 'error occured during processing.'
+    write(*,*) 'error occurred during processing.'
     write(*,*) 'Blank line in middle of processing.'
     write(*,*) 'Likely fatal error during EnergyPlus execution.'
     write(*,*) 'ReadVarsESO program terminated.'
     write(auditunit,*) 'Output file='//trim(outputfilename)
-    write(auditunit,*) 'error occured during processing.'
+    write(auditunit,*) 'error occurred during processing.'
     write(auditunit,*) 'Blank line in middle of processing.'
     write(auditunit,*) 'Likely fatal error during EnergyPlus execution.'
     write(auditunit,*) 'ReadVarsESO program terminated.'

--- a/src/ReadVars/ReadVarsESO.f90
+++ b/src/ReadVars/ReadVarsESO.f90
@@ -150,6 +150,7 @@
   character(len=30) cdayofsim
   integer :: commacount
   integer :: commalimit
+  logical :: FixHeader
 
   write(*,*) 'ReadVarsESO program starting.'
   maxrptnum=-1
@@ -166,6 +167,7 @@
   Freqs=0
   gotinputfilename=.false.
   gotoutputfilename=.false.
+  FixHeader=.false.
 
   commalimit=LEN(outline)-10
 
@@ -199,6 +201,8 @@
       if (LineArg(1:1) == 'u' .or. LineArg(1:1) == 'U') Limited=.false.
       ! nolimit
       if (LineArg(1:1) == 'n' .or. LineArg(1:1) == 'N') Limited=.false.
+      ! fixheader
+      if (LineArg(1:1) == 'f' .or. LineArg(1:1) == 'F') FixHeader=.true.
     enddo
   endif
 
@@ -978,7 +982,11 @@
       write(auditunit,*) 'line 904 variable =',tracknum(ij),' not found'
     endif
   enddo
-  write(csvunit,inoutformat)     !  final..trim(outline)
+  if (FixHeader) then
+    write(csvunit,inoutformat)     !  final..trim(outline)
+  else
+    write(csvunit,inoutformat) ' '
+  endif
   read(esounit,inoutformat) line ! first environment line
   curdate=blank
   curmonday=blank


### PR DESCRIPTION
ReadVarsESO places an extra space character at the end of the header line in the csv file. I only noticed the issue when I was using Python/Pandas to reference columns by name, and found that one had an extra space. It's super minor, so feel free to ignore it, especially if it has a purpose that I'm not seeing.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
