### PR TITLE
Fix allocation issue for metered output variables, Fixes #6827

### DIFF
--- a/src/EnergyPlus/RuntimeLanguageProcessor.cc
+++ b/src/EnergyPlus/RuntimeLanguageProcessor.cc
@@ -2799,6 +2799,10 @@ namespace RuntimeLanguageProcessor {
             inputProcessor->getObjectDefMaxArgs(cCurrentModuleObject, TotalArgs, NumAlphas, NumNums);
             MaxNumNumbers = max(MaxNumNumbers, NumNums);
             MaxNumAlphas = max(MaxNumAlphas, NumAlphas);
+            cCurrentModuleObject = "EnergyManagementSystem:MeteredOutputVariable";
+            inputProcessor->getObjectDefMaxArgs(cCurrentModuleObject, TotalArgs, NumAlphas, NumNums);
+            MaxNumNumbers = max(MaxNumNumbers, NumNums);
+            MaxNumAlphas = max(MaxNumAlphas, NumAlphas);
             cCurrentModuleObject = "ExternalInterface:Variable";
             inputProcessor->getObjectDefMaxArgs(cCurrentModuleObject, TotalArgs, NumAlphas, NumNums);
             MaxNumNumbers = max(MaxNumNumbers, NumNums);

--- a/tst/EnergyPlus/unit/RuntimeLanguageProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/RuntimeLanguageProcessor.unit.cc
@@ -109,3 +109,34 @@ TEST_F(EnergyPlusFixture, ERLExpression_TestExponentials)
     EXPECT_TRUE(errorsFound);
     EXPECT_EQ(0, response7.Number);
 }
+
+TEST_F(EnergyPlusFixture, TestOutOfRangeAlphaFields)
+{
+    std::string const idf_objects = delimited_string({
+        "EnergyManagementSystem:Sensor,",
+        "  EMSSensor,",
+        "  *,",
+        "  Electricity:Facility;",
+        "EnergyManagementSystem:Program,",
+        "  DummyProgram,",
+        "  SET N = EMSSensor;",
+        "EnergyManagementSystem:ProgramCallingManager,",
+        "  DummyManager,",
+        "  BeginTimestepBeforePredictor,",
+        "  DummyProgram;",
+        "EnergyManagementSystem:MeteredOutputVariable,",
+        "  MyLongMeteredOutputVariable,",
+        "  EMSSensor,",
+        "  ZoneTimeStep,",
+        "  ,",
+        "  Electricity,",
+        "  Building,",
+        "  ExteriorEquipment,",
+        "  Transformer,",
+        "  J;"
+    });
+    ASSERT_TRUE(process_idf(idf_objects));
+    RuntimeLanguageProcessor::GetRuntimeLanguageUserInput();
+
+
+}


### PR DESCRIPTION
Pull request overview
---------------------
User encountered a crash with an EMS:MeteredOutputVariable; #6827.  Original defect file posted with that issue.

- Debugging, I found it was an array out of bounds problem in the runtime language processor get input.  Alphas was not big enough.
- I investigated the input file and found that the other EMS objects were very small, tightly defined with very few fields.
- As a workaround, I increased the size of one of the EMS programs with dummy lines, and the defect file ran to completion: [in-extendedprogram.idf.txt](https://github.com/NREL/EnergyPlus/files/2184804/in-extendedprogram.idf.txt)
- To make the proper fix, I put in the added check to update max alphas and max numbers for this object.
- Now if this object is the longest of the EMS types, it will be respected.
- This usually isn't encountered because there are usually other EMS objects with longer definitions.
