### PR TITLE
Change Kiva error to warning

### DIFF
--- a/src/EnergyPlus/HeatBalanceKivaManager.cc
+++ b/src/EnergyPlus/HeatBalanceKivaManager.cc
@@ -779,10 +779,13 @@ namespace HeatBalanceKivaManager {
                             ShowWarningError("Foundation:Kiva=\"" + foundationInputs[surface.OSCPtr].name + "\".");
                             ShowContinueError("   Wall Surface=\"" + Surfaces(wl).Name + "\", does not have any vertices that are");
                             ShowContinueError("   coplanar with the corresponding Floor Surface=\"" + Surfaces(surfNum).Name + "\".");
-                            ShowContinueError("   Simulation will continue with <Language to be inserted from NK>.");
+                            ShowContinueError("   Simulation will continue using the distance between the two lowest points in the wall for the interface distance.");
 
                             // sort vertices by Z-value
-                            std::vector<int> zs = {0, 1, 2, 3};
+                            std::vector<int> zs;
+                            for (std::size_t i = 0; i < numVs; ++i) {
+                                zs.push_back(i);
+                            }
                             sort(zs.begin(), zs.end(), [v](int a, int b) { return v[a].z < v[b].z; });
                             perimeter = distance(v[zs[0]], v[zs[1]]);
                         }

--- a/src/EnergyPlus/HeatBalanceKivaManager.cc
+++ b/src/EnergyPlus/HeatBalanceKivaManager.cc
@@ -776,10 +776,15 @@ namespace HeatBalanceKivaManager {
                         }
 
                         if (perimeter == 0.0) {
-                            ErrorsFound = true;
-                            ShowSevereError("Foundation:Kiva=\"" + foundationInputs[surface.OSCPtr].name + "\".");
+                            ShowWarningError("Foundation:Kiva=\"" + foundationInputs[surface.OSCPtr].name + "\".");
                             ShowContinueError("   Wall Surface=\"" + Surfaces(wl).Name + "\", does not have any vertices that are");
                             ShowContinueError("   coplanar with the corresponding Floor Surface=\"" + Surfaces(surfNum).Name + "\".");
+                            ShowContinueError("   Simulation will continue with <Language to be inserted from NK>.");
+
+                            // sort vertices by Z-value
+                            std::vector<int> zs = {0, 1, 2, 3};
+                            sort(zs.begin(), zs.end(), [v](int a, int b) { return v[a].z < v[b].z; });
+                            perimeter = distance(v[zs[0]], v[zs[1]]);
                         }
 
                         Real64 surfHeight = Surfaces(wl).get_average_height();


### PR DESCRIPTION
Pull request overview
---------------------
Convert Kiva error to warning for buildings where the foundation wall surface edge is not connected to the floor surface. This was changed E+ 9.0 as part of [this PR](https://github.com/NREL/EnergyPlus/pull/6852), which causes E+ 9.0 simulations from running successfully for buildings without full, enclosed 3D geometry specified. This change allows the simulations to run as they did in previous versions of E+.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
