### PR TITLE
Singlezone setpoint managers - correct no flow setpoint

### DIFF
--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -5585,7 +5585,7 @@ namespace SetPointManager {
         ZoneTemp = Node(ZoneNode).Temp;
         // CR7654 IF (ZoneLoadtoHeatSP.GT.0.0) THEN
         if (ZoneMassFlow <= SmallMassFlow) {
-            this->SetPt = this->MaxSetTemp;
+            this->SetPt = this->MinSetTemp;
         } else {
             CpAir = PsyCpAirFnWTdb(Node(ZoneInletNode).HumRat, Node(ZoneInletNode).Temp);
             this->SetPt = ZoneTemp + ZoneLoadtoHeatSP / (CpAir * ZoneMassFlow);
@@ -5649,7 +5649,7 @@ namespace SetPointManager {
         ZoneTemp = Node(ZoneNode).Temp;
         // CR7654 IF (ZoneLoadtoCoolSP.LT.0.0) THEN
         if (ZoneMassFlow <= SmallMassFlow) {
-            this->SetPt = this->MinSetTemp;
+            this->SetPt = this->MaxSetTemp;
         } else {
             CpAir = PsyCpAirFnWTdb(Node(ZoneInletNode).HumRat, Node(ZoneInletNode).Temp);
             this->SetPt = ZoneTemp + ZoneLoadtoCoolSP / (CpAir * ZoneMassFlow);

--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -5547,28 +5547,10 @@ namespace SetPointManager {
         // From the heating load of the control zone, calculate the supply air setpoint
         // needed to meet that zone load (based on CalcSingZoneRhSetPoint)
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
         using DataHVACGlobals::SmallLoad;
         using DataHVACGlobals::SmallMassFlow;
         using DataZoneEnergyDemands::ZoneSysEnergyDemand;
 
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-
-        // INTERFACE BLOCK SPECIFICATIONS
-
-        // DERIVED TYPE DEFINITIONS
-        // na
-
-        // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         Real64 ZoneLoadtoHeatSP; // required zone load to zone heating setpoint [W]
         Real64 ZoneMassFlow;     // zone inlet mass flow rate [kg/s]
         Real64 CpAir;            // inlet air specific heat [J/kg-C]
@@ -5583,7 +5565,6 @@ namespace SetPointManager {
         ZoneMassFlow = Node(ZoneInletNode).MassFlowRate;
         ZoneLoadtoHeatSP = ZoneSysEnergyDemand(ZoneNum).OutputRequiredToHeatingSP;
         ZoneTemp = Node(ZoneNode).Temp;
-        // CR7654 IF (ZoneLoadtoHeatSP.GT.0.0) THEN
         if (ZoneMassFlow <= SmallMassFlow) {
             this->SetPt = this->MinSetTemp;
         } else {
@@ -5592,9 +5573,6 @@ namespace SetPointManager {
             this->SetPt = max(this->SetPt, this->MinSetTemp);
             this->SetPt = min(this->SetPt, this->MaxSetTemp);
         }
-        // CR7654 ELSE
-        // CR7654   SingZoneHtSetPtMgr(SetPtMgrNum)%SetPt = SingZoneHtSetPtMgr(SetPtMgrNum)%MinSetTemp
-        // CR7654 END IF
     }
 
     void DefineSZCoolingSetPointManager::calculate()
@@ -5611,28 +5589,10 @@ namespace SetPointManager {
         // From the Cooling load of the control zone, calculate the supply air setpoint
         // needed to meet that zone load (based on CalcSingZoneRhSetPoint)
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
         using DataHVACGlobals::SmallLoad;
         using DataHVACGlobals::SmallMassFlow;
         using DataZoneEnergyDemands::ZoneSysEnergyDemand;
 
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-
-        // INTERFACE BLOCK SPECIFICATIONS
-
-        // DERIVED TYPE DEFINITIONS
-        // na
-
-        // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         Real64 ZoneLoadtoCoolSP; // required zone load to zone Cooling setpoint [W]
         Real64 ZoneMassFlow;     // zone inlet mass flow rate [kg/s]
         Real64 CpAir;            // inlet air specific Cool [J/kg-C]
@@ -5647,7 +5607,6 @@ namespace SetPointManager {
         ZoneMassFlow = Node(ZoneInletNode).MassFlowRate;
         ZoneLoadtoCoolSP = ZoneSysEnergyDemand(ZoneNum).OutputRequiredToCoolingSP;
         ZoneTemp = Node(ZoneNode).Temp;
-        // CR7654 IF (ZoneLoadtoCoolSP.LT.0.0) THEN
         if (ZoneMassFlow <= SmallMassFlow) {
             this->SetPt = this->MaxSetTemp;
         } else {
@@ -5656,9 +5615,6 @@ namespace SetPointManager {
             this->SetPt = max(this->SetPt, this->MinSetTemp);
             this->SetPt = min(this->SetPt, this->MaxSetTemp);
         }
-        // CR7654 ELSE
-        // CR7654   SingZoneClSetPtMgr(SetPtMgrNum)%SetPt = SingZoneClSetPtMgr(SetPtMgrNum)%MaxSetTemp
-        // CR7654 END IF
     }
 
     void DefineSZOneStageCoolinggSetPointManager::calculate()


### PR DESCRIPTION
Pull request overview
---------------------
Partially addresses #7145.
SetpointManager:SingleZone:Heating and SetpointManager:SingleZone:Cooling were setting the wrong setpoint if the system had zero flow at the time the setpoint manager was executed. At the time that the setpoint managers are executed, the mass flow is from the end of the prior timestep.  This primarily caused problems for timesteps in which a night-cycle availability manager (or some other trigger) caused the system to run after a period of being off.

SetpointManager:SingleZone:Heating now sets the minimum setpoint for no flow, and SetpointManager:SingleZone:Cooling now sets the maximum setpoint.

Diffs
--------------
SmOffPSZ-MultiModeDX - some significant changes at the timestep level, but an annual simulation has <0.1% change in electric and gas use and identical hours not met.
AirflowNetwork_MultiAirLoops - similar, tiny change in annual results.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
