### PR TITLE
Hotfix: GatherHeatEmissionReport fails when you have refrigeration objects after #7040

### DIFF
--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -5047,13 +5047,13 @@ namespace OutputReportTabular {
                 SysTotalHVACRejectHeatLoss += RefrigRack(iRef).EvapPumpConsumption + RefrigRack(iRef).BasinHeaterConsumption +
                                               RefrigRack(iRef).EvapWaterConsumption * RhoWater * H2OHtOfVap_HVAC;
             } else if (RefrigRack(iRef).CondenserType == WaterCooled) {
-                SysTotalHVACRejectHeatLoss += RefrigRack(iCoil).CondEnergy;
+                SysTotalHVACRejectHeatLoss += RefrigRack(iRef).CondEnergy;
             }
         }
 
         // Refrigerated Case - Condenser
         for (iRef = 1; iRef <= NumRefrigCondensers; ++iRef) {
-            SysTotalHVACRejectHeatLoss += RefrigRack(iCoil).CondEnergy;
+            SysTotalHVACRejectHeatLoss += RefrigRack(iRef).CondEnergy;
         }
 
         // Evaporative coolers

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -4871,6 +4871,7 @@ namespace OutputReportTabular {
         using PlantChillers::NumEngineDrivenChillers;
         using PlantChillers::NumGTChillers;
         using RefrigeratedCase::RefrigRack;
+        using RefrigeratedCase::Condenser;
         using VariableSpeedCoils::NumVarSpeedCoils;
         using VariableSpeedCoils::VarSpeedCoil;
         using WaterThermalTanks::AmbientTempOutsideAir;
@@ -5053,7 +5054,7 @@ namespace OutputReportTabular {
 
         // Refrigerated Case - Condenser
         for (iRef = 1; iRef <= NumRefrigCondensers; ++iRef) {
-            SysTotalHVACRejectHeatLoss += RefrigRack(iRef).CondEnergy;
+            SysTotalHVACRejectHeatLoss += Condenser(iRef).CondEnergy;
         }
 
         // Evaporative coolers


### PR DESCRIPTION
Pull request overview
---------------------

Fix for one item in #7191

`GatherHeatEmissionReport` fails when you have refrigeration objects after #7040, due to wrong array indexes, and a a wrong array reference.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Functional code review (it has to work!)
 - [x] If defect, results of running current develop vs this branch should exhibit the fix
 - [x] CI status: all green or justified
 - [x] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - IDD changes: n/a
