### PR TITLE
Addressed SurfaceControl:MovableInsulation doesn't catch wrong Material types

### DIFF
--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -9702,6 +9702,16 @@ namespace SurfaceGeometry {
                     ShowContinueError(" invalid (not found) " + cAlphaFieldNames(3) + "=\"" + cAlphaArgs(3) + "\"");
                     ErrorsFound = true;
                 } else {
+                    int const MaterialLayerGroup = Material(MaterNum).Group;
+                    if ((MaterialLayerGroup == WindowSimpleGlazing) || (MaterialLayerGroup == GlassEquivalentLayer) ||
+                        (MaterialLayerGroup == ShadeEquivalentLayer) || (MaterialLayerGroup == DrapeEquivalentLayer) ||
+                        (MaterialLayerGroup == BlindEquivalentLayer) || (MaterialLayerGroup == ScreenEquivalentLayer) ||
+                        (MaterialLayerGroup == GapEquivalentLayer)) {
+                        ShowSevereError("Invalid movable insulation material for " + cCurrentModuleObject + ":");
+                        ShowSevereError("...Movable insulation material type specified = " + DataHeatBalance::cMaterialGroupType(MaterialLayerGroup));
+                        ShowSevereError("...Movable insulation material name specified = " + cAlphaArgs(3));
+                        ErrorsFound = true;
+                    }
                     if (SchNum == 0) {
                         ShowSevereError(cCurrentModuleObject + ", " + cAlphaFieldNames(2) + "=\"" + cAlphaArgs(2) + "\", invalid data.");
                         ShowContinueError(" invalid (not found) " + cAlphaFieldNames(4) + "=\"" + cAlphaArgs(4) + "\"");

--- a/tst/EnergyPlus/unit/HeatBalanceMovableInsulation.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceMovableInsulation.unit.cc
@@ -57,7 +57,10 @@
 #include <EnergyPlus/DataHeatBalSurface.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
 #include <EnergyPlus/DataSurfaces.hh>
+#include <EnergyPlus/HeatBalanceManager.hh>
 #include <EnergyPlus/HeatBalanceMovableInsulation.hh>
+#include <EnergyPlus/ScheduleManager.hh>
+#include <EnergyPlus/SurfaceGeometry.hh>
 
 using namespace EnergyPlus::HeatBalanceMovableInsulation;
 
@@ -133,5 +136,138 @@ TEST_F(EnergyPlusFixture, HeatBalanceMovableInsulation_EvalInsideMovableInsulati
     EvalInsideMovableInsulation(SurfNum, HMovInsul, AbsExt);
     EXPECT_EQ(0.55, AbsExt);
 }
+TEST_F(EnergyPlusFixture, SurfaceControlMovableInsulation_InvalidWindowSimpleGlazingTest)
+{
 
+    std::string const idf_objects = delimited_string({
+
+        "  Version,9.2;",
+
+        "  Construction,",
+        "    EXTWALL80,               !- Name",
+        "    A1 - 1 IN STUCCO,        !- Outside Layer",
+        "    C4 - 4 IN COMMON BRICK,  !- Layer 2",
+        "    E1 - 3 / 4 IN PLASTER OR GYP BOARD;  !- Layer 3",
+
+        "  Material,",
+        "    A1 - 1 IN STUCCO,        !- Name",
+        "    Smooth,                  !- Roughness",
+        "    2.5389841E-02,           !- Thickness {m}",
+        "    0.6918309,               !- Conductivity {W/m-K}",
+        "    1858.142,                !- Density {kg/m3}",
+        "    836.8000,                !- Specific Heat {J/kg-K}",
+        "    0.9000000,               !- Thermal Absorptance",
+        "    0.9200000,               !- Solar Absorptance",
+        "    0.9200000;               !- Visible Absorptance",
+
+        "  Material,",
+        "    C4 - 4 IN COMMON BRICK,  !- Name",
+        "    Rough,                   !- Roughness",
+        "    0.1014984,               !- Thickness {m}",
+        "    0.7264224,               !- Conductivity {W/m-K}",
+        "    1922.216,                !- Density {kg/m3}",
+        "    836.8000,                !- Specific Heat {J/kg-K}",
+        "    0.9000000,               !- Thermal Absorptance",
+        "    0.7600000,               !- Solar Absorptance",
+        "    0.7600000;               !- Visible Absorptance",
+
+        "  Material,",
+        "    E1 - 3 / 4 IN PLASTER OR GYP BOARD,  !- Name",
+        "    Smooth,                  !- Roughness",
+        "    1.9050000E-02,           !- Thickness {m}",
+        "    0.7264224,               !- Conductivity {W/m-K}",
+        "    1601.846,                !- Density {kg/m3}",
+        "    836.8000,                !- Specific Heat {J/kg-K}",
+        "    0.9000000,               !- Thermal Absorptance",
+        "    0.9200000,               !- Solar Absorptance",
+        "    0.9200000;               !- Visible Absorptance",
+
+        "  BuildingSurface:Detailed,",
+        "    Zn001:Wall001,           !- Name",
+        "    Wall,                    !- Surface Type",
+        "    EXTWALL80,               !- Construction Name",
+        "    ZONE ONE,                !- Zone Name",
+        "    Outdoors,                !- Outside Boundary Condition",
+        "    ,                        !- Outside Boundary Condition Object",
+        "    SunExposed,              !- Sun Exposure",
+        "    WindExposed,             !- Wind Exposure",
+        "    0.5000000,               !- View Factor to Ground",
+        "    4,                       !- Number of Vertices",
+        "    0,0,4.572000,            !- X,Y,Z ==> Vertex 1 {m}",
+        "    0,0,0,                   !- X,Y,Z ==> Vertex 2 {m}",
+        "    15.24000,0,0,            !- X,Y,Z ==> Vertex 3 {m}",
+        "    15.24000,0,4.572000;     !- X,Y,Z ==> Vertex 4 {m}",
+
+        "  WindowMaterial:SimpleGlazingSystem,",
+        "    SimpleGlazingSystem,     !- Name",
+        "    2.8,                     !- U-Factor {W/m2-K}",
+        "    0.7;                     !- Solar Heat Gain Coefficient",
+
+        "  SurfaceControl:MovableInsulation,",
+        "    Outside,                 !- Insulation Type",
+        "    Zn001:Wall001,           !- Surface Name",
+        "    SimpleGlazingSystem,     !- Material Name",
+        "    ON;                      !- Schedule Name",
+
+        "  Schedule:Compact,",
+        "    ON,                      !- Name",
+        "    FRACTION,                !- Schedule Type Limits Name",
+        "    Through: 12/31,          !- Field 1",
+        "    For: Alldays,            !- Field 2",
+        "    Until: 24:00,1.00;       !- Field 3",
+
+        "  ScheduleTypeLimits,",
+        "    Fraction,                !- Name",
+        "    0.0,                     !- Lower Limit Value",
+        "    1.0,                     !- Upper Limit Value",
+        "    CONTINUOUS;              !- Numeric Type",
+
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+
+    // set error to false
+    bool ErrorsFound(false);
+    // set zone data
+    DataGlobals::NumOfZones = 1;
+    DataHeatBalance::Zone.allocate(1);
+    DataHeatBalance::Zone(1).Name = "ZONE ONE";
+    // get schedule data
+    ScheduleManager::ProcessScheduleInput();
+    // get materials data
+    HeatBalanceManager::GetMaterialData(ErrorsFound);
+    EXPECT_FALSE(ErrorsFound);
+    EXPECT_EQ(4, DataHeatBalance::TotMaterials);
+    EXPECT_EQ(DataHeatBalance::Material(4).Group, DataHeatBalance::WindowSimpleGlazing);
+    // get construction data
+    HeatBalanceManager::GetConstructData(ErrorsFound);
+    EXPECT_EQ(1, DataHeatBalance::TotConstructs);
+    EXPECT_FALSE(ErrorsFound);
+    // set relative coordinate
+    SurfaceGeometry::GetGeometryParameters(ErrorsFound);
+    SurfaceGeometry::CosZoneRelNorth.allocate(2);
+    SurfaceGeometry::SinZoneRelNorth.allocate(2);
+    SurfaceGeometry::CosZoneRelNorth = 1.0;
+    SurfaceGeometry::CosBldgRelNorth = 1.0;
+    SurfaceGeometry::SinZoneRelNorth = 0.0;
+    SurfaceGeometry::SinBldgRelNorth = 0.0;
+    // set surface data
+    DataSurfaces::TotSurfaces = 1;
+    SurfaceGeometry::SurfaceTmp.allocate(1);
+    int SurfNum = 0;
+    int TotHTSurfs = DataSurfaces::TotSurfaces = 1;
+    Array1D_string const BaseSurfCls(1, {"WALL"});
+    Array1D_int const BaseSurfIDs(1, {1});
+    int NeedToAddSurfaces;
+    // get heat tranfer surface data
+    SurfaceGeometry::GetHTSurfaceData(ErrorsFound, SurfNum, TotHTSurfs, 0, 0, 0, BaseSurfCls, BaseSurfIDs, NeedToAddSurfaces);
+    // get movable insulation object data
+    SurfaceGeometry::GetMovableInsulationData(ErrorsFound);
+    // check movable insulation material
+    EXPECT_EQ(SurfaceGeometry::SurfaceTmp(1).BaseSurfName, "ZN001:WALL001");             // base surface name
+    EXPECT_EQ(SurfaceGeometry::SurfaceTmp(1).MaterialMovInsulExt, 4);                    // index to movable insulation material
+    EXPECT_EQ(DataHeatBalance::Material(4).Name, "SIMPLEGLAZINGSYSTEM");                 // name of movable insulation material
+    EXPECT_EQ(DataHeatBalance::Material(4).Group, DataHeatBalance::WindowSimpleGlazing); // invalid material group type
+    EXPECT_TRUE(ErrorsFound);                                                            // error found due to invalid material
+}
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------
Addressed issue #7355. This fix checks the material ground and if the material type is invalid, then fatal out with severe error message. Diffs are not expected/justified based on this change.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus


### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things

