### PR TITLE
Fix issue with infinite loop in epJSON schema generator

### DIFF
--- a/scripts/dev/generate_epJSON_schema/idd_parser.py
+++ b/scripts/dev/generate_epJSON_schema/idd_parser.py
@@ -271,8 +271,9 @@ def parse_obj(data):
                 root['legacy_idd']['extensibles'] = [field_name]
                 parse_extensibles(root['properties']['extensions']['items'], field_data, field_name)
                 extensible_count += 1
-                if comma_or_semicolon != TOKEN_SEMICOLON:
-                    continue
+                if comma_or_semicolon == TOKEN_SEMICOLON:
+                    return root
+                continue
             elif 'extensible_size' in root and extensible_count >= root['extensible_size'] \
                     and comma_or_semicolon != TOKEN_SEMICOLON:
                 continue
@@ -285,8 +286,9 @@ def parse_obj(data):
                     root['legacy_idd']['extensibles'].append(field_name)
                     parse_extensibles(root['properties']['extensions']['items'], field_data, field_name)
                     extensible_count += 1
-                if comma_or_semicolon != TOKEN_SEMICOLON:
-                    continue
+                if comma_or_semicolon == TOKEN_SEMICOLON:
+                    return root
+                continue
 
             field_name = re.sub('[^0-9a-zA-Z]+', '_', field_name)
             if field_name in root['properties']:

--- a/scripts/dev/generate_epJSON_schema/idd_parser.py
+++ b/scripts/dev/generate_epJSON_schema/idd_parser.py
@@ -271,7 +271,8 @@ def parse_obj(data):
                 root['legacy_idd']['extensibles'] = [field_name]
                 parse_extensibles(root['properties']['extensions']['items'], field_data, field_name)
                 extensible_count += 1
-                continue
+                if comma_or_semicolon != TOKEN_SEMICOLON:
+                    continue
             elif 'extensible_size' in root and extensible_count >= root['extensible_size'] \
                     and comma_or_semicolon != TOKEN_SEMICOLON:
                 continue
@@ -284,9 +285,8 @@ def parse_obj(data):
                     root['legacy_idd']['extensibles'].append(field_name)
                     parse_extensibles(root['properties']['extensions']['items'], field_data, field_name)
                     extensible_count += 1
-                if comma_or_semicolon == TOKEN_SEMICOLON:
-                    return root
-                continue
+                if comma_or_semicolon != TOKEN_SEMICOLON:
+                    continue
 
             field_name = re.sub('[^0-9a-zA-Z]+', '_', field_name)
             if field_name in root['properties']:


### PR DESCRIPTION
Pull request overview
---------------------
Fixes #6803

The epJSON schema generator would hang when last field ends with '\begin-extensible', causing an infinite loop.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
