### PR TITLE
Issue severe error for vertex size mismatch between base and boundary surfaces

### DIFF
--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -3178,7 +3178,7 @@ namespace SurfaceGeometry {
 
                 CheckConvexity(SurfNum, SurfaceTmp(SurfNum).Sides);
                 if (UtilityRoutines::SameString(cAlphaArgs(5), "Surface")) {
-                    if (SurfaceTmp(SurfNum).Sides != SurfaceTmp(SurfNum).Vertex.size()) {
+                    if (SurfaceTmp(SurfNum).Sides != static_cast<int>(SurfaceTmp(SurfNum).Vertex.size())) {
                         ShowSevereError(cCurrentModuleObject + "=\"" + SurfaceTmp(SurfNum).Name +
                             "\", After CheckConvexity, mismatch between Sides (" + TrimSigDigits(SurfaceTmp(SurfNum).Sides) + ") and size of Vertex (" + TrimSigDigits(SurfaceTmp(SurfNum).Vertex.size()) + ").");
                         ShowContinueError("CheckConvexity is used to verify the convexity of a surface and detect collinear points." );
@@ -3218,8 +3218,8 @@ namespace SurfaceGeometry {
                  ExtSurfNum = UtilityRoutines::FindItemInList(SurfaceTmp(i).ExtBoundCondName, SurfaceTmp);
                  if (SurfaceTmp(i).Vertex.size() != SurfaceTmp(ExtSurfNum).Vertex.size()) {
                      ShowSevereError(cCurrentModuleObject + "=\"" + SurfaceTmp(i).Name +
-                         "\", Vertex size mismatch between base surface :" + SurfaceTmp(i).Name + " and exterior boundary surface: " + SurfaceTmp(ExtSurfNum).Name);
-                     ShowContinueError("The vertex sizes are "+ TrimSigDigits(SurfaceTmp(i).Vertex.size()) + " for base surface and "+ TrimSigDigits(SurfaceTmp(ExtSurfNum).Vertex.size()) + " for exterior boundary surface. Please check inputs.");
+                         "\", Vertex size mismatch between base surface :" + SurfaceTmp(i).Name + " and outside boundary surface: " + SurfaceTmp(ExtSurfNum).Name);
+                     ShowContinueError("The vertex sizes are "+ TrimSigDigits(SurfaceTmp(i).Vertex.size()) + " for base surface and "+ TrimSigDigits(SurfaceTmp(ExtSurfNum).Vertex.size()) + " for outside boundary surface. Please check inputs.");
                      ErrorsFound = true;
                  }
             }

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -3177,6 +3177,14 @@ namespace SurfaceGeometry {
                 }
 
                 CheckConvexity(SurfNum, SurfaceTmp(SurfNum).Sides);
+                if (UtilityRoutines::SameString(cAlphaArgs(5), "Surface")) {
+                    if (SurfaceTmp(SurfNum).Sides != SurfaceTmp(SurfNum).Vertex.size()) {
+                        ShowSevereError(cCurrentModuleObject + "=\"" + SurfaceTmp(SurfNum).Name +
+                            "\", After CheckConvexity, mismatch between Sides (" + TrimSigDigits(SurfaceTmp(SurfNum).Sides) + ") and size of Vertex (" + TrimSigDigits(SurfaceTmp(SurfNum).Vertex.size()) + ").");
+                        ShowContinueError("CheckConvexity is used to verify the convexity of a surface and detect collinear points." );
+                        ErrorsFound = true;
+                    }
+                }
                 if (SurfaceTmp(SurfNum).Construction > 0) {
                     // Check wall height for the CFactor walls
                     if (SurfaceTmp(SurfNum).Class == SurfaceClass_Wall && Construct(SurfaceTmp(SurfNum).Construction).TypeIsCfactorWall) {
@@ -3203,6 +3211,20 @@ namespace SurfaceGeometry {
                 }
             }
         } // Item Looop
+        // Check number of Vertex between base surface and Outside Boundary surface
+        int ExtSurfNum;
+        for (int i = 1; i <= SurfNum; i++) {
+            if (SurfaceTmp(i).ExtBoundCond == UnreconciledZoneSurface && SurfaceTmp(i).ExtBoundCondName != "") {
+                 ExtSurfNum = UtilityRoutines::FindItemInList(SurfaceTmp(i).ExtBoundCondName, SurfaceTmp);
+                 if (SurfaceTmp(i).Vertex.size() != SurfaceTmp(ExtSurfNum).Vertex.size()) {
+                     ShowSevereError(cCurrentModuleObject + "=\"" + SurfaceTmp(i).Name +
+                         "\", Vertex size mismatch between base surface :" + SurfaceTmp(i).Name + " and exterior boundary surface: " + SurfaceTmp(ExtSurfNum).Name);
+                     ShowContinueError("The vertex sizes are "+ TrimSigDigits(SurfaceTmp(i).Vertex.size()) + " for base surface and "+ TrimSigDigits(SurfaceTmp(ExtSurfNum).Vertex.size()) + " for exterior boundary surface. Please check inputs.");
+                     ErrorsFound = true;
+                 }
+            }
+
+        }
     }
 
     void GetRectSurfaces(bool &ErrorsFound,             // Error flag indicator (true if errors found)

--- a/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
+++ b/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
@@ -2960,3 +2960,100 @@ TEST_F(EnergyPlusFixture, MakeRectangularVertices)
     EXPECT_NEAR(-5., SurfaceTmp(surfNum).Vertex(4).y, 0.001);
     EXPECT_NEAR(3., SurfaceTmp(surfNum).Vertex(4).z, 0.001);
 }
+
+TEST_F(EnergyPlusFixture, SurfaceGeometry_VertexNumberMismatchTest)
+{
+    bool ErrorsFound(false);
+
+    std::string const idf_objects = delimited_string({
+        "Version,                                                        ",
+        "	8.6;                     !- Version Identifier               ",
+        "	                                                             ",
+        "Material,",
+        "  8 in.Concrete Block Basement Wall,     !- Name",
+        "  MediumRough,                            !- Roughness",
+        "  0.2032,                                 !- Thickness{ m }",
+        "  1.326,                                  !- Conductivity{ W / m - K }",
+        "  1841.99999999999,                       !- Density{ kg / m3 }",
+        "  911.999999999999,                       !- Specific Heat{ J / kg - K }",
+        "  0.9,                                    !- Thermal Absorptance",
+        "  0.7,                                    !- Solar Absorptance",
+        "  0.7;                                    !- Visible Absorptance",
+        "Construction,",
+        "   Typical,   !- Name",
+        "   8 in.Concrete Block Basement Wall;     !- Layer 1",
+
+        "BuildingSurface:Detailed,                                   ",
+        "	016W88_WaterMeter - Floor : a, !- Name",
+        "	Floor, !- Surface Type",
+        "	Typical, !- Construction Name",
+        "	ZONE 1, !- Zone Name",
+        "	Surface, !- Outside Boundary Condition",
+        "	006W27_Restrooms - RoofCeiling : a, !- Outside Boundary Condition Object",
+        "	NoSun, !- Sun Exposure",
+        "	NoWind, !- Wind Exposure",
+        "	, !- View Factor to Ground",
+        "	, !- Number of Vertices",
+        "	251.4600375, 3.5052, 0, !- X, Y, Z Vertex 1 {m}",
+        "	251.4600375, 0, 0, !- X, Y, Z Vertex 2 {m}",
+        "	253.9571375, 0, 0, !- X, Y, Z Vertex 3 {m}",
+        "	248.5215375, 0, 0, !- X, Y, Z Vertex 4 {m}",
+        "	248.5215375, 3.5052, 0;                 !- X, Y, Z Vertex 5 {m}",
+
+        "BuildingSurface:Detailed,",
+        "   006W27_Restrooms - RoofCeiling : a, !- Name",
+        "   Ceiling, !- Surface Type",
+        "   Typical, !- Construction Name",
+        "   ZONE 2, !- Zone Name",
+        "   Surface, !- Outside Boundary Condition",
+        "   016W88_WaterMeter - Floor : a, !- Outside Boundary Condition Object",
+        "   NoSun, !- Sun Exposure",
+        "   NoWind, !- Wind Exposure",
+        "   , !- View Factor to Ground",
+        "   , !- Number of Vertices",
+        "   174.6425, 0, 6.1976, !- X, Y, Z Vertex 1 {m}",
+        "   174.6425, 3.5052, 6.1976, !- X, Y, Z Vertex 2 {m}",
+        "   171.704, 3.5052, 6.1976, !- X, Y, Z Vertex 3 {m}",
+        "   171.704, 0, 6.1976;                     !- X, Y, Z Vertex 4 {m}",
+
+        });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+
+    DataGlobals::NumOfZones = 2;
+    Zone.allocate(2);
+    Zone(1).Name = "ZONE 1";
+    Zone(2).Name = "ZONE 2";
+    SurfaceTmp.allocate(2);
+    int SurfNum = 0;
+    int TotHTSurfs = 2;
+    Array1D_string const BaseSurfCls(3, { "WALL", "FLOOR", "ROOF" });
+    Array1D_int const BaseSurfIDs(3, { 1, 2, 3 });
+    int NeedToAddSurfaces;
+
+    GetGeometryParameters(ErrorsFound);
+    CosZoneRelNorth.allocate(2);
+    SinZoneRelNorth.allocate(2);
+
+    CosZoneRelNorth = 1.0;
+    SinZoneRelNorth = 0.0;
+    SinBldgRelNorth = 0.0;
+    CosBldgRelNorth = 1.0;
+
+    GetHTSurfaceData(ErrorsFound, SurfNum, TotHTSurfs, 0, 0, 0, BaseSurfCls, BaseSurfIDs,
+        NeedToAddSurfaces);
+
+    EXPECT_EQ(2, SurfNum);
+    std::string const error_string = delimited_string({
+        "   ** Severe  ** BuildingSurface:Detailed=\"016W88_WATERMETER - FLOOR : A\", invalid Construction Name=\"TYPICAL\".",
+        "   ** Severe  ** BuildingSurface:Detailed=\"016W88_WATERMETER - FLOOR : A\", After CheckConvexity, mismatch between Sides (4) and size of Vertex (5).",
+        "   **   ~~~   ** CheckConvexity is used to verify the convexity of a surface and detect collinear points.",
+        "   ** Severe  ** BuildingSurface:Detailed=\"006W27_RESTROOMS - ROOFCEILING : A\", invalid Construction Name=\"TYPICAL\".",
+        "   ** Severe  ** RoofCeiling:Detailed=\"016W88_WATERMETER - FLOOR : A\", Vertex size mismatch between base surface :016W88_WATERMETER - FLOOR : A and exterior boundary surface: 006W27_RESTROOMS - ROOFCEILING : A",
+        "   **   ~~~   ** The vertex sizes are 5 for base surface and 4 for exterior boundary surface. Please check inputs.",
+        "   ** Severe  ** RoofCeiling:Detailed=\"006W27_RESTROOMS - ROOFCEILING : A\", Vertex size mismatch between base surface :006W27_RESTROOMS - ROOFCEILING : A and exterior boundary surface: 016W88_WATERMETER - FLOOR : A",
+        "   **   ~~~   ** The vertex sizes are 4 for base surface and 5 for exterior boundary surface. Please check inputs."
+        });
+    EXPECT_TRUE(compare_err_stream(error_string, true));
+
+}

--- a/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
+++ b/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
@@ -3049,10 +3049,10 @@ TEST_F(EnergyPlusFixture, SurfaceGeometry_VertexNumberMismatchTest)
         "   ** Severe  ** BuildingSurface:Detailed=\"016W88_WATERMETER - FLOOR : A\", After CheckConvexity, mismatch between Sides (4) and size of Vertex (5).",
         "   **   ~~~   ** CheckConvexity is used to verify the convexity of a surface and detect collinear points.",
         "   ** Severe  ** BuildingSurface:Detailed=\"006W27_RESTROOMS - ROOFCEILING : A\", invalid Construction Name=\"TYPICAL\".",
-        "   ** Severe  ** RoofCeiling:Detailed=\"016W88_WATERMETER - FLOOR : A\", Vertex size mismatch between base surface :016W88_WATERMETER - FLOOR : A and exterior boundary surface: 006W27_RESTROOMS - ROOFCEILING : A",
-        "   **   ~~~   ** The vertex sizes are 5 for base surface and 4 for exterior boundary surface. Please check inputs.",
-        "   ** Severe  ** RoofCeiling:Detailed=\"006W27_RESTROOMS - ROOFCEILING : A\", Vertex size mismatch between base surface :006W27_RESTROOMS - ROOFCEILING : A and exterior boundary surface: 016W88_WATERMETER - FLOOR : A",
-        "   **   ~~~   ** The vertex sizes are 4 for base surface and 5 for exterior boundary surface. Please check inputs."
+        "   ** Severe  ** RoofCeiling:Detailed=\"016W88_WATERMETER - FLOOR : A\", Vertex size mismatch between base surface :016W88_WATERMETER - FLOOR : A and outside boundary surface: 006W27_RESTROOMS - ROOFCEILING : A",
+        "   **   ~~~   ** The vertex sizes are 5 for base surface and 4 for outside boundary surface. Please check inputs.",
+        "   ** Severe  ** RoofCeiling:Detailed=\"006W27_RESTROOMS - ROOFCEILING : A\", Vertex size mismatch between base surface :006W27_RESTROOMS - ROOFCEILING : A and outside boundary surface: 016W88_WATERMETER - FLOOR : A",
+        "   **   ~~~   ** The vertex sizes are 4 for base surface and 5 for outside boundary surface. Please check inputs."
         });
     EXPECT_TRUE(compare_err_stream(error_string, true));
 


### PR DESCRIPTION
Pull request overview
---------------------
This issue has two problems.

The first problem is that after calling CheckConvexity, the Sides of the 016W88_WATERMETER - FLOOR:A becomes 4, even though the surface has 5 points.

The boundary surface of 016W88_WATERMETER - FLOOR:A is 006W27_RESTROOMS - ROOFCEILING:A. The vertex size of base surface is 5, while the vertex size of boundary surface is 4. Mismatch occurs.

Two severe errors are issued.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
