### PR TITLE
Correct Fan:SystemModel crash when Continuous mode is used without power as a function of flow fraction curve

### DIFF
--- a/src/EnergyPlus/HVACFan.cc
+++ b/src/EnergyPlus/HVACFan.cc
@@ -278,7 +278,7 @@ namespace HVACFan {
         // calculate total fan system efficiency at design
         m_fanTotalEff = designAirVolFlowRate * deltaPress / designElecPower;
 
-        if (m_numSpeeds > 1) { // set up values at speeds
+        if (speedControl == SpeedControlMethod::Discrete && m_numSpeeds > 1) { // set up values at speeds
             m_massFlowAtSpeed.resize(m_numSpeeds, 0.0);
             m_totEfficAtSpeed.resize(m_numSpeeds, 0.0);
             for (auto loop = 0; loop < m_numSpeeds; ++loop) {
@@ -461,6 +461,7 @@ namespace HVACFan {
             if (speedControl == SpeedControlMethod::Continuous) {
                 ShowWarningError(routineName + locCurrentModuleObject + "=\"" + alphaArgs(1) + "\", invalid entry.");
                 ShowContinueError("Continuous speed control requires a fan power curve in " + alphaFieldNames(7) + " = " + alphaArgs(7));
+                errorsFound = true;
             }
         }
         m_nightVentPressureDelta = numericArgs(10);
@@ -538,8 +539,8 @@ namespace HVACFan {
             if (foundMissingPowerFraction) {
                 // field set input does not match number of speeds, throw warning
                 ShowSevereError(routineName + locCurrentModuleObject + "=\"" + alphaArgs(1) + "\", invalid entry.");
-                ShowContinueError(
-                    "Fan with Discrete speed control does not have input for power fraction at all speed levels and does not have a power curve.");
+                ShowContinueError("Fan with Discrete speed control does not have input for power fraction at one or more speed levels and does not "
+                                  "have a power curve.");
                 errorsFound = true;
             }
         }

--- a/src/EnergyPlus/HVACFan.cc
+++ b/src/EnergyPlus/HVACFan.cc
@@ -539,8 +539,8 @@ namespace HVACFan {
             if (foundMissingPowerFraction) {
                 // field set input does not match number of speeds, throw warning
                 ShowSevereError(routineName + locCurrentModuleObject + "=\"" + alphaArgs(1) + "\", invalid entry.");
-                ShowContinueError("Fan with Discrete speed control does not have input for power fraction at one or more speed levels and does not "
-                                  "have a power curve.");
+                ShowContinueError(
+                    "Fan with Discrete speed control does not have input for power fraction at all speed levels and does not have a power curve.");
                 errorsFound = true;
             }
         }

--- a/tst/EnergyPlus/unit/HVACFan.unit.cc
+++ b/tst/EnergyPlus/unit/HVACFan.unit.cc
@@ -461,4 +461,85 @@ TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc4)
     EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
 }
 
+TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc_noPowerFFlowCurve)
+{
+    // this unit test checks the power averaging when cycling between a hi and low speed
+    // this uses fan power curve instead of speed level power fractions
+    // this unit test uses the optional two-mode arguments
+
+    std::string const idf_objects = delimited_string({
+
+        "  Fan:SystemModel,",
+        "    Test Fan ,              !- Name",
+        "    ,                       !- Availability Schedule Name",
+        "    TestFanAirInletNode,    !- Air Inlet Node Name",
+        "    TestFanOutletNode,      !- Air Outlet Node Name",
+        "    1.0 ,                   !- Design Maximum Air Flow Rate",
+        "    Discrete,               !- Speed Control Method",
+        "    0.0,                    !- Electric Power Minimum Flow Rate Fraction",
+        "    100.0,                  !- Design Pressure Rise",
+        "    0.9 ,                   !- Motor Efficiency",
+        "    1.0 ,                   !- Motor In Air Stream Fraction",
+        "    100.0,                  !- Design Electric Power Consumption",
+        "    ,                       !- Design Power Sizing Method",
+        "    ,                       !- Electric Power Per Unit Flow Rate",
+        "    ,                       !- Electric Power Per Unit Flow Rate Per Unit Pressure",
+        "    ,                       !- Fan Total Efficiency",
+        "    ;                       !- Electric Power Function of Flow Fraction Curve Name",
+
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+    std::string fanName = "TEST FAN";
+    HVACFan::fanObjs.emplace_back(new HVACFan::FanSystem(fanName)); // call constructor
+    DataSizing::CurZoneEqNum = 0;
+    DataSizing::CurSysNum = 0;
+    DataSizing::CurOASysNum = 0;
+    DataEnvironment::StdRhoAir = 1.2;
+    HVACFan::fanObjs[0]->simulate(_, _, _, _);
+    Real64 locFanSizeVdot = HVACFan::fanObjs[0]->designAirVolFlowRate;
+    EXPECT_NEAR(1.00, locFanSizeVdot, 0.00001);
+
+    // 50% of the time at speed 1 (0.5 flow) and 50% of the time at speed 2 (1.0 flow), average flow 0.75, on for entire timestep
+    Real64 designMassFlowRate = locFanSizeVdot * DataEnvironment::StdRhoAir;
+    Real64 massFlow1 = 0.5 * designMassFlowRate;
+    Real64 massFlow2 = designMassFlowRate;
+    Real64 runTimeFrac1 = 0.5;
+    Real64 runTimeFrac2 = 0.5;
+    HVACFan::fanObjs[0]->simulate(_, _, _, _, massFlow1, runTimeFrac1, massFlow2, runTimeFrac2);
+    Real64 locFanElecPower = HVACFan::fanObjs[0]->fanPower();
+    Real64 locExpectPower = (0.5 * 0.5 + 0.5 * 1.0) * HVACFan::fanObjs[0]->designElecPower;
+    EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
+
+    // 100% of the time at average flow 0.75, on for entire timestep
+    massFlow1 = 0.0;
+    massFlow2 = 0.75 * designMassFlowRate;
+    runTimeFrac1 = 0.0;
+    runTimeFrac2 = 1.0;
+    HVACFan::fanObjs[0]->simulate(_, _, _, _, massFlow1, runTimeFrac1, massFlow2, runTimeFrac2);
+    locFanElecPower = HVACFan::fanObjs[0]->fanPower();
+    locExpectPower = 0.75 * HVACFan::fanObjs[0]->designElecPower;
+    EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
+
+    // 100% of the time at full flow, on for the entire timestep
+    massFlow1 = 0.0;
+    massFlow2 = 1.0 * designMassFlowRate;
+    runTimeFrac1 = 0.0;
+    runTimeFrac2 = 1.0;
+    HVACFan::fanObjs[0]->simulate(_, _, _, _, massFlow1, runTimeFrac1, massFlow2, runTimeFrac2);
+    locFanElecPower = HVACFan::fanObjs[0]->fanPower();
+    locExpectPower = HVACFan::fanObjs[0]->designElecPower; // expect full power
+    EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
+
+    // 85% of the time at full flow, on for the entire timestep
+    massFlow1 = 0.0;
+    massFlow2 = 1.0 * designMassFlowRate;
+    runTimeFrac1 = 0.0;
+    runTimeFrac2 = 0.85;
+    HVACFan::fanObjs[0]->simulate(_, _, _, _, massFlow1, runTimeFrac1, massFlow2, runTimeFrac2);
+    locFanElecPower = HVACFan::fanObjs[0]->fanPower();
+    locExpectPower = 0.85 * HVACFan::fanObjs[0]->designElecPower; // expect 85% of full power
+    EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
+}
+
 } // namespace EnergyPlus

--- a/tst/EnergyPlus/unit/HVACFan.unit.cc
+++ b/tst/EnergyPlus/unit/HVACFan.unit.cc
@@ -461,10 +461,10 @@ TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc4)
     EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
 }
 
-TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc_noPowerFFlowCurve)
+TEST_F(EnergyPlusFixture, SystemFanObj_DiscreteMode_noPowerFFlowCurve)
 {
     // this unit test checks the power averaging when cycling between a hi and low speed
-    // this uses fan power curve instead of speed level power fractions
+    // this uses fan speed level power fractions
     // this unit test uses the optional two-mode arguments
 
     std::string const idf_objects = delimited_string({
@@ -508,7 +508,8 @@ TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc_noPowerFFlowCurve)
     Real64 runTimeFrac2 = 0.5;
     HVACFan::fanObjs[0]->simulate(_, _, _, _, massFlow1, runTimeFrac1, massFlow2, runTimeFrac2);
     Real64 locFanElecPower = HVACFan::fanObjs[0]->fanPower();
-    Real64 locExpectPower = (0.5 * 0.5 + 0.5 * 1.0) * HVACFan::fanObjs[0]->designElecPower;
+    // uses flow weighted power calculation. 50% of time at 50% flow and 50% of time at 100% flow
+    Real64 locExpectPower = (0.5 * 0.5 + 0.5 * 1.0) * HVACFan::fanObjs[0]->designElecPower; // expect 75% of power
     EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
 
     // 100% of the time at average flow 0.75, on for entire timestep
@@ -518,7 +519,8 @@ TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc_noPowerFFlowCurve)
     runTimeFrac2 = 1.0;
     HVACFan::fanObjs[0]->simulate(_, _, _, _, massFlow1, runTimeFrac1, massFlow2, runTimeFrac2);
     locFanElecPower = HVACFan::fanObjs[0]->fanPower();
-    locExpectPower = 0.75 * HVACFan::fanObjs[0]->designElecPower;
+    // uses flow weighted power calculation. 0% of time at 0% flow and 100% of time at 75% flow
+    locExpectPower = (0.0 * 0.0 + 1.0 * 0.75) * HVACFan::fanObjs[0]->designElecPower; // expect 75% of power
     EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
 
     // 100% of the time at full flow, on for the entire timestep
@@ -528,7 +530,8 @@ TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc_noPowerFFlowCurve)
     runTimeFrac2 = 1.0;
     HVACFan::fanObjs[0]->simulate(_, _, _, _, massFlow1, runTimeFrac1, massFlow2, runTimeFrac2);
     locFanElecPower = HVACFan::fanObjs[0]->fanPower();
