### PR TITLE
Catch NaNs in Windows debug build

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -18,9 +18,6 @@ IF ( MSVC AND NOT ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" ) ) # Visual C++
     #  4996 Deprecated functions (/D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS)
     #  4503 The decorated name was longer than the compiler limit (4096), and was truncated.
 
-    # need to figure out how to set this to avoid the major slow-down in debugging:
-    # Configuration Properties ->Debugging -> Environment, use drop-down list to choose <Edit> and type _NO_DEBUG_HEAP=1 then click OK
-
     # COMPILER FLAGS
     ADD_CXX_DEFINITIONS("/nologo")
     ADD_CXX_DEFINITIONS("/EHsc")
@@ -38,6 +35,8 @@ IF ( MSVC AND NOT ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" ) ) # Visual C++
     # ADDITIONAL DEBUG-MODE-SPECIFIC FLAGS
     ADD_CXX_DEBUG_DEFINITIONS("/Ob0") # Disable inlining
     ADD_CXX_DEBUG_DEFINITIONS("/RTCsu") # Runtime checks
+    ADD_CXX_DEBUG_DEFINITIONS("/fp:strict") # Floating point model
+    ADD_CXX_DEBUG_DEFINITIONS("/DMSVC_DEBUG") # Triggers code in main.cc to catch floating point NaNs
 
 ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" ) # g++/Clang
     option(ENABLE_THREAD_SANITIZER "Enable thread sanitizer testing in gcc/clang" FALSE)

--- a/src/EnergyPlus/main.cc
+++ b/src/EnergyPlus/main.cc
@@ -51,8 +51,11 @@ using EnergyPlus::CommandLineInterface::ProcessArgs;
 
 int main(int argc, const char *argv[])
 {
-    // the following line is only needed when debugging issues related to NaN in Visual Studio. See
-    // https://github.com/NREL/EnergyPlus/wiki/Debugging-Tips unsigned int fp_control_state = _controlfp( _EM_INEXACT, _MCW_EM );
+#ifdef MSVC_DEBUG
+    // the following line enables NaN detection in Visual Studio debug builds. See
+    // https://github.com/NREL/EnergyPlus/wiki/Debugging-Tips
+    unsigned int fp_control_state = _controlfp(_EM_INEXACT, _MCW_EM);
+#endif
     ProcessArgs(argc, argv);
     EnergyPlusPgm();
 }

--- a/third_party/SQLite/CMakeLists.txt
+++ b/third_party/SQLite/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 IF ( MSVC ) # visual c++ (VS 2013)
     ADD_DEFINITIONS("-W0")
+    ADD_CXX_DEBUG_DEFINITIONS("/fp:fast") # override fp:strict in debug builds
+
 ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" ) # g++/Clang
     ADD_DEFINITIONS("-w")
 ELSEIF ( WIN32 AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )


### PR DESCRIPTION
Pull request overview
---------------------
Attempt to automate settings to catch NaNs in windows debug builds. Addressing #7152.

If an NaN bug causes a user file to fail, sometimes the NaN propagates forward and shows in the text of an error message. On Mac and Linux and debug build will trap the NaN where it first occurs, but not so much on Windows. 

For years, [some manual steps](https://github.com/NREL/EnergyPlus/wiki/Debugging-Tips) have been required to catch an NaN when debugging a file on Windows. Kind of a pain, especially since SQLite won't compile with fp:strict because of some declarations with computed constants, requiring another manual step to build. So, this PR fixes all that with:

1. Add /fp:strict for Win debug build.
2. Override that with /fp:fast for SQLite.
3. Add a #def flag `MSVC_DEBUG` to enable a line of code in main.cc

The defect file from #7092 can be used to test this (at least until #7144 gets merged.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
