### PR TITLE
Removed Repeated I/O Reference Section on FC Factor Method

### DIFF
--- a/doc/input-output-reference/src/overview/group-surface-construction-elements.tex
+++ b/doc/input-output-reference/src/overview/group-surface-construction-elements.tex
@@ -3900,22 +3900,6 @@ Construction, DOUBLE PANE WITH ROLL SHADE,  !- Material layer names follow:
         ROLL SHADE - LIGHT
 \end{lstlisting}
 
-\subsection{Site:GroundTemperature:FCfactorMethod}\label{sitegroundtemperaturefcfactormethod-000}
-
-Site:GroundTemperature:FCfactorMethod is used only by the underground walls or slabs-on-grade or underground floors defined with C-factor (\hyperref[constructioncfactorundergroundwall]{Construction:CfactorUndergroundWall}) and F-factor (\hyperref[constructionffactorgroundfloor]{Construction:FfactorGroundFloor}) method for code compliance calculations where detailed construction layers are unknown. Only one such ground temperature object can be included. The monthly ground temperatures for this object are close to the monthly outside air temperatures delayed by three months. If user does not input this object in the IDF file, it will be defaulted to the 0.5m set of monthly ground temperatures from the weather file if they are available.
-
-\subsubsection{Inputs}\label{inputs-35-000}
-
-\paragraph{Field: Month Temperature(s) -- 12 fields in all}\label{field-month-temperatures-12-fields-in-all-000}
-
-Each numeric field is the monthly ground temperature (degrees Celsius) used for the indicated month (January = 1\(^{st}\) field, February = 2\(^{nd}\) field, etc.)
-
-And, the IDF example:
-
-\begin{lstlisting}
-Site:GroundTemperature:FCfactorMethod,  9.5,3.5,-0.7,-1.7,-0.6,3.6,9.3,14,18.2,22.7,21.2,16.8;
-\end{lstlisting}
-
 \subsection{Constructions - Modeling Underground Walls and Ground Floors Defined with C and F Factors for Building Energy Code Compliance}\label{constructions---modeling-underground-walls-and-ground-floors-defined-with-c-and-f-factors-for-building-energy-code-compliance}
 
 Building energy code and standards like ASHRAE 90.1, 90.2 and California Title 24 require the underground wall constructions and slabs-on-grade or underground floors not to exceed certain maximum values of C-factor and F-factor, which do not specify detailed layer-by-layer materials for the constructions.


### PR DESCRIPTION
Pull request overview
---------------------
This documentation correction deleted a repeated section in the I/O Reference.  The deletion was done where it made less sense to have this section on Site:GroundTemperature:FCfactorMethod.  So, it was left near where there are other Site: inputs and removed from the Construction and Material section.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue #7027 (documentation mod only)

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces