### PR TITLE
EvapCooler crash with autosized field and no design days run

### DIFF
--- a/src/EnergyPlus/EvaporativeCoolers.cc
+++ b/src/EnergyPlus/EvaporativeCoolers.cc
@@ -1203,6 +1203,7 @@ namespace EvaporativeCoolers {
                     }
                 }
             } else { // Autosize or hardsize with design data
+                CheckSysSizing(CompType, EvapCond(EvapCoolNum).EvapCoolerName);
                 if (CoolerOnMainAirLoop) {
                     IndirectVolFlowRateDes = FinalSysSizing(CurSysNum).DesMainVolFlow;
                 } else if (CoolerOnOApath) {
@@ -1288,6 +1289,7 @@ namespace EvaporativeCoolers {
                 //"User-Specified Secondary Fan Flow Rate [m3/s]", EvapCond( EvapCoolNum ).VolFlowRate );
                 //}
             } else { // Autosize or hardsize with design data
+                CheckSysSizing(CompType, EvapCond(EvapCoolNum).EvapCoolerName);
                 if (CoolerOnMainAirLoop) {
                     volFlowRateDes = FinalSysSizing(CurSysNum).DesMainVolFlow;
                 } else if (CoolerOnOApath) {
@@ -1370,6 +1372,7 @@ namespace EvaporativeCoolers {
                                            EvapCond(EvapCoolNum).PadArea);
                     }
                 } else { // Autosize or hardsize with design data
+                    CheckSysSizing(CompType, EvapCond(EvapCoolNum).EvapCoolerName);
                     if (CoolerOnMainAirLoop) {
                         IndirectVolFlowRateDes = FinalSysSizing(CurSysNum).DesMainVolFlow;
                     } else if (CoolerOnOApath) {
@@ -1498,6 +1501,7 @@ namespace EvaporativeCoolers {
                                            EvapCond(EvapCoolNum).IndirectPadArea);
                     }
                 } else { // Autosize or hardsize with design data
+                    CheckSysSizing(CompType, EvapCond(EvapCoolNum).EvapCoolerName);
                     if (!CoolerOnMainAirLoop) {
                         CoolerOnOApath = true;
                     }


### PR DESCRIPTION
Pull request overview
---------------------
This fixes #7083. This crash is caused when EvapCooler trying to retrieve flow rate from system sizing variable (FinalSysSizing) when the system sizing did not run and FinalSysSizing not allocated. This fix checks system sizing run before allowing evaporative cooler accessing final system sizing variable. The fix avoids crash, instead fatal out with appropriate error message. The fix was applied to six evaporator cooler types. Diffs are not expected based on this change.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Performance: This pull request includes code changes that are directed at improving the runtime 
### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things

