### PR TITLE
Make the output variable parser script recurse through the source dirs

### DIFF
--- a/doc/tools/parse_output_variables.py
+++ b/doc/tools/parse_output_variables.py
@@ -10,6 +10,8 @@ import io
 import sys
 from os import path
 import re
+import fnmatch
+import os
 
 # generates a csv summary of the output variables in E+
 # assumption: doesn't check for commented lines
@@ -140,8 +142,10 @@ def main():
     # this is the    master list of calls
     output_variables = []
 
-    # find all the source files
-    files = sorted(glob.glob(path.join(source_dir, "*.cc")))
+    files = []
+    for root, _, filenames in os.walk(source_dir):
+        for filename in fnmatch.filter(filenames, '*.cc'):
+            files.append(os.path.join(root, filename))
 
     for this_file in files:
 


### PR DESCRIPTION
Pull request overview
---------------------
The script that creates the SetupOutputVariables.csv file for packages did not know to recurse into subdirectories when scanning EnergyPlus source.  This left out a handful of output variables that have been added recently in subdirectories inside src/EnergyPlus.  This modifies the script to search all subdirectories.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
 - [ ] Functional code review (it has to work!)
 - [ ] CI status: all green or justified
