### PR TITLE
Fix documentation for HybridModel:Zone model

### DIFF
--- a/doc/input-output-reference/src/overview.tex
+++ b/doc/input-output-reference/src/overview.tex
@@ -119,3 +119,5 @@ The following descriptions are ``grouped'' by the elements in the IDD (ref: Gett
 \input{src/overview/group-performance-tables}
 
 \input{src/overview/group-fluid-properties}
+
+\input{src/overview/group-hybrid-model}

--- a/doc/input-output-reference/src/overview/group-hybrid-model.tex
+++ b/doc/input-output-reference/src/overview/group-hybrid-model.tex
@@ -1,4 +1,4 @@
-\section{Group - Hybrid Model}\label{group---hybrid-model}
+\section{Group -- Hybrid Model}\label{group-hybrid-model}
 
 This object is to provide a hybrid model feature to enhance the accuracy of the building energy simulation for existing buildings. The hybrid model feature replaces internal thermal mass and infiltration air flow rates with zone air temperature data. The hybrid model feature calculates a temperature capacitance multiplier, equivalent to the zone internal thermal mass and infiltration air change per hour (ACH) based on the inverse modeling of the heat balance algorithms. 
 

--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -5137,15 +5137,6 @@ namespace HeatBalanceManager {
             "Zone Outdoor Air Wind Speed", OutputProcessor::Unit::m_s, Zone(ZoneLoop).WindSpeed, "Zone", "Average", Zone(ZoneLoop).Name);
         SetupOutputVariable(
             "Zone Outdoor Air Wind Direction", OutputProcessor::Unit::deg, Zone(ZoneLoop).WindDir, "Zone", "Average", Zone(ZoneLoop).Name);
-
-        if (FlagHybridModel) {
-            SetupOutputVariable("Zone Infiltration Hybrid Model Air Change Rate",
-                                OutputProcessor::Unit::ach,
-                                Zone(ZoneLoop).InfilOAAirChangeRateHM,
-                                "Zone",
-                                "Average",
-                                Zone(ZoneLoop).Name);
-        }
     }
 
     // End of Get Input subroutines for the HB Module

--- a/src/EnergyPlus/HybridModel.cc
+++ b/src/EnergyPlus/HybridModel.cc
@@ -59,6 +59,7 @@
 #include <InputProcessing/InputProcessor.hh>
 #include <ScheduleManager.hh>
 #include <UtilityRoutines.hh>
+#include <OutputProcessor.hh>
 
 namespace EnergyPlus {
 
@@ -216,9 +217,14 @@ namespace HybridModel {
                         AirModel(ZonePtr).AirModelType = RoomAirModel_Mixing;
                         ShowWarningError("Room Air Model Type should be Mixing if Hybrid Modeling is performed for the zone.");
                     }
+                    SetupOutputVariable("Zone Infiltration Hybrid Model Air Change Rate",
+                                        OutputProcessor::Unit::ach,
+                                        Zone(ZonePtr).InfilOAAirChangeRateHM,
+                                        "Zone",
+                                        "Average",
+                                        Zone(ZonePtr).Name);
                 }
             }
-
             if (ErrorsFound) {
                 ShowFatalError("Errors getting Hybrid Model input data. Preceding condition(s) cause termination.");
             }


### PR DESCRIPTION
- [x] I/O Ref section for HybridModel:Zone is not in the pdf. The source files were added in #5882 but there's no line in overview.tex 
- [x] I/O Ref doesn't have the output variables for "Zone Infiltration Hybrid Model Air Change Rate"
- [x] For example file HybridZoneModel.idf with the request for Output:VariableDictionary, "Zone Infiltration Hybrid Model Air Change Rate" is not in the RDD, while the Flag should be initialized here since there are objects that have Calculate Zone Internal Thermal Mass or Calculate Zone Air Infiltration Rate enabled.
- [x] This object could read begin/end day and month from the RunPeriod.