### PR TITLE
Fixes duplicate line in the desuperheater IO documentation.

### DIFF
--- a/doc/input-output-reference/src/overview/group-heating-and-cooling-coils.tex
+++ b/doc/input-output-reference/src/overview/group-heating-and-cooling-coils.tex
@@ -4681,8 +4681,6 @@ This alpha field contains the name of the specific water heater tank (\hyperref[
 
 This alpha (choice) field defines the source of superheated refrigerant gas from which the desuperheater water heating coil recovers energy through heat reclaim. Valid choices are:
 
-This alpha (choice) field defines the source of superheated refrigerant gas from which the desuperheater water heating coil recovers energy through heat reclaim. Valid choices are:
-
 \begin{itemize}
 \item
   \hyperref[coilcoolingdxsinglespeed]{Coil:Cooling:DX:SingleSpeed}


### PR DESCRIPTION
Fixes duplicate line in the desuperheater IO documentation.

This can be seen at: https://bigladdersoftware.com/epx/docs/9-0/input-output-reference/group-heating-and-cooling-coils.html#field-heating-source-object-type-1