### PR TITLE
Fix divide by zero in Kiva foundations for certain wall orientations

### DIFF
--- a/src/EnergyPlus/DataSurfaces.cc
+++ b/src/EnergyPlus/DataSurfaces.cc
@@ -1013,7 +1013,7 @@ namespace DataSurfaces {
         Real64 const &caz(CosAzim);
         for (Vertices::size_type i = 0; i < n; ++i) {
             Vector const &v(Vertex[i]);
-            v2d[i] = Vertex2D((v.x - xRef)*caz + (v.y - yRef)*saz, v.z);
+            v2d[i] = Vertex2D(-(v.x - xRef)*caz + (v.y - yRef)*saz, v.z);
         }
 
         // piecewise linear integration
@@ -1026,6 +1026,12 @@ namespace DataSurfaces {
             maxX = std::max(maxX, v.x);
         }
         Real64 totalWidth = maxX - minX;
+
+        if (totalWidth == 0.0) {
+            // This should never happen, but if it does, print a somewhat meaningful fatal error
+            // (instead of allowing a divide by zero).
+            ShowFatalError("Calculated projected surface width is zero for surface=\"" + Name + "\"");
+        }
 
         Real64 averageHeight = 0.0;
         for (Vertices::size_type i = 0; i < n; ++i) {

--- a/tst/EnergyPlus/unit/DataSurfaces.unit.cc
+++ b/tst/EnergyPlus/unit/DataSurfaces.unit.cc
@@ -278,6 +278,25 @@ TEST(SurfaceTest, AverageHeightRectangle)
         s.SinTilt = std::sin(s.Tilt * DegToRadians);
 
         EXPECT_DOUBLE_EQ(s.get_average_height(), 1.0 / s.SinTilt );
+
+        s.Vertex = { Vector(0, 0, 0), Vector(0, 1, 0), Vector(0, 1, 1), Vector(0, 0, 1) };
+        Vectors::CreateNewellSurfaceNormalVector(s.Vertex, s.Vertex.size(), s.NewellSurfaceNormalVector);
+        Vectors::DetermineAzimuthAndTilt(s.Vertex, s.Vertex.size(), s.Azimuth, s.Tilt, s.lcsx, s.lcsy, s.lcsz, s.GrossArea, s.NewellSurfaceNormalVector);
+        s.SinAzim = std::sin(s.Azimuth * DegToRadians);
+        s.CosAzim = std::cos(s.Azimuth * DegToRadians);
+        s.SinTilt = std::sin(s.Tilt * DegToRadians);
+
+        EXPECT_DOUBLE_EQ(s.get_average_height(), 1.0);
+
+        s.Vertex = { Vector(1, -1, 0), Vector(1, -1, -1), Vector(0, 0, -1), Vector(0, 0, 0) };
+        Vectors::CreateNewellSurfaceNormalVector(s.Vertex, s.Vertex.size(), s.NewellSurfaceNormalVector);
+        Vectors::DetermineAzimuthAndTilt(s.Vertex, s.Vertex.size(), s.Azimuth, s.Tilt, s.lcsx, s.lcsy, s.lcsz, s.GrossArea, s.NewellSurfaceNormalVector);
+        s.SinAzim = std::sin(s.Azimuth * DegToRadians);
+        s.CosAzim = std::cos(s.Azimuth * DegToRadians);
+        s.SinTilt = std::sin(s.Tilt * DegToRadians);
+
+        EXPECT_DOUBLE_EQ(s.get_average_height(), 1.0);
+
     }
 }
 


### PR DESCRIPTION
Pull request overview
---------------------
Resolves #7088.

Problem was related to incorrect matrix rotation when projecting wall surface vertices into 2D plane for numerical integration of average surface height. In some cases this resulted in a divide by zero and propagated "nan"s into other code resulting in an infinite loop. 

Work completed under NREL task order KAGX-8-82297-01.

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - [ ] If new idf included, locally check the err file and other outputs
