### PR TITLE
Fix #7310: ReadVarsEso launched from energyplus commandline does not work for folders with spaces in path

### DIFF
--- a/src/EnergyPlus/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/EnergyPlusPgm.cc
@@ -543,9 +543,12 @@ int RunEnergyPlus(std::string const & filepath)
                 ObjexxFCL::gio::close(fileUnitNumber);
             }
 
-            std::string const readVarsRviCommand = "\"" + readVarsPath + "\"" + " " + RVIfile + " unlimited";
-            std::string const readVarsMviCommand = "\"" + readVarsPath + "\"" + " " + MVIfile + " unlimited";
+            // We quote the paths in case we have spaces
+            // "/Path/to/ReadVarEso" "/Path/to/folder with spaces/file.rvi" unlimited
+            std::string const readVarsRviCommand = "\"" + readVarsPath + "\" \"" + RVIfile + "\" unlimited";
+            std::string const readVarsMviCommand = "\"" + readVarsPath + "\" \"" + MVIfile + "\" unlimited";
 
+            // systemCall will be responsible to handle to above command on Windows versus Unix
             systemCall(readVarsRviCommand);
             systemCall(readVarsMviCommand);
 

--- a/src/EnergyPlus/FileSystem.cc
+++ b/src/EnergyPlus/FileSystem.cc
@@ -249,7 +249,10 @@ namespace FileSystem {
     int systemCall(std::string const &command)
     {
 #ifdef _WIN32
-        return system("cmd /C \"" + command.c_str() + "\"");
+        // Wrap in double quotes and pass that to cmd /C
+        // Ends up calling something that looks like the following:
+        // cmd /C ""C:\path\to\ReadVarsESO.exe" "A folder with spaces\1ZoneUncontrolled.mvi" unlimited"
+        return system(("cmd /C \"" + command + "\"").c_str());
 #else
         return system(command.c_str());
 #endif

--- a/src/EnergyPlus/FileSystem.cc
+++ b/src/EnergyPlus/FileSystem.cc
@@ -247,7 +247,11 @@ namespace FileSystem {
 
     int systemCall(std::string const &command)
     {
+#ifdef _WIN32
+        return system("cmd /C \"" + command.c_str() + "\"");
+#else
         return system(command.c_str());
+#endif
     }
 
     void removeFile(std::string const &fileName)

--- a/src/EnergyPlus/FileSystem.cc
+++ b/src/EnergyPlus/FileSystem.cc
@@ -249,10 +249,12 @@ namespace FileSystem {
     int systemCall(std::string const &command)
     {
 #ifdef _WIN32
-        // Wrap in double quotes and pass that to cmd /C
+        // Wrap in double quotes and pass that to system
+        // Note: on Windows, system(command) will already send the command through "cmd /C command"
+        // cf C:\Program Files (x86)\Windows Kits\10\Source\10.0.17763.0\ucrt\exec
         // Ends up calling something that looks like the following:
         // cmd /C ""C:\path\to\ReadVarsESO.exe" "A folder with spaces\1ZoneUncontrolled.mvi" unlimited"
-        return system(("cmd /C \"" + command + "\"").c_str());
+        return system(("\"" + command + "\"").c_str());
 #else
         return system(command.c_str());
 #endif

--- a/src/EnergyPlus/FileSystem.cc
+++ b/src/EnergyPlus/FileSystem.cc
@@ -101,7 +101,8 @@ namespace FileSystem {
         int pathCharPosition = tempPath.find_last_of(pathChar);
         tempPath = tempPath.substr(0, pathCharPosition + 1);
 
-        if (tempPath == "") tempPath = ".";
+        // If empty, then current dir, but with trailing separator too: eg `./`
+        if (tempPath == "") tempPath = {'.', pathChar};
 
         return tempPath;
     }

--- a/src/EnergyPlus/FileSystem.hh
+++ b/src/EnergyPlus/FileSystem.hh
@@ -60,6 +60,7 @@ namespace FileSystem {
 
     std::string getFileName(std::string const &filePath);
 
+    // Returns the parent directory of a path, with the trailing pathChar included
     std::string getParentDirectoryPath(std::string const &filePath);
 
     std::string getAbsolutePath(std::string const &filePath);


### PR DESCRIPTION
Pull request overview
---------------------

Fix #7310: ReadVarsEso launched from energyplus commandline does not work for folders with spaces in path.

I escaped the RVIfile path in the command. I also modified `Filesystem::systemCall` to add double quotes around any command passed to it, and that ends up passed to cmd /C via the system stdlib implementation, eg:

```
cmd /C ""C:\path\to\ReadVarsESO.exe" "A folder with spaces\1ZoneUncontrolled.mvi" unlimited"
```

Tested with the defect files I added for 7310 in a folder named `A folder with spaces`
```
cd EnergyPlusDevSupport\DefectFiles\7000s\7310
C:\Users\julien\Software\Others\EnergyPlus\build\Products\Debug\energyplus.exe -D -r "A folder with spaces\1ZoneUncontrolled.idf"
```

and the equivalent on Unix.


I also modified `FileSystem::getParentDirectoryPath` since I noticed it was returning `.` for current directory and a path with a trailing pathChar for all other cases (eg: `/path/to/a/folder/`). This would then make path manipulation return `RVIfile = ".NameOfRVIFile.rvi` for eg.
Now will return `./` for consistency.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
