### PR TITLE
Setup a correct value for an exp function with underflow value

### DIFF
--- a/src/EnergyPlus/PlantHeatExchangerFluidToFluid.cc
+++ b/src/EnergyPlus/PlantHeatExchangerFluidToFluid.cc
@@ -1730,7 +1730,8 @@ namespace PlantHeatExchangerFluidToFluid {
                         } else {
                             Effectiveness = 1.0;
                         }
-
+                    } else if (ExpCheckValue2 < EXP_LowerLimit) {
+                        Effectiveness = 1.0;
                     } else if ((std::exp(-NTU) == 1.0) || (NTU == 0.0) || (std::exp(-CapRatio * NTU) == 1.0)) { // don't div by zero
 
                         Effectiveness = 0.0;

--- a/tst/EnergyPlus/unit/PlantHeatExchangerFluidToFluid.unit.cc
+++ b/tst/EnergyPlus/unit/PlantHeatExchangerFluidToFluid.unit.cc
@@ -2481,6 +2481,14 @@ TEST_F(EnergyPlusFixture, PlantHXControl_CoolingSetpointOnOffWithComponentOverri
     PlantHeatExchangerFluidToFluid::InitFluidHeatExchanger(1, 1);
 
     EXPECT_NEAR(DataPlant::PlantLoop(1).LoopSide(2).Branch(2).Comp(1).FreeCoolCntrlMinCntrlTemp, 9.5, 0.001);
+
+    // Force Effectiveness = 1 when -NTU < EXP_LowerLimit #6516
+    PlantHeatExchangerFluidToFluid::FluidHX(1).HeatExchangeModelType = PlantHeatExchangerFluidToFluid::CrossFlowBothMixed;
+    PlantHeatExchangerFluidToFluid::FluidHX(1).UA = 9000.0;
+
+    PlantHeatExchangerFluidToFluid::CalcFluidHeatExchanger(1, 0.1, 0.1);
+    EXPECT_NEAR(PlantHeatExchangerFluidToFluid::FluidHX(1).Effectiveness, 1.0, 0.001);
+
 }
 
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------
Add one more level protection when -NTU < EXP_LowerLimit.

Differences were found in two example files: 5ZoneCoolBeam.idf and FourPipeBeamLargeOffice.idf.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
