### PR TITLE
Correction of Missing Equation Reference in DOE-2 Convection Model in Engineering Reference

### DIFF
--- a/doc/engineering-reference/src/surface-heat-balance-manager-processes/outside-surface-heat-balance.tex
+++ b/doc/engineering-reference/src/surface-heat-balance-manager-processes/outside-surface-heat-balance.tex
@@ -482,12 +482,14 @@ For no temperature difference OR a vertical surface the following correlation is
 
 \begin{equation}
 h = 1.31{\left| {\Delta T} \right|^{\frac{1}{3}}}
+\label{eq:HcVertical}
 \end{equation}
 
 For ($\Delta$T \textless{} 0.0 AND an upward facing surface)~ OR~ ($\Delta$T \textgreater{} 0.0 AND an downward facing surface) an enhanced convection correlation is used:
 
 \begin{equation}
 h = \frac{{9.482{{\left| {\Delta T} \right|}^{\frac{1}{3}}}}}{{7.283 - \left| {\cos \Sigma } \right|}}
+\label{eq:HcEnhanced}
 \end{equation}
 
 where $\Sigma$ is the surface tilt angle.
@@ -496,6 +498,7 @@ For ($\Delta$T \textgreater{} 0.0 AND an upward facing surface)~ OR~ ($\Delta$T 
 
 \begin{equation}
 h = \frac{{1.810{{\left| {\Delta T} \right|}^{\frac{1}{3}}}}}{{1.382 + \left| {\cos \Sigma } \right|}}
+\label{eq:HcReduced}
 \end{equation}
 
 where $\Sigma$ is the surface tilt angle.
@@ -594,7 +597,7 @@ The DOE-2 convection model is a combination of the MoWiTT and BLAST Detailed con
 {h_{c,glass}} = \sqrt {h_n^2 + {{\left[ {aV_z^b} \right]}^2}}
 \end{equation}
 
-h\(_{n}\) is calculated using Equation or Equation .~ Constants a and b are given in Table~\ref{table:mowitt-coefficients-yazdanian-and-klems-1994}.
+h\(_{n}\) is calculated using Equation ~\ref{eq:HcVertical}, ~\ref{eq:HcEnhanced} or ~\ref{eq:HcReduced} .~ Constants a and b are given in Table~\ref{table:mowitt-coefficients-yazdanian-and-klems-1994}.
 
 For less smooth surfaces, the convection coefficient is modified according to the equation
 


### PR DESCRIPTION
Pull request overview
---------------------
References in the description of the DOE-2 outside convection model were missing.  This means that the equation numbers referring back to the natural convection correlation models were missing.  So, instead of referring to "as seen in equation x or y", the text was saying "as seen in equation or".  These missing references (as well as the addition of another equation that should have shown up in the listing originally but did not) were added and the text correctly refers to the proper equation now.
Addresses #6517.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ x ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ x ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue #6517
### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Documentation changes in place
 - [x] Changed docs build successfully
