### PR TITLE
Revert merge mistake of deleting initialization of CoilDesWaterDeltaT

### DIFF
--- a/src/EnergyPlus/ReportSizingManager.cc
+++ b/src/EnergyPlus/ReportSizingManager.cc
@@ -337,9 +337,9 @@ namespace ReportSizingManager {
         using DataGlobals::DisplayExtraWarnings;
         using namespace DataSizing;
         using namespace DataHVACGlobals;
+        using DXCoils::ValidateADP;
         using DataPlant::PlantLoop;
         using DesiccantDehumidifiers::DesicDehum;
-        using DXCoils::ValidateADP;
         using Fans::FanDesDT;
         using Fans::FanDesHeatGain;
         using FluidProperties::GetDensityGlycol;
@@ -1279,6 +1279,7 @@ namespace ReportSizingManager {
                         }
                     }
                 } else if (SizingType == CoolingWaterflowSizing) {
+                    CoilDesWaterDeltaT = DataWaterCoilSizCoolDeltaT;
                     Cp = GetSpecificHeatGlycol(
                         PlantLoop(DataWaterLoopNum).FluidName, DataGlobals::CWInitConvTemp, PlantLoop(DataWaterLoopNum).FluidIndex, CallingRoutine);
                     rho = GetDensityGlycol(
@@ -1529,9 +1530,9 @@ namespace ReportSizingManager {
                         // For autosizing the rated SHR, we set a minimum SHR of 0.676 and a maximum of 0.798. The min SHR occurs occurs at the
                         // minimum flow / capacity ratio = MinRatedVolFlowPerRatedTotCap = 0.00004027 [m3/s / W] = 300 [cfm/ton].
                         // The max SHR occurs at maximum flow / capacity ratio = MaxRatedVolFlowPerRatedTotCap = 0.00006041 [m3/s / W] = 450
-                        // [cfm/ton]. For flow / capacity ratios between the min and max we linearly interpolate between min and max SHR. Thus rated
-                        // SHR is a linear function of the rated flow / capacity ratio. This linear function (see below) is the result of a regression
-                        // of flow/capacity ratio vs SHR for several actual coils.
+                        // [cfm/ton]. For flow / capacity ratios between the min and max we linearly interpolate between min and max SHR. Thus
+                        // rated SHR is a linear function of the rated flow / capacity ratio. This linear function (see below) is the result of a
+                        // regression of flow/capacity ratio vs SHR for several actual coils.
                         RatedVolFlowPerRatedTotCap = DataFlowUsedForSizing / DataCapacityUsedForSizing;
                         if (DXCT == RegularDXCoil) {
                             if (RatedVolFlowPerRatedTotCap > MaxRatedVolFlowPerRatedTotCap(DXCT)) {
@@ -2504,9 +2505,9 @@ namespace ReportSizingManager {
                         // For autosizing the rated SHR, we set a minimum SHR of 0.676 and a maximum of 0.798. The min SHR occurs occurs at the
                         // minimum flow / capacity ratio = MinRatedVolFlowPerRatedTotCap = 0.00004027 [m3/s / W] = 300 [cfm/ton].
                         // The max SHR occurs at maximum flow / capacity ratio = MaxRatedVolFlowPerRatedTotCap = 0.00006041 [m3/s / W] = 450
-                        // [cfm/ton]. For flow / capacity ratios between the min and max we linearly interpolate between min and max SHR. Thus rated
-                        // SHR is a linear function of the rated flow / capacity ratio. This linear function (see below) is the result of a regression
-                        // of flow/capacity ratio vs SHR for several actual coils.
+                        // [cfm/ton]. For flow / capacity ratios between the min and max we linearly interpolate between min and max SHR. Thus
+                        // rated SHR is a linear function of the rated flow / capacity ratio. This linear function (see below) is the result of a
+                        // regression of flow/capacity ratio vs SHR for several actual coils.
                         RatedVolFlowPerRatedTotCap = DataFlowUsedForSizing / DataCapacityUsedForSizing;
                         if (DXCT == RegularDXCoil) {
                             if (RatedVolFlowPerRatedTotCap > MaxRatedVolFlowPerRatedTotCap(DXCT)) {


### PR DESCRIPTION
Pull request overview
---------------------
Corrects merge mistake made 4 days ago [here](https://github.com/NREL/EnergyPlus/commit/fb7543800d9a4f53560fdb3c9e4d9209c4fe1a1f#diff-de781ad7ec80e690e175811f4da40a5aL1282). Any branches created after this time should pull develop to correct the uninitialized variable warning.
Addresses #6849.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Code style (parentheses padding, variable names)
 - [x] Functional code review (it has to work!)
 - [x] If defect, results of running current develop vs this branch should exhibit the fix
 - [x] CI status: all green or justified
 - [x] Performance: CI Linux results include performance check -- verify this
 - [x] Unit Test(s) - should fix exisiting unit test HeatRecoveryHXOnMainBranch_SimHeatRecoveryTest which was failing on Windows debug locally
