### PR TITLE
AFN tests fail to run serially following up addition of new tests in #7338

### DIFF
--- a/src/EnergyPlus/AirflowNetworkBalanceManager.cc
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.cc
@@ -497,9 +497,9 @@ namespace AirflowNetworkBalanceManager {
         if (AirflowNetworkFanActivated && SimulateAirflowNetwork > AirflowNetworkControlMultizone) {
             if (ValidateDistributionSystemFlag) {
                 ValidateDistributionSystem();
+                ValidateFanFlowRate();
                 ValidateDistributionSystemFlag = false;
             }
-            ValidateFanFlowRate();
         }
         CalcAirflowNetworkAirBalance();
 
@@ -10447,14 +10447,12 @@ namespace AirflowNetworkBalanceManager {
             {
                 auto const SELECT_CASE_var(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).CompTypeNum);
                 if (SELECT_CASE_var == CompTypeNum_CVF) { // 'CVF'
-                    int nodeNum = AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusNodeNum;
                     int typeNum = AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum;
-                    // Will potentially be passed by ref to Fans::GetFanVolFlow so make a copy instead of using a ref
-                    Real64 FanFlow = Node(nodeNum).MassFlowRate;
                     if (DisSysCompCVFData(typeNum).FanTypeNum == FanType_SimpleVAV) {
                         if (DisSysCompCVFData(typeNum).FanModelFlag) {
                             DisSysCompCVFData(typeNum).MaxAirMassFlowRate = HVACFan::fanObjs[DisSysCompCVFData(typeNum).FanIndex]->designAirVolFlowRate * StdRhoAir;
                         } else {
+                            Real64 FanFlow; // Return type
                             GetFanVolFlow(DisSysCompCVFData(typeNum).FanIndex, FanFlow);
                             DisSysCompCVFData(typeNum).MaxAirMassFlowRate = FanFlow * StdRhoAir;
                         }

--- a/src/EnergyPlus/AirflowNetworkBalanceManager.cc
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.cc
@@ -233,6 +233,14 @@ namespace AirflowNetworkBalanceManager {
     // Report variables
 
     // MODULE VARIABLE DECLARATIONS:
+
+     namespace {
+        // These are purposefully not in the header file as an extern variable. No one outside of this should
+        // use these. They are cleared by clear_state() for use by unit tests, but normal simulations should be unaffected.
+        // This is purposefully in an anonymous namespace so nothing outside this implementation file can use it.
+        bool ValidateDistributionSystemFlag(true);
+    }
+
     // Report variables
     Array1D<Real64> PZ;
     // Inverse matrix
@@ -313,6 +321,7 @@ namespace AirflowNetworkBalanceManager {
         IVEC.deallocate();
         SplitterNodeNumbers.deallocate();
         AirflowNetworkGetInputFlag = true;
+        ValidateDistributionSystemFlag = true;
         VentilationCtrl = 0;
         NumOfExhaustFans = 0;
         NumAirflowNetwork = 0;
@@ -486,7 +495,11 @@ namespace AirflowNetworkBalanceManager {
         if (present(FirstHVACIteration) && FirstHVACIteration) VAVTerminalRatio = 0.0;
 
         if (AirflowNetworkFanActivated && SimulateAirflowNetwork > AirflowNetworkControlMultizone) {
-            ValidateDistributionSystem();
+            if (ValidateDistributionSystemFlag) {
+                ValidateDistributionSystem();
+                ValidateDistributionSystemFlag = false;
+            }
+            ValidateFanFlowRate();
         }
         CalcAirflowNetworkAirBalance();
 
@@ -9619,6 +9632,7 @@ namespace AirflowNetworkBalanceManager {
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine validates the inputs of distribution system, since node data from a primary airloop
         // are not available in the first call during reading input data of airflownetwork objects.
+        // Note: this routine shouldn't be called more than once
 
         // Using/Aliasing
         using BranchNodeConnections::GetNodeConnectionType;
@@ -9652,781 +9666,786 @@ namespace AirflowNetworkBalanceManager {
         int S2;
         int R1;
         int R2;
-        static bool OneTimeFlag(true);
-        static bool ErrorsFound(false);
         bool LocalError;
         Array1D_bool NodeFound;
-        Real64 FanFlow;
-        static bool IsNotOK(false);
-        static bool errFlag(false);
+
+        bool ErrorsFound(false);
+        bool IsNotOK(false);
+        bool errFlag(false);
         Array1D_int NodeConnectionType; // Specifies the type of node connection
         std::string CurrentModuleObject;
 
         // Validate supply and return connections
-        if (OneTimeFlag) {
-            NodeFound.dimension(NumOfNodes, false);
-            // Validate inlet and outlet nodes for zone exhaust fans
-            for (i = 1; i <= AirflowNetworkNumOfExhFan; ++i) {
-                NodeFound(MultizoneCompExhaustFanData(i).InletNode) = true;
-                NodeFound(MultizoneCompExhaustFanData(i).OutletNode) = true;
-            }
-            // Validate EPlus Node names and types
-            for (i = 1; i <= DisSysNumOfNodes; ++i) {
-                if (UtilityRoutines::SameString(DisSysNodeData(i).EPlusName, "") || UtilityRoutines::SameString(DisSysNodeData(i).EPlusName, "Other"))
-                    continue;
-                LocalError = false;
-                for (j = 1; j <= NumOfNodes; ++j) { // NodeID
-                    if (DisSysNodeData(i).EPlusName == NodeID(j)) {
-                        DisSysNodeData(i).AirLoopNum = GetAirLoopNumber(j);
-                        if (DisSysNodeData(i).AirLoopNum == 0) {
-                            ShowSevereError(RoutineName + "The Node or Component Name defined in " + DisSysNodeData(i).Name +
-                                            " is not found in the AirLoopHVAC.");
-                            ShowContinueError("The entered name is " + DisSysNodeData(i).EPlusName +
-                                              " in an AirflowNetwork:Distribution:Node object.");
-                            ErrorsFound = true;
-                        }
-                        DisSysNodeData(i).EPlusNodeNum = j;
-                        AirflowNetworkNodeData(NumOfNodesMultiZone + i).EPlusNodeNum = j;
-                        AirflowNetworkNodeData(NumOfNodesMultiZone + i).AirLoopNum = DisSysNodeData(i).AirLoopNum;
-                        NodeFound(j) = true;
-                        LocalError = true;
-                        break;
-                    }
-                }
-                // Check outdoor air node
-                if (UtilityRoutines::SameString(DisSysNodeData(i).EPlusType, "OutdoorAir:NodeList") ||
-                    UtilityRoutines::SameString(DisSysNodeData(i).EPlusType, "OutdoorAir:Node")) {
-                    if (!LocalError) {
-                        ShowSevereError(RoutineName + "The Node or Component Name defined in " + DisSysNodeData(i).Name + " is not found in the " +
-                                        DisSysNodeData(i).EPlusType);
-                        ShowContinueError("The entered name is " + DisSysNodeData(i).EPlusName + " in an AirflowNetwork:Distribution:Node object.");
+        NodeFound.dimension(NumOfNodes, false);
+        // Validate inlet and outlet nodes for zone exhaust fans
+        for (i = 1; i <= AirflowNetworkNumOfExhFan; ++i) {
+            NodeFound(MultizoneCompExhaustFanData(i).InletNode) = true;
+            NodeFound(MultizoneCompExhaustFanData(i).OutletNode) = true;
+        }
+        // Validate EPlus Node names and types
+        for (i = 1; i <= DisSysNumOfNodes; ++i) {
+            if (UtilityRoutines::SameString(DisSysNodeData(i).EPlusName, "") || UtilityRoutines::SameString(DisSysNodeData(i).EPlusName, "Other"))
+                continue;
+            LocalError = false;
+            for (j = 1; j <= NumOfNodes; ++j) { // NodeID
+                if (DisSysNodeData(i).EPlusName == NodeID(j)) {
+                    DisSysNodeData(i).AirLoopNum = GetAirLoopNumber(j);
+                    if (DisSysNodeData(i).AirLoopNum == 0) {
+                        ShowSevereError(RoutineName + "The Node or Component Name defined in " + DisSysNodeData(i).Name +
+                                        " is not found in the AirLoopHVAC.");
+                        ShowContinueError("The entered name is " + DisSysNodeData(i).EPlusName +
+                                          " in an AirflowNetwork:Distribution:Node object.");
                         ErrorsFound = true;
                     }
+                    DisSysNodeData(i).EPlusNodeNum = j;
+                    AirflowNetworkNodeData(NumOfNodesMultiZone + i).EPlusNodeNum = j;
+                    AirflowNetworkNodeData(NumOfNodesMultiZone + i).AirLoopNum = DisSysNodeData(i).AirLoopNum;
+                    NodeFound(j) = true;
+                    LocalError = true;
+                    break;
                 }
-                if (DisSysNodeData(i).EPlusNodeNum == 0) {
-                    ShowSevereError(RoutineName +
-                                    "Primary Air Loop Node is not found in AIRFLOWNETWORK:DISTRIBUTION:NODE = " + DisSysNodeData(i).Name);
+            }
+            // Check outdoor air node
+            if (UtilityRoutines::SameString(DisSysNodeData(i).EPlusType, "OutdoorAir:NodeList") ||
+                UtilityRoutines::SameString(DisSysNodeData(i).EPlusType, "OutdoorAir:Node")) {
+                if (!LocalError) {
+                    ShowSevereError(RoutineName + "The Node or Component Name defined in " + DisSysNodeData(i).Name + " is not found in the " +
+                                    DisSysNodeData(i).EPlusType);
+                    ShowContinueError("The entered name is " + DisSysNodeData(i).EPlusName + " in an AirflowNetwork:Distribution:Node object.");
                     ErrorsFound = true;
                 }
             }
-
-            // Determine node numbers for zone inlets
-            for (i = 1; i <= NumOfZones; ++i) {
-                if (!ZoneEquipConfig(i).IsControlled) continue;
-                for (j = 1; j <= ZoneEquipConfig(i).NumInletNodes; ++j) {
-                    for (k = 1; k <= AirflowNetworkNumOfNodes; ++k) {
-                        if (ZoneEquipConfig(i).InletNode(j) == AirflowNetworkNodeData(k).EPlusNodeNum) {
-                            AirflowNetworkNodeData(k).EPlusTypeNum = EPlusTypeNum_ZIN;
-                            break;
-                        }
-                    }
-                }
+            if (DisSysNodeData(i).EPlusNodeNum == 0) {
+                ShowSevereError(RoutineName +
+                                "Primary Air Loop Node is not found in AIRFLOWNETWORK:DISTRIBUTION:NODE = " + DisSysNodeData(i).Name);
+                ErrorsFound = true;
             }
+        }
 
-            // Eliminate node not related to AirLoopHVAC
-            for (k = 1; k <= NumOfNodeConnections; ++k) {
-                if (NodeFound(NodeConnections(k).NodeNumber)) continue;
-                if (NodeConnections(k).FluidStream == 2) {
-                    NodeFound(NodeConnections(k).NodeNumber) = true;
-                }
-            }
-
-            // Eliminate nodes with fluidtype = water
-            for (k = 1; k <= NumOfNodes; ++k) {
-                if (NodeFound(k)) continue;
-                if (Node(k).FluidType == 2) {
-                    NodeFound(k) = true;
-                }
-            }
-
-            // Eliminate local external air node for network
-            for (k = 1; k <= NumOfNodes; ++k) {
-                if (NodeFound(k)) continue;
-                if (Node(k).IsLocalNode) NodeFound(k) = true;
-            }
-
-            // Ensure all the nodes used in Eplus are a subset of AirflowNetwork Nodes
-            for (i = 1; i <= NumOfNodes; ++i) {
-                if (NodeFound(i)) continue;
-                // Skip the inlet and outlet nodes of zone dehumidifiers
-                if (GetZoneDehumidifierNodeNumber(i)) NodeFound(i) = true;
-
-                for (j = 1; j <= NumOfZones; ++j) {
-                    if (!ZoneEquipConfig(j).IsControlled) continue;
-                    if (ZoneEquipConfig(j).ZoneNode == i) {
-                        if (ZoneEquipConfig(j).ActualZoneNum > AirflowNetworkNumOfNodes) {
-                            ShowSevereError(RoutineName + "'" + NodeID(i) + "' is not defined as an AirflowNetwork:Distribution:Node object.");
-                            ShowContinueError("This Node is the zone air node for Zone '" + ZoneEquipConfig(j).ZoneName + "'.");
-                            ErrorsFound = true;
-                        } else {
-                            NodeFound(i) = true;
-                            AirflowNetworkNodeData(ZoneEquipConfig(j).ActualZoneNum).EPlusNodeNum = i;
-                        }
+        // Determine node numbers for zone inlets
+        for (i = 1; i <= NumOfZones; ++i) {
+            if (!ZoneEquipConfig(i).IsControlled) continue;
+            for (j = 1; j <= ZoneEquipConfig(i).NumInletNodes; ++j) {
+                for (k = 1; k <= AirflowNetworkNumOfNodes; ++k) {
+                    if (ZoneEquipConfig(i).InletNode(j) == AirflowNetworkNodeData(k).EPlusNodeNum) {
+                        AirflowNetworkNodeData(k).EPlusTypeNum = EPlusTypeNum_ZIN;
                         break;
                     }
                 }
+            }
+        }
 
-                //   skip nodes that are not part of an airflow network
+        // Eliminate node not related to AirLoopHVAC
+        for (k = 1; k <= NumOfNodeConnections; ++k) {
+            if (NodeFound(NodeConnections(k).NodeNumber)) continue;
+            if (NodeConnections(k).FluidStream == 2) {
+                NodeFound(NodeConnections(k).NodeNumber) = true;
+            }
+        }
 
-                //     DX COIL CONDENSER NODE TEST:
-                //     Outside air nodes are used for DX coil condenser inlet nodes, these are specified in an outside air node or
-                //     OutdoorAir:NodeList object (and classified with NodeConnectionType as OutsideAir). In addition,
-                //     this same node is specified in a Coil:DX:CoolingBypassFactorEmpirical object (and classified with
-                //     NodeConnectionType as OutsideAirReference). In the NodeConnectionType structure, both of these nodes have a
-                //     unique index but have the same node number. The Outside Air Node will usually be listed first. Search for all
-                //     indexes with the same node number and check if it is classified as NodeConnectionType = OutsideAirReference.
-                //     Mark this node as found since it is not used in an airflownetwork simulation.
-                //     Example (using AirflowNetwork_MultiZone_SmallOffice.idf with a single OA Mixer):
-                //             (the example shown below is identical to AirflowNetwork_SimpleHouse.idf with no OA Mixer except
-                //              that the NodeConnections indexes are (7) and (31), respectively and the NodeNumber = 6)
-                //   The GetNodeConnectionType CALL below returns NodeConnectionType_OutsideAir = 7 and NodeConnectionType_OutsideAirReference = 14.
-                //     NodeConnections info from OUTSIDE AIR NODE object read:
-                //     NodeConnections(9)NodeNumber      = 10
-                //     NodeConnections(9)NodeName        = ACDXCOIL 1 CONDENSER NODE
-                //     NodeConnections(9)ObjectType      = OUTSIDE AIR NODE
-                //     NodeConnections(9)ObjectName      = OUTSIDE AIR NODE
-                //     NodeConnections(9)ConnectionType  = OutsideAir
-                //     NodeConnections info from Coil:DX:CoolingBypassFactorEmpirical object read:
-                //     NodeConnections(64)NodeNumber     = 10
-                //     NodeConnections(64)NodeName       = ACDXCOIL 1 CONDENSER NODE
-                //     NodeConnections(64)ObjectType     = COIL:DX:COOLINGBYPASSFACTOREMPIRICAL
-                //     NodeConnections(64)ObjectName     = ACDXCOIL 1
-                //     NodeConnections(64)ConnectionType = OutsideAirReference
+        // Eliminate nodes with fluidtype = water
+        for (k = 1; k <= NumOfNodes; ++k) {
+            if (NodeFound(k)) continue;
+            if (Node(k).FluidType == 2) {
+                NodeFound(k) = true;
+            }
+        }
 
-                errFlag = false;
-                GetNodeConnectionType(i, NodeConnectionType, errFlag); // Gets all connection types for a given node number
-                if (errFlag) {
-                    ShowContinueError("...occurs in Airflow Network simulation.");
-                } else {
-                    //   skip nodes for air cooled condensers
-                    for (j = 1; j <= isize(NodeConnectionType); ++j) {
-                        if (NodeConnectionType(j) == NodeConnectionType_OutsideAirReference) {
-                            NodeFound(i) = true;
-                        }
-                    }
-                }
+        // Eliminate local external air node for network
+        for (k = 1; k <= NumOfNodes; ++k) {
+            if (NodeFound(k)) continue;
+            if (Node(k).IsLocalNode) NodeFound(k) = true;
+        }
 
-                if (!NodeFound(i)) {
-                    // Check if this node is the OA relief node. For the time being, OA relief node is not used
-                    if (GetNumOAMixers() > 1) {
-                        //						ShowSevereError( RoutineName + "Only one OutdoorAir:Mixer is allowed in the
-                        // AirflowNetwork model." ); 						ErrorsFound = true;
-                        int OAFanNum;
-                        int OARelNum;
-                        int OAMixerNum;
+        // Ensure all the nodes used in Eplus are a subset of AirflowNetwork Nodes
+        for (i = 1; i <= NumOfNodes; ++i) {
+            if (NodeFound(i)) continue;
+            // Skip the inlet and outlet nodes of zone dehumidifiers
+            if (GetZoneDehumidifierNodeNumber(i)) NodeFound(i) = true;
 
-                        for (OAFanNum = 1; OAFanNum <= NumOfOAFans; ++OAFanNum) {
-                            DisSysCompOutdoorAirData(OAFanNum).InletNode = GetOAMixerInletNodeNumber(DisSysCompOutdoorAirData(OAFanNum).OAMixerNum);
-                            //							NodeFound( DisSysCompOutdoorAirData( OAFanNum ).InletNode ) = true;
-                        }
-                        for (OARelNum = 1; OARelNum <= NumOfReliefFans; ++OARelNum) {
-                            DisSysCompReliefAirData(OARelNum).OutletNode = GetOAMixerInletNodeNumber(DisSysCompReliefAirData(OARelNum).OAMixerNum);
-                            //							NodeFound( DisSysCompOutdoorAirData( OAFanNum ).InletNode ) = true;
-                        }
-                        // Check NodeFound status
-                        for (OAMixerNum = 1; OAMixerNum <= GetNumOAMixers(); ++OAMixerNum) {
-                            if (i == GetOAMixerReliefNodeNumber(OAMixerNum)) {
-                                NodeFound(i) = true;
-                                break;
-                            } else if (i == GetOAMixerInletNodeNumber(OAMixerNum)) {
-                                NodeFound(i) = true;
-                                break;
-                            } else {
-                                if (OAMixerNum == GetNumOAMixers()) {
-                                    ShowSevereError(RoutineName + "'" + NodeID(i) + "' is not defined as an AirflowNetwork:Distribution:Node object.");
-                                    ErrorsFound = true;
-                                }
-                            }
-                        }
-                    } else if (GetNumOAMixers() == 0) {
+            for (j = 1; j <= NumOfZones; ++j) {
+                if (!ZoneEquipConfig(j).IsControlled) continue;
+                if (ZoneEquipConfig(j).ZoneNode == i) {
+                    if (ZoneEquipConfig(j).ActualZoneNum > AirflowNetworkNumOfNodes) {
                         ShowSevereError(RoutineName + "'" + NodeID(i) + "' is not defined as an AirflowNetwork:Distribution:Node object.");
+                        ShowContinueError("This Node is the zone air node for Zone '" + ZoneEquipConfig(j).ZoneName + "'.");
                         ErrorsFound = true;
                     } else {
-                        // TODO: I fail to see how you could enter this block given than NumOAMixers (returned by GetNumOAMixers())
-                        // is initialized to zero, and we check above if '> 0' or '== 0'
-                        if (NumOfOAFans == 1 && DisSysCompOutdoorAirData(1).InletNode == 0) {
-                            DisSysCompOutdoorAirData(1).InletNode = GetOAMixerInletNodeNumber(1);
-                        }
-                        if (NumOfReliefFans == 1 && DisSysCompReliefAirData(1).OutletNode == 0) {
-                            DisSysCompReliefAirData(1).OutletNode = GetOAMixerInletNodeNumber(1);
-                        }
-                        if (i == GetOAMixerReliefNodeNumber(1)) {
+                        NodeFound(i) = true;
+                        AirflowNetworkNodeData(ZoneEquipConfig(j).ActualZoneNum).EPlusNodeNum = i;
+                    }
+                    break;
+                }
+            }
+
+            //   skip nodes that are not part of an airflow network
+
+            //     DX COIL CONDENSER NODE TEST:
+            //     Outside air nodes are used for DX coil condenser inlet nodes, these are specified in an outside air node or
+            //     OutdoorAir:NodeList object (and classified with NodeConnectionType as OutsideAir). In addition,
+            //     this same node is specified in a Coil:DX:CoolingBypassFactorEmpirical object (and classified with
+            //     NodeConnectionType as OutsideAirReference). In the NodeConnectionType structure, both of these nodes have a
+            //     unique index but have the same node number. The Outside Air Node will usually be listed first. Search for all
+            //     indexes with the same node number and check if it is classified as NodeConnectionType = OutsideAirReference.
+            //     Mark this node as found since it is not used in an airflownetwork simulation.
+            //     Example (using AirflowNetwork_MultiZone_SmallOffice.idf with a single OA Mixer):
+            //             (the example shown below is identical to AirflowNetwork_SimpleHouse.idf with no OA Mixer except
+            //              that the NodeConnections indexes are (7) and (31), respectively and the NodeNumber = 6)
+            //   The GetNodeConnectionType CALL below returns NodeConnectionType_OutsideAir = 7 and NodeConnectionType_OutsideAirReference = 14.
+            //     NodeConnections info from OUTSIDE AIR NODE object read:
+            //     NodeConnections(9)NodeNumber      = 10
+            //     NodeConnections(9)NodeName        = ACDXCOIL 1 CONDENSER NODE
+            //     NodeConnections(9)ObjectType      = OUTSIDE AIR NODE
+            //     NodeConnections(9)ObjectName      = OUTSIDE AIR NODE
+            //     NodeConnections(9)ConnectionType  = OutsideAir
+            //     NodeConnections info from Coil:DX:CoolingBypassFactorEmpirical object read:
+            //     NodeConnections(64)NodeNumber     = 10
+            //     NodeConnections(64)NodeName       = ACDXCOIL 1 CONDENSER NODE
+            //     NodeConnections(64)ObjectType     = COIL:DX:COOLINGBYPASSFACTOREMPIRICAL
+            //     NodeConnections(64)ObjectName     = ACDXCOIL 1
+            //     NodeConnections(64)ConnectionType = OutsideAirReference
+
+            errFlag = false;
+            GetNodeConnectionType(i, NodeConnectionType, errFlag); // Gets all connection types for a given node number
+            if (errFlag) {
+                ShowContinueError("...occurs in Airflow Network simulation.");
+            } else {
+                //   skip nodes for air cooled condensers
+                for (j = 1; j <= isize(NodeConnectionType); ++j) {
+                    if (NodeConnectionType(j) == NodeConnectionType_OutsideAirReference) {
+                        NodeFound(i) = true;
+                    }
+                }
+            }
+
+            if (!NodeFound(i)) {
+                // Check if this node is the OA relief node. For the time being, OA relief node is not used
+                if (GetNumOAMixers() > 1) {
+                    //						ShowSevereError( RoutineName + "Only one OutdoorAir:Mixer is allowed in the
+                    // AirflowNetwork model." ); 						ErrorsFound = true;
+                    int OAFanNum;
+                    int OARelNum;
+                    int OAMixerNum;
+
+                    for (OAFanNum = 1; OAFanNum <= NumOfOAFans; ++OAFanNum) {
+                        DisSysCompOutdoorAirData(OAFanNum).InletNode = GetOAMixerInletNodeNumber(DisSysCompOutdoorAirData(OAFanNum).OAMixerNum);
+                        //							NodeFound( DisSysCompOutdoorAirData( OAFanNum ).InletNode ) = true;
+                    }
+                    for (OARelNum = 1; OARelNum <= NumOfReliefFans; ++OARelNum) {
+                        DisSysCompReliefAirData(OARelNum).OutletNode = GetOAMixerInletNodeNumber(DisSysCompReliefAirData(OARelNum).OAMixerNum);
+                        //							NodeFound( DisSysCompOutdoorAirData( OAFanNum ).InletNode ) = true;
+                    }
+                    // Check NodeFound status
+                    for (OAMixerNum = 1; OAMixerNum <= GetNumOAMixers(); ++OAMixerNum) {
+                        if (i == GetOAMixerReliefNodeNumber(OAMixerNum)) {
                             NodeFound(i) = true;
-                        } else if (i == GetOAMixerInletNodeNumber(1)) {
+                            break;
+                        } else if (i == GetOAMixerInletNodeNumber(OAMixerNum)) {
                             NodeFound(i) = true;
+                            break;
                         } else {
-                            ShowSevereError(RoutineName + "'" + NodeID(i) + "' is not defined as an AirflowNetwork:Distribution:Node object.");
-                            ErrorsFound = true;
-                        }
-                    }
-                }
-            }
-            NodeFound.deallocate();
-
-            // Assign AirLoop Number to every node and linkage
-            // Zone first
-            for (i = 1; i <= AirflowNetworkNumOfZones; i++) {
-                for (j = 1; j <= NumOfZones; j++) {
-                    if (!ZoneEquipConfig(j).IsControlled) continue;
-                    if ((MultizoneZoneData(i).ZoneNum == j) && (ZoneEquipConfig(j).NumInletNodes > 0)) {
-                        // No multiple Airloop
-                        AirflowNetworkNodeData(i).AirLoopNum = ZoneEquipConfig(j).InletNodeAirLoopNum(1);
-                    }
-                }
-            }
-            // Air Distribution system
-            for (i = AirflowNetworkNumOfSurfaces + 1; i <= AirflowNetworkNumOfLinks; ++i) {
-                j = AirflowNetworkLinkageData(i).NodeNums[0];
-                k = AirflowNetworkLinkageData(i).NodeNums[1];
-                if (AirflowNetworkNodeData(j).AirLoopNum == 0 && AirflowNetworkNodeData(k).AirLoopNum == 0) {
-                    // Error messaage
-                    ShowSevereError("ValidateDistributionSystem: AIRFLOWNETWORK:DISTRIBUTION:LINKAGE = " + AirflowNetworkLinkageData(i).Name +
-                                    " is not valid for AirLoopNum assignment");
-                    ShowContinueError("AirLoopNum is not found in both nodes for the linkage: " + AirflowNetworkLinkageData(i).NodeNames[0] +
-                                      " and " + AirflowNetworkLinkageData(i).NodeNames[1]);
-                    ShowContinueError("Please ensure one of two AIRFLOWNETWORK:DISTRIBUTION:NODEs in the first AIRFLOWNETWORK:DISTRIBUTION:LINKAGE "
-                                      "object should be defined as EnergyPlus NodeID.");
-                    ErrorsFound = true;
-                }
-                if (AirflowNetworkNodeData(j).AirLoopNum > 0 && AirflowNetworkNodeData(k).AirLoopNum == 0) {
-                    AirflowNetworkNodeData(k).AirLoopNum = AirflowNetworkNodeData(j).AirLoopNum;
-                }
-                if (AirflowNetworkNodeData(j).AirLoopNum == 0 && AirflowNetworkNodeData(k).AirLoopNum > 0) {
-                    AirflowNetworkNodeData(j).AirLoopNum = AirflowNetworkNodeData(k).AirLoopNum;
-                }
-                if (AirflowNetworkNodeData(j).AirLoopNum == AirflowNetworkNodeData(k).AirLoopNum) {
-                    AirflowNetworkLinkageData(i).AirLoopNum = AirflowNetworkNodeData(j).AirLoopNum;
-                }
-                if (AirflowNetworkNodeData(j).AirLoopNum != AirflowNetworkNodeData(k).AirLoopNum && AirflowNetworkNodeData(j).AirLoopNum > 0 &&
-                    AirflowNetworkNodeData(k).AirLoopNum > 0) {
-                    AirflowNetworkLinkageData(i).AirLoopNum = AirflowNetworkNodeData(j).AirLoopNum;
-                    ShowSevereError("The AirLoopNum defined in both AIRFLOWNETWORK:DISTRIBUTION:NODE objects in " +
-                                    AirflowNetworkLinkageData(i).Name +
-                                    " are not the same. Please make sure both nodes should be listed in the same AirLoop as a valid linkage.");
-                    ShowContinueError("AirLoop defined in " + AirflowNetworkNodeData(j).Name + " is " +
-                                      PrimaryAirSystem(AirflowNetworkNodeData(j).AirLoopNum).Name + ", and AirLoop defined in " +
-                                      AirflowNetworkNodeData(k).Name + " is " + PrimaryAirSystem(AirflowNetworkNodeData(k).AirLoopNum).Name);
-                    ErrorsFound = true;
-                }
-                // Set AirLoopNum to fans and coils
-                if (AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).EPlusTypeNum == EPlusTypeNum_FAN) {
-                    n = DisSysCompCVFData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).FanIndex;
-                    DisSysCompCVFData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).AirLoopNum =
-                        AirflowNetworkLinkageData(i).AirLoopNum;
-                    if (DisSysCompCVFData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).FanModelFlag) {
-                        HVACFan::fanObjs[DisSysCompCVFData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).FanIndex]->AirLoopNum = AirflowNetworkLinkageData(i).AirLoopNum;
-                    } else {
-                        SetFanAirLoopNumber(n, AirflowNetworkLinkageData(i).AirLoopNum);
-                    }
-                }
-                if (AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).EPlusTypeNum == EPlusTypeNum_COI) {
-                    DisSysCompCoilData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).AirLoopNum =
-                        AirflowNetworkLinkageData(i).AirLoopNum;
-                }
-            }
-
-            // Validate coil name and type
-            CurrentModuleObject = "AirflowNetwork:Distribution:Component:Coil";
-            MultiSpeedHPIndicator = 0;
-            for (i = 1; i <= DisSysNumOfCoils; ++i) {
-                {
-                    auto const SELECT_CASE_var(UtilityRoutines::MakeUPPERCase(DisSysCompCoilData(i).EPlusType));
-
-                    if (SELECT_CASE_var == "COIL:COOLING:DX:SINGLESPEED") {
-                        ValidateComponent("Coil:Cooling:DX:SingleSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        } else {
-                            SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:HEATING:DX:SINGLESPEED") {
-                        ValidateComponent("Coil:Heating:DX:SingleSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        } else {
-                            SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:HEATING:FUEL") {
-                        ValidateComponent("Coil:Heating:Fuel", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        } else {
-                            SetHeatingCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum, ErrorsFound);
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:HEATING:ELECTRIC") {
-                        ValidateComponent("Coil:Heating:Electric", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        } else {
-                            SetHeatingCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum, ErrorsFound);
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:COOLING:WATER") {
-                        ValidateComponent("Coil:Cooling:Water", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:HEATING:WATER") {
-                        ValidateComponent("Coil:Heating:Water", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:COOLING:WATER:DETAILEDGEOMETRY") {
-                        ValidateComponent(
-                            "Coil:Cooling:Water:DetailedGeometry", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:COOLING:DX:TWOSTAGEWITHHUMIDITYCONTROLMODE") {
-                        ValidateComponent("Coil:Cooling:DX:TwoStageWithHumidityControlMode",
-                                          DisSysCompCoilData(i).Name,
-                                          IsNotOK,
-                                          RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        } else {
-                            SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:COOLING:DX:MULTISPEED") {
-                        ValidateComponent("Coil:Cooling:DX:MultiSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        ++MultiSpeedHPIndicator;
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        } else {
-                            SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:HEATING:DX:MULTISPEED") {
-                        ValidateComponent("Coil:Heating:DX:MultiSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        ++MultiSpeedHPIndicator;
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        } else {
-                            SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:HEATING:DESUPERHEATER") {
-                        ValidateComponent("Coil:Heating:Desuperheater", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        }
-
-                    } else if (SELECT_CASE_var == "COIL:COOLING:DX:TWOSPEED") {
-                        ValidateComponent("Coil:Cooling:DX:TwoSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        } else {
-                            SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
-                        }
-
-                    } else {
-                        ShowSevereError(RoutineName + CurrentModuleObject + " Invalid coil type = " + DisSysCompCoilData(i).Name);
-                        ErrorsFound = true;
-                    }
-                }
-            }
-
-            // Validate terminal unit name and type
-            for (i = 1; i <= DisSysNumOfTermUnits; ++i) {
-                if (UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:ConstantVolume:Reheat") ||
-                    UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:VAV:Reheat")) {
-                    LocalError = false;
-                    if (UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:ConstantVolume:Reheat"))
-                        GetHVACSingleDuctSysIndex(
-                            DisSysCompTermUnitData(i).Name, n, LocalError, "AirflowNetwork:Distribution:Component:TerminalUnit");
-                    if (UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:VAV:Reheat"))
-                        GetHVACSingleDuctSysIndex(DisSysCompTermUnitData(i).Name,
-                                                  n,
-                                                  LocalError,
-                                                  "AirflowNetwork:Distribution:Component:TerminalUnit",
-                                                  DisSysCompTermUnitData(i).DamperInletNode,
-                                                  DisSysCompTermUnitData(i).DamperOutletNode);
-                    if (LocalError) ErrorsFound = true;
-                    if (VAVSystem) {
-                        for (j = 1; j <= DisSysNumOfCVFs; j++) {
-                            if (DisSysCompCVFData(j).FanTypeNum == FanType_SimpleVAV) {
-                                if (DisSysCompCVFData(j).AirLoopNum == DisSysCompTermUnitData(i).AirLoopNum &&
-                                    !UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:VAV:Reheat")) {
-                                    ShowSevereError(RoutineName + CurrentModuleObject +
-                                                    " Invalid terminal type for a VAV system = " + DisSysCompTermUnitData(i).Name);
-                                    ShowContinueError("The input type = " + DisSysCompTermUnitData(i).EPlusType);
-                                    ShowContinueError("A VAV system requires all terminal units with type = AirTerminal:SingleDuct:VAV:Reheat");
-                                    ErrorsFound = true;
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    ShowSevereError(RoutineName + "AIRFLOWNETWORK:DISTRIBUTION:COMPONENT TERMINAL UNIT: Invalid Terminal unit type = " +
-                                    DisSysCompTermUnitData(i).Name);
-                    ErrorsFound = true;
-                }
-            }
-
-            // Validate heat exchanger name and type
-            CurrentModuleObject = "AirflowNetwork:Distribution:Component:HeatExchanger";
-            for (i = 1; i <= DisSysNumOfHXs; ++i) {
-                {
-                    auto const SELECT_CASE_var(UtilityRoutines::MakeUPPERCase(DisSysCompHXData(i).EPlusType));
-
-                    if (SELECT_CASE_var == "HEATEXCHANGER:AIRTOAIR:FLATPLATE") {
-                        ValidateComponent("HeatExchanger:AirToAir:FlatPlate", DisSysCompHXData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        }
-
-                    } else if (SELECT_CASE_var == "HEATEXCHANGER:AIRTOAIR:SENSIBLEANDLATENT") {
-                        ValidateComponent(
-                            "HeatExchanger:AirToAir:SensibleAndLatent", DisSysCompHXData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        }
-
-                    } else if (SELECT_CASE_var == "HEATEXCHANGER:DESICCANT:BALANCEDFLOW") {
-                        ValidateComponent(
-                            "HeatExchanger:Desiccant:BalancedFlow", DisSysCompHXData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
-                        if (IsNotOK) {
-                            ErrorsFound = true;
-                        }
-
-                    } else {
-                        ShowSevereError(RoutineName + CurrentModuleObject + " Invalid heat exchanger type = " + DisSysCompHXData(i).EPlusType);
-                        ErrorsFound = true;
-                    }
-                }
-            }
-
-            // Assign supply and return connection
-            for (j = 1; j <= NumPrimaryAirSys; ++j) {
-                S1 = 0;
-                S2 = 0;
-                R1 = 0;
-                R2 = 0;
-                for (i = 1; i <= AirflowNetworkNumOfNodes; ++i) {
-                    if (AirflowNetworkNodeData(i).EPlusNodeNum == AirToZoneNodeInfo(j).AirLoopSupplyNodeNum(1)) S1 = i;
-                    if (AirflowNetworkNodeData(i).EPlusNodeNum == AirToZoneNodeInfo(j).ZoneEquipSupplyNodeNum(1)) S2 = i;
-                    if (AirflowNetworkNodeData(i).EPlusNodeNum == AirToZoneNodeInfo(j).ZoneEquipReturnNodeNum(1)) R1 = i;
-                    if (AirflowNetworkNodeData(i).EPlusNodeNum == AirToZoneNodeInfo(j).AirLoopReturnNodeNum(1)) R2 = i;
-                }
-                for (i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
-                    if (AirflowNetworkLinkageData(i).NodeNums[0] == R1 && AirflowNetworkLinkageData(i).NodeNums[1] == R2) {
-                        AirflowNetworkLinkageData(i).ConnectionFlag = EPlusTypeNum_RCN;
-                    }
-                    if (AirflowNetworkLinkageData(i).NodeNums[0] == S1 && AirflowNetworkLinkageData(i).NodeNums[1] == S2) {
-                        AirflowNetworkLinkageData(i).ConnectionFlag = EPlusTypeNum_SCN;
-                    }
-                }
-            }
-
-            // Assign fan inlet and outlet node, and coil outlet
-            for (i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
-                j = AirflowNetworkLinkageData(i).CompNum;
-                if (AirflowNetworkCompData(j).CompTypeNum == CompTypeNum_CVF) {
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum == 0)
-                        AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum = EPlusTypeNum_FIN;
-                    AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum = EPlusTypeNum_FOU;
-                }
-                if (AirflowNetworkCompData(j).EPlusTypeNum == EPlusTypeNum_COI) {
-                    AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum = EPlusTypeNum_COU;
-                }
-                if (AirflowNetworkCompData(j).EPlusTypeNum == EPlusTypeNum_HEX) {
-                    AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum = EPlusTypeNum_HXO;
-                }
-                if (AirflowNetworkCompData(j).CompTypeNum == CompTypeNum_TMU) {
-                    if (DisSysCompTermUnitData(AirflowNetworkCompData(j).TypeNum).DamperInletNode > 0) {
-                        if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusNodeNum ==
-                                DisSysCompTermUnitData(AirflowNetworkCompData(j).TypeNum).DamperInletNode &&
-                            AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusNodeNum ==
-                                DisSysCompTermUnitData(AirflowNetworkCompData(j).TypeNum).DamperOutletNode) {
-                            AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum = EPlusTypeNum_DIN;
-                            AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum = EPlusTypeNum_DOU;
-                            AirflowNetworkLinkageData(i).VAVTermDamper = true;
-                        }
-                    }
-                }
-            }
-
-            // Validate the position of constant pressure drop component
-            CurrentModuleObject = "AirflowNetwork:Distribution:Component:ConstantPressureDrop";
-            for (i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
-                if (AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).CompTypeNum == CompTypeNum_CPD) {
-                    for (j = 1; j <= AirflowNetworkNumOfLinks; ++j) {
-                        if (AirflowNetworkLinkageData(i).NodeNums[0] == AirflowNetworkLinkageData(j).NodeNums[1]) {
-                            if (AirflowNetworkCompData(AirflowNetworkLinkageData(j).CompNum).CompTypeNum != CompTypeNum_DWC) {
-                                ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName +
-                                                ')');
-                                ShowContinueError("must connect a duct component upstream and not " + AirflowNetworkLinkageData(j).Name);
+                            if (OAMixerNum == GetNumOAMixers()) {
+                                ShowSevereError(RoutineName + "'" + NodeID(i) + "' is not defined as an AirflowNetwork:Distribution:Node object.");
                                 ErrorsFound = true;
                             }
                         }
                     }
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum == EPlusTypeNum_SPL) {
-                        ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
-                        ShowContinueError("does not allow a AirLoopHVAC:ZoneSplitter node = " +
-                                          AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).Name);
-                        ErrorsFound = true;
+                } else if (GetNumOAMixers() == 0) {
+                    ShowSevereError(RoutineName + "'" + NodeID(i) + "' is not defined as an AirflowNetwork:Distribution:Node object.");
+                    ErrorsFound = true;
+                } else {
+                    // TODO: I fail to see how you could enter this block given than NumOAMixers (returned by GetNumOAMixers())
+                    // is initialized to zero, and we check above if '> 0' or '== 0'
+                    if (NumOfOAFans == 1 && DisSysCompOutdoorAirData(1).InletNode == 0) {
+                        DisSysCompOutdoorAirData(1).InletNode = GetOAMixerInletNodeNumber(1);
                     }
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum == EPlusTypeNum_SPL) {
-                        ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
-                        ShowContinueError("does not allow a AirLoopHVAC:ZoneSplitter node = " +
-                                          AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).Name);
-                        ErrorsFound = true;
+                    if (NumOfReliefFans == 1 && DisSysCompReliefAirData(1).OutletNode == 0) {
+                        DisSysCompReliefAirData(1).OutletNode = GetOAMixerInletNodeNumber(1);
                     }
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum == EPlusTypeNum_MIX) {
-                        ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
-                        ShowContinueError("does not allow a AirLoopHVAC:ZoneMixer node = " +
-                                          AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).Name);
-                        ErrorsFound = true;
-                    }
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum == EPlusTypeNum_MIX) {
-                        ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
-                        ShowContinueError("does not allow a AirLoopHVAC:ZoneMixer node = " +
-                                          AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).Name);
-                        ErrorsFound = true;
-                    }
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusNodeNum > 0) {
-                        ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
-                        ShowContinueError("does not allow to connect an EnergyPlus node = " +
-                                          AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).Name);
-                        ErrorsFound = true;
-                    }
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusNodeNum > 0) {
-                        ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
-                        ShowContinueError("does not allow to connect an EnergyPlus node = " +
-                                          AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).Name);
-                        ErrorsFound = true;
-                    }
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusZoneNum > 0) {
-                        ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
-                        ShowContinueError("does not allow to connect an EnergyPlus zone = " +
-                                          AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).Name);
-                        ErrorsFound = true;
-                    }
-                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusZoneNum > 0) {
-                        ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
-                        ShowContinueError("does not allow to connect an EnergyPlus zone = " +
-                                          AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).Name);
+                    if (i == GetOAMixerReliefNodeNumber(1)) {
+                        NodeFound(i) = true;
+                    } else if (i == GetOAMixerInletNodeNumber(1)) {
+                        NodeFound(i) = true;
+                    } else {
+                        ShowSevereError(RoutineName + "'" + NodeID(i) + "' is not defined as an AirflowNetwork:Distribution:Node object.");
                         ErrorsFound = true;
                     }
                 }
             }
+        }
+        NodeFound.deallocate();
 
-            for (i = NumOfNodesMultiZone + 1; i <= AirflowNetworkNumOfNodes; ++i) {
-                if (AirflowNetworkNodeData(i).EPlusTypeNum == EPlusTypeNum_SPL) {
-                    LocalError = false;
-                    j = GetSplitterOutletNumber("", 1, LocalError);
-                    SplitterNodeNumbers.allocate(j + 2);
-                    SplitterNodeNumbers = GetSplitterNodeNumbers("", 1, LocalError);
-                    if (LocalError) ErrorsFound = true;
+        // Assign AirLoop Number to every node and linkage
+        // Zone first
+        for (i = 1; i <= AirflowNetworkNumOfZones; i++) {
+            for (j = 1; j <= NumOfZones; j++) {
+                if (!ZoneEquipConfig(j).IsControlled) continue;
+                if ((MultizoneZoneData(i).ZoneNum == j) && (ZoneEquipConfig(j).NumInletNodes > 0)) {
+                    // No multiple Airloop
+                    AirflowNetworkNodeData(i).AirLoopNum = ZoneEquipConfig(j).InletNodeAirLoopNum(1);
                 }
             }
+        }
+        // Air Distribution system
+        for (i = AirflowNetworkNumOfSurfaces + 1; i <= AirflowNetworkNumOfLinks; ++i) {
+            j = AirflowNetworkLinkageData(i).NodeNums[0];
+            k = AirflowNetworkLinkageData(i).NodeNums[1];
+            if (AirflowNetworkNodeData(j).AirLoopNum == 0 && AirflowNetworkNodeData(k).AirLoopNum == 0) {
+                // Error messaage
+                ShowSevereError("ValidateDistributionSystem: AIRFLOWNETWORK:DISTRIBUTION:LINKAGE = " + AirflowNetworkLinkageData(i).Name +
+                                " is not valid for AirLoopNum assignment");
+                ShowContinueError("AirLoopNum is not found in both nodes for the linkage: " + AirflowNetworkLinkageData(i).NodeNames[0] +
+                                  " and " + AirflowNetworkLinkageData(i).NodeNames[1]);
+                ShowContinueError("Please ensure one of two AIRFLOWNETWORK:DISTRIBUTION:NODEs in the first AIRFLOWNETWORK:DISTRIBUTION:LINKAGE "
+                                  "object should be defined as EnergyPlus NodeID.");
+                ErrorsFound = true;
+            }
+            if (AirflowNetworkNodeData(j).AirLoopNum > 0 && AirflowNetworkNodeData(k).AirLoopNum == 0) {
+                AirflowNetworkNodeData(k).AirLoopNum = AirflowNetworkNodeData(j).AirLoopNum;
+            }
+            if (AirflowNetworkNodeData(j).AirLoopNum == 0 && AirflowNetworkNodeData(k).AirLoopNum > 0) {
+                AirflowNetworkNodeData(j).AirLoopNum = AirflowNetworkNodeData(k).AirLoopNum;
+            }
+            if (AirflowNetworkNodeData(j).AirLoopNum == AirflowNetworkNodeData(k).AirLoopNum) {
+                AirflowNetworkLinkageData(i).AirLoopNum = AirflowNetworkNodeData(j).AirLoopNum;
+            }
+            if (AirflowNetworkNodeData(j).AirLoopNum != AirflowNetworkNodeData(k).AirLoopNum && AirflowNetworkNodeData(j).AirLoopNum > 0 &&
+                AirflowNetworkNodeData(k).AirLoopNum > 0) {
+                AirflowNetworkLinkageData(i).AirLoopNum = AirflowNetworkNodeData(j).AirLoopNum;
+                ShowSevereError("The AirLoopNum defined in both AIRFLOWNETWORK:DISTRIBUTION:NODE objects in " +
+                                AirflowNetworkLinkageData(i).Name +
+                                " are not the same. Please make sure both nodes should be listed in the same AirLoop as a valid linkage.");
+                ShowContinueError("AirLoop defined in " + AirflowNetworkNodeData(j).Name + " is " +
+                                  PrimaryAirSystem(AirflowNetworkNodeData(j).AirLoopNum).Name + ", and AirLoop defined in " +
+                                  AirflowNetworkNodeData(k).Name + " is " + PrimaryAirSystem(AirflowNetworkNodeData(k).AirLoopNum).Name);
+                ErrorsFound = true;
+            }
+            // Set AirLoopNum to fans and coils
+            if (AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).EPlusTypeNum == EPlusTypeNum_FAN) {
+                n = DisSysCompCVFData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).FanIndex;
+                DisSysCompCVFData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).AirLoopNum =
+                    AirflowNetworkLinkageData(i).AirLoopNum;
+                if (DisSysCompCVFData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).FanModelFlag) {
+                    HVACFan::fanObjs[DisSysCompCVFData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).FanIndex]->AirLoopNum = AirflowNetworkLinkageData(i).AirLoopNum;
+                } else {
+                    SetFanAirLoopNumber(n, AirflowNetworkLinkageData(i).AirLoopNum);
+                }
+            }
+            if (AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).EPlusTypeNum == EPlusTypeNum_COI) {
+                DisSysCompCoilData(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum).AirLoopNum =
+                    AirflowNetworkLinkageData(i).AirLoopNum;
+            }
+        }
 
-            // Assigning inlet and outlet nodes for a splitter
+        // Validate coil name and type
+        CurrentModuleObject = "AirflowNetwork:Distribution:Component:Coil";
+        MultiSpeedHPIndicator = 0;
+        for (i = 1; i <= DisSysNumOfCoils; ++i) {
+            {
+                auto const SELECT_CASE_var(UtilityRoutines::MakeUPPERCase(DisSysCompCoilData(i).EPlusType));
+
+                if (SELECT_CASE_var == "COIL:COOLING:DX:SINGLESPEED") {
+                    ValidateComponent("Coil:Cooling:DX:SingleSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    } else {
+                        SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:HEATING:DX:SINGLESPEED") {
+                    ValidateComponent("Coil:Heating:DX:SingleSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    } else {
+                        SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:HEATING:FUEL") {
+                    ValidateComponent("Coil:Heating:Fuel", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    } else {
+                        SetHeatingCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum, ErrorsFound);
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:HEATING:ELECTRIC") {
+                    ValidateComponent("Coil:Heating:Electric", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    } else {
+                        SetHeatingCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum, ErrorsFound);
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:COOLING:WATER") {
+                    ValidateComponent("Coil:Cooling:Water", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:HEATING:WATER") {
+                    ValidateComponent("Coil:Heating:Water", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:COOLING:WATER:DETAILEDGEOMETRY") {
+                    ValidateComponent(
+                        "Coil:Cooling:Water:DetailedGeometry", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:COOLING:DX:TWOSTAGEWITHHUMIDITYCONTROLMODE") {
+                    ValidateComponent("Coil:Cooling:DX:TwoStageWithHumidityControlMode",
+                                      DisSysCompCoilData(i).Name,
+                                      IsNotOK,
+                                      RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    } else {
+                        SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:COOLING:DX:MULTISPEED") {
+                    ValidateComponent("Coil:Cooling:DX:MultiSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    ++MultiSpeedHPIndicator;
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    } else {
+                        SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:HEATING:DX:MULTISPEED") {
+                    ValidateComponent("Coil:Heating:DX:MultiSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    ++MultiSpeedHPIndicator;
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    } else {
+                        SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:HEATING:DESUPERHEATER") {
+                    ValidateComponent("Coil:Heating:Desuperheater", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    }
+
+                } else if (SELECT_CASE_var == "COIL:COOLING:DX:TWOSPEED") {
+                    ValidateComponent("Coil:Cooling:DX:TwoSpeed", DisSysCompCoilData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    } else {
+                        SetDXCoilAirLoopNumber(DisSysCompCoilData(i).Name, DisSysCompCoilData(i).AirLoopNum);
+                    }
+
+                } else {
+                    ShowSevereError(RoutineName + CurrentModuleObject + " Invalid coil type = " + DisSysCompCoilData(i).Name);
+                    ErrorsFound = true;
+                }
+            }
+        }
+
+        // Validate terminal unit name and type
+        for (i = 1; i <= DisSysNumOfTermUnits; ++i) {
+            if (UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:ConstantVolume:Reheat") ||
+                UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:VAV:Reheat")) {
+                LocalError = false;
+                if (UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:ConstantVolume:Reheat"))
+                    GetHVACSingleDuctSysIndex(
+                        DisSysCompTermUnitData(i).Name, n, LocalError, "AirflowNetwork:Distribution:Component:TerminalUnit");
+                if (UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:VAV:Reheat"))
+                    GetHVACSingleDuctSysIndex(DisSysCompTermUnitData(i).Name,
+                                              n,
+                                              LocalError,
+                                              "AirflowNetwork:Distribution:Component:TerminalUnit",
+                                              DisSysCompTermUnitData(i).DamperInletNode,
+                                              DisSysCompTermUnitData(i).DamperOutletNode);
+                if (LocalError) ErrorsFound = true;
+                if (VAVSystem) {
+                    for (j = 1; j <= DisSysNumOfCVFs; j++) {
+                        if (DisSysCompCVFData(j).FanTypeNum == FanType_SimpleVAV) {
+                            if (DisSysCompCVFData(j).AirLoopNum == DisSysCompTermUnitData(i).AirLoopNum &&
+                                !UtilityRoutines::SameString(DisSysCompTermUnitData(i).EPlusType, "AirTerminal:SingleDuct:VAV:Reheat")) {
+                                ShowSevereError(RoutineName + CurrentModuleObject +
+                                                " Invalid terminal type for a VAV system = " + DisSysCompTermUnitData(i).Name);
+                                ShowContinueError("The input type = " + DisSysCompTermUnitData(i).EPlusType);
+                                ShowContinueError("A VAV system requires all terminal units with type = AirTerminal:SingleDuct:VAV:Reheat");
+                                ErrorsFound = true;
+                            }
+                        }
+                    }
+                }
+            } else {
+                ShowSevereError(RoutineName + "AIRFLOWNETWORK:DISTRIBUTION:COMPONENT TERMINAL UNIT: Invalid Terminal unit type = " +
+                                DisSysCompTermUnitData(i).Name);
+                ErrorsFound = true;
+            }
+        }
+
+        // Validate heat exchanger name and type
+        CurrentModuleObject = "AirflowNetwork:Distribution:Component:HeatExchanger";
+        for (i = 1; i <= DisSysNumOfHXs; ++i) {
+            {
+                auto const SELECT_CASE_var(UtilityRoutines::MakeUPPERCase(DisSysCompHXData(i).EPlusType));
+
+                if (SELECT_CASE_var == "HEATEXCHANGER:AIRTOAIR:FLATPLATE") {
+                    ValidateComponent("HeatExchanger:AirToAir:FlatPlate", DisSysCompHXData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    }
+
+                } else if (SELECT_CASE_var == "HEATEXCHANGER:AIRTOAIR:SENSIBLEANDLATENT") {
+                    ValidateComponent(
+                        "HeatExchanger:AirToAir:SensibleAndLatent", DisSysCompHXData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    }
+
+                } else if (SELECT_CASE_var == "HEATEXCHANGER:DESICCANT:BALANCEDFLOW") {
+                    ValidateComponent(
+                        "HeatExchanger:Desiccant:BalancedFlow", DisSysCompHXData(i).Name, IsNotOK, RoutineName + CurrentModuleObject);
+                    if (IsNotOK) {
+                        ErrorsFound = true;
+                    }
+
+                } else {
+                    ShowSevereError(RoutineName + CurrentModuleObject + " Invalid heat exchanger type = " + DisSysCompHXData(i).EPlusType);
+                    ErrorsFound = true;
+                }
+            }
+        }
+
+        // Assign supply and return connection
+        for (j = 1; j <= NumPrimaryAirSys; ++j) {
+            S1 = 0;
+            S2 = 0;
+            R1 = 0;
+            R2 = 0;
             for (i = 1; i <= AirflowNetworkNumOfNodes; ++i) {
-                if (AirflowNetworkNodeData(i).EPlusNodeNum == SplitterNodeNumbers(1)) {
-                    if (AirflowNetworkNodeData(i).EPlusTypeNum == 0) AirflowNetworkNodeData(i).EPlusTypeNum = EPlusTypeNum_SPI;
+                if (AirflowNetworkNodeData(i).EPlusNodeNum == AirToZoneNodeInfo(j).AirLoopSupplyNodeNum(1)) S1 = i;
+                if (AirflowNetworkNodeData(i).EPlusNodeNum == AirToZoneNodeInfo(j).ZoneEquipSupplyNodeNum(1)) S2 = i;
+                if (AirflowNetworkNodeData(i).EPlusNodeNum == AirToZoneNodeInfo(j).ZoneEquipReturnNodeNum(1)) R1 = i;
+                if (AirflowNetworkNodeData(i).EPlusNodeNum == AirToZoneNodeInfo(j).AirLoopReturnNodeNum(1)) R2 = i;
+            }
+            for (i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
+                if (AirflowNetworkLinkageData(i).NodeNums[0] == R1 && AirflowNetworkLinkageData(i).NodeNums[1] == R2) {
+                    AirflowNetworkLinkageData(i).ConnectionFlag = EPlusTypeNum_RCN;
                 }
-                for (j = 1; j <= SplitterNodeNumbers(2); ++j) {
-                    if (AirflowNetworkNodeData(i).EPlusNodeNum == SplitterNodeNumbers(j + 2)) {
-                        if (AirflowNetworkNodeData(i).EPlusTypeNum == 0) AirflowNetworkNodeData(i).EPlusTypeNum = EPlusTypeNum_SPO;
+                if (AirflowNetworkLinkageData(i).NodeNums[0] == S1 && AirflowNetworkLinkageData(i).NodeNums[1] == S2) {
+                    AirflowNetworkLinkageData(i).ConnectionFlag = EPlusTypeNum_SCN;
+                }
+            }
+        }
+
+        // Assign fan inlet and outlet node, and coil outlet
+        for (i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
+            j = AirflowNetworkLinkageData(i).CompNum;
+            if (AirflowNetworkCompData(j).CompTypeNum == CompTypeNum_CVF) {
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum == 0)
+                    AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum = EPlusTypeNum_FIN;
+                AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum = EPlusTypeNum_FOU;
+            }
+            if (AirflowNetworkCompData(j).EPlusTypeNum == EPlusTypeNum_COI) {
+                AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum = EPlusTypeNum_COU;
+            }
+            if (AirflowNetworkCompData(j).EPlusTypeNum == EPlusTypeNum_HEX) {
+                AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum = EPlusTypeNum_HXO;
+            }
+            if (AirflowNetworkCompData(j).CompTypeNum == CompTypeNum_TMU) {
+                if (DisSysCompTermUnitData(AirflowNetworkCompData(j).TypeNum).DamperInletNode > 0) {
+                    if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusNodeNum ==
+                            DisSysCompTermUnitData(AirflowNetworkCompData(j).TypeNum).DamperInletNode &&
+                        AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusNodeNum ==
+                            DisSysCompTermUnitData(AirflowNetworkCompData(j).TypeNum).DamperOutletNode) {
+                        AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum = EPlusTypeNum_DIN;
+                        AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum = EPlusTypeNum_DOU;
+                        AirflowNetworkLinkageData(i).VAVTermDamper = true;
                     }
                 }
             }
+        }
 
-            // Add additional output variables
-            if (DisSysNumOfCVFs > 1) {
-                bool OnOffFanFlag = false;
-                for (i = 1; i <= DisSysNumOfCVFs; i++) {
-                    if (DisSysCompCVFData(i).FanTypeNum == FanType_SimpleOnOff && !DisSysCompCVFData(i).FanModelFlag) {
+        // Validate the position of constant pressure drop component
+        CurrentModuleObject = "AirflowNetwork:Distribution:Component:ConstantPressureDrop";
+        for (i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
+            if (AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).CompTypeNum == CompTypeNum_CPD) {
+                for (j = 1; j <= AirflowNetworkNumOfLinks; ++j) {
+                    if (AirflowNetworkLinkageData(i).NodeNums[0] == AirflowNetworkLinkageData(j).NodeNums[1]) {
+                        if (AirflowNetworkCompData(AirflowNetworkLinkageData(j).CompNum).CompTypeNum != CompTypeNum_DWC) {
+                            ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName +
+                                            ')');
+                            ShowContinueError("must connect a duct component upstream and not " + AirflowNetworkLinkageData(j).Name);
+                            ErrorsFound = true;
+                        }
+                    }
+                }
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum == EPlusTypeNum_SPL) {
+                    ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
+                    ShowContinueError("does not allow a AirLoopHVAC:ZoneSplitter node = " +
+                                      AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).Name);
+                    ErrorsFound = true;
+                }
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum == EPlusTypeNum_SPL) {
+                    ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
+                    ShowContinueError("does not allow a AirLoopHVAC:ZoneSplitter node = " +
+                                      AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).Name);
+                    ErrorsFound = true;
+                }
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusTypeNum == EPlusTypeNum_MIX) {
+                    ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
+                    ShowContinueError("does not allow a AirLoopHVAC:ZoneMixer node = " +
+                                      AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).Name);
+                    ErrorsFound = true;
+                }
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusTypeNum == EPlusTypeNum_MIX) {
+                    ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
+                    ShowContinueError("does not allow a AirLoopHVAC:ZoneMixer node = " +
+                                      AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).Name);
+                    ErrorsFound = true;
+                }
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusNodeNum > 0) {
+                    ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
+                    ShowContinueError("does not allow to connect an EnergyPlus node = " +
+                                      AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).Name);
+                    ErrorsFound = true;
+                }
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusNodeNum > 0) {
+                    ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
+                    ShowContinueError("does not allow to connect an EnergyPlus node = " +
+                                      AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).Name);
+                    ErrorsFound = true;
+                }
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusZoneNum > 0) {
+                    ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
+                    ShowContinueError("does not allow to connect an EnergyPlus zone = " +
+                                      AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).Name);
+                    ErrorsFound = true;
+                }
+                if (AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusZoneNum > 0) {
+                    ShowSevereError(RoutineName + "An " + CurrentModuleObject + " object (" + AirflowNetworkLinkageData(i).CompName + ')');
+                    ShowContinueError("does not allow to connect an EnergyPlus zone = " +
+                                      AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).Name);
+                    ErrorsFound = true;
+                }
+            }
+        }
+
+        for (i = NumOfNodesMultiZone + 1; i <= AirflowNetworkNumOfNodes; ++i) {
+            if (AirflowNetworkNodeData(i).EPlusTypeNum == EPlusTypeNum_SPL) {
+                LocalError = false;
+                j = GetSplitterOutletNumber("", 1, LocalError);
+                SplitterNodeNumbers.allocate(j + 2);
+                SplitterNodeNumbers = GetSplitterNodeNumbers("", 1, LocalError);
+                if (LocalError) ErrorsFound = true;
+            }
+        }
+
+        // Assigning inlet and outlet nodes for a splitter
+        for (i = 1; i <= AirflowNetworkNumOfNodes; ++i) {
+            if (AirflowNetworkNodeData(i).EPlusNodeNum == SplitterNodeNumbers(1)) {
+                if (AirflowNetworkNodeData(i).EPlusTypeNum == 0) AirflowNetworkNodeData(i).EPlusTypeNum = EPlusTypeNum_SPI;
+            }
+            for (j = 1; j <= SplitterNodeNumbers(2); ++j) {
+                if (AirflowNetworkNodeData(i).EPlusNodeNum == SplitterNodeNumbers(j + 2)) {
+                    if (AirflowNetworkNodeData(i).EPlusTypeNum == 0) AirflowNetworkNodeData(i).EPlusTypeNum = EPlusTypeNum_SPO;
+                }
+            }
+        }
+
+        // Add additional output variables
+        if (DisSysNumOfCVFs > 1) {
+            bool OnOffFanFlag = false;
+            for (i = 1; i <= DisSysNumOfCVFs; i++) {
+                if (DisSysCompCVFData(i).FanTypeNum == FanType_SimpleOnOff && !DisSysCompCVFData(i).FanModelFlag) {
+                    OnOffFanFlag = true;
+                    break;
+                }
+                if (DisSysCompCVFData(i).FanModelFlag && DisSysCompCVFData(i).FanTypeNum == FanType_SimpleOnOff) {
+                    int fanIndex = HVACFan::getFanObjectVectorIndex(DisSysCompCVFData(i).Name);
+                    if ( HVACFan::fanObjs[fanIndex]->AirPathFlag) {
+                        DisSysCompCVFData(i).FanTypeNum = FanType_SimpleConstVolume;
+                    } else {
                         OnOffFanFlag = true;
                         break;
                     }
-                    if (DisSysCompCVFData(i).FanModelFlag && DisSysCompCVFData(i).FanTypeNum == FanType_SimpleOnOff) {
-                        int fanIndex = HVACFan::getFanObjectVectorIndex(DisSysCompCVFData(i).Name);
-                        if ( HVACFan::fanObjs[fanIndex]->AirPathFlag) {
-                            DisSysCompCVFData(i).FanTypeNum = FanType_SimpleConstVolume;
-                        } else {
-                            OnOffFanFlag = true;
-                            break;
+                }
+            }
+            if (OnOffFanFlag) {
+                for (j = 1; j <= AirflowNetworkNumOfZones; ++j) {
+                    if (!ZoneEquipConfig(AirflowNetworkNodeData(j).EPlusZoneNum).IsControlled) continue;
+                    for (i = 1; i <= DisSysNumOfCVFs; i++) {
+                        if (DisSysCompCVFData(i).AirLoopNum == AirflowNetworkNodeData(j).AirLoopNum &&
+                            DisSysCompCVFData(i).FanTypeNum != FanType_SimpleOnOff) {
+                            SetupOutputVariable("AFN Node Total Pressure",
+                                                OutputProcessor::Unit::Pa,
+                                                AirflowNetworkNodeSimu(j).PZ,
+                                                "System",
+                                                "Average",
+                                                AirflowNetworkNodeData(j).Name);
                         }
                     }
                 }
-                if (OnOffFanFlag) {
-                    for (j = 1; j <= AirflowNetworkNumOfZones; ++j) {
-                        if (!ZoneEquipConfig(AirflowNetworkNodeData(j).EPlusZoneNum).IsControlled) continue;
-                        for (i = 1; i <= DisSysNumOfCVFs; i++) {
-                            if (DisSysCompCVFData(i).AirLoopNum == AirflowNetworkNodeData(j).AirLoopNum &&
-                                DisSysCompCVFData(i).FanTypeNum != FanType_SimpleOnOff) {
-                                SetupOutputVariable("AFN Node Total Pressure",
-                                                    OutputProcessor::Unit::Pa,
-                                                    AirflowNetworkNodeSimu(j).PZ,
-                                                    "System",
-                                                    "Average",
-                                                    AirflowNetworkNodeData(j).Name);
-                            }
-                        }
-                    }
-                    for (i = 1; i <= NumOfLinksMultiZone; ++i) {
-                        if (!ZoneEquipConfig(AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusZoneNum).IsControlled) continue;
-                        for (j = 1; j <= DisSysNumOfCVFs; j++) {
-                            if (DisSysCompCVFData(j).AirLoopNum == AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).AirLoopNum &&
-                                DisSysCompCVFData(j).FanTypeNum != FanType_SimpleOnOff) {
-                                SetupOutputVariable("AFN Linkage Node 1 to Node 2 Mass Flow Rate",
-                                                    OutputProcessor::Unit::kg_s,
-                                                    AirflowNetworkLinkReport(i).FLOW,
-                                                    "System",
-                                                    "Average",
-                                                    AirflowNetworkLinkageData(i).Name);
-                                SetupOutputVariable("AFN Linkage Node 2 to Node 1 Mass Flow Rate",
-                                                    OutputProcessor::Unit::kg_s,
-                                                    AirflowNetworkLinkReport(i).FLOW2,
-                                                    "System",
-                                                    "Average",
-                                                    AirflowNetworkLinkageData(i).Name);
-                                SetupOutputVariable("AFN Linkage Node 1 to Node 2 Volume Flow Rate",
-                                                    OutputProcessor::Unit::m3_s,
-                                                    AirflowNetworkLinkReport(i).VolFLOW,
-                                                    "System",
-                                                    "Average",
-                                                    AirflowNetworkLinkageData(i).Name);
-                                SetupOutputVariable("AFN Linkage Node 2 to Node 1 Volume Flow Rate",
-                                                    OutputProcessor::Unit::m3_s,
-                                                    AirflowNetworkLinkReport(i).VolFLOW2,
-                                                    "System",
-                                                    "Average",
-                                                    AirflowNetworkLinkageData(i).Name);
-                                SetupOutputVariable("AFN Linkage Node 1 to Node 2 Pressure Difference",
-                                                    OutputProcessor::Unit::Pa,
-                                                    AirflowNetworkLinkSimu(i).DP,
-                                                    "System",
-                                                    "Average",
-                                                    AirflowNetworkLinkageData(i).Name);
-                            }
+                for (i = 1; i <= NumOfLinksMultiZone; ++i) {
+                    if (!ZoneEquipConfig(AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).EPlusZoneNum).IsControlled) continue;
+                    for (j = 1; j <= DisSysNumOfCVFs; j++) {
+                        if (DisSysCompCVFData(j).AirLoopNum == AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[0]).AirLoopNum &&
+                            DisSysCompCVFData(j).FanTypeNum != FanType_SimpleOnOff) {
+                            SetupOutputVariable("AFN Linkage Node 1 to Node 2 Mass Flow Rate",
+                                                OutputProcessor::Unit::kg_s,
+                                                AirflowNetworkLinkReport(i).FLOW,
+                                                "System",
+                                                "Average",
+                                                AirflowNetworkLinkageData(i).Name);
+                            SetupOutputVariable("AFN Linkage Node 2 to Node 1 Mass Flow Rate",
+                                                OutputProcessor::Unit::kg_s,
+                                                AirflowNetworkLinkReport(i).FLOW2,
+                                                "System",
+                                                "Average",
+                                                AirflowNetworkLinkageData(i).Name);
+                            SetupOutputVariable("AFN Linkage Node 1 to Node 2 Volume Flow Rate",
+                                                OutputProcessor::Unit::m3_s,
+                                                AirflowNetworkLinkReport(i).VolFLOW,
+                                                "System",
+                                                "Average",
+                                                AirflowNetworkLinkageData(i).Name);
+                            SetupOutputVariable("AFN Linkage Node 2 to Node 1 Volume Flow Rate",
+                                                OutputProcessor::Unit::m3_s,
+                                                AirflowNetworkLinkReport(i).VolFLOW2,
+                                                "System",
+                                                "Average",
+                                                AirflowNetworkLinkageData(i).Name);
+                            SetupOutputVariable("AFN Linkage Node 1 to Node 2 Pressure Difference",
+                                                OutputProcessor::Unit::Pa,
+                                                AirflowNetworkLinkSimu(i).DP,
+                                                "System",
+                                                "Average",
+                                                AirflowNetworkLinkageData(i).Name);
                         }
                     }
                 }
-            }
-            bool FanModelConstFlag = false;
-            for (i = 1; i <= DisSysNumOfCVFs; i++) {
-                if (DisSysCompCVFData(i).FanModelFlag) {
-                    int fanIndex = HVACFan::getFanObjectVectorIndex(DisSysCompCVFData(i).Name);
-                    if (DisSysCompCVFData(i).FanTypeNum == FanType_SimpleOnOff && HVACFan::fanObjs[fanIndex]->AirPathFlag) {
-                        DisSysCompCVFData(i).FanTypeNum = FanType_SimpleConstVolume;
-                        SupplyFanType = FanType_SimpleConstVolume;
-                        FanModelConstFlag = true;
-                        break;
-                    }
-                }
-            }
-            if (FanModelConstFlag) {
-                for (i = 1; i <= AirflowNetworkNumOfSurfaces; ++i) {
-                    if (SupplyFanType == FanType_SimpleConstVolume) {
-                        SetupOutputVariable("AFN Linkage Node 1 to Node 2 Mass Flow Rate",
-                            OutputProcessor::Unit::kg_s,
-                            AirflowNetworkLinkReport(i).FLOW,
-                            "System",
-                            "Average",
-                            AirflowNetworkLinkageData(i).Name);
-                        SetupOutputVariable("AFN Linkage Node 2 to Node 1 Mass Flow Rate",
-                            OutputProcessor::Unit::kg_s,
-                            AirflowNetworkLinkReport(i).FLOW2,
-                            "System",
-                            "Average",
-                            AirflowNetworkLinkageData(i).Name);
-                        SetupOutputVariable("AFN Linkage Node 1 to Node 2 Volume Flow Rate",
-                            OutputProcessor::Unit::m3_s,
-                            AirflowNetworkLinkReport(i).VolFLOW,
-                            "System",
-                            "Average",
-                            AirflowNetworkLinkageData(i).Name);
-                        SetupOutputVariable("AFN Linkage Node 2 to Node 1 Volume Flow Rate",
-                            OutputProcessor::Unit::m3_s,
-                            AirflowNetworkLinkReport(i).VolFLOW2,
-                            "System",
-                            "Average",
-                            AirflowNetworkLinkageData(i).Name);
-                        SetupOutputVariable("AFN Linkage Node 1 to Node 2 Pressure Difference",
-                            OutputProcessor::Unit::Pa,
-                            AirflowNetworkLinkSimu(i).DP,
-                            "System",
-                            "Average",
-                            AirflowNetworkLinkageData(i).Name);
-                    }
-                }
-            }
-
-            // Add AirLoopNum to pressure control object
-            for (i = 1; i <= NumOfPressureControllers; ++i) {
-                for (j = 1; j <= NumOfZones; ++j) {
-                    if (PressureControllerData(i).ZoneNum == j) {
-                        for (k = 1; k <= ZoneEquipConfig(j).NumInletNodes; ++k) {
-                            if (ZoneEquipConfig(j).InletNodeAirLoopNum(k) > 0) {
-                                PressureControllerData(i).AirLoopNum = ZoneEquipConfig(j).InletNodeAirLoopNum(k);
-                                if (PressureControllerData(i).ControlTypeSet == PressureCtrlRelief) {
-                                    PressureControllerData(i).OANodeNum = PrimaryAirSystem(PressureControllerData(i).AirLoopNum).OAMixOAInNodeNum;
-                                    for (n = 1; n <= NumOfReliefFans; ++n) {
-                                        if (DisSysCompReliefAirData(n).OutletNode == PressureControllerData(i).OANodeNum) {
-                                            DisSysCompReliefAirData(n).PressCtrlNum = i;
-                                        }
-                                    }
-                                }
-                                if (PressureControllerData(i).ControlTypeSet == PressureCtrlExhaust) {
-                                    PressureControllerData(i).OANodeNum = ZoneEquipConfig(PressureControllerData(i).ZoneNum).ExhaustNode(1);
-                                    for (n = 1; n <= AirflowNetworkNumOfExhFan; ++n) {
-                                        if (MultizoneCompExhaustFanData(n).EPlusZoneNum == PressureControllerData(i).ZoneNum) {
-                                            MultizoneCompExhaustFanData(n).PressCtrlNum = i;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Check number of fans specified in an AirLoop #6748
-            int BranchNum;
-            int CompNum;
-            int NumOfFans;
-            std::string FanNames;
-            for (BranchNum = 1; BranchNum <= PrimaryAirSystem(1).NumBranches; ++BranchNum) {
-                NumOfFans = 0;
-                FanNames = "";
-                for (CompNum = 1; CompNum <= PrimaryAirSystem(1).Branch(BranchNum).TotalComponents; ++CompNum) {
-                    if (UtilityRoutines::SameString(PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).TypeOf, "Fan:ConstantVolume") ||
-                        UtilityRoutines::SameString(PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).TypeOf, "Fan:OnOff") ||
-                        UtilityRoutines::SameString(PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).TypeOf, "Fan:VariableVolume")) {
-                        NumOfFans++;
-                        if (NumOfFans > 1) {
-                            FanNames += PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).Name;
-                            break;
-                        } else {
-                            FanNames += PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).Name + ",";
-                        }
-                    }
-                }
-                if (NumOfFans > 1) break;
-            }
-            if (NumOfFans > 1) {
-                ShowSevereError(RoutineName + "An AirLoop branch, " + PrimaryAirSystem(1).Branch(BranchNum).Name +
-                                ", has two or more fans: " + FanNames);
-                ShowContinueError(
-                    "The AirflowNetwork model allows a single supply fan in an AirLoop only. Please make changes in the input file accordingly.");
-                ErrorsFound = true;
-            }
-
-            OneTimeFlag = false;
-            if (ErrorsFound) {
-                ShowFatalError(RoutineName + "Program terminates for preceding reason(s).");
             }
         }
+        bool FanModelConstFlag = false;
+        for (i = 1; i <= DisSysNumOfCVFs; i++) {
+            if (DisSysCompCVFData(i).FanModelFlag) {
+                int fanIndex = HVACFan::getFanObjectVectorIndex(DisSysCompCVFData(i).Name);
+                if (DisSysCompCVFData(i).FanTypeNum == FanType_SimpleOnOff && HVACFan::fanObjs[fanIndex]->AirPathFlag) {
+                    DisSysCompCVFData(i).FanTypeNum = FanType_SimpleConstVolume;
+                    SupplyFanType = FanType_SimpleConstVolume;
+                    FanModelConstFlag = true;
+                    break;
+                }
+            }
+        }
+        if (FanModelConstFlag) {
+            for (i = 1; i <= AirflowNetworkNumOfSurfaces; ++i) {
+                if (SupplyFanType == FanType_SimpleConstVolume) {
+                    SetupOutputVariable("AFN Linkage Node 1 to Node 2 Mass Flow Rate",
+                        OutputProcessor::Unit::kg_s,
+                        AirflowNetworkLinkReport(i).FLOW,
+                        "System",
+                        "Average",
+                        AirflowNetworkLinkageData(i).Name);
+                    SetupOutputVariable("AFN Linkage Node 2 to Node 1 Mass Flow Rate",
+                        OutputProcessor::Unit::kg_s,
+                        AirflowNetworkLinkReport(i).FLOW2,
+                        "System",
+                        "Average",
+                        AirflowNetworkLinkageData(i).Name);
+                    SetupOutputVariable("AFN Linkage Node 1 to Node 2 Volume Flow Rate",
+                        OutputProcessor::Unit::m3_s,
+                        AirflowNetworkLinkReport(i).VolFLOW,
+                        "System",
+                        "Average",
+                        AirflowNetworkLinkageData(i).Name);
+                    SetupOutputVariable("AFN Linkage Node 2 to Node 1 Volume Flow Rate",
+                        OutputProcessor::Unit::m3_s,
+                        AirflowNetworkLinkReport(i).VolFLOW2,
+                        "System",
+                        "Average",
+                        AirflowNetworkLinkageData(i).Name);
+                    SetupOutputVariable("AFN Linkage Node 1 to Node 2 Pressure Difference",
+                        OutputProcessor::Unit::Pa,
+                        AirflowNetworkLinkSimu(i).DP,
+                        "System",
+                        "Average",
+                        AirflowNetworkLinkageData(i).Name);
+                }
+            }
+        }
+
+        // Add AirLoopNum to pressure control object
+        for (i = 1; i <= NumOfPressureControllers; ++i) {
+            for (j = 1; j <= NumOfZones; ++j) {
+                if (PressureControllerData(i).ZoneNum == j) {
+                    for (k = 1; k <= ZoneEquipConfig(j).NumInletNodes; ++k) {
+                        if (ZoneEquipConfig(j).InletNodeAirLoopNum(k) > 0) {
+                            PressureControllerData(i).AirLoopNum = ZoneEquipConfig(j).InletNodeAirLoopNum(k);
+                            if (PressureControllerData(i).ControlTypeSet == PressureCtrlRelief) {
+                                PressureControllerData(i).OANodeNum = PrimaryAirSystem(PressureControllerData(i).AirLoopNum).OAMixOAInNodeNum;
+                                for (n = 1; n <= NumOfReliefFans; ++n) {
+                                    if (DisSysCompReliefAirData(n).OutletNode == PressureControllerData(i).OANodeNum) {
+                                        DisSysCompReliefAirData(n).PressCtrlNum = i;
+                                    }
+                                }
+                            }
+                            if (PressureControllerData(i).ControlTypeSet == PressureCtrlExhaust) {
+                                PressureControllerData(i).OANodeNum = ZoneEquipConfig(PressureControllerData(i).ZoneNum).ExhaustNode(1);
+                                for (n = 1; n <= AirflowNetworkNumOfExhFan; ++n) {
+                                    if (MultizoneCompExhaustFanData(n).EPlusZoneNum == PressureControllerData(i).ZoneNum) {
+                                        MultizoneCompExhaustFanData(n).PressCtrlNum = i;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check number of fans specified in an AirLoop #6748
+        int BranchNum;
+        int CompNum;
+        int NumOfFans;
+        std::string FanNames;
+        for (BranchNum = 1; BranchNum <= PrimaryAirSystem(1).NumBranches; ++BranchNum) {
+            NumOfFans = 0;
+            FanNames = "";
+            for (CompNum = 1; CompNum <= PrimaryAirSystem(1).Branch(BranchNum).TotalComponents; ++CompNum) {
+                if (UtilityRoutines::SameString(PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).TypeOf, "Fan:ConstantVolume") ||
+                    UtilityRoutines::SameString(PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).TypeOf, "Fan:OnOff") ||
+                    UtilityRoutines::SameString(PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).TypeOf, "Fan:VariableVolume")) {
+                    NumOfFans++;
+                    if (NumOfFans > 1) {
+                        FanNames += PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).Name;
+                        break;
+                    } else {
+                        FanNames += PrimaryAirSystem(1).Branch(BranchNum).Comp(CompNum).Name + ",";
+                    }
+                }
+            }
+            if (NumOfFans > 1) break;
+        }
+        if (NumOfFans > 1) {
+            ShowSevereError(RoutineName + "An AirLoop branch, " + PrimaryAirSystem(1).Branch(BranchNum).Name +
+                            ", has two or more fans: " + FanNames);
+            ShowContinueError(
+                "The AirflowNetwork model allows a single supply fan in an AirLoop only. Please make changes in the input file accordingly.");
+            ErrorsFound = true;
+        }
+
+        if (ErrorsFound) {
+            ShowFatalError(RoutineName + "Program terminates for preceding reason(s).");
+        }
+
+    }
+
+    void ValidateFanFlowRate() {
+
+        int i;
+        int j;
+        int k;
+        Real64 FanFlow;
 
         // Catch a fan flow rate from EPlus input file and add a flag for VAV terminal damper
         for (i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
@@ -10573,7 +10592,7 @@ namespace AirflowNetworkBalanceManager {
             if (ErrorsFound) {
                 ShowFatalError(RoutineName + "Program terminates for preceding reason(s).");
             }
-        }
+        } // End if OneTimeFlag
     }
 
     void HybridVentilationControl()

--- a/src/EnergyPlus/AirflowNetworkBalanceManager.cc
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.cc
@@ -10442,25 +10442,21 @@ namespace AirflowNetworkBalanceManager {
 
     void ValidateFanFlowRate() {
 
-        int i;
-        int j;
-        int k;
-        Real64 FanFlow;
-
         // Catch a fan flow rate from EPlus input file and add a flag for VAV terminal damper
-        for (i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
+        for (int i = 1; i <= AirflowNetworkNumOfLinks; ++i) {
             {
                 auto const SELECT_CASE_var(AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).CompTypeNum);
                 if (SELECT_CASE_var == CompTypeNum_CVF) { // 'CVF'
-                    j = AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusNodeNum;
-                    k = AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum;
-                    FanFlow = Node(j).MassFlowRate;
-                    if (DisSysCompCVFData(k).FanTypeNum == FanType_SimpleVAV) {
-                        if (DisSysCompCVFData(k).FanModelFlag) {
-                            DisSysCompCVFData(k).MaxAirMassFlowRate = HVACFan::fanObjs[DisSysCompCVFData(k).FanIndex]->designAirVolFlowRate * StdRhoAir;
+                    int nodeNum = AirflowNetworkNodeData(AirflowNetworkLinkageData(i).NodeNums[1]).EPlusNodeNum;
+                    int typeNum = AirflowNetworkCompData(AirflowNetworkLinkageData(i).CompNum).TypeNum;
+                    // Will potentially be passed by ref to Fans::GetFanVolFlow so make a copy instead of using a ref
+                    Real64 FanFlow = Node(nodeNum).MassFlowRate;
+                    if (DisSysCompCVFData(typeNum).FanTypeNum == FanType_SimpleVAV) {
+                        if (DisSysCompCVFData(typeNum).FanModelFlag) {
+                            DisSysCompCVFData(typeNum).MaxAirMassFlowRate = HVACFan::fanObjs[DisSysCompCVFData(typeNum).FanIndex]->designAirVolFlowRate * StdRhoAir;
                         } else {
-                            GetFanVolFlow(DisSysCompCVFData(k).FanIndex, FanFlow);
-                            DisSysCompCVFData(k).MaxAirMassFlowRate = FanFlow * StdRhoAir;
+                            GetFanVolFlow(DisSysCompCVFData(typeNum).FanIndex, FanFlow);
+                            DisSysCompCVFData(typeNum).MaxAirMassFlowRate = FanFlow * StdRhoAir;
                         }
                     }
                 } else if (SELECT_CASE_var == CompTypeNum_FAN) { //'FAN'

--- a/src/EnergyPlus/AirflowNetworkBalanceManager.hh
+++ b/src/EnergyPlus/AirflowNetworkBalanceManager.hh
@@ -228,6 +228,8 @@ namespace AirflowNetworkBalanceManager {
 
     void ValidateDistributionSystem();
 
+    void ValidateFanFlowRate(); // Catch a fan flow rate from EPlus input file and add a flag for VAV terminal damper
+
     void ValidateExhaustFanInput();
 
     void HybridVentilationControl();


### PR DESCRIPTION
Pull request overview
---------------------

Following up on this comment: https://github.com/NREL/EnergyPlus/pull/7338#issuecomment-513941939, the unit tests will fail to run serially after adding a few in #7338 because there is OneTimeFlag that isn't being reset.

This PR aims to address this by putting the OneTimeFlag is an anynomous namespace at the global level (so you cannot access it / reset it outside of this modules) and have it being reset in the `AirflowNetworkBalanceManager::clear_state` function.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
