### PR TITLE
Heating water coil sizing mixing up hot and cold initialization temperatures

### DIFF
--- a/src/EnergyPlus/BaseboardRadiator.cc
+++ b/src/EnergyPlus/BaseboardRadiator.cc
@@ -661,7 +661,7 @@ namespace BaseboardRadiator {
             RhoAirStdInit = StdRhoAir;
             WaterInletNode = Baseboard(BaseboardNum).WaterInletNode;
             rho = GetDensityGlycol(PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidName,
-                                   DataGlobals::CWInitConvTemp,
+                                   DataGlobals::HWInitConvTemp,
                                    PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidIndex,
                                    RoutineName);
             Baseboard(BaseboardNum).WaterMassFlowRateMax = rho * Baseboard(BaseboardNum).WaterVolFlowRateMax;
@@ -673,7 +673,7 @@ namespace BaseboardRadiator {
                                Baseboard(BaseboardNum).LoopSideNum,
                                Baseboard(BaseboardNum).BranchNum,
                                Baseboard(BaseboardNum).CompNum);
-            Node(WaterInletNode).Temp = 60.0;
+            Node(WaterInletNode).Temp = DataGlobals::HWInitConvTemp;
             Cp = GetSpecificHeatGlycol(PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidName,
                                        Node(WaterInletNode).Temp,
                                        PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidIndex,
@@ -848,7 +848,7 @@ namespace BaseboardRadiator {
                                                    PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidIndex,
                                                    RoutineName);
                         rho = GetDensityGlycol(PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidIndex,
                                                RoutineName);
                         WaterVolFlowRateMaxDes = DesCoilLoad / (PlantSizData(PltSizHeatNum).DeltaT * Cp * rho);
@@ -910,7 +910,7 @@ namespace BaseboardRadiator {
                     Baseboard(BaseboardNum).AirInletHumRat = FinalZoneSizing(CurZoneEqNum).ZoneHumRatAtHeatPeak;
                     WaterInletNode = Baseboard(BaseboardNum).WaterInletNode;
                     rho = GetDensityGlycol(PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidName,
-                                           DataGlobals::CWInitConvTemp,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(Baseboard(BaseboardNum).LoopNum).FluidIndex,
                                            RoutineName);
                     Node(WaterInletNode).MassFlowRate = rho * Baseboard(BaseboardNum).WaterVolFlowRateMax;

--- a/src/EnergyPlus/Boilers.cc
+++ b/src/EnergyPlus/Boilers.cc
@@ -822,7 +822,7 @@ namespace Boilers {
                                        PlantLoop(Boiler(BoilerNum).LoopNum).FluidIndex,
                                        RoutineName);
                 Cp = GetSpecificHeatGlycol(PlantLoop(Boiler(BoilerNum).LoopNum).FluidName,
-                                           Boiler(BoilerNum).TempDesBoilerOut,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(Boiler(BoilerNum).LoopNum).FluidIndex,
                                            RoutineName);
                 tmpNomCap = Cp * rho * Boiler(BoilerNum).SizFac * PlantSizData(PltSizNum).DeltaT * PlantSizData(PltSizNum).DesVolFlowRate;

--- a/src/EnergyPlus/Boilers.cc
+++ b/src/EnergyPlus/Boilers.cc
@@ -696,7 +696,7 @@ namespace Boilers {
         if (MyEnvrnFlag(BoilerNum) && BeginEnvrnFlag && (PlantFirstSizesOkayToFinalize)) {
             // if ( ! PlantFirstSizeCompleted ) SizeBoiler( BoilerNum );
             rho = GetDensityGlycol(PlantLoop(Boiler(BoilerNum).LoopNum).FluidName,
-                                   DataGlobals::CWInitConvTemp,
+                                   DataGlobals::HWInitConvTemp,
                                    PlantLoop(Boiler(BoilerNum).LoopNum).FluidIndex,
                                    RoutineName);
             Boiler(BoilerNum).DesMassFlowRate = Boiler(BoilerNum).VolFlowRate * rho;
@@ -818,7 +818,7 @@ namespace Boilers {
             if (PlantSizData(PltSizNum).DesVolFlowRate >= SmallWaterVolFlow) {
 
                 rho = GetDensityGlycol(PlantLoop(Boiler(BoilerNum).LoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(Boiler(BoilerNum).LoopNum).FluidIndex,
                                        RoutineName);
                 Cp = GetSpecificHeatGlycol(PlantLoop(Boiler(BoilerNum).LoopNum).FluidName,

--- a/src/EnergyPlus/ChillerAbsorption.cc
+++ b/src/EnergyPlus/ChillerAbsorption.cc
@@ -949,7 +949,7 @@ namespace ChillerAbsorption {
 
                 if (BLASTAbsorber(ChillNum).GenHeatSourceType == NodeType_Water) {
                     rho = GetDensityGlycol(PlantLoop(BLASTAbsorber(ChillNum).GenLoopNum).FluidName,
-                                           DataGlobals::CWInitConvTemp,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(BLASTAbsorber(ChillNum).GenLoopNum).FluidIndex,
                                            RoutineName);
 
@@ -1571,11 +1571,11 @@ namespace ChillerAbsorption {
             } else if (BLASTAbsorber(ChillNum).GenHeatSourceType == NodeType_Water) {
                 if (PlantFirstSizesOkayToFinalize) {
                     Cp = GetSpecificHeatGlycol(PlantLoop(BLASTAbsorber(ChillNum).GenLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(BLASTAbsorber(ChillNum).GenLoopNum).FluidIndex,
                                                RoutineName);
                     rho = GetDensityGlycol(PlantLoop(BLASTAbsorber(ChillNum).GenLoopNum).FluidName,
-                                           DataGlobals::CWInitConvTemp,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(BLASTAbsorber(ChillNum).GenLoopNum).FluidIndex,
                                            RoutineName);
 

--- a/src/EnergyPlus/ChillerExhaustAbsorption.cc
+++ b/src/EnergyPlus/ChillerExhaustAbsorption.cc
@@ -1006,7 +1006,7 @@ namespace ChillerExhaustAbsorption {
 
             if (ExhaustAbsorber(ChillNum).HWLoopNum > 0) {
                 rho = GetDensityGlycol(PlantLoop(ExhaustAbsorber(ChillNum).HWLoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(ExhaustAbsorber(ChillNum).HWLoopNum).FluidIndex,
                                        RoutineName);
             } else {

--- a/src/EnergyPlus/ChillerGasAbsorption.cc
+++ b/src/EnergyPlus/ChillerGasAbsorption.cc
@@ -997,7 +997,7 @@ namespace ChillerGasAbsorption {
 
             if (GasAbsorber(ChillNum).HWLoopNum > 0) {
                 rho = GetDensityGlycol(PlantLoop(GasAbsorber(ChillNum).HWLoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(GasAbsorber(ChillNum).HWLoopNum).FluidIndex,
                                        RoutineName);
             } else {

--- a/src/EnergyPlus/ChillerIndirectAbsorption.cc
+++ b/src/EnergyPlus/ChillerIndirectAbsorption.cc
@@ -1071,7 +1071,7 @@ namespace ChillerIndirectAbsorption {
                 if (IndirectAbsorber(ChillNum).GenHeatSourceType == NodeType_Water) {
 
                     rho = GetDensityGlycol(PlantLoop(IndirectAbsorber(ChillNum).GenLoopNum).FluidName,
-                                           DataGlobals::CWInitConvTemp,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(IndirectAbsorber(ChillNum).GenLoopNum).FluidIndex,
                                            RoutineName);
                     IndirectAbsorber(ChillNum).GenMassFlowRateMax = rho * IndirectAbsorber(ChillNum).GeneratorVolFlowRate;
@@ -1732,7 +1732,7 @@ namespace ChillerIndirectAbsorption {
                 IndirectAbsorber(ChillNum).GeneratorDeltaTemp = max(0.5, PlantSizData(PltSizHeatingNum).DeltaT);
             } else if (IndirectAbsorber(ChillNum).GenHeatSourceType == NodeType_Water) {
                 rho = GetDensityGlycol(PlantLoop(IndirectAbsorber(ChillNum).GenLoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(IndirectAbsorber(ChillNum).GenLoopNum).FluidIndex,
                                        RoutineName);
                 CpWater = GetSpecificHeatGlycol(PlantLoop(IndirectAbsorber(ChillNum).GenLoopNum).FluidName,

--- a/src/EnergyPlus/ChillerReformulatedEIR.cc
+++ b/src/EnergyPlus/ChillerReformulatedEIR.cc
@@ -1116,7 +1116,7 @@ namespace ChillerReformulatedEIR {
 
             if (ElecReformEIRChiller(EIRChillNum).HeatRecActive) {
                 rho = GetDensityGlycol(PlantLoop(ElecReformEIRChiller(EIRChillNum).HRLoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(ElecReformEIRChiller(EIRChillNum).HRLoopNum).FluidIndex,
                                        RoutineName);
                 ElecReformEIRChiller(EIRChillNum).DesignHeatRecMassFlowRate = rho * ElecReformEIRChiller(EIRChillNum).DesignHeatRecVolFlowRate;

--- a/src/EnergyPlus/DesiccantDehumidifiers.cc
+++ b/src/EnergyPlus/DesiccantDehumidifiers.cc
@@ -1789,7 +1789,7 @@ namespace DesiccantDehumidifiers {
                         GetCoilMaxWaterFlowRate("Coil:Heating:Water", DesicDehum(DesicDehumNum).RegenCoilName, ErrorFlag);
                     if (DesicDehum(DesicDehumNum).MaxCoilFluidFlow > 0.0) {
                         FluidDensity = GetDensityGlycol(PlantLoop(DesicDehum(DesicDehumNum).LoopNum).FluidName,
-                                                        DataGlobals::CWInitConvTemp,
+                                                        DataGlobals::HWInitConvTemp,
                                                         PlantLoop(DesicDehum(DesicDehumNum).LoopNum).FluidIndex,
                                                         initCBVAV);
                         DesicDehum(DesicDehumNum).MaxCoilFluidFlow *= FluidDensity;
@@ -1912,7 +1912,7 @@ namespace DesiccantDehumidifiers {
                                 }
                                 if (CoilMaxVolFlowRate != AutoSize) {
                                     FluidDensity = GetDensityGlycol(PlantLoop(DesicDehum(DesicDehumNum).LoopNum).FluidName,
-                                                                    DataGlobals::CWInitConvTemp,
+                                                                    DataGlobals::HWInitConvTemp,
                                                                     PlantLoop(DesicDehum(DesicDehumNum).LoopNum).FluidIndex,
                                                                     RoutineName);
                                     DesicDehum(DesicDehumNum).MaxCoilFluidFlow = CoilMaxVolFlowRate * FluidDensity;

--- a/src/EnergyPlus/Furnaces.cc
+++ b/src/EnergyPlus/Furnaces.cc
@@ -4938,7 +4938,7 @@ namespace Furnaces {
                         GetCoilMaxWaterFlowRate("Coil:Heating:Water", Furnace(FurnaceNum).HeatingCoilName, ErrorsFound);
                     if (Furnace(FurnaceNum).MaxHeatCoilFluidFlow > 0.0) {
                         rho = GetDensityGlycol(PlantLoop(Furnace(FurnaceNum).LoopNum).FluidName,
-                                               CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(Furnace(FurnaceNum).LoopNum).FluidIndex,
                                                RoutineName);
                         Furnace(FurnaceNum).MaxHeatCoilFluidFlow *= rho;
@@ -5007,7 +5007,7 @@ namespace Furnaces {
                         GetCoilMaxWaterFlowRate("Coil:Heating:Water", Furnace(FurnaceNum).SuppHeatCoilName, ErrorsFound);
                     if (Furnace(FurnaceNum).MaxSuppCoilFluidFlow > 0.0) {
                         rho = GetDensityGlycol(PlantLoop(Furnace(FurnaceNum).LoopNumSupp).FluidName,
-                                               CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(Furnace(FurnaceNum).LoopNumSupp).FluidIndex,
                                                RoutineName);
                         Furnace(FurnaceNum).MaxSuppCoilFluidFlow *= rho;
@@ -5079,7 +5079,7 @@ namespace Furnaces {
                         CoilMaxVolFlowRate = GetCoilMaxWaterFlowRate("Coil:Heating:Water", Furnace(FurnaceNum).HeatingCoilName, ErrorsFound);
                         if (CoilMaxVolFlowRate != AutoSize) {
                             rho = GetDensityGlycol(PlantLoop(Furnace(FurnaceNum).LoopNum).FluidName,
-                                                   CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(Furnace(FurnaceNum).LoopNum).FluidIndex,
                                                    RoutineName);
                             Furnace(FurnaceNum).MaxHeatCoilFluidFlow = CoilMaxVolFlowRate * rho;
@@ -5118,7 +5118,7 @@ namespace Furnaces {
                         CoilMaxVolFlowRate = GetCoilMaxWaterFlowRate("Coil:Heating:Water", Furnace(FurnaceNum).SuppHeatCoilName, ErrorsFound);
                         if (CoilMaxVolFlowRate != AutoSize) {
                             rho = GetDensityGlycol(PlantLoop(Furnace(FurnaceNum).LoopNumSupp).FluidName,
-                                                   CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(Furnace(FurnaceNum).LoopNumSupp).FluidIndex,
                                                    RoutineName);
                             Furnace(FurnaceNum).MaxSuppCoilFluidFlow = CoilMaxVolFlowRate * rho;

--- a/src/EnergyPlus/HVACFourPipeBeam.cc
+++ b/src/EnergyPlus/HVACFourPipeBeam.cc
@@ -965,7 +965,7 @@ namespace FourPipeBeam {
         }
         if (this->beamHeatingPresent) {
             rho = FluidProperties::GetDensityGlycol(DataPlant::PlantLoop(this->hWLocation.loopNum).FluidName,
-                                                    DataGlobals::CWInitConvTemp,
+                                                    DataGlobals::HWInitConvTemp,
                                                     DataPlant::PlantLoop(this->hWLocation.loopNum).FluidIndex,
                                                     routineName);
             this->mDotNormRatedHW = this->vDotNormRatedHW * rho;
@@ -1040,7 +1040,7 @@ namespace FourPipeBeam {
         if (vDotDesignHWWasAutosized) {
             this->vDotDesignHW = this->vDotNormRatedHW * this->totBeamLength;
             rho = FluidProperties::GetDensityGlycol(DataPlant::PlantLoop(this->hWLocation.loopNum).FluidName,
-                                                    DataGlobals::CWInitConvTemp,
+                                                    DataGlobals::HWInitConvTemp,
                                                     DataPlant::PlantLoop(this->hWLocation.loopNum).FluidIndex,
                                                     routineName);
             this->mDotNormRatedHW = this->vDotNormRatedHW * rho;

--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
@@ -1314,7 +1314,7 @@ namespace HVACMultiSpeedHeatPump {
             MSHeatPump(MSHPNum).DesignHeatRecFlowRate = Numbers(6);
             if (MSHeatPump(MSHPNum).DesignHeatRecFlowRate > 0.0) {
                 MSHeatPump(MSHPNum).HeatRecActive = true;
-                MSHeatPump(MSHPNum).DesignHeatRecMassFlowRate = RhoH2O(CWInitConvTemp) * MSHeatPump(MSHPNum).DesignHeatRecFlowRate;
+                MSHeatPump(MSHPNum).DesignHeatRecMassFlowRate = RhoH2O(DataGlobals::HWInitConvTemp) * MSHeatPump(MSHPNum).DesignHeatRecFlowRate;
                 MSHeatPump(MSHPNum).HeatRecInletNodeNum = GetOnlySingleNode(
                     Alphas(16), ErrorsFound, CurrentModuleObject, Alphas(1), NodeType_Water, NodeConnectionType_Inlet, 3, ObjectIsNotParent);
                 if (MSHeatPump(MSHPNum).HeatRecInletNodeNum == 0) {
@@ -1883,7 +1883,7 @@ namespace HVACMultiSpeedHeatPump {
 
                 if (MSHeatPump(MSHeatPumpNum).MaxCoilFluidFlow > 0.0) {
                     rho = GetDensityGlycol(PlantLoop(MSHeatPump(MSHeatPumpNum).LoopNum).FluidName,
-                                           CWInitConvTemp,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(MSHeatPump(MSHeatPumpNum).LoopNum).FluidIndex,
                                            RoutineName);
                     MSHeatPump(MSHeatPumpNum).MaxCoilFluidFlow =
@@ -1951,7 +1951,7 @@ namespace HVACMultiSpeedHeatPump {
 
                 if (MSHeatPump(MSHeatPumpNum).MaxSuppCoilFluidFlow > 0.0) {
                     rho = GetDensityGlycol(PlantLoop(MSHeatPump(MSHeatPumpNum).SuppLoopNum).FluidName,
-                                           CWInitConvTemp,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(MSHeatPump(MSHeatPumpNum).SuppLoopNum).FluidIndex,
                                            RoutineName);
                     MSHeatPump(MSHeatPumpNum).MaxSuppCoilFluidFlow =
@@ -2128,7 +2128,7 @@ namespace HVACMultiSpeedHeatPump {
                         CoilMaxVolFlowRate = GetCoilMaxWaterFlowRate("Coil:Heating:Water", MSHeatPump(MSHeatPumpNum).HeatCoilName, ErrorsFound);
                         if (CoilMaxVolFlowRate != AutoSize) {
                             rho = GetDensityGlycol(PlantLoop(MSHeatPump(MSHeatPumpNum).LoopNum).FluidName,
-                                                   CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(MSHeatPump(MSHeatPumpNum).LoopNum).FluidIndex,
                                                    RoutineName);
                             MSHeatPump(MSHeatPumpNum).MaxCoilFluidFlow = CoilMaxVolFlowRate * rho;
@@ -2176,7 +2176,7 @@ namespace HVACMultiSpeedHeatPump {
                         CoilMaxVolFlowRate = GetCoilMaxWaterFlowRate("Coil:Heating:Water", MSHeatPump(MSHeatPumpNum).SuppHeatCoilName, ErrorsFound);
                         if (CoilMaxVolFlowRate != AutoSize) {
                             rho = GetDensityGlycol(PlantLoop(MSHeatPump(MSHeatPumpNum).SuppLoopNum).FluidName,
-                                                   CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(MSHeatPump(MSHeatPumpNum).SuppLoopNum).FluidIndex,
                                                    RoutineName);
                             MSHeatPump(MSHeatPumpNum).MaxSuppCoilFluidFlow = CoilMaxVolFlowRate * rho;

--- a/src/EnergyPlus/HVACUnitaryBypassVAV.cc
+++ b/src/EnergyPlus/HVACUnitaryBypassVAV.cc
@@ -1551,7 +1551,7 @@ namespace HVACUnitaryBypassVAV {
 
                     if (CBVAV(CBVAVNum).MaxHeatCoilFluidFlow > 0.0) {
                         FluidDensity = GetDensityGlycol(PlantLoop(CBVAV(CBVAVNum).LoopNum).FluidName,
-                                                        DataGlobals::CWInitConvTemp,
+                                                        DataGlobals::HWInitConvTemp,
                                                         PlantLoop(CBVAV(CBVAVNum).LoopNum).FluidIndex,
                                                         RoutineName);
                         CBVAV(CBVAVNum).MaxHeatCoilFluidFlow =
@@ -1651,7 +1651,7 @@ namespace HVACUnitaryBypassVAV {
                         }
                         if (CoilMaxVolFlowRate != AutoSize) {
                             FluidDensity = GetDensityGlycol(PlantLoop(CBVAV(CBVAVNum).LoopNum).FluidName,
-                                                            DataGlobals::CWInitConvTemp,
+                                                            DataGlobals::HWInitConvTemp,
                                                             PlantLoop(CBVAV(CBVAVNum).LoopNum).FluidIndex,
                                                             RoutineName);
                             CBVAV(CBVAVNum).MaxHeatCoilFluidFlow = CoilMaxVolFlowRate * FluidDensity;

--- a/src/EnergyPlus/HVACUnitarySystem.cc
+++ b/src/EnergyPlus/HVACUnitarySystem.cc
@@ -721,7 +721,7 @@ namespace HVACUnitarySystem {
 
                     if (UnitarySystem(UnitarySysNum).MaxHeatCoilFluidFlow > 0.0) {
                         rho = GetDensityGlycol(PlantLoop(UnitarySystem(UnitarySysNum).HeatCoilLoopNum).FluidName,
-                                               CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(UnitarySystem(UnitarySysNum).HeatCoilLoopNum).FluidIndex,
                                                RoutineName);
                         UnitarySystem(UnitarySysNum).MaxHeatCoilFluidFlow =
@@ -780,7 +780,7 @@ namespace HVACUnitarySystem {
 
                 if (UnitarySystem(UnitarySysNum).MaxSuppCoilFluidFlow > 0.0) {
                     rho = GetDensityGlycol(PlantLoop(UnitarySystem(UnitarySysNum).SuppCoilLoopNum).FluidName,
-                                           CWInitConvTemp,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(UnitarySystem(UnitarySysNum).SuppCoilLoopNum).FluidIndex,
                                            RoutineNames);
                     UnitarySystem(UnitarySysNum).MaxSuppCoilFluidFlow =
@@ -910,7 +910,7 @@ namespace HVACUnitarySystem {
                             "Coil:Heating:Water", UnitarySystem(UnitarySysNum).HeatingCoilName, InitUnitarySystemsErrorsFound);
                         if (CoilMaxVolFlowRate != AutoSize) {
                             rho = GetDensityGlycol(PlantLoop(UnitarySystem(UnitarySysNum).HeatCoilLoopNum).FluidName,
-                                                   CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(UnitarySystem(UnitarySysNum).HeatCoilLoopNum).FluidIndex,
                                                    RoutineNames);
                             UnitarySystem(UnitarySysNum).MaxHeatCoilFluidFlow = CoilMaxVolFlowRate * rho;
@@ -951,7 +951,7 @@ namespace HVACUnitarySystem {
                             "Coil:Heating:Water", UnitarySystem(UnitarySysNum).SuppHeatCoilName, InitUnitarySystemsErrorsFound);
                         if (CoilMaxVolFlowRate != AutoSize) {
                             rho = GetDensityGlycol(PlantLoop(UnitarySystem(UnitarySysNum).SuppCoilLoopNum).FluidName,
-                                                   CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(UnitarySystem(UnitarySysNum).SuppCoilLoopNum).FluidIndex,
                                                    RoutineNames);
                             UnitarySystem(UnitarySysNum).MaxSuppCoilFluidFlow = CoilMaxVolFlowRate * rho;
@@ -1586,7 +1586,7 @@ namespace HVACUnitarySystem {
                         CoilMaxVolFlowRate = GetCoilMaxWaterFlowRate("Coil:Heating:Water", UnitarySystem(UnitarySysNum).HeatingCoilName, ErrorsFound);
                         if (CoilMaxVolFlowRate != AutoSize) {
                             rho = GetDensityGlycol(PlantLoop(UnitarySystem(UnitarySysNum).HeatCoilLoopNum).FluidName,
-                                                   CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(UnitarySystem(UnitarySysNum).HeatCoilLoopNum).FluidIndex,
                                                    RoutineName);
                             UnitarySystem(UnitarySysNum).MaxHeatCoilFluidFlow = CoilMaxVolFlowRate * rho;
@@ -1627,7 +1627,7 @@ namespace HVACUnitarySystem {
                             GetCoilMaxWaterFlowRate("Coil:Heating:Water", UnitarySystem(UnitarySysNum).SuppHeatCoilName, ErrorsFound);
                         if (CoilMaxVolFlowRate != AutoSize) {
                             rho = GetDensityGlycol(PlantLoop(UnitarySystem(UnitarySysNum).SuppCoilLoopNum).FluidName,
-                                                   CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(UnitarySystem(UnitarySysNum).SuppCoilLoopNum).FluidIndex,
                                                    RoutineName);
                             UnitarySystem(UnitarySysNum).MaxSuppCoilFluidFlow = CoilMaxVolFlowRate * rho;

--- a/src/EnergyPlus/HWBaseboardRadiator.cc
+++ b/src/EnergyPlus/HWBaseboardRadiator.cc
@@ -848,7 +848,7 @@ namespace HWBaseboardRadiator {
             WaterInletNode = HWBaseboard(BaseboardNum).WaterInletNode;
 
             rho = GetDensityGlycol(PlantLoop(HWBaseboard(BaseboardNum).LoopNum).FluidName,
-                                   CWInitConvTemp,
+                                   DataGlobals::HWInitConvTemp,
                                    PlantLoop(HWBaseboard(BaseboardNum).LoopNum).FluidIndex,
                                    RoutineName);
 
@@ -1080,7 +1080,7 @@ namespace HWBaseboardRadiator {
                                                    PlantLoop(HWBaseboard(BaseboardNum).LoopNum).FluidIndex,
                                                    RoutineName);
                         rho = GetDensityGlycol(PlantLoop(HWBaseboard(BaseboardNum).LoopNum).FluidName,
-                                               CWInitConvTemp,
+                                               HWInitConvTemp,
                                                PlantLoop(HWBaseboard(BaseboardNum).LoopNum).FluidIndex,
                                                RoutineName);
                         WaterVolFlowRateMaxDes = DesCoilLoad / (PlantSizData(PltSizHeatNum).DeltaT * Cp * rho);
@@ -1127,7 +1127,7 @@ namespace HWBaseboardRadiator {
                 } else if (HWBaseboard(BaseboardNum).RatedCapacity == AutoSize || HWBaseboard(BaseboardNum).RatedCapacity == 0.0) {
                     DesCoilLoad = RatedCapacityDes;
                     rho = GetDensityGlycol(PlantLoop(HWBaseboard(BaseboardNum).LoopNum).FluidName,
-                                           CWInitConvTemp,
+                                           DataGlobals::HWInitConvTemp,
                                            PlantLoop(HWBaseboard(BaseboardNum).LoopNum).FluidIndex,
                                            RoutineNameFull);
                     WaterMassFlowRateStd = HWBaseboard(BaseboardNum).WaterVolFlowRateMax * rho;

--- a/src/EnergyPlus/LowTempRadiantSystem.cc
+++ b/src/EnergyPlus/LowTempRadiantSystem.cc
@@ -2735,11 +2735,11 @@ namespace LowTempRadiantSystem {
                         if (PltSizCoolNum > 0) {
                             if (DesCoilLoad >= SmallLoad) {
                                 rho = GetDensityGlycol(PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidName,
-                                                       5.,
+                                                       DataGlobals::CWInitConvTemp,
                                                        PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidIndex,
                                                        RoutineName);
                                 Cp = GetSpecificHeatGlycol(PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidName,
-                                                           5.0,
+                                                           DataGlobals::CWInitConvTemp,
                                                            PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidIndex,
                                                            RoutineName);
                                 WaterVolFlowMaxCoolDes = DesCoilLoad / (PlantSizData(PltSizCoolNum).DeltaT * Cp * rho);

--- a/src/EnergyPlus/LowTempRadiantSystem.cc
+++ b/src/EnergyPlus/LowTempRadiantSystem.cc
@@ -2914,11 +2914,11 @@ namespace LowTempRadiantSystem {
                     if (PltSizCoolNum > 0) {
                         if (FinalZoneSizing(CurZoneEqNum).NonAirSysDesCoolLoad >= SmallLoad) {
                             rho = GetDensityGlycol(PlantLoop(CFloRadSys(RadSysNum).CWLoopNum).FluidName,
-                                                   5.0,
+                                                   DataGlobals::CWInitConvTemp,
                                                    PlantLoop(CFloRadSys(RadSysNum).CWLoopNum).FluidIndex,
                                                    "SizeLowTempRadiantSystem");
                             Cp = GetSpecificHeatGlycol(PlantLoop(CFloRadSys(RadSysNum).CWLoopNum).FluidName,
-                                                       5.0,
+                                                       DataGlobals::CWInitConvTemp,
                                                        PlantLoop(CFloRadSys(RadSysNum).CWLoopNum).FluidIndex,
                                                        "SizeLowTempRadiantSystem");
                             WaterVolFlowMaxCoolDes =

--- a/src/EnergyPlus/OutdoorAirUnit.cc
+++ b/src/EnergyPlus/OutdoorAirUnit.cc
@@ -1245,7 +1245,7 @@ namespace OutdoorAirUnit {
                         OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxVolWaterFlow = GetWaterCoilMaxFlowRate(
                             OutAirUnit(OAUnitNum).OAEquip(compLoop).ComponentType, OutAirUnit(OAUnitNum).OAEquip(compLoop).ComponentName, errFlag);
                         rho = GetDensityGlycol(PlantLoop(OutAirUnit(OAUnitNum).OAEquip(compLoop).LoopNum).FluidName,
-                                               5.0,
+                                               DataGlobals::CWInitConvTemp,
                                                PlantLoop(OutAirUnit(OAUnitNum).OAEquip(compLoop).LoopNum).FluidIndex,
                                                RoutineName);
                         OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxWaterMassFlow = rho * OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxVolWaterFlow;
@@ -1264,7 +1264,7 @@ namespace OutdoorAirUnit {
                         OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxVolWaterFlow = GetWaterCoilMaxFlowRate(
                             OutAirUnit(OAUnitNum).OAEquip(compLoop).ComponentType, OutAirUnit(OAUnitNum).OAEquip(compLoop).ComponentName, errFlag);
                         rho = GetDensityGlycol(PlantLoop(OutAirUnit(OAUnitNum).OAEquip(compLoop).LoopNum).FluidName,
-                                               HWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(OutAirUnit(OAUnitNum).OAEquip(compLoop).LoopNum).FluidIndex,
                                                RoutineName);
                         OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxWaterMassFlow = rho * OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxVolWaterFlow;
@@ -1299,7 +1299,7 @@ namespace OutdoorAirUnit {
                         OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxVolWaterFlow = GetWaterCoilMaxFlowRate(
                             OutAirUnit(OAUnitNum).OAEquip(compLoop).ComponentType, OutAirUnit(OAUnitNum).OAEquip(compLoop).ComponentName, errFlag);
                         rho = GetDensityGlycol(PlantLoop(OutAirUnit(OAUnitNum).OAEquip(compLoop).LoopNum).FluidName,
-                                               60.0,
+                                               DataGlobals::CWInitConvTemp,
                                                PlantLoop(OutAirUnit(OAUnitNum).OAEquip(compLoop).LoopNum).FluidIndex,
                                                RoutineName);
                         OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxWaterMassFlow = rho * OutAirUnit(OAUnitNum).OAEquip(compLoop).MaxVolWaterFlow;

--- a/src/EnergyPlus/PackagedTerminalHeatPump.cc
+++ b/src/EnergyPlus/PackagedTerminalHeatPump.cc
@@ -3825,7 +3825,7 @@ namespace PackagedTerminalHeatPump {
 
                     if (PTUnit(PTUnitNum).MaxHeatCoilFluidFlow > 0.0) {
                         rho = GetDensityGlycol(PlantLoop(PTUnit(PTUnitNum).HeatCoilLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(PTUnit(PTUnitNum).HeatCoilLoopNum).FluidIndex,
                                                RoutineName);
 
@@ -3896,7 +3896,7 @@ namespace PackagedTerminalHeatPump {
 
                     if (PTUnit(PTUnitNum).MaxSuppCoilFluidFlow > 0.0) {
                         rho = GetDensityGlycol(PlantLoop(PTUnit(PTUnitNum).SuppCoilLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(PTUnit(PTUnitNum).SuppCoilLoopNum).FluidIndex,
                                                RoutineName);
                         PTUnit(PTUnitNum).MaxSuppCoilFluidFlow =
@@ -4250,7 +4250,7 @@ namespace PackagedTerminalHeatPump {
                     if (CoilMaxVolFlowRate != AutoSize) {
 
                         rho = GetDensityGlycol(PlantLoop(PTUnit(PTUnitNum).HeatCoilLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(PTUnit(PTUnitNum).HeatCoilLoopNum).FluidIndex,
                                                RoutineNameSpace);
                         PTUnit(PTUnitNum).MaxHeatCoilFluidFlow = CoilMaxVolFlowRate * rho;
@@ -4273,7 +4273,7 @@ namespace PackagedTerminalHeatPump {
                     CoilMaxVolFlowRate = GetCoilMaxWaterFlowRate("Coil:Heating:Water", PTUnit(PTUnitNum).SuppHeatCoilName, ErrorsFound);
                     if (CoilMaxVolFlowRate != AutoSize) {
                         rho = GetDensityGlycol(PlantLoop(PTUnit(PTUnitNum).SuppCoilLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(PTUnit(PTUnitNum).SuppCoilLoopNum).FluidIndex,
                                                RoutineNameSpace);
                         PTUnit(PTUnitNum).MaxSuppCoilFluidFlow = CoilMaxVolFlowRate * rho;

--- a/src/EnergyPlus/PlantChillers.cc
+++ b/src/EnergyPlus/PlantChillers.cc
@@ -3172,7 +3172,7 @@ namespace PlantChillers {
 
             if (ElectricChiller(ChillNum).HeatRecActive) {
                 rho = GetDensityGlycol(PlantLoop(ElectricChiller(ChillNum).HRLoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(ElectricChiller(ChillNum).HRLoopNum).FluidIndex,
                                        RoutineName);
                 ElectricChiller(ChillNum).DesignHeatRecMassFlowRate = rho * ElectricChiller(ChillNum).DesignHeatRecVolFlowRate;
@@ -3564,7 +3564,7 @@ namespace PlantChillers {
 
             if (EngineDrivenChiller(ChillNum).HeatRecActive) {
                 rho = GetDensityGlycol(PlantLoop(EngineDrivenChiller(ChillNum).HRLoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(EngineDrivenChiller(ChillNum).HRLoopNum).FluidIndex,
                                        RoutineName);
                 EngineDrivenChiller(ChillNum).DesignHeatRecMassFlowRate = rho * EngineDrivenChiller(ChillNum).DesignHeatRecVolFlowRate;
@@ -3904,7 +3904,7 @@ namespace PlantChillers {
 
             if (GTChiller(ChillNum).HeatRecActive) {
                 rho = GetDensityGlycol(PlantLoop(GTChiller(ChillNum).HRLoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(GTChiller(ChillNum).HRLoopNum).FluidIndex,
                                        RoutineName);
                 GTChiller(ChillNum).DesignHeatRecMassFlowRate = rho * GTChiller(ChillNum).DesignHeatRecVolFlowRate;

--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -1280,7 +1280,8 @@ namespace ReportSizingManager {
                     }
                 } else if (SizingType == CoolingWaterflowSizing) {
                     CoilDesWaterDeltaT = DataWaterCoilSizCoolDeltaT;
-                    Cp = GetSpecificHeatGlycol(PlantLoop(DataWaterLoopNum).FluidName, 5.0, PlantLoop(DataWaterLoopNum).FluidIndex, CallingRoutine);
+                    Cp = GetSpecificHeatGlycol(
+                        PlantLoop(DataWaterLoopNum).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(DataWaterLoopNum).FluidIndex, CallingRoutine);
                     rho = GetDensityGlycol(
                         PlantLoop(DataWaterLoopNum).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(DataWaterLoopNum).FluidIndex, CallingRoutine);
                     if (TermUnitIU && (CurTermUnitSizingNum > 0)) {
@@ -1436,8 +1437,10 @@ namespace ReportSizingManager {
                     bCheckForZero = false;
                 } else if (SizingType == CoolingWaterDesAirOutletTempSizing) {
                     if (TermUnitIU) {
-                        Cp =
-                            GetSpecificHeatGlycol(PlantLoop(DataWaterLoopNum).FluidName, 5.0, PlantLoop(DataWaterLoopNum).FluidIndex, CallingRoutine);
+                        Cp = GetSpecificHeatGlycol(PlantLoop(DataWaterLoopNum).FluidName,
+                                                   DataGlobals::CWInitConvTemp,
+                                                   PlantLoop(DataWaterLoopNum).FluidIndex,
+                                                   CallingRoutine);
                         rho = GetDensityGlycol(PlantLoop(DataWaterLoopNum).FluidName,
                                                DataGlobals::CWInitConvTemp,
                                                PlantLoop(DataWaterLoopNum).FluidIndex,
@@ -2296,8 +2299,10 @@ namespace ReportSizingManager {
                         CoilDesWaterDeltaT = DataWaterCoilSizCoolDeltaT;
                     }
                     if (DataCapacityUsedForSizing >= SmallLoad) {
-                        Cp =
-                            GetSpecificHeatGlycol(PlantLoop(DataWaterLoopNum).FluidName, 5.0, PlantLoop(DataWaterLoopNum).FluidIndex, CallingRoutine);
+                        Cp = GetSpecificHeatGlycol(PlantLoop(DataWaterLoopNum).FluidName,
+                                                   DataGlobals::CWInitConvTemp,
+                                                   PlantLoop(DataWaterLoopNum).FluidIndex,
+                                                   CallingRoutine);
                         rho = GetDensityGlycol(PlantLoop(DataWaterLoopNum).FluidName,
                                                DataGlobals::CWInitConvTemp,
                                                PlantLoop(DataWaterLoopNum).FluidIndex,

--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -1309,7 +1309,7 @@ namespace ReportSizingManager {
                                                    PlantLoop(DataWaterLoopNum).FluidIndex,
                                                    CallingRoutine);
                         rho = GetDensityGlycol(PlantLoop(DataWaterLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(DataWaterLoopNum).FluidIndex,
                                                CallingRoutine);
                         DesCoilLoad = AutosizeDes * DataWaterCoilSizHeatDeltaT * Cp * rho;
@@ -1320,7 +1320,7 @@ namespace ReportSizingManager {
                                                    PlantLoop(DataWaterLoopNum).FluidIndex,
                                                    CallingRoutine);
                         rho = GetDensityGlycol(PlantLoop(DataWaterLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(DataWaterLoopNum).FluidIndex,
                                                CallingRoutine);
                         DesCoilLoad = AutosizeDes * DataWaterCoilSizHeatDeltaT * Cp * rho;
@@ -1351,7 +1351,7 @@ namespace ReportSizingManager {
                                                        PlantLoop(DataWaterLoopNum).FluidIndex,
                                                        CallingRoutine);
                             rho = GetDensityGlycol(PlantLoop(DataWaterLoopNum).FluidName,
-                                                   DataGlobals::CWInitConvTemp,
+                                                   DataGlobals::HWInitConvTemp,
                                                    PlantLoop(DataWaterLoopNum).FluidIndex,
                                                    CallingRoutine);
                             AutosizeDes = DesCoilLoad / (DataWaterCoilSizHeatDeltaT * Cp * rho);
@@ -1761,7 +1761,7 @@ namespace ReportSizingManager {
                                                    PlantLoop(DataWaterLoopNum).FluidIndex,
                                                    CallingRoutine);
                         rho = GetDensityGlycol(PlantLoop(DataWaterLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(DataWaterLoopNum).FluidIndex,
                                                CallingRoutine);
                         NominalCapacityDes = DesMassFlow * DataWaterCoilSizHeatDeltaT * Cp * rho;
@@ -1772,7 +1772,7 @@ namespace ReportSizingManager {
                                                    PlantLoop(DataWaterLoopNum).FluidIndex,
                                                    CallingRoutine);
                         rho = GetDensityGlycol(PlantLoop(DataWaterLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(DataWaterLoopNum).FluidIndex,
                                                CallingRoutine);
                         NominalCapacityDes = DesMassFlow * DataWaterCoilSizHeatDeltaT * Cp * rho;
@@ -2315,7 +2315,7 @@ namespace ReportSizingManager {
                                                    PlantLoop(DataWaterLoopNum).FluidIndex,
                                                    CallingRoutine);
                         rho = GetDensityGlycol(PlantLoop(DataWaterLoopNum).FluidName,
-                                               DataGlobals::CWInitConvTemp,
+                                               DataGlobals::HWInitConvTemp,
                                                PlantLoop(DataWaterLoopNum).FluidIndex,
                                                CallingRoutine);
                         AutosizeDes = DataCapacityUsedForSizing / (DataWaterCoilSizHeatDeltaT * Cp * rho);

--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -2106,7 +2106,7 @@ namespace SingleDuct {
 
             if (Sys(SysNum).HWLoopNum > 0 && Sys(SysNum).ReheatComp_Num != HCoilType_SteamAirHeating) { // protect early calls before plant is setup
                 rho = GetDensityGlycol(PlantLoop(Sys(SysNum).HWLoopNum).FluidName,
-                                       DataGlobals::CWInitConvTemp,
+                                       DataGlobals::HWInitConvTemp,
                                        PlantLoop(Sys(SysNum).HWLoopNum).FluidIndex,
                                        RoutineName);
             } else {

--- a/src/EnergyPlus/VentilatedSlab.cc
+++ b/src/EnergyPlus/VentilatedSlab.cc
@@ -1625,8 +1625,10 @@ namespace VentilatedSlab {
                 // Only initialize these if a cooling coil is actually present
                 if ((VentSlab(Item).CCoil_PlantTypeNum == TypeOf_CoilWaterCooling) ||
                     (VentSlab(Item).CCoil_PlantTypeNum == TypeOf_CoilWaterDetailedFlatCooling)) {
-                    rho = GetDensityGlycol(
-                        PlantLoop(VentSlab(Item).CWLoopNum).FluidName, CWInitConvTemp, PlantLoop(VentSlab(Item).CWLoopNum).FluidIndex, RoutineName);
+                    rho = GetDensityGlycol(PlantLoop(VentSlab(Item).CWLoopNum).FluidName,
+                                           DataGlobals::CWInitConvTemp,
+                                           PlantLoop(VentSlab(Item).CWLoopNum).FluidIndex,
+                                           RoutineName);
                     VentSlab(Item).MaxColdWaterFlow = rho * VentSlab(Item).MaxVolColdWaterFlow;
                     VentSlab(Item).MinColdWaterFlow = rho * VentSlab(Item).MinVolColdWaterFlow;
                     InitComponentNodes(VentSlab(Item).MinColdWaterFlow,

--- a/tst/EnergyPlus/unit/BoilerHotWater.unit.cc
+++ b/tst/EnergyPlus/unit/BoilerHotWater.unit.cc
@@ -100,7 +100,7 @@ TEST_F(EnergyPlusFixture, Boiler_HotWaterSizingTest)
     // see if boiler volume flow rate returned is autosized value
     EXPECT_NEAR(Boilers::Boiler(1).VolFlowRate, 1.2, 0.000001);
     // see if boiler nominal capacity returned is autosized value
-    EXPECT_NEAR(Boilers::Boiler(1).NomCap, 49567438.0, 1.0);
+    EXPECT_NEAR(Boilers::Boiler(1).NomCap, 49376304.0, 1.0);
     // clear
     Boilers::Boiler.deallocate();
     DataSizing::PlantSizData.deallocate();

--- a/tst/EnergyPlus/unit/BoilerHotWater.unit.cc
+++ b/tst/EnergyPlus/unit/BoilerHotWater.unit.cc
@@ -100,7 +100,7 @@ TEST_F(EnergyPlusFixture, Boiler_HotWaterSizingTest)
     // see if boiler volume flow rate returned is autosized value
     EXPECT_NEAR(Boilers::Boiler(1).VolFlowRate, 1.2, 0.000001);
     // see if boiler nominal capacity returned is autosized value
-    EXPECT_NEAR(Boilers::Boiler(1).NomCap, 50409257.0, 1.0);
+    EXPECT_NEAR(Boilers::Boiler(1).NomCap, 49567438.0, 1.0);
     // clear
     Boilers::Boiler.deallocate();
     DataSizing::PlantSizData.deallocate();

--- a/tst/EnergyPlus/unit/HVACFourPipeBeam.unit.cc
+++ b/tst/EnergyPlus/unit/HVACFourPipeBeam.unit.cc
@@ -177,9 +177,15 @@ TEST_F(EnergyPlusFixture, Beam_FactoryAllAutosize)
 
     DataZoneEquipment::ZoneEquipConfig(1).InletNode(1) = 3;
     bool ErrorsFound = false;
-    DataZoneEquipment::ZoneEquipConfig(1).ZoneNode =
-        NodeInputManager::GetOnlySingleNode("Zone 1 Node", ErrorsFound, "Zone", "BeamTest", DataLoopNode::NodeType_Air,
-                                            DataLoopNode::NodeConnectionType_ZoneNode, 1, DataLoopNode::ObjectIsNotParent, "Test zone node");
+    DataZoneEquipment::ZoneEquipConfig(1).ZoneNode = NodeInputManager::GetOnlySingleNode("Zone 1 Node",
+                                                                                         ErrorsFound,
+                                                                                         "Zone",
+                                                                                         "BeamTest",
+                                                                                         DataLoopNode::NodeType_Air,
+                                                                                         DataLoopNode::NodeConnectionType_ZoneNode,
+                                                                                         1,
+                                                                                         DataLoopNode::ObjectIsNotParent,
+                                                                                         "Test zone node");
 
     DataDefineEquip::NumAirDistUnits = 1;
     DataDefineEquip::AirDistUnit.allocate(1);
@@ -1689,8 +1695,8 @@ TEST_F(EnergyPlusFixture, Beam_sizeandSimulateOneZone)
 
     EXPECT_DOUBLE_EQ(DataLoopNode::Node(15).Temp, 14.0);
     EXPECT_DOUBLE_EQ(DataLoopNode::Node(15).MassFlowRate, 0.0);
-    EXPECT_NEAR(DataLoopNode::Node(39).Temp, 35.064466069323743, 0.00001);
-    EXPECT_NEAR(DataLoopNode::Node(39).MassFlowRate, 0.19320550334974979, 0.00001);
+    EXPECT_NEAR(DataLoopNode::Node(39).Temp, 34.895727719471829, 0.00001);
+    EXPECT_NEAR(DataLoopNode::Node(39).MassFlowRate, 0.18997902875440670, 0.00001);
 
     EXPECT_NEAR(NonAirSysOutput, 8023.9273066417645, 0.0001);
 
@@ -1732,8 +1738,8 @@ TEST_F(EnergyPlusFixture, Beam_sizeandSimulateOneZone)
 
     EXPECT_DOUBLE_EQ(DataLoopNode::Node(15).Temp, 14.0);
     EXPECT_DOUBLE_EQ(DataLoopNode::Node(15).MassFlowRate, 0.0);
-    EXPECT_NEAR(DataLoopNode::Node(39).Temp, 33.836239364981424, 0.00001);
-    EXPECT_NEAR(DataLoopNode::Node(39).MassFlowRate, 0.10040605035467959, 0.00001);
+    EXPECT_NEAR(DataLoopNode::Node(39).Temp, 33.646641648256931, 0.00001);
+    EXPECT_NEAR(DataLoopNode::Node(39).MassFlowRate, 0.098729299097229120, 0.00001);
     // EXPECT_DOUBLE_EQ( DataLoopNode::Node( 15 ).Temp, 14.0 );
     // EXPECT_DOUBLE_EQ( DataLoopNode::Node( 15 ).MassFlowRate, 0.0 );
     // EXPECT_NEAR( DataLoopNode::Node( 39 ).Temp, 33.836239364981424, 0.00001 );

--- a/tst/EnergyPlus/unit/HVACUnitarySystem.unit.cc
+++ b/tst/EnergyPlus/unit/HVACUnitarySystem.unit.cc
@@ -124,7 +124,6 @@ using namespace EnergyPlus::ZoneAirLoopEquipmentManager;
 
 using DataEnvironment::OutDryBulbTemp;
 using General::TrimSigDigits;
-using General::TrimSigDigits;
 using WaterCoils::SimpleAnalysis;
 using WaterCoils::WaterCoil;
 using WaterCoils::WaterCoil_Cooling;
@@ -2359,9 +2358,13 @@ TEST_F(EnergyPlusFixture, UnitarySystemSizingTest_ConfirmUnitarySystemSizingTest
     int iCoolingSizingType(1);
     int iHeatingSizingType(1);
     bool FirstHVACIteration(true);
-    Array1D_int SizingTypes({DataSizing::None, DataSizing::SupplyAirFlowRate, DataSizing::FlowPerFloorArea,
-                             DataSizing::FractionOfAutosizedCoolingAirflow, DataSizing::FractionOfAutosizedHeatingAirflow,
-                             DataSizing::FlowPerCoolingCapacity, DataSizing::FlowPerHeatingCapacity});
+    Array1D_int SizingTypes({DataSizing::None,
+                             DataSizing::SupplyAirFlowRate,
+                             DataSizing::FlowPerFloorArea,
+                             DataSizing::FractionOfAutosizedCoolingAirflow,
+                             DataSizing::FractionOfAutosizedHeatingAirflow,
+                             DataSizing::FlowPerCoolingCapacity,
+                             DataSizing::FlowPerHeatingCapacity});
 
     //	int const None( 1 );
     //	int const SupplyAirFlowRate( 2 );
@@ -2863,8 +2866,14 @@ TEST_F(EnergyPlusFixture, HVACUnitarySystem_CalcUnitaryCoolingSystem)
 
     WaterCoil(1).TotWaterCoolingCoilRate = 0.0;
 
-    CalcUnitaryCoolingSystem(UnitarySysNum, FirstHVACIteration, AirLoopNum, UnitarySystem(UnitarySysNum).CoolingCycRatio, CompOn, OnOffAirFlowRatio,
-                             CoilCoolHeatRat, false);
+    CalcUnitaryCoolingSystem(UnitarySysNum,
+                             FirstHVACIteration,
+                             AirLoopNum,
+                             UnitarySystem(UnitarySysNum).CoolingCycRatio,
+                             CompOn,
+                             OnOffAirFlowRatio,
+                             CoilCoolHeatRat,
+                             false);
 
     EXPECT_NEAR(27530.0, WaterCoil(1).TotWaterCoolingCoilRate, 2.0);
 }
@@ -5808,7 +5817,8 @@ TEST_F(EnergyPlusFixture, UnitarySystem_MultispeedDXCoilSizing)
     EXPECT_EQ(UnitarySystem(1).DesignCoolingCapacity, DXCoil(UnitarySystem(1).CoolingCoilIndex).MSRatedTotCap(UnitarySystem(1).NumOfSpeedCooling));
     // 64-bit MSVS shows these next variables as identical yet other compilers show diff's, changing ASSERT_EQ to EXPECT_NEAR
     EXPECT_NEAR(UnitarySystem(1).DesignHeatingCapacity,
-                VarSpeedCoil(UnitarySystem(1).HeatingCoilIndex).MSRatedTotCap(UnitarySystem(1).NumOfSpeedHeating), 0.001);
+                VarSpeedCoil(UnitarySystem(1).HeatingCoilIndex).MSRatedTotCap(UnitarySystem(1).NumOfSpeedHeating),
+                0.001);
 
     // 3 cooling speeds with autosized MSHP design spec yielding equally distributed air flow at 1/3 per speed
     EXPECT_NEAR(UnitarySystem(1).CoolVolumeFlowRate(1), 0.031373, 0.000001);
@@ -5822,11 +5832,14 @@ TEST_F(EnergyPlusFixture, UnitarySystem_MultispeedDXCoilSizing)
     EXPECT_NEAR(HVACUnitarySystem::DesignSpecMSHP(1).CoolingVolFlowRatio(2), 0.666666, 0.000001);
     EXPECT_NEAR(HVACUnitarySystem::DesignSpecMSHP(1).CoolingVolFlowRatio(3), 1.000000, 0.000001);
 
-    EXPECT_NEAR(DXCoil(1).MSRatedAirVolFlowRate(1), UnitarySystem(1).MaxCoolAirVolFlow * HVACUnitarySystem::DesignSpecMSHP(1).CoolingVolFlowRatio(1),
+    EXPECT_NEAR(DXCoil(1).MSRatedAirVolFlowRate(1),
+                UnitarySystem(1).MaxCoolAirVolFlow * HVACUnitarySystem::DesignSpecMSHP(1).CoolingVolFlowRatio(1),
                 0.000001);
-    EXPECT_NEAR(DXCoil(1).MSRatedAirVolFlowRate(2), UnitarySystem(1).MaxCoolAirVolFlow * HVACUnitarySystem::DesignSpecMSHP(1).CoolingVolFlowRatio(2),
+    EXPECT_NEAR(DXCoil(1).MSRatedAirVolFlowRate(2),
+                UnitarySystem(1).MaxCoolAirVolFlow * HVACUnitarySystem::DesignSpecMSHP(1).CoolingVolFlowRatio(2),
                 0.000001);
-    EXPECT_NEAR(DXCoil(1).MSRatedAirVolFlowRate(3), UnitarySystem(1).MaxCoolAirVolFlow * HVACUnitarySystem::DesignSpecMSHP(1).CoolingVolFlowRatio(3),
+    EXPECT_NEAR(DXCoil(1).MSRatedAirVolFlowRate(3),
+                UnitarySystem(1).MaxCoolAirVolFlow * HVACUnitarySystem::DesignSpecMSHP(1).CoolingVolFlowRatio(3),
                 0.000001);
 
     // 10 heating speeds with autosized MSHP design spec yielding equally distributed air flow at 1/10 per speed
@@ -8347,9 +8360,10 @@ TEST_F(EnergyPlusFixture, UnitarySystem_ASHRAEModel_WaterCoils)
     // these next 2 variables are used to modulate the coil PLR irrespective of the fan PLR - they are non-zero when the model is called and CAN be 0
     // when load exceeds capacity the ASHRAE model is the only model that uses these variables, and flow is determined by Heat/CoolWaterFlowRatio *
     // max other models will show 0 here and in this case water flow will equal max flow * PartLoadRatio
-    EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.0135, 0.0001); // heating coil water flow ratio, heating coil is on
-    EXPECT_NEAR(UnitarySystem(1).CoolCoilWaterFlowRatio, 0.0, 0.0001);    // cooling coil water flow ratio, cooling coil is off
-    EXPECT_NEAR(UnitarySystem(1).FanPartLoadRatio, UnitarySystem(1).MaxNoCoolHeatAirMassFlow / UnitarySystem(1).MaxHeatAirMassFlow,
+    EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.01374, 0.0001); // heating coil water flow ratio, heating coil is on
+    EXPECT_NEAR(UnitarySystem(1).CoolCoilWaterFlowRatio, 0.0, 0.0001);     // cooling coil water flow ratio, cooling coil is off
+    EXPECT_NEAR(UnitarySystem(1).FanPartLoadRatio,
+                UnitarySystem(1).MaxNoCoolHeatAirMassFlow / UnitarySystem(1).MaxHeatAirMassFlow,
                 0.0001);                                                    // fan PLR at minimum speed
     EXPECT_LT(Node(OutletNode).Temp, UnitarySystem(1).DesignMaxOutletTemp); // outlet temperature does not exceed max limit
 
@@ -8375,9 +8389,10 @@ TEST_F(EnergyPlusFixture, UnitarySystem_ASHRAEModel_WaterCoils)
     EXPECT_GT(Node(InletNode).MassFlowRate, UnitarySystem(1).MaxNoCoolHeatAirMassFlow);       // air flow higher than low speed fan flow
     EXPECT_LT(Node(InletNode).MassFlowRate, UnitarySystem(1).MaxHeatAirMassFlow);             // air flow lower than high speed fan flow
     EXPECT_DOUBLE_EQ(Node(InletNode).MassFlowRate, Node(OutletNode).MassFlowRate);            // inlet = outlet flow rate
-    EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.0655, 0.0001);                     // heating coil water flow ratio, heating coil is on
+    EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.0667, 0.0001);                     // heating coil water flow ratio, heating coil is on
     EXPECT_NEAR(UnitarySystem(1).CoolCoilWaterFlowRatio, 0.0, 0.0001);                        // cooling coil water flow ratio, cooling coil is off
-    EXPECT_NEAR(UnitarySystem(1).FanPartLoadRatio, 0.6197,
+    EXPECT_NEAR(UnitarySystem(1).FanPartLoadRatio,
+                0.6198,
                 0.0001); // fan PLR above minimum and below maximum speed (0-1 means fraction between no load flow and full flow)
     EXPECT_NEAR(Node(OutletNode).Temp, UnitarySystem(1).DesignMaxOutletTemp, 0.01); // outlet temperature modulated to meet max limit
 
@@ -8401,7 +8416,7 @@ TEST_F(EnergyPlusFixture, UnitarySystem_ASHRAEModel_WaterCoils)
     // test model performance
     EXPECT_NEAR(ZoneSysEnergyDemand(ControlZoneNum).RemainingOutputRequired, Qsens_sys, 10.0); // Watts
     EXPECT_DOUBLE_EQ(Node(InletNode).MassFlowRate, Node(OutletNode).MassFlowRate);             // inlet = outlet flow rate
-    EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.2489, 0.001);                       // heating coil water flow ratio, heating coil is on
+    EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.2532, 0.001);                       // heating coil water flow ratio, heating coil is on
     EXPECT_NEAR(UnitarySystem(1).CoolCoilWaterFlowRatio, 0.0, 0.0001);                         // cooling coil water flow ratio, cooling coil is off
     EXPECT_EQ(UnitarySystem(1).FanPartLoadRatio, 1.0); // fan PLR at maximum speed (0-1 means fraction between no load flow and full flow)
     EXPECT_GT(Node(OutletNode).Temp, UnitarySystem(1).DesignMaxOutletTemp); // outlet temperature exceeds max limit
@@ -8425,10 +8440,11 @@ TEST_F(EnergyPlusFixture, UnitarySystem_ASHRAEModel_WaterCoils)
 
     // test model performance
     EXPECT_GT(ZoneSysEnergyDemand(ControlZoneNum).RemainingOutputRequired, Qsens_sys);                            // Watts - system CANNOT meet load
-    EXPECT_NEAR(Qsens_sys, 11330.43, 0.1);                                                                        // system maxed out on capacity
+    EXPECT_NEAR(Qsens_sys, 11316.64, 0.1);                                                                        // system maxed out on capacity
     EXPECT_DOUBLE_EQ(Node(InletNode).MassFlowRate, Node(OutletNode).MassFlowRate);                                // inlet = outlet flow rate
     EXPECT_EQ(Node(UnitarySystem(1).HeatCoilFluidInletNode).MassFlowRate, UnitarySystem(1).MaxHeatCoilFluidFlow); // water coil water flow rate at max
-    EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.0,
+    EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio,
+                0.0,
                 0.0001); // heating coil water flow ratio not set, heating coil is on since function returned when load exceeded capacity
     EXPECT_NEAR(UnitarySystem(1).CoolCoilWaterFlowRatio, 0.0, 0.0001); // cooling coil water flow ratio, cooling coil is off
     EXPECT_EQ(UnitarySystem(1).FanPartLoadRatio, 1.0); // fan PLR at maximum speed (0-1 means fraction between no load flow and full flow)
@@ -8473,7 +8489,8 @@ TEST_F(EnergyPlusFixture, UnitarySystem_ASHRAEModel_WaterCoils)
     EXPECT_DOUBLE_EQ(Node(InletNode).MassFlowRate, Node(OutletNode).MassFlowRate);             // inlet = outlet flow rate
     EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.0, 0.0001);                         // heating coil water flow ratio, heating coil is off
     EXPECT_NEAR(UnitarySystem(1).CoolCoilWaterFlowRatio, 0.103, 0.001);                        // cooling coil water flow ratio, cooling coil is on
-    EXPECT_NEAR(UnitarySystem(1).FanPartLoadRatio, UnitarySystem(1).MaxNoCoolHeatAirMassFlow / UnitarySystem(1).MaxCoolAirMassFlow,
+    EXPECT_NEAR(UnitarySystem(1).FanPartLoadRatio,
+                UnitarySystem(1).MaxNoCoolHeatAirMassFlow / UnitarySystem(1).MaxCoolAirMassFlow,
                 0.0001);                                                    // fan PLR at minimum speed
     EXPECT_GT(Node(OutletNode).Temp, UnitarySystem(1).DesignMinOutletTemp); // outlet temperature is not below min limit
 
@@ -8550,7 +8567,8 @@ TEST_F(EnergyPlusFixture, UnitarySystem_ASHRAEModel_WaterCoils)
     EXPECT_DOUBLE_EQ(Node(InletNode).MassFlowRate, Node(OutletNode).MassFlowRate);                                // inlet = outlet flow rate
     EXPECT_EQ(Node(UnitarySystem(1).CoolCoilFluidInletNode).MassFlowRate, UnitarySystem(1).MaxCoolCoilFluidFlow); // water coil water flow rate at max
     EXPECT_NEAR(UnitarySystem(1).HeatCoilWaterFlowRatio, 0.0, 0.0001); // heating coil water flow ratio, heating coil is off
-    EXPECT_NEAR(UnitarySystem(1).CoolCoilWaterFlowRatio, 0.0,
+    EXPECT_NEAR(UnitarySystem(1).CoolCoilWaterFlowRatio,
+                0.0,
                 0.001); // cooling coil water flow ratio not set, cooling coil is on since function returned when load exceeded capacity
     EXPECT_NEAR(UnitarySystem(1).FanPartLoadRatio, 1.0, 0.0001);            // fan PLR at maximum speed
     EXPECT_LT(Node(OutletNode).Temp, UnitarySystem(1).DesignMinOutletTemp); // outlet temperature below minimum temperature limit

--- a/tst/EnergyPlus/unit/LowTempRadiantSystem.unit.cc
+++ b/tst/EnergyPlus/unit/LowTempRadiantSystem.unit.cc
@@ -1140,15 +1140,33 @@ TEST_F(EnergyPlusFixture, AutosizeLowTempRadiantVariableFlowTest)
     EXPECT_EQ(LowTempRadiantSystem::HydronicSystem, RadSysTypes(RadSysNum).SystemType);
 
     ErrorsFound = false;
-    PlantUtilities::ScanPlantLoopsForObject(HydrRadSys(RadSysNum).Name, TypeOf_LowTempRadiant_VarFlow, HydrRadSys(RadSysNum).HWLoopNum,
-                                            HydrRadSys(RadSysNum).HWLoopSide, HydrRadSys(RadSysNum).HWBranchNum, HydrRadSys(RadSysNum).HWCompNum, _,
-                                            _, _, HydrRadSys(RadSysNum).HotWaterInNode, _, ErrorsFound);
+    PlantUtilities::ScanPlantLoopsForObject(HydrRadSys(RadSysNum).Name,
+                                            TypeOf_LowTempRadiant_VarFlow,
+                                            HydrRadSys(RadSysNum).HWLoopNum,
+                                            HydrRadSys(RadSysNum).HWLoopSide,
+                                            HydrRadSys(RadSysNum).HWBranchNum,
+                                            HydrRadSys(RadSysNum).HWCompNum,
+                                            _,
+                                            _,
+                                            _,
+                                            HydrRadSys(RadSysNum).HotWaterInNode,
+                                            _,
+                                            ErrorsFound);
     EXPECT_FALSE(ErrorsFound);
 
     ErrorsFound = false;
-    PlantUtilities::ScanPlantLoopsForObject(HydrRadSys(RadSysNum).Name, TypeOf_LowTempRadiant_VarFlow, HydrRadSys(RadSysNum).CWLoopNum,
-                                            HydrRadSys(RadSysNum).CWLoopSide, HydrRadSys(RadSysNum).CWBranchNum, HydrRadSys(RadSysNum).CWCompNum, _,
-                                            _, _, HydrRadSys(RadSysNum).ColdWaterInNode, _, ErrorsFound);
+    PlantUtilities::ScanPlantLoopsForObject(HydrRadSys(RadSysNum).Name,
+                                            TypeOf_LowTempRadiant_VarFlow,
+                                            HydrRadSys(RadSysNum).CWLoopNum,
+                                            HydrRadSys(RadSysNum).CWLoopSide,
+                                            HydrRadSys(RadSysNum).CWBranchNum,
+                                            HydrRadSys(RadSysNum).CWCompNum,
+                                            _,
+                                            _,
+                                            _,
+                                            HydrRadSys(RadSysNum).ColdWaterInNode,
+                                            _,
+                                            ErrorsFound);
     EXPECT_FALSE(ErrorsFound);
 
     DataSizing::CurZoneEqNum = 1;
@@ -1166,15 +1184,23 @@ TEST_F(EnergyPlusFixture, AutosizeLowTempRadiantVariableFlowTest)
     FinalZoneSizing(DataSizing::CurZoneEqNum).NonAirSysDesCoolLoad = 10000.0;
     CoolingCapacity = FinalZoneSizing(DataSizing::CurZoneEqNum).NonAirSysDesCoolLoad * HydrRadSys(RadSysNum).ScaledCoolingCapacity;
     // hot water flow rate sizing calculation
-    Density = GetDensityGlycol(PlantLoop(HydrRadSys(RadSysNum).HWLoopNum).FluidName, 60.0, PlantLoop(HydrRadSys(RadSysNum).HWLoopNum).FluidIndex,
+    Density = GetDensityGlycol(PlantLoop(HydrRadSys(RadSysNum).HWLoopNum).FluidName,
+                               60.0,
+                               PlantLoop(HydrRadSys(RadSysNum).HWLoopNum).FluidIndex,
                                "AutosizeLowTempRadiantVariableFlowTest");
-    Cp = GetSpecificHeatGlycol(PlantLoop(HydrRadSys(RadSysNum).HWLoopNum).FluidName, 60.0, PlantLoop(HydrRadSys(RadSysNum).HWLoopNum).FluidIndex,
+    Cp = GetSpecificHeatGlycol(PlantLoop(HydrRadSys(RadSysNum).HWLoopNum).FluidName,
+                               60.0,
+                               PlantLoop(HydrRadSys(RadSysNum).HWLoopNum).FluidIndex,
                                "AutosizeLowTempRadiantVariableFlowTest");
     HotWaterFlowRate = HeatingCapacity / (PlantSizData(1).DeltaT * Cp * Density);
     // chilled water flow rate sizing calculation
-    Density = GetDensityGlycol(PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidName, 5.0, PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidIndex,
+    Density = GetDensityGlycol(PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidName,
+                               5.05,
+                               PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidIndex,
                                "AutosizeLowTempRadiantVariableFlowTest");
-    Cp = GetSpecificHeatGlycol(PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidName, 5.0, PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidIndex,
+    Cp = GetSpecificHeatGlycol(PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidName,
+                               5.05,
+                               PlantLoop(HydrRadSys(RadSysNum).CWLoopNum).FluidIndex,
                                "AutosizeLowTempRadiantVariableFlowTest");
     ChilledWaterFlowRate = CoolingCapacity / (PlantSizData(2).DeltaT * Cp * Density);
     // tuble length sizing calculation
@@ -1695,4 +1721,80 @@ TEST_F(LowTempRadiantSystemTest, SizeRadSysTubeLengthTest)
     RadSysNum = 1;
     FuncCalc = SizeRadSysTubeLength(RadSysType, RadSysNum);
     EXPECT_NEAR(FuncCalc, 60.0, 0.1);
+}
+TEST_F(LowTempRadiantSystemTest, LowTempRadConFlowSystemAutoSizeTempTest)
+{
+
+    Real64 Density;
+    Real64 Cp;
+
+    SystemType = ConstantFlowSystem;
+    CFloRadSys(RadSysNum).Name = "LowTempConstantFlow";
+    CFloRadSys(RadSysNum).ZonePtr = 1;
+    HydronicRadiantSysNumericFields(RadSysNum).FieldNames(2) = "Rated Flow Rate";
+    HydronicRadiantSysNumericFields(RadSysNum).FieldNames(3) = "Total length of pipe embedded in surface";
+
+    CFloRadSys(RadSysNum).HotWaterInNode = 1;
+    CFloRadSys(RadSysNum).HotWaterOutNode = 2;
+    CFloRadSys(RadSysNum).HWLoopNum = 1;
+    PlantLoop(1).LoopSide(1).Branch(1).Comp(1).NodeNumIn = CFloRadSys(RadSysNum).HotWaterInNode;
+
+    CFloRadSys(RadSysNum).ColdWaterInNode = 3;
+    CFloRadSys(RadSysNum).ColdWaterOutNode = 4;
+    CFloRadSys(RadSysNum).CWLoopNum = 2;
+    PlantLoop(2).LoopSide(1).Branch(1).Comp(1).NodeNumIn = CFloRadSys(RadSysNum).ColdWaterInNode;
+
+    CFloRadSys(RadSysNum).SurfacePtr.allocate(1);
+    CFloRadSys(RadSysNum).SurfacePtr(1) = 1;
+    Surface.allocate(1);
+    Surface(1).Construction = 1;
+    Surface(1).Area = 150.0;
+    Construct.allocate(1);
+    Construct(1).ThicknessPerpend = 0.075;
+
+    // Hydronic - Hot water volume flow rate autosize
+    CFloRadSys(RadSysNum).ColdWaterInNode = 0;
+    CFloRadSys(RadSysNum).ColdWaterOutNode = 0;
+    CFloRadSys(RadSysNum).WaterVolFlowMax = AutoSize;
+    FinalZoneSizing(CurZoneEqNum).NonAirSysDesHeatLoad = 1000.0;
+    FinalZoneSizing(CurZoneEqNum).NonAirSysDesCoolLoad = 1000.0;
+
+    // hot water volume flow rate sizing calculation
+    Density = GetDensityGlycol(PlantLoop(CFloRadSys(RadSysNum).HWLoopNum).FluidName,
+                               60.0,
+                               PlantLoop(CFloRadSys(RadSysNum).HWLoopNum).FluidIndex,
+                               "LowTempRadConFlowSystemAutoSizeTempTest");
+    Cp = GetSpecificHeatGlycol(PlantLoop(CFloRadSys(RadSysNum).HWLoopNum).FluidName,
+                               60.0,
+                               PlantLoop(CFloRadSys(RadSysNum).HWLoopNum).FluidIndex,
+                               "LowTempRadConFlowSystemAutoSizeTempTest");
+    Real64 HeatingLoad = FinalZoneSizing(1).NonAirSysDesHeatLoad;
+    Real64 DesHotWaterVolFlowRate = HeatingLoad / (PlantSizData(1).DeltaT * Density * Cp);
+
+    SizeLowTempRadiantSystem(RadSysNum, SystemType);
+    // check hot water design flow rate calculated here and autosized flow are identical
+    EXPECT_DOUBLE_EQ(DesHotWaterVolFlowRate, CFloRadSys(RadSysNum).WaterVolFlowMax);
+
+    // Hydronic - cold water volume flow rate autosize
+    CFloRadSys(RadSysNum).HotWaterInNode = 0;
+    CFloRadSys(RadSysNum).HotWaterOutNode = 0;
+    CFloRadSys(RadSysNum).ColdWaterInNode = 3;
+    CFloRadSys(RadSysNum).ColdWaterOutNode = 4;
+    CFloRadSys(RadSysNum).WaterVolFlowMax = AutoSize;
+
+    // chilled water volume flow rate sizing calculation
+    Density = GetDensityGlycol(PlantLoop(CFloRadSys(RadSysNum).CWLoopNum).FluidName,
+                               5.05,
+                               PlantLoop(CFloRadSys(RadSysNum).CWLoopNum).FluidIndex,
+                               "LowTempRadConFlowSystemAutoSizeTempTest");
+    Cp = GetSpecificHeatGlycol(PlantLoop(CFloRadSys(RadSysNum).CWLoopNum).FluidName,
+                               5.05,
+                               PlantLoop(CFloRadSys(RadSysNum).CWLoopNum).FluidIndex,
+                               "LowTempRadConFlowSystemAutoSizeTempTest");
+    Real64 CoolingLoad = FinalZoneSizing(CurZoneEqNum).NonAirSysDesCoolLoad;
+    Real64 DesChilledWaterVolFlowRate = CoolingLoad / (PlantSizData(2).DeltaT * Density * Cp);
+
+    SizeLowTempRadiantSystem(RadSysNum, SystemType);
+    // check chilled water design flow rate calculated here and autosized flow are identical
+    EXPECT_DOUBLE_EQ(DesChilledWaterVolFlowRate, CFloRadSys(RadSysNum).WaterVolFlowMax);
 }

--- a/tst/EnergyPlus/unit/WaterCoils.unit.cc
+++ b/tst/EnergyPlus/unit/WaterCoils.unit.cc
@@ -378,7 +378,7 @@ TEST_F(WaterCoilsTest, WaterCoolingCoilSizing)
     SizeWaterCoil(CoilNum);
     EXPECT_NEAR(WaterCoil(CoilNum).InletAirTemp, 16.0, 0.0001); // a mixture of zone air (20 C) and 10% OA (-20 C) = 16 C
     EXPECT_NEAR(WaterCoil(CoilNum).DesTotWaterCoilLoad, 1709.8638, 0.0001);
-    EXPECT_NEAR(WaterCoil(CoilNum).UACoil, 51.3278, 0.0001);
+    EXPECT_NEAR(WaterCoil(CoilNum).UACoil, 51.2456, 0.0001);
     EXPECT_NEAR(WaterCoil(CoilNum).OutletAirTemp, 30.1302, 0.0001); // reasonable delta T above inlet air temp
 }
 
@@ -489,14 +489,14 @@ TEST_F(WaterCoilsTest, CoilHeatingWaterUASizing)
     Real64 DesWaterFlowRate = 0;
 
     Cp = GetSpecificHeatGlycol(PlantLoop(1).FluidName, DataGlobals::HWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
-    rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
+    rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::HWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
     DesWaterFlowRate = WaterCoil(CoilNum).DesWaterHeatingCoilRate / (10.0 * Cp * rho);
 
     // check heating coil design water flow rate
     EXPECT_DOUBLE_EQ(DesWaterFlowRate, WaterCoil(CoilNum).MaxWaterVolFlowRate);
 
     // check coil UA-value sizing
-    EXPECT_NEAR(1439.30, WaterCoil(CoilNum).UACoil, 0.01);
+    EXPECT_NEAR(1435.01, WaterCoil(CoilNum).UACoil, 0.01);
 
     // test single zone VAV reheat coil sizing
     CurZoneEqNum = 1;
@@ -543,7 +543,7 @@ TEST_F(WaterCoilsTest, CoilHeatingWaterUASizing)
     SizeWaterCoil(CoilNum);
 
     // check coil UA-value sizing
-    EXPECT_NEAR(558.656, WaterCoil(CoilNum).UACoil, 0.01); // smaller UA than result above at 1435.00
+    EXPECT_NEAR(577.686, WaterCoil(CoilNum).UACoil, 0.01); // smaller UA than result above at 1435.00
 }
 
 TEST_F(WaterCoilsTest, CoilHeatingWaterLowAirFlowUASizing)
@@ -641,14 +641,14 @@ TEST_F(WaterCoilsTest, CoilHeatingWaterLowAirFlowUASizing)
     Real64 DesWaterFlowRate = 0;
 
     Cp = GetSpecificHeatGlycol(PlantLoop(1).FluidName, DataGlobals::HWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
-    rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
+    rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::HWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
     DesWaterFlowRate = WaterCoil(CoilNum).DesWaterHeatingCoilRate / (10.0 * Cp * rho);
 
     // check heating coil design water flow rate
     EXPECT_DOUBLE_EQ(DesWaterFlowRate, WaterCoil(CoilNum).MaxWaterVolFlowRate);
 
     // check coil UA-value sizing
-    EXPECT_NEAR(1439.30, WaterCoil(CoilNum).UACoil, 0.01);
+    EXPECT_NEAR(1435.01, WaterCoil(CoilNum).UACoil, 0.01);
 
     // test single zone VAV reheat coil sizing
     CurZoneEqNum = 1;
@@ -798,14 +798,14 @@ TEST_F(WaterCoilsTest, CoilHeatingWaterUASizingLowHwaterInletTemp)
     Real64 DesWaterFlowRate = 0;
 
     Cp = GetSpecificHeatGlycol(PlantLoop(1).FluidName, DataGlobals::HWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
-    rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
+    rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::HWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
     DesWaterFlowRate = WaterCoil(CoilNum).DesWaterHeatingCoilRate / (10.0 * Cp * rho);
 
     // check heating coil design water flow rate
     EXPECT_DOUBLE_EQ(DesWaterFlowRate, WaterCoil(CoilNum).MaxWaterVolFlowRate);
 
     // check coil UA-value sizing for low design loop exit temp
-    EXPECT_NEAR(2491.37, WaterCoil(CoilNum).UACoil, 0.01);
+    EXPECT_NEAR(2479.27, WaterCoil(CoilNum).UACoil, 0.01);
 
     Real64 DesCoilInletWaterTempUsed = 0.0;
     Real64 DataFanOpMode = ContFanCycCoil;
@@ -1123,7 +1123,7 @@ TEST_F(WaterCoilsTest, CoilHeatingWaterSimpleSizing)
     Real64 DesWaterFlowRate = 0;
 
     Cp = GetSpecificHeatGlycol(PlantLoop(1).FluidName, DataGlobals::HWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
-    rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
+    rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::HWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
     DesWaterFlowRate = WaterCoil(CoilNum).DesWaterHeatingCoilRate / (11.0 * Cp * rho);
 
     // check heating coil design water flow rate

--- a/tst/EnergyPlus/unit/WaterCoils.unit.cc
+++ b/tst/EnergyPlus/unit/WaterCoils.unit.cc
@@ -910,7 +910,7 @@ TEST_F(WaterCoilsTest, CoilCoolingWaterSimpleSizing)
     Real64 rho = 0;
     Real64 DesWaterFlowRate = 0;
 
-    Cp = GetSpecificHeatGlycol(PlantLoop(1).FluidName, 5.0, PlantLoop(1).FluidIndex, "Unit Test");
+    Cp = GetSpecificHeatGlycol(PlantLoop(1).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
     rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
     DesWaterFlowRate = WaterCoil(CoilNum).DesWaterCoolingCoilRate / (WaterCoil(CoilNum).DesignWaterDeltaTemp * Cp * rho);
 
@@ -1025,7 +1025,7 @@ TEST_F(WaterCoilsTest, CoilCoolingWaterDetailedSizing)
     Real64 rho = 0;
     Real64 DesWaterFlowRate = 0;
 
-    Cp = GetSpecificHeatGlycol(PlantLoop(1).FluidName, 5.0, PlantLoop(1).FluidIndex, "Unit Test");
+    Cp = GetSpecificHeatGlycol(PlantLoop(1).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
     rho = GetDensityGlycol(PlantLoop(1).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(1).FluidIndex, "Unit Test");
     DesWaterFlowRate = WaterCoil(CoilNum).DesWaterCoolingCoilRate / (6.67 * Cp * rho);
     // check cooling coil design water flow rate


### PR DESCRIPTION
Issue #5821 and #6502

Pull request overview
---------------------
This fix replaces water initialization temperature for Hot Water related sizing calculations in various modules. Historically DataGlobals::CWInitConvTemp (5.05C) value was used in several modules for chilled and hot water related sizing calculations for flow rate, capacity, coil UA, etc. This fix now replaces DataGlobals::CWInitConvTemp with DataGlobals::HWInitConvTemp(60.0C) for hot water related sizing calculations. Changes were made in several functions including:  InitGasAbsorber, SizeAbsorpChiller, InitBLASTAbsorberModel, InitExhaustAbsorber, InitIndirectAbsorpChiller, SizeIndirectAbsorpChiller, InitElecReformEIRChiller, InitDesiccantDehumidifier, InitFurnace, InitGshp, HVACFourPipeBeam, GetMSHeatPumpInput, InitCBVAV, InitUnitarySystems, InitHWBaseboard, PackagedTerminalHeatPump::InitPTUnit, PLantChillers::InitElectricChiller, SingleDuct::InitSys. The changes made include in sizing calculations in hot water coils, hot water baseboard and radiators, chillers heat recovery, absorption chillers generators. So, hot water related sizing and output variables are expected to show diffs. Also several unit tests failed due to this fix were also addressed.  

Also replaced hard value 5.0C with DataGlobals::CWInitConvTemp (5.05C) in LowTempRadiantSystem, ReportSizingManager, OutdoorAirUnit, and WaterCoils.Unit.cc modules. This change produces small diffs. Selective review of various EIO and output files shown expected diffs. 

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
