### PR TITLE
Hotfix: ZoneHVACEquipmentList transition rules aren't working after new IDD extensible groups added in #7171

### DIFF
--- a/src/Transition/CreateNewIDFUsingRulesV9_1_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV9_1_0.f90
@@ -434,7 +434,7 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
 
               ! If your original object starts with Z, insert the rules here
 
-              CASE('ZoneHVAC:EquipmentList')
+              CASE('ZONEHVAC:EQUIPMENTLIST')
                   CALL GetNewObjectDefInIDD(ObjectName,NwNumArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
                   nodiff=.false.
                   OutArgs(1) = InArgs(1)


### PR DESCRIPTION
Fix for one item in #7191

I'm in the process of updating OpenStudio to use E+ 9.1.0 (based off the IOFreeze release for now), and I was hitting a problem were transitioned files wouldn't run. I tracked it to PR #7171.

Given the following snippet:

```
Version,9.0;

ZoneHVAC:EquipmentList,
    Dining Equipment,        !- Name
    SequentialLoad,          !- Load Distribution Scheme
    Fan:ZoneExhaust,         !- Zone Equipment 1 Object Type
    Dining Exhaust Fan,      !- Zone Equipment 1 Name
    1,                       !- Zone Equipment 1 Cooling Sequence
    1,                       !- Zone Equipment 1 Heating or No-Load Sequence
    AirTerminal:SingleDuct:Uncontrolled,  !- Zone Equipment 2 Object Type
    Dining Direct Air,       !- Zone Equipment 2 Name
    2,                       !- Zone Equipment 2 Cooling Sequence
    2;                       !- Zone Equipment 2 Heating or No-Load Sequence
```

After:

```bash
./Transition-V9-0-0-to-V9-1-0 testZoneHVACEqList.idf 
```

I obtain this, which obviously makes E+ crash.

```
  Version,9.1;

  ZoneHVAC:EquipmentList,
    Dining Equipment,        !- Name
    SequentialLoad,          !- Load Distribution Scheme
    Fan:ZoneExhaust,         !- Zone Equipment 1 Object Type
    Dining Exhaust Fan,      !- Zone Equipment 1 Name
    1,                       !- Zone Equipment 1 Cooling Sequence
    1,                       !- Zone Equipment 1 Heating or No-Load Sequence
    AirTerminal:SingleDuct:Uncontrolled,  !- Zone Equipment 1 Sequential Cooling Fraction
    Dining Direct Air,       !- Zone Equipment 1 Sequential Heating Fraction
    2,                       !- Zone Equipment 2 Object Type
    2;                       !- Zone Equipment 2 Name
```

After trial and error, I realized it was just a case issue...