### PR TITLE
Correction of Equations in Exponential Curve Sections of Input/Output Reference

### DIFF
--- a/doc/input-output-reference/src/overview/group-performance-curves.tex
+++ b/doc/input-output-reference/src/overview/group-performance-curves.tex
@@ -2116,7 +2116,7 @@ Curve:ExponentialDecay,
 Input for the double exponential decay curve consists of the curve name, the five coefficients, and the maximum and minimum valid independent variable values. Optional inputs for the curve include the minimum and maximum output of the performance curve. The equation is:
 
 \begin{equation}
-  y = C_1 + C_2 \cdot e^{C_3 x} + C_4 e^{C_5 x}
+y = {C_1} + {C_2}{\exp ^{({C_3}x)}} + {C_4}{\exp ^{({C_5}x)}}
 \end{equation}
 
 \subsubsection{Inputs}\label{inputs-18-005}


### PR DESCRIPTION
Pull request overview
---------------------
Equations for some things in the exponential curve sections of the input/output reference got slightly messed up as part of a large check-in.  This work fixes the problem so that the equations in Curve:DoubleExponentialDecay now look as they should.  This is related to GitHub Issue #6476 (which was addressed in #6494).

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ x ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ x ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue #6476

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Documentation changes in place
 - [x] Changed docs build successfully
