### PR TITLE
Use RunPeriod names in error messages and use right array for SizingPeriod:WeatherFileXXX

### DIFF
--- a/src/EnergyPlus/OutputReportPredefined.cc
+++ b/src/EnergyPlus/OutputReportPredefined.cc
@@ -1874,7 +1874,7 @@ namespace OutputReportPredefined {
         pdchFanPwrPerFlow = newPreDefColumn(pdstFan, "Rated Power Per Max Air Flow Rate [W-s/m3]");
         pdchFanMotorIn = newPreDefColumn(pdstFan, "Motor Heat In Air Fraction");
         pdchFanEnergyIndex = newPreDefColumn(pdstFan, "Fan Energy Index");
-        pdchFanEndUse = newPreDefColumn(pdstFan, "End Use");
+        pdchFanEndUse = newPreDefColumn(pdstFan, "End Use Subcategory");
         pdchFanDesDay = newPreDefColumn(pdstFan, "Design Day Name for Fan Sizing Peak");
         pdchFanPkTime = newPreDefColumn(pdstFan, "Date/Time for Fan Sizing Peak");
 

--- a/src/EnergyPlus/WeatherManager.cc
+++ b/src/EnergyPlus/WeatherManager.cc
@@ -6412,6 +6412,8 @@ namespace WeatherManager {
                                           cNumericFieldNames);
             GlobalNames::VerifyUniqueInterObjectName(
                 RunPeriodDesignInputUniqueNames, cAlphaArgs(1), cCurrentModuleObject, cAlphaFieldNames(1), ErrorsFound);
+
+            // Increment Count
             ++Count;
             RunPeriodDesignInput(Count).title = cAlphaArgs(1);
             RunPeriodDesignInput(Count).periodType = "User Selected WeatherFile RunPeriod (Design)";
@@ -6429,24 +6431,24 @@ namespace WeatherManager {
                     (SELECT_CASE_var == 10) || (SELECT_CASE_var == 12)) {
                     if (RunPeriodDesignInput(Count).startDay > 31) {
                         ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodDesignInput(Count).title + ' ' + cNumericFieldNames(2) +
-                                        " invalid (Day of Month) [" + TrimSigDigits(RunPeriodInput(Loop).startDay) + ']');
+                                        " invalid (Day of Month) [" + TrimSigDigits(RunPeriodDesignInput(Count).startDay) + ']');
                         ErrorsFound = true;
                     }
                 } else if ((SELECT_CASE_var == 4) || (SELECT_CASE_var == 6) || (SELECT_CASE_var == 9) || (SELECT_CASE_var == 11)) {
                     if (RunPeriodDesignInput(Count).startDay > 30) {
                         ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodDesignInput(Count).title + ' ' + cNumericFieldNames(2) +
-                                        " invalid (Day of Month) [" + TrimSigDigits(RunPeriodInput(Loop).startDay) + ']');
+                                        " invalid (Day of Month) [" + TrimSigDigits(RunPeriodDesignInput(Count).startDay) + ']');
                         ErrorsFound = true;
                     }
                 } else if (SELECT_CASE_var == 2) {
                     if (RunPeriodDesignInput(Count).startDay > 28 + LeapYearAdd) {
                         ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodDesignInput(Count).title + ' ' + cNumericFieldNames(2) +
-                                        " invalid (Day of Month) [" + TrimSigDigits(RunPeriodInput(Loop).startDay) + ']');
+                                        " invalid (Day of Month) [" + TrimSigDigits(RunPeriodDesignInput(Count).startDay) + ']');
                         ErrorsFound = true;
                     }
                 } else {
                     ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodDesignInput(Count).title + ' ' + cNumericFieldNames(1) +
-                                    " invalid (Month) [" + TrimSigDigits(RunPeriodInput(Loop).startMonth) + ']');
+                                    " invalid (Month) [" + TrimSigDigits(RunPeriodDesignInput(Count).startMonth) + ']');
                     ErrorsFound = true;
                 }
             }

