### PR TITLE
Move array and allocate flag to namespace and include in clear_state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Energy+.schema.epJSON.in
 
 # now that we have python, ignore some things
 *.pyc
+venv
 
 # build folder, if the dev chooses to put it there
 #  could also do a wildcard for build-* if we suggest that naming approach

--- a/src/EnergyPlus/ZoneEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneEquipmentManager.cc
@@ -189,6 +189,8 @@ namespace ZoneEquipmentManager {
         bool InitZoneEquipmentOneTimeFlag(true);
         bool InitZoneEquipmentEnvrnFlag(true);
         bool FirstPassZoneEquipFlag(true); // indicates first pass through zone equipment, used to reset selected ZoneEqSizing variables
+        bool AllocateFlag(true);
+        Array1D_bool fixedReturn;
     }                                      // namespace
 
     Array1D<Real64> AvgData; // scratch array for storing averaged data
@@ -215,6 +217,8 @@ namespace ZoneEquipmentManager {
         PrioritySimOrder.deallocate();
         FirstPassZoneEquipFlag = true;
         reportDOASZoneSizingHeader = true;
+        AllocateFlag = true;
+        fixedReturn.deallocate();
     }
 
     void ManageZoneEquipment(bool const FirstHVACIteration, bool &SimZone, bool &SimAir)
@@ -4943,8 +4947,6 @@ namespace ZoneEquipmentManager {
                              Real64 &FinalTotalReturnMassFlow // Final total return air mass flow rate
     )
     {
-        static Array1D_bool fixedReturn;
-        static bool AllocateFlag = true;
         if (AllocateFlag) {
             AllocateFlag = false;
             int maxReturnNodes = 0;


### PR DESCRIPTION
Pull request overview
---------------------
@nmerket [noticed](https://github.com/NREL/EnergyPlus/commit/0ac3fd3a0b7260cced18ac4cf318bc2d9ef47a40#commitcomment-32223019) that a static variable was causing issues during unit testing.  This quick fix moves the variable and the allocate flag to the namespace level and includes them in the clear_state function so that it should be all good with unit tests again.

@nmerket if you are able to pull this branch into yours and verify it works well now, that would be helpful. If not, I think it's good to go anyway :upside_down_face: 

FYI @mjwitte  
