### PR TITLE
Fixed Read Vars compiler warnings on Mac

### DIFF
--- a/src/ReadVars/ReadVarsESO.f90
+++ b/src/ReadVars/ReadVarsESO.f90
@@ -416,7 +416,11 @@
             ignorethisone=.true.
             pos=index(line,'[')
             if (pos /= 0) then
-              line=line(2:pos-1)
+              ! Without the indexes on the LHS, the compiler is complaining that we are squeezing a character position out
+              ! We add these and it works, but it could potentially leave a trailing character from the prior string
+              ! So we'll add a space to that trailing point
+              line(1:pos-2)=line(2:pos-1)
+              line(pos-1:pos-1) = ' '
             else
               line=line(2:)
             endif
@@ -659,7 +663,10 @@
               line=line(i:)
               i=index(line,'!')
               if (i /= 0) then
-                stovar(nstore)=line(1:i-1)
+                ! Without the array bounds on the LHS, the compiler warns about mismatched sizes
+                ! Adding them forces both LHS and RHS to be the same size
+                ! stovar should be blank coming into this section, so trailing blanks should persist
+                stovar(nstore)(1:i-1)=line(1:i-1)
                 stovar(nstore)=trim(stovar(nstore))//'('
                 i=i+1
                 line=line(i:)
@@ -704,7 +711,10 @@
             line=line(i:)
             i=index(line,'!')
             if (i /= 0) then
-              trackvar(ij)=line(1:i-1)
+              ! The compiler warns if you try to take part of the line and apply it to the entire trackvar
+              ! Adding explicit indeces seems unnecessary, but it hushes up the compiler
+              ! The trackvar should be blank at this point, so this should be fine
+              trackvar(ij)(1:i-1)=line(1:i-1)
               trackvar(ij)=trim(trackvar(ij))//'('
               i=i+1
               line=line(i:)
@@ -790,7 +800,10 @@
             ! Check frequency part -- after !
             i=index(line,'!')
             if (i /= 0) then
-              trackvar(ij)=line(1:i-1)
+              ! The compiler warns if you try to take part of the line and apply it to the entire trackvar
+              ! Adding explicit indeces seems unnecessary, but it hushes up the compiler
+              ! The trackvar should be blank at this point, so this should be fine
+              trackvar(ij)(1:i-1)=line(1:i-1)
               trackvar(ij)=trim(trackvar(ij))//'('
               i=i+1
               line=line(i:)


### PR DESCRIPTION
Pull request overview
---------------------
A few compiler warnings were coming out of Mac related to string assignments where the size of the strings are not the same.  I'm not sure why it was singling out just a few assignments, but I digress.

After making these changes, I tried debugging to make sure the output was still good, but there are a couple of these points that I couldn't hit even throwing quite a few ESO files at it.  Instead I decided to take the approach of running the read vars against every ESO I could find.  I took all the ESO files from a full test suite run and ran them with develop and this branch.  I know it doesn't mean much, but here's the final output from the run:

```
Completed 613 files; number different = 0
```

CI uses ReadVars, so I figure if something is going to be off, it will show up there too.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
