### PR TITLE
Hotpatch for #6549 - Move Ninja compiler flags to the CompilerFlags.cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,31 +289,6 @@ if (BUILD_DOCS)
   set_property(CACHE TEX_INTERACTION PROPERTY STRINGS "nonstopmode" "batchmode")
 endif()
 
-# Add Color Output if Using Ninja
-macro(AddCXXFlagIfSupported flag test)
-   CHECK_CXX_COMPILER_FLAG(${flag} ${test})
-   if( ${${test}} )
-      message("adding ${flag}")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-   endif()
-endmacro()
-
-if("Ninja" STREQUAL ${CMAKE_GENERATOR})
-  include(CheckCXXCompilerFlag)
-  # Clang
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
-  endif()
-
-  # g
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    # For some reason it doesn't say its supported, but it works...
-    # AddCXXFlagIfSupported(-fdiagnostics-color COMPILER_SUPPORTS_fdiagnostics-color)
-    # message("Forcing -fdiagnostics-color=always")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
-  endif()
-endif()
-
 # some parameters are simply not needed for everyday building
 mark_as_advanced(CMAKE_INSTALL_PREFIX)
 mark_as_advanced(BUILD_SHARED_LIBS)

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -213,3 +213,40 @@ ELSEIF ( UNIX AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
     ADD_CXX_DEBUG_DEFINITIONS("-traceback") # Enables traceback on error
 
 ENDIF () # COMPILER TYPE
+
+
+# Add Color Output if Using Ninja:
+# Wave to do it before the folders are imported etc (here is the perfect place)
+
+# We use "add_compile_options" instead of just appending to CXX_FLAGS
+# That way it'll work for pretty much everything including Fortran stuff
+macro(AddFlagIfSupported flag test)
+  CHECK_CXX_COMPILER_FLAG(${flag} ${test})
+  if( ${${test}} )
+    message(STATUS "Adding ${flag}")
+    add_compile_options("${flag}")
+  else()
+    message(STATUS "Flag ${flag} isn't supported")
+  endif()
+endmacro()
+
+if("Ninja" STREQUAL ${CMAKE_GENERATOR})
+  include(CheckCXXCompilerFlag)
+  # Clang
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    AddFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fdiagnostics_color)
+  endif()
+
+  # g++
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    AddFlagIfSupported(-fdiagnostics-color=always COMPILER_SUPPORTS_fdiagnostics_color)
+
+    # On some older gcc, it doesn't say that it's supported, but it works anyways
+    if (NOT COMPILER_SUPPORTS_fdiagnostics_color)
+      message(STATUS "Forcing -fdiagnostics-color=always")
+      add_compile_options (-fdiagnostics-color=always)
+    endif()
+
+  endif()
+endif()
+


### PR DESCRIPTION
Pull request overview
---------------------

"Hotpatch" for #6549 - Move Ninja compiler flags to the CompilerFlags.cmake file for clarity.

@Myoldmopar I just realized that it'd be better to put it there, and that I could use "add_compile_options" to also color warnings from Fortran etc.

I promise you can just hit "merge" here.