### PR TITLE
Use setpoints averaged in a zone time step to calculate "hours of setpoint not met" with onoff thermostat

### DIFF
--- a/src/EnergyPlus/DataHeatBalFanSys.cc
+++ b/src/EnergyPlus/DataHeatBalFanSys.cc
@@ -212,6 +212,8 @@ namespace DataHeatBalFanSys {
     Array1D<Real64> AdapComfortCoolingSetPoint;
     Array1D<Real64> ZoneThermostatSetPointHi;
     Array1D<Real64> ZoneThermostatSetPointLo;
+    Array1D<Real64> ZoneThermostatSetPointHiAver;
+    Array1D<Real64> ZoneThermostatSetPointLoAver;
 
     Array1D<Real64> LoadCorrectionFactor; // PH 3/3/04
 
@@ -332,6 +334,8 @@ namespace DataHeatBalFanSys {
         AdapComfortCoolingSetPoint.deallocate();
         ZoneThermostatSetPointHi.deallocate();
         ZoneThermostatSetPointLo.deallocate();
+        ZoneThermostatSetPointHiAver.deallocate();
+        ZoneThermostatSetPointLoAver.deallocate();
         LoadCorrectionFactor.deallocate();
         AIRRAT.deallocate();
         ZTM1.deallocate();

--- a/src/EnergyPlus/DataHeatBalFanSys.hh
+++ b/src/EnergyPlus/DataHeatBalFanSys.hh
@@ -205,6 +205,8 @@ namespace DataHeatBalFanSys {
     extern Array1D<Real64> AdapComfortCoolingSetPoint;
     extern Array1D<Real64> ZoneThermostatSetPointHi;
     extern Array1D<Real64> ZoneThermostatSetPointLo;
+    extern Array1D<Real64> ZoneThermostatSetPointHiAver;
+    extern Array1D<Real64> ZoneThermostatSetPointLoAver;
 
     extern Array1D<Real64> LoadCorrectionFactor; // PH 3/3/04
 

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -269,6 +269,10 @@ namespace HVACManager {
         using DataHeatBalFanSys::SysDepZoneLoads;
         using DataHeatBalFanSys::SysDepZoneLoadsLagged;
         using DataHeatBalFanSys::ZoneAirHumRatAvgComf;
+        using DataHeatBalFanSys::ZoneThermostatSetPointHi;
+        using DataHeatBalFanSys::ZoneThermostatSetPointLo;
+        using DataHeatBalFanSys::ZoneThermostatSetPointHiAver;
+        using DataHeatBalFanSys::ZoneThermostatSetPointLoAver;
         using DataHeatBalFanSys::ZTAVComf;
         using DataSystemVariables::ReportDuringWarmup; // added for FMI
         using DataSystemVariables::UpdateDataDuringWarmupExternalInterface;
@@ -295,7 +299,7 @@ namespace HVACManager {
         using ZoneContaminantPredictorCorrector::ManageZoneContaminanUpdates;
         using ZoneEquipmentManager::CalcAirFlowSimple;
         using ZoneEquipmentManager::UpdateZoneSizing;
-
+        using ZoneTempPredictorCorrector::NumOnOffCtrZone;
         // Locals
         // SUBROUTINE ARGUMENT DEFINITIONS:
         // na
@@ -348,6 +352,8 @@ namespace HVACManager {
         ZTAVComf = ZTAV;
         ZoneAirHumRatAvgComf = ZoneAirHumRatAvg;
         ZTAV = 0.0;
+        ZoneThermostatSetPointHiAver = 0.0;
+        ZoneThermostatSetPointLoAver = 0.0;
         ZoneAirHumRatAvg = 0.0;
         PrintedWarmup = false;
         if (Contaminant.CO2Simulation) {
@@ -495,6 +501,10 @@ namespace HVACManager {
                 ZoneAirHumRatAvg(ZoneNum) += ZoneAirHumRat(ZoneNum) * FracTimeStepZone;
                 if (Contaminant.CO2Simulation) ZoneAirCO2Avg(ZoneNum) += ZoneAirCO2(ZoneNum) * FracTimeStepZone;
                 if (Contaminant.GenericContamSimulation) ZoneAirGCAvg(ZoneNum) += ZoneAirGC(ZoneNum) * FracTimeStepZone;
+                if (NumOnOffCtrZone > 0) {
+                    ZoneThermostatSetPointHiAver(ZoneNum) += ZoneThermostatSetPointHi(ZoneNum) * FracTimeStepZone;
+                    ZoneThermostatSetPointLoAver(ZoneNum) += ZoneThermostatSetPointLo(ZoneNum) * FracTimeStepZone;
+                }
             }
 
             DetectOscillatingZoneTemp();

--- a/src/EnergyPlus/ThermalComfort.cc
+++ b/src/EnergyPlus/ThermalComfort.cc
@@ -77,6 +77,7 @@
 #include <ScheduleManager.hh>
 #include <ThermalComfort.hh>
 #include <UtilityRoutines.hh>
+#include <ZoneTempPredictorCorrector.hh>
 
 namespace EnergyPlus {
 
@@ -2399,6 +2400,8 @@ namespace ThermalComfort {
         using DataHeatBalFanSys::TempTstatAir;
         using DataHeatBalFanSys::ZoneThermostatSetPointHi;
         using DataHeatBalFanSys::ZoneThermostatSetPointLo;
+        using DataHeatBalFanSys::ZoneThermostatSetPointHiAver;
+        using DataHeatBalFanSys::ZoneThermostatSetPointLoAver;
         using DataZoneEnergyDemands::ZoneSysEnergyDemand;
         using namespace OutputReportPredefined;
         using DataHVACGlobals::deviationFromSetPtThresholdClg;
@@ -2409,6 +2412,7 @@ namespace ThermalComfort {
         using DataHVACGlobals::SingleHeatingSetPoint;
         using DataRoomAirModel::AirModel;
         using DataRoomAirModel::RoomAirModel_Mixing;
+        using ZoneTempPredictorCorrector::NumOnOffCtrZone;
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         Real64 SensibleLoadPredictedNoAdj;
@@ -2453,7 +2457,11 @@ namespace ThermalComfort {
                 if (AirModel(iZone).AirModelType != RoomAirModel_Mixing) {
                     deltaT = TempTstatAir(iZone) - ZoneThermostatSetPointLo(iZone);
                 } else {
-                    deltaT = ZTAV(iZone) - ZoneThermostatSetPointLo(iZone);
+                    if (NumOnOffCtrZone > 0) {
+                        deltaT = ZTAV(iZone) - ZoneThermostatSetPointLoAver(iZone);
+                    } else {
+                        deltaT = ZTAV(iZone) - ZoneThermostatSetPointLo(iZone);
+                    }
                 }
                 if (deltaT < deviationFromSetPtThresholdHtg) {
                     ThermalComfortSetPoint(iZone).notMetHeating = TimeStepZone;
@@ -2470,7 +2478,11 @@ namespace ThermalComfort {
                 if (AirModel(iZone).AirModelType != RoomAirModel_Mixing) {
                     deltaT = TempTstatAir(iZone) - ZoneThermostatSetPointHi(iZone);
                 } else {
-                    deltaT = ZTAV(iZone) - ZoneThermostatSetPointHi(iZone);
+                    if (NumOnOffCtrZone > 0) {
+                        deltaT = ZTAV(iZone) - ZoneThermostatSetPointHiAver(iZone);
+                    } else {
+                        deltaT = ZTAV(iZone) - ZoneThermostatSetPointHi(iZone);
+                    }
                 }
 
                 if (Zone(iZone).HasAdjustedReturnTempByITE) {

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -328,6 +328,7 @@ namespace ZoneTempPredictorCorrector {
         AdapComfortDailySetPointSchedule.ThermalComfortAdaptiveCEN15251_Upper_I.deallocate();
         AdapComfortDailySetPointSchedule.ThermalComfortAdaptiveCEN15251_Upper_II.deallocate();
         AdapComfortDailySetPointSchedule.ThermalComfortAdaptiveCEN15251_Upper_III.deallocate();
+        NumOnOffCtrZone = 0;
     }
 
     void ManageZoneAirUpdates(int const UpdateType,   // Can be iGetZoneSetPoints, iPredictStep, iCorrectStep
@@ -2766,6 +2767,8 @@ namespace ZoneTempPredictorCorrector {
             AdapComfortCoolingSetPoint.dimension(NumOfZones, 0.0);
             ZoneThermostatSetPointHi.dimension(NumOfZones, 0.0);
             ZoneThermostatSetPointLo.dimension(NumOfZones, 0.0);
+            ZoneThermostatSetPointHiAver.dimension(NumOfZones, 0.0);
+            ZoneThermostatSetPointLoAver.dimension(NumOfZones, 0.0);
 
             LoadCorrectionFactor.dimension(NumOfZones, 0.0); // PH 3/3/04
             TempControlType.dimension(NumOfZones, 0);

--- a/tst/EnergyPlus/unit/ThermalComfort.unit.cc
+++ b/tst/EnergyPlus/unit/ThermalComfort.unit.cc
@@ -68,6 +68,7 @@
 #include <EnergyPlus/SimulationManager.hh>
 #include <EnergyPlus/ThermalComfort.hh>
 #include <EnergyPlus/UtilityRoutines.hh>
+#include <EnergyPlus/ZoneTempPredictorCorrector.hh>
 
 using namespace EnergyPlus;
 using namespace EnergyPlus::ThermalComfort;
@@ -889,4 +890,62 @@ TEST_F(EnergyPlusFixture, ThermalComfort_CalcThermalComfortAdaptiveASH55Test)
     EXPECT_NEAR(ThermalComfort::runningAverageASH, 9.29236111, 0.001);
     useEpwData = false;
     DataGlobals::BeginDayFlag = false;
+}
+
+TEST_F(EnergyPlusFixture, ThermalComfort_CalcIfSetPointMetWithCutoutTest)
+{
+    NumOfZones = 1;
+    ZoneSysEnergyDemand.allocate(NumOfZones);
+    ThermalComfortSetPoint.allocate(NumOfZones);
+    TempControlType.allocate(1);
+    AirModel.allocate(NumOfZones);
+    AirModel(1).AirModelType = RoomAirModel_Mixing;
+    ZTAV.allocate(NumOfZones);
+    ZoneThermostatSetPointLo.allocate(NumOfZones);
+    ZoneThermostatSetPointHi.allocate(NumOfZones);
+    ZoneThermostatSetPointLoAver.allocate(NumOfZones);
+    ZoneThermostatSetPointHiAver.allocate(NumOfZones);
+    ThermalComfortInASH55.allocate(NumOfZones);
+    ThermalComfortInASH55(1).ZoneIsOccupied = true;
+    TimeStepZone = 0.25;
+    Zone.allocate(NumOfZones);
+    ZoneTempPredictorCorrector::NumOnOffCtrZone = 1;
+
+    TempControlType(1) = DualSetPointWithDeadBand;
+
+    // heating
+    ZTAV(1) = 21.1;                                     // 70F
+    ZoneThermostatSetPointLo(1) = 22.2;                 // 72F
+    ZoneThermostatSetPointLoAver(1) = 22.2;                 // 72F
+    ZoneSysEnergyDemand(1).TotalOutputRequired = 500.0; // must be greater than zero
+    CalcIfSetPointMet();
+    EXPECT_EQ(TimeStepZone, ThermalComfortSetPoint(1).notMetHeating);
+    EXPECT_EQ(TimeStepZone, ThermalComfortSetPoint(1).notMetHeatingOccupied);
+    EXPECT_EQ(0., ThermalComfortSetPoint(1).notMetCooling);
+    EXPECT_EQ(0., ThermalComfortSetPoint(1).notMetCoolingOccupied);
+
+    // cooling
+    ZTAV(1) = 25.0;                                      // 77F
+    ZoneThermostatSetPointHi(1) = 23.9;                  // 75F
+    ZoneThermostatSetPointHiAver(1) = 23.9;                  // 75F
+    ZoneSysEnergyDemand(1).TotalOutputRequired = -500.0; // must be less than zero
+    CalcIfSetPointMet();
+    EXPECT_EQ(0, ThermalComfortSetPoint(1).notMetHeating);
+    EXPECT_EQ(0, ThermalComfortSetPoint(1).notMetHeatingOccupied);
+    EXPECT_EQ(TimeStepZone, ThermalComfortSetPoint(1).notMetCooling);
+    EXPECT_EQ(TimeStepZone, ThermalComfortSetPoint(1).notMetCoolingOccupied);
+
+    // no cooling or heating
+    ZTAV(1) = 23.0;                                      // 73F
+    ZoneSysEnergyDemand(1).TotalOutputRequired = 0.0; // must be zero
+    CalcIfSetPointMet();
+    EXPECT_EQ(0, ThermalComfortSetPoint(1).notMetHeating);
+    EXPECT_EQ(0, ThermalComfortSetPoint(1).notMetHeatingOccupied);
+    EXPECT_EQ(0, ThermalComfortSetPoint(1).notMetCooling);
+    EXPECT_EQ(0, ThermalComfortSetPoint(1).notMetCoolingOccupied);
+    EXPECT_EQ(TimeStepZone, ThermalComfortSetPoint(1).totalNotMetHeating);
+    EXPECT_EQ(TimeStepZone, ThermalComfortSetPoint(1).totalNotMetHeatingOccupied);
+    EXPECT_EQ(TimeStepZone, ThermalComfortSetPoint(1).totalNotMetCooling);
+    EXPECT_EQ(TimeStepZone, ThermalComfortSetPoint(1).totalNotMetCoolingOccupied);
+
 }


### PR DESCRIPTION
Pull request overview
---------------------
ZoneThermostatSetPointLo and ZoneThermostatSetPointHi are used to calculate "hours of setpoint not met" at every zone time step. When onoff thermostat is applied, ZoneThermostatSetPointLo and ZoneThermostatSetPointHi are calculated at every system time step. The setpoint averaged in a zone time step is used.

This fix addresses the last item in #6546.
### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Code style (parentheses padding, variable names)
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check -- verify this
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add rules to spreadsheet
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Documentation changes in place
 - [ ] Changed docs build successfully
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