-    locExpectPower = HVACFan::fanObjs[0]->designElecPower; // expect full power
+    // uses flow weighted power calculation. 0% of time at 0% flow and 100% of time at 100% flow
+    locExpectPower = (0.0 * 0.0 + 1.0 * 1.0) * HVACFan::fanObjs[0]->designElecPower; // expect full power
     EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
 
     // 85% of the time at full flow, on for the entire timestep
@@ -538,7 +541,8 @@ TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc_noPowerFFlowCurve)
     runTimeFrac2 = 0.85;
     HVACFan::fanObjs[0]->simulate(_, _, _, _, massFlow1, runTimeFrac1, massFlow2, runTimeFrac2);
     locFanElecPower = HVACFan::fanObjs[0]->fanPower();
-    locExpectPower = 0.85 * HVACFan::fanObjs[0]->designElecPower; // expect 85% of full power
+    // uses flow weighted power calculation. 0% of time at 0% flow and 85% of time at 100% flow
+    locExpectPower = (0.0 * 0.25 + 0.85 * 1.0) * HVACFan::fanObjs[0]->designElecPower; // expect 85% of full power
     EXPECT_NEAR(locFanElecPower, locExpectPower, 0.01);
 }
 


### PR DESCRIPTION
Pull request overview
---------------------
The Fan:SystemModel has two operating modes, Discrete and Continuous. The Continuous operating mode requires that a power as a function of flow fraction curve is provided so that power can be calculated. If this curve is not provided the simulation will crash. This corrects #6598.

Work around: Provide the required performance curve.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [x] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [x] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