--- a/src/EnergyPlus/WeatherManager.cc
+++ b/src/EnergyPlus/WeatherManager.cc
@@ -6026,10 +6026,10 @@ namespace WeatherManager {
         cCurrentModuleObject = "RunPeriod";
         Count = 0;
         // if ( ! WFAllowsLeapYears ) {
-        //	LocalLeapYearAdd = 0;
-        //} else {
-        //	LocalLeapYearAdd = 1;
-        //}
+        //   LocalLeapYearAdd = 0;
+        // } else {
+        //  LocalLeapYearAdd = 1;
+        // }
         for (Loop = 1; Loop <= TotRunPers; ++Loop) {
             inputProcessor->getObjectItem(cCurrentModuleObject,
                                           Loop,
@@ -6051,6 +6051,8 @@ namespace WeatherManager {
 
             ++Count;
             // Loop = RP + Ptr;
+            // Note JM 2018-11-20: IDD allows blank name, but input processor will create a name such as "RUNPERIOD 1" anyways
+            // which is fine for our reporting below
             RunPeriodInput(Loop).title = cAlphaArgs(1);
 
             // set the start and end day of month from user input
@@ -6078,18 +6080,18 @@ namespace WeatherManager {
             // Validate year inputs
             if (RunPeriodInput(Loop).startYear == 0) {
                 if (RunPeriodInput(Loop).endYear != 0) { // Have to have an input start year to input an end year
-                    ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) +
+                    ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title +
                                     ", end year cannot be specified if the start year is not.");
                     ErrorsFound = true;
                 }
             } else if (RunPeriodInput(Loop).startYear < 1583) { // Bail on the proleptic Gregorian calendar
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", start year (" +
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", start year (" +
                                 std::to_string(RunPeriodInput(Loop).startYear) + ") is too early, please choose a date after 1582.");
                 ErrorsFound = true;
             }
 
             if (RunPeriodInput(Loop).endYear != 0 && RunPeriodInput(Loop).startYear > RunPeriodInput(Loop).endYear) {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", start year (" +
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", start year (" +
                                 std::to_string(RunPeriodInput(Loop).startYear) + ") is after the end year (" +
                                 std::to_string(RunPeriodInput(Loop).endYear) + ").");
                 ErrorsFound = true;
@@ -6100,7 +6102,7 @@ namespace WeatherManager {
             if (!lAlphaFieldBlanks(2)) { // Have input
                 auto result = weekDayLookUp.find(cAlphaArgs(2));
                 if (result == weekDayLookUp.end()) {
-                    ShowWarningError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(2) + " invalid (Day of Week) [" +
+                    ShowWarningError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + cAlphaFieldNames(2) + " invalid (Day of Week) [" +
                                      cAlphaArgs(2) + "] for Start is not valid, Sunday will be used.");
                     RunPeriodInput(Loop).startWeekDay = WeekDay::Sunday;
                 } else {
@@ -6126,7 +6128,7 @@ namespace WeatherManager {
                     }
                 } else {                                               // Have an input start year
                     if (!isLeapYear(RunPeriodInput(Loop).startYear)) { // Start year is not a leap year
-                        ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", start year (" +
+                        ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", start year (" +
                                         std::to_string(RunPeriodInput(Loop).startYear) +
                                         ") is not a leap year but the requested start date is 2/29.");
                         ErrorsFound = true;
@@ -6135,7 +6137,7 @@ namespace WeatherManager {
                             calculateDayOfWeek(RunPeriodInput(Loop).startYear, RunPeriodInput(Loop).startMonth, RunPeriodInput(Loop).startDay);
                         if (inputWeekday) { // Check for correctness of input
                             if (weekday != RunPeriodInput(Loop).startWeekDay) {
-                                ShowWarningError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", start weekday (" + cAlphaArgs(2) +
+                                ShowWarningError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", start weekday (" + cAlphaArgs(2) +
                                                  ") does not match the start year (" + std::to_string(RunPeriodInput(Loop).startYear) +
                                                  "), corrected to " + DaysOfWeek(static_cast<int>(weekday)) + ".");
                                 RunPeriodInput(Loop).startWeekDay = weekday;
@@ -6148,7 +6150,7 @@ namespace WeatherManager {
             } else {
                 // Non leap-day start date
                 if (!validMonthDay(RunPeriodInput(Loop).startMonth, RunPeriodInput(Loop).startDay)) {
-                    ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", Invalid input start month/day (" +
+                    ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", Invalid input start month/day (" +
                                     TrimSigDigits(RunPeriodInput(Loop).startMonth) + '/' + TrimSigDigits(RunPeriodInput(Loop).startDay) + ')');
                     ErrorsFound = true;
                 } else {                                       // Month/day is valid
@@ -6167,7 +6169,7 @@ namespace WeatherManager {
                             calculateDayOfWeek(RunPeriodInput(Loop).startYear, RunPeriodInput(Loop).startMonth, RunPeriodInput(Loop).startDay);
                         if (inputWeekday) { // Check for correctness of input
                             if (weekday != RunPeriodInput(Loop).startWeekDay) {
-                                ShowWarningError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", start weekday (" + cAlphaArgs(2) +
+                                ShowWarningError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", start weekday (" + cAlphaArgs(2) +
                                                  ") does not match the start year (" + std::to_string(RunPeriodInput(Loop).startYear) +
                                                  "), corrected to " + DaysOfWeek(static_cast<int>(weekday)) + ".");
                                 RunPeriodInput(Loop).startWeekDay = weekday;
@@ -6201,14 +6203,14 @@ namespace WeatherManager {
                     }
                 } else {                                             // Have an input end year
                     if (!isLeapYear(RunPeriodInput(Loop).endYear)) { // End year is not a leap year
-                        ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", end year (" +
+                        ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", end year (" +
                                         std::to_string(RunPeriodInput(Loop).startYear) + ") is not a leap year but the requested end date is 2/29.");
                         ErrorsFound = true;
                     } else {
                         RunPeriodInput(Loop).endJulianDate =
                             computeJulianDate(RunPeriodInput(Loop).endYear, RunPeriodInput(Loop).endMonth, RunPeriodInput(Loop).endDay);
                         if (RunPeriodInput(Loop).startJulianDate > RunPeriodInput(Loop).endJulianDate) {
-                            ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", start Julian date (" +
+                            ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", start Julian date (" +
                                             std::to_string(RunPeriodInput(Loop).startJulianDate) + ") is after the end Julian date (" +
                                             std::to_string(RunPeriodInput(Loop).endJulianDate) + ").");
                             ErrorsFound = true;
@@ -6218,7 +6220,7 @@ namespace WeatherManager {
             } else {
                 // Non leap-day end date
                 if (!validMonthDay(RunPeriodInput(Loop).endMonth, RunPeriodInput(Loop).endDay)) {
-                    ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", Invalid input end month/day (" +
+                    ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", Invalid input end month/day (" +
                                     TrimSigDigits(RunPeriodInput(Loop).startMonth) + '/' + TrimSigDigits(RunPeriodInput(Loop).startDay) + ')');
                     ErrorsFound = true;
                 } else {                                     // Month/day is valid
@@ -6235,7 +6237,7 @@ namespace WeatherManager {
                         RunPeriodInput(Loop).endJulianDate =
                             computeJulianDate(RunPeriodInput(Loop).endYear, RunPeriodInput(Loop).endMonth, RunPeriodInput(Loop).endDay);
                         if (RunPeriodInput(Loop).startJulianDate > RunPeriodInput(Loop).endJulianDate) {
-                            ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + ", start Julian date (" +
+                            ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + ", start Julian date (" +
                                             std::to_string(RunPeriodInput(Loop).startJulianDate) + ") is after the end Julian date (" +
                                             std::to_string(RunPeriodInput(Loop).endJulianDate) + ").");
                             ErrorsFound = true;
@@ -6257,7 +6259,7 @@ namespace WeatherManager {
             } else if (UtilityRoutines::SameString(cAlphaArgs(3), "NO")) {
                 RunPeriodInput(Loop).useHolidays = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(3) + " invalid [" + cAlphaArgs(3) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + cAlphaFieldNames(3) + " invalid [" + cAlphaArgs(3) + ']');
                 ErrorsFound = true;
             }
 
@@ -6267,7 +6269,7 @@ namespace WeatherManager {
             } else if (UtilityRoutines::SameString(cAlphaArgs(4), "NO")) {
                 RunPeriodInput(Loop).useDST = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(4) + " invalid [" + cAlphaArgs(4) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + cAlphaFieldNames(4) + " invalid [" + cAlphaArgs(4) + ']');
                 ErrorsFound = true;
             }
 
@@ -6277,7 +6279,7 @@ namespace WeatherManager {
             } else if (UtilityRoutines::SameString(cAlphaArgs(5), "NO")) {
                 RunPeriodInput(Loop).applyWeekendRule = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(5) + " invalid [" + cAlphaArgs(5) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + cAlphaFieldNames(5) + " invalid [" + cAlphaArgs(5) + ']');
                 ErrorsFound = true;
             }
 
@@ -6287,7 +6289,7 @@ namespace WeatherManager {
             } else if (UtilityRoutines::SameString(cAlphaArgs(6), "NO")) {
                 RunPeriodInput(Loop).useRain = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(6) + " invalid [" + cAlphaArgs(6) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + cAlphaFieldNames(6) + " invalid [" + cAlphaArgs(6) + ']');
                 ErrorsFound = true;
             }
 
@@ -6297,7 +6299,7 @@ namespace WeatherManager {
             } else if (UtilityRoutines::SameString(cAlphaArgs(7), "NO")) {
                 RunPeriodInput(Loop).useSnow = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(7) + " invalid [" + cAlphaArgs(7) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + cAlphaFieldNames(7) + " invalid [" + cAlphaArgs(7) + ']');
                 ErrorsFound = true;
             }
 
@@ -6307,7 +6309,7 @@ namespace WeatherManager {
             } else if (UtilityRoutines::SameString(cAlphaArgs(8), "YES")) {
                 RunPeriodInput(Loop).actualWeather = true;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(8) + " invalid [" + cAlphaArgs(8) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodInput(Loop).title + cAlphaFieldNames(8) + " invalid [" + cAlphaArgs(8) + ']');
                 ErrorsFound = true;
             }
 

--- a/src/EnergyPlus/WeatherManager.cc
+++ b/src/EnergyPlus/WeatherManager.cc
@@ -6469,7 +6469,7 @@ namespace WeatherManager {
             } else if (UtilityRoutines::SameString(cAlphaArgs(3), "NO")) {
                 RunPeriodDesignInput(Count).useDST = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(3) + " invalid [" + cAlphaArgs(3) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodDesignInput(Count).title + ' ' + cAlphaFieldNames(3) + " invalid [" + cAlphaArgs(3) + ']');
                 ErrorsFound = true;
             }
 
@@ -6480,7 +6480,7 @@ namespace WeatherManager {
                 RunPeriodDesignInput(Count).useRain = false;
                 RunPeriodDesignInput(Count).useSnow = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(4) + " invalid [" + cAlphaArgs(4) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodDesignInput(Count).title + ' ' + cAlphaFieldNames(4) + " invalid [" + cAlphaArgs(4) + ']');
                 ErrorsFound = true;
             }
 
@@ -6522,6 +6522,8 @@ namespace WeatherManager {
                                           cNumericFieldNames);
             GlobalNames::VerifyUniqueInterObjectName(
                 RunPeriodDesignInputUniqueNames, cAlphaArgs(1), cCurrentModuleObject, cAlphaFieldNames(1), ErrorsFound);
+
+            // Increment count
             ++Count;
             RunPeriodDesignInput(Count).title = cAlphaArgs(1);
             RunPeriodDesignInput(Count).periodType = "User Selected WeatherFile Typical/Extreme Period (Design)=" + cAlphaArgs(2);
@@ -6590,7 +6592,7 @@ namespace WeatherManager {
             } else if (UtilityRoutines::SameString(cAlphaArgs(4), "NO")) {
                 RunPeriodDesignInput(Count).useDST = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(4) + " invalid [" + cAlphaArgs(4) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodDesignInput(Count).title + ' ' + cAlphaFieldNames(4) + " invalid [" + cAlphaArgs(4) + ']');
                 ErrorsFound = true;
             }
 
@@ -6601,7 +6603,7 @@ namespace WeatherManager {
                 RunPeriodDesignInput(Count).useRain = false;
                 RunPeriodDesignInput(Count).useSnow = false;
             } else {
-                ShowSevereError(cCurrentModuleObject + ": object #" + TrimSigDigits(Loop) + cAlphaFieldNames(5) + " invalid [" + cAlphaArgs(5) + ']');
+                ShowSevereError(cCurrentModuleObject + ": object=" + RunPeriodDesignInput(Count).title + ' ' + cAlphaFieldNames(5) + " invalid [" + cAlphaArgs(5) + ']');
                 ErrorsFound = true;
             }
             RunPeriodDesignInput(1).monWeekDay = 0;

--- a/tst/EnergyPlus/unit/ReportSizingManager.unit.cc
+++ b/tst/EnergyPlus/unit/ReportSizingManager.unit.cc
@@ -880,4 +880,7 @@ TEST_F(EnergyPlusFixture, ReportSizingManager_FanPeak) {
     // Check that the Design Day/Time is filled
     EXPECT_EQ(DDTitle, OutputReportPredefined::RetrievePreDefTableEntry(OutputReportPredefined::pdchFanDesDay, CompName));
     EXPECT_EQ("7/15 18:00:00", OutputReportPredefined::RetrievePreDefTableEntry(OutputReportPredefined::pdchFanPkTime, CompName));
+
+    // Bonus test for #6949
+    EXPECT_EQ("End Use Subcategory", OutputReportPredefined::columnTag(OutputReportPredefined::pdchFanEndUse).heading);
 }

--- a/tst/EnergyPlus/unit/RunPeriod.unit.cc
+++ b/tst/EnergyPlus/unit/RunPeriod.unit.cc
@@ -312,13 +312,13 @@ TEST_F(EnergyPlusFixture, RunPeriod_NameOfPeriodInWarning)
         EXPECT_FALSE(ErrorsFound);
 
         std::string const error_string =
-            delimited_string({"   ** Warning ** RunPeriod: object=Jan, start weekday (TUESDAY) does not match the start year (2005), corrected to SATURDAY."});
+            delimited_string({"   ** Warning ** RunPeriod: object=JAN, start weekday (TUESDAY) does not match the start year (2005), corrected to SATURDAY."});
 
         EXPECT_TRUE(compare_err_stream(error_string, true));
 
     }
 
-    // Case 2: doesn't have a name, should default to "RunPeriod #1"
+    // Case 2: doesn't have a name, should default to "RUNPERIOD 1" via InputProcessor
     {
 
         std::string const idf_objects = delimited_string({
@@ -349,7 +349,7 @@ TEST_F(EnergyPlusFixture, RunPeriod_NameOfPeriodInWarning)
         EXPECT_FALSE(ErrorsFound);
 
         std::string const error_string =
-            delimited_string({"   ** Warning ** RunPeriod: object=RunPeriod #1, start weekday (TUESDAY) does not match the start year (2005), corrected to SATURDAY."});
+            delimited_string({"   ** Warning ** RunPeriod: object=RUNPERIOD 1, start weekday (TUESDAY) does not match the start year (2005), corrected to SATURDAY."});
 
         EXPECT_TRUE(compare_err_stream(error_string, true));
 

--- a/tst/EnergyPlus/unit/RunPeriod.unit.cc
+++ b/tst/EnergyPlus/unit/RunPeriod.unit.cc
@@ -387,7 +387,7 @@ TEST_F(EnergyPlusFixture, RunPeriod_NameOfPeriodInWarning)
         EXPECT_TRUE(ErrorsFound);
 
         std::string const error_string =
-            delimited_string({"   ** Warning ** RunPeriod: object=JAN, start year (2005) is not a leap year but the requested start date is 2/29."});
+            delimited_string({"   ** Severe  ** RunPeriod: object=NOTLEAP, start year (2005) is not a leap year but the requested start date is 2/29."});
 
         EXPECT_TRUE(compare_err_stream(error_string, true));
 


### PR DESCRIPTION
Pull request overview
---------------------


* Fix #6937: I didn't do any IDD change to make the name of the `RunPeriod` a required field. By default the InputProcessor will attribute a name such as "RUN PERIOD 1" when it's empty.
Regardless or whether the name (in the code `title`) is autogenerated or not, use that in the Warning/Severe messages.
* Fix #7067: 
    * In GetRunPeriodDesignData, some warning messages were referring to the wrong array, which could end up throwing an assert contains.
     * Also, 4 warnings messages referred to the object number rather than its name like in #6937, so I fixed that for consistency. But there's 0 chance it'll ever reach them: the code checks if Yes/No fields are appropriate, and the InputProcessor would fatal before it reaches them. That's also why I didn't add an explicit unit test for this portion (can't do).

Bonus: Fix #6949: really trivial so not worth adding it to another PR

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
