### PR TITLE
Address epJSON conversion issue with Schedule:Year

### DIFF
--- a/scripts/dev/generate_epJSON_schema/generate_epJSON_schema.py
+++ b/scripts/dev/generate_epJSON_schema/generate_epJSON_schema.py
@@ -17,6 +17,7 @@ modify_schema.change_special_cased_enums(data.schema)
 modify_schema.change_special_cased_name_fields(data.schema)
 modify_schema.change_extensions_name(data.schema)
 modify_schema.change_89_release_issues(data.schema)
+modify_schema.add_explicit_extensible_bounds(data.schema)
 
 with open(source_dir_path + '/idd/Energy+.schema.epJSON.in', 'w') as f2:
     f2.write(json.dumps(data.schema, indent=4))

--- a/scripts/dev/generate_epJSON_schema/modify_schema.py
+++ b/scripts/dev/generate_epJSON_schema/modify_schema.py
@@ -113,7 +113,8 @@ extension_renaming = {
     'SurfaceProperty:ExposedFoundationPerimeter': 'surfaces',
     'SurfaceProperty:SurroundingSurfaces': 'surfaces',
     'ZoneHVAC:HybridUnitaryHVAC': 'modes',
-    'ShadowCalculation': 'shading_zone_groups'
+    'ShadowCalculation': 'shading_zone_groups',
+    'Schedule:Year': 'schedule_weeks'
 }
 remaining_objects = [
     'Site:SpectrumData',
@@ -203,6 +204,14 @@ def change_utility_cost(schema):
     loc['minimum_monthly_charge_or_variable_name']['anyOf'] = anyOf()
     loc['monthly_charge_or_variable_name'].pop('type')
     loc['monthly_charge_or_variable_name']['anyOf'] = anyOf()
+
+
+def add_explicit_extensible_bounds(schema):
+    # Schedule:Year
+    loc = schema['properties']['Schedule:Year']['patternProperties']['.*']['properties']['schedule_weeks']
+    loc['minItems'] = 1
+    loc['maxItems'] = 53
+
 
 
 def change_special_cased_name_fields(schema):

--- a/tst/EnergyPlus/unit/ScheduleManager.unit.cc
+++ b/tst/EnergyPlus/unit/ScheduleManager.unit.cc
@@ -578,3 +578,72 @@ TEST_F(EnergyPlusFixture, ScheduleDayInterval_LinearInterpIntervalNotTimestep)
     EXPECT_NEAR(75.0, LookUpScheduleValue(ASchedIndex, 8, 3), 0.000001);
     EXPECT_NEAR(100.0, LookUpScheduleValue(ASchedIndex, 8, 4), 0.000001);
 }
+
+TEST_F(EnergyPlusFixture, ScheduleYearMaxItems)
+{
+    std::string const idf_objects = delimited_string({
+        "Schedule:Year,",
+        "  SchYr_A,   !- Name",
+        "  AnyNumber, !- Schedule Type Limits Name",
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31,"
+        "  SchWk_A1,1,1,12,31;"
+        "",
+    });
+
+    ASSERT_FALSE(process_idf(idf_objects, false));
+
+    EXPECT_TRUE(compare_err_stream(delimited_string({"   ** Severe  ** <root>[Schedule:Year][SchYr_A][schedule_weeks] - Array should contain no more than 53 elements."})));
+
+}


### PR DESCRIPTION
Pull request overview
---------------------
Fixes #6729

Since Schedule:Year uses shorthand notation for weeks 27-53, it was not being properly parsed into epJSON during conversion. This PR makes Schedule:Year extensible but then within the epJSON schema explicitly limits the number of schedule_weeks to 1-53 only.

There may be other objects with a similar issue as this one, which will require a fix to the idf->epJSON converter and a fix to the IDD similar to this PR.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
