### PR TITLE
Added Ability to Report Interior Moveable Insulation Inside Face Surface Temperature

### DIFF
--- a/doc/engineering-reference/src/surface-heat-balance-manager-processes/surface-heat-balance-with-moveable-insulation.tex
+++ b/doc/engineering-reference/src/surface-heat-balance-manager-processes/surface-heat-balance-with-moveable-insulation.tex
@@ -1,13 +1,90 @@
-\section{Surface Heat Balance With Moveable Insulation}\label{surface-heat-balance-with-moveable-insulation}
+\section{Surface Heat Balances With Moveable Insulation}\label{surface-heat-balances-with-moveable-insulation}
 
-\subsection{Basic Heat Balance Cases}\label{basic-heat-balance-cases}
+In EnergyPlus, moveable insulation can be present either on the interior or exterior side of a particular construction. Different heat balances are impacted depending on the location of the moveable insulation.  Having moveable insulation on the interior side results in a modified form of the inside surface heat balance equation.  Having moveable insulation on the exterior side results in different cases for the outside surface heat balance.  Information on the modeling equations for each of these types of moveable insulation are shown in the next several sections.
 
-A heat balance must exist at the outside surface-air interface. The incoming conductive, convective, and radiative fluxes must sum up to zero:
+\subsection{Inside Heat Balance with Interior Moveable Insulation}\label{inside-heat-balance-with-interior-moveable-insulation}
+
+There are two different heat balances which must be maintained to model interior moveable insulation.  At both the interface between the zone air and the moveable insulation and the interface between the moveable insulation and the surface (wall, roof, etc.), the following general heat balance must be maintained:
 
 \begin{equation}
 Conductive + Convective + Radiative = 0
 \label{eq:BasicSteadyStateHeatBalanceEquation}
 \end{equation}
+
+One significant complication of the inside heat balance is the fact that surfaces within the same zone can interact with each other radiatively.  This means that a solution for all surface temperatures must be done at the same time to maintain a radiation heat balance among the surfaces.  This requires some iteration of the inside surface heat balance as will be seen in the equations that are shown later in this subsection.
+
+Another complication of the inside heat balance relates to the presense of moveable insulation.  When moveable insulation is present, a second heat balance equation is required to determine the temperature at both the air-moveable insulation interface as well as the moveable insulation-surface interface.  This sets up a system of two equations with two unknowns: the temperatures at the air-moveable insulation interface and the moveable insulation-surface interface.
+
+Applying the basic steady state heat balance equation at each of these interfaces results in the following two equations:
+
+\begin{equation}
+H_c \cdot \left( T_a - T_{mi} \right) + Q_{lw} + H_{mi} \cdot  \left( T_i - T_{mi} \right) + I_t \cdot  \left( T_{old} - T_{mi} \right) = 0
+\label{eq:InsideHBAirMovInsInterface}
+\end{equation}
+
+\begin{equation}
+H_{mi} \cdot \left( T_{mi} - T_i \right) + Q_{sw} + Q_{cond} = 0
+\label{eq:InsideHBMovInsSurfInterface}
+\end{equation}
+
+where:
+
+\(H_c\) is the convective heat transfer coefficient between the moveable insulation and the air
+
+\(T_a\) is the zone air temperature
+
+\(T_{mi}\) is the temperature at the interface between the air and the moveable insulation
+
+\(Q_{lw}\) is the long wavelength radiation incident on the interface between the air and the moveable insulation
+
+\(H_{mi}\) is the U-value of the moveable insulation material
+
+\(T_i\) is the temperature at the interface between the moveable insulation and the surface
+
+\(I_t\) is a damping constant for iterating to achieve a stable radiant exchange between zone surfaces
+
+\(T_{old}\) is the previous surface temperature at the last solution iteration
+
+\(Q_{sw}\) is the short wavelength radiation incident on the interface between the moveable insulation and the surface
+
+\(Q_{cond}\) is the conduction heat transfer through the surface.
+
+Equation~\ref{eq:InsideHBAirMovInsInterface} is the heat balance at the air-moveable insulation interface and can be rearranged to solve for the temperature at this interface, T\(_{mi}\).  Equation~\ref{eq:InsideHBMovInsSurfInterface} is the heat balance at the moveable insulation-surface interface and provides a second equation for T\(_{mi}\).  Both equations leave T\(_{mi}\) as a function of T\(_{i}\) and other known quantities as shown below.
+
+It should be noted that there are some assumptions built into these equations.  First, all long wavelength radiation whether from other surfaces or other elements (such as heat sources which add radiation to the zone) is all assumed to be incident at and influence the air-moveable insulation interface.  This also means that no long wavelength radiation is transmitted through the moveable insulation to the moveable insulation-surface interface.  Second, all short wavelength radiation is assumed to be transmitted through the moveable insulation to the moveable-insulation interface.  This is a simplification that is consistent with transparent insulation and assumes that the moveable insulation material itself does not absorb any short wavelength as it passes through it.  Third, the term Q\(_{cond}\) includes several terms that all relate to the method for calculating heat conduction through the actual surface to which the moveable insulation is attached.  Finally, the moveable insulation material is sufficiently lightweight thermally that it has no thermal mass and it can be treated as an equivalent resistance.
+
+Equation~\ref{eq:InsideHBAirMovInsInterface} can be rearranged to obtain:
+
+\begin{equation}
+\left( H_c + H_{mi} + I_t \right) \cdot T_m = H_c \cdot T_a + H_m \cdot T_i + Q_{lw} + I_t \cdot T_{old}
+\label{eq:RearrangedHBAirMovIns}
+\end{equation}
+
+When Equation~\ref{eq:InsideHBMovInsSurfInterface} is rearranged to solve for \(T_m\) and this is substituted back into Equation~\ref{eq:RearrangedHBAirMovIns}, one obtains a single equation that allows for the solution of \(T_i\).  This can then be used to solve for \(T_{mi}\).
+
+The C++ code that is used to solve for \(T_i\) and \(T_{mi}\) for cases where moveable insulation is present on the interior side is shown below.
+
+\begin{lstlisting}
+F1 = HMovInsul / (HMovInsul + HConvIn_surf + IterDampConst);
+
+TempSurfIn(SurfNum) = (CTFConstInPart(SurfNum) + QRadSWInAbs(SurfNum) + construct.CTFCross(0) * TH11 +
+                       F1 * (QRadThermInAbs(SurfNum) + HConvIn_surf * RefAirTemp(SurfNum) +
+                       NetLWRadToSurf(SurfNum) + QHTRadSysSurf(SurfNum) +
+                       QCoolingPanelSurf(SurfNum) + QHWBaseboardSurf(SurfNum) +
+                       QSteamBaseboardSurf(SurfNum) + QElecBaseboardSurf(SurfNum) +
+                       QAdditionalHeatSourceInside(SurfNum) +
+                       IterDampConst * TempInsOld(SurfNum)))
+                       / (construct.CTFInside(0) + HMovInsul - F1 * HMovInsul); 
+
+TempSurfInTmp(SurfNum) = (construct.CTFInside(0) * TempSurfIn(SurfNum) + 
+                          HMovInsul * TempSurfIn(SurfNum) -
+                          QRadSWInAbs(SurfNum) - CTFConstInPart(SurfNum) -
+                          construct.CTFCross(0) * TH11) / (HMovInsul);
+\end{lstlisting}
+
+\subsection{Outside Heat Balance Cases for Exterior Moveable Insulation}\label{outside-heat-balance-cases-for-exterior-moveable-insulation}
+
+Just like at the inside surface-air interface, a heat balance must exist at the outside surface-air interface. The incoming conductive, convective, and radiative fluxes must sum up to zero as shown in Equation~\ref{eq:BasicSteadyStateHeatBalanceEquation}.
 
 In contrast to the internal surface heat balance that treats all surfaces simultaneously, the external thermal balance for each surface is performed independent of all other surfaces. This implies that there is no direct interaction between the individual surfaces.
 

--- a/doc/input-output-reference/src/overview/group-thermal-zone-description-geometry.tex
+++ b/doc/input-output-reference/src/overview/group-thermal-zone-description-geometry.tex
@@ -2403,6 +2403,7 @@ Additionally, the output variables applicable to all heat transfer surfaces:
 \begin{lstlisting}
 Zone,Sum,Surface Inside Face Heat Balance Calculation Iteration Count []
 Zone,Average,Surface Inside Face Temperature [C]
+Zone,Average,Surface Inside Face Interior Movable Insulation Temperature [C]
 Zone,Average,Surface Outside Face Temperature [C]
 Zone,Average,Surface Inside Face Adjacent Air Temperature [C]
 Zone,Average,Surface Inside Face Convection Heat Transfer Coefficient [W/m2-K]
@@ -2653,6 +2654,16 @@ This output is the number of iterations used in a part of the solution for surfa
 \subsubsection{Surface Inside Face Temperature {[}C{]}}\label{surface-inside-face-temperature-c}
 
 This is the temperature of the surface's inside face, in degrees Celsius. Former Name: Prior to version 7.1 this output was called Surface Inside Temperature.
+
+\subsubsection{Surface Inside Face Interior Movable Insulation Temperature {[}C{]}}\label{surface-inside-face-interior-movable-insulation-temperature-c}
+
+This is the temperature of movable insulation installed on the inside of the construction at the movable insulation's inside face (the one facing the zone), in degrees Celsius. This variable is only valid when the surface has movable insulation and the movable insulation is actually scheduled to be present.  For surfaces that have no movable insulation or the movable insulation is not scheduled to be present, the value of this variable is set to the Surface Inside Face Temperature.  It should be noted that users can limit how often this output variable is generating by using a schedule to control when this output is produced.  For example, this user could add the following syntax to an input file that includes movable insulation:
+
+\begin{lstlisting}
+  Output:Variable,Zone1:WestWall,Surface Inside Face Interior Movable Insulation Temperature,timestep,MovableInsulationSchedule;
+\end{lstlisting}
+
+In this example, interior movable insulation is used on the west wall of zone 1 and is only present when the schedule (MovableInsulationSchedule) is greater than zero.  Adding this output variable syntax to the input file reports the temperature at the inside face of the interior movable insulation only when the movable insulation is present.  The use of the movable insulation schedule in the output variable designation limits when this value shows up in the EnergyPlus output file to when it is actually scheduled to be present.  At other times, no value will be reported.  The limiting of when the output is generated allows the user to generate useful statistics instead of having those statistics influenced by values for when the movable insulation is not present.  If the user does not use the output variable schedule feature, the output for this variable will equal the surface inside face temperature when the movable insulation is not present.
 
 \subsubsection{Surface Outside Face Temperature {[}C{]}}\label{surface-outside-face-temperature-c}
 

--- a/src/EnergyPlus/DataHeatBalSurface.cc
+++ b/src/EnergyPlus/DataHeatBalSurface.cc
@@ -102,6 +102,7 @@ namespace DataHeatBalSurface {
     Array1D<Real64> TempSource;                   // Temperature at the source location for each heat transfer surface
     Array1D<Real64> TempUserLoc;                  // Temperature at the user specified location for each heat transfer surface
     Array1D<Real64> TempSurfInRep;                // Temperature of the Inside Surface for each heat transfer surface
+    Array1D<Real64> TempSurfInMovInsRep;          // Temperature of interior movable insulation on the side facing the zone
     // (report)
     Array1D<Real64> QConvInReport; // Surface convection heat gain at inside face [J]
     Array1D<Real64> QdotConvInRep; // Surface convection heat transfer rate at inside face surface [W]
@@ -273,6 +274,7 @@ namespace DataHeatBalSurface {
         TempSource.deallocate();
         TempUserLoc.deallocate();
         TempSurfInRep.deallocate();
+        TempSurfInMovInsRep.deallocate();
         QConvInReport.deallocate();
         QdotConvInRep.deallocate();
         QdotConvInRepPerArea.deallocate();

--- a/src/EnergyPlus/DataHeatBalSurface.hh
+++ b/src/EnergyPlus/DataHeatBalSurface.hh
@@ -89,6 +89,7 @@ namespace DataHeatBalSurface {
     extern Array1D<Real64> TempSource;            // Temperature at the source location for each heat transfer surface
     extern Array1D<Real64> TempUserLoc;           // Temperature at the user specified location for each heat transfer surface
     extern Array1D<Real64> TempSurfInRep;         // Temperature of the Inside Surface for each heat transfer surface
+    extern Array1D<Real64> TempSurfInMovInsRep;   // Temperature of interior movable insulation on the side facing the zone
     // (report)
     extern Array1D<Real64> QConvInReport; // Surface convection heat gain at inside face [J]
     extern Array1D<Real64> QdotConvInRep; // Surface convection heat transfer rate at inside face surface [W]

--- a/src/EnergyPlus/HeatBalanceSurfaceManager.cc
+++ b/src/EnergyPlus/HeatBalanceSurfaceManager.cc
@@ -1376,6 +1376,7 @@ namespace HeatBalanceSurfaceManager {
         TH.dimension(2, MaxCTFTerms, TotSurfaces, 0.0);
         TempSurfOut.dimension(TotSurfaces, 0.0);
         TempSurfInRep.dimension(TotSurfaces, 0.0);
+        TempSurfInMovInsRep.dimension(TotSurfaces, 0.0);
         QConvInReport.dimension(TotSurfaces, 0.0);
         QdotConvInRepPerArea.dimension(TotSurfaces, 0.0);
         QdotConvInRep.dimension(TotSurfaces, 0.0);
@@ -1498,6 +1499,8 @@ namespace HeatBalanceSurfaceManager {
             if (!Surface(loop).HeatTransSurf) continue;
             SetupOutputVariable(
                 "Surface Inside Face Temperature", OutputProcessor::Unit::C, TempSurfInRep(loop), "Zone", "State", Surface(loop).Name);
+            SetupOutputVariable(
+                "Surface Inside Face Interior Movable Insulation Temperature", OutputProcessor::Unit::C, TempSurfInMovInsRep(loop), "Zone", "State", Surface(loop).Name);
 
             if (Surface(loop).ExtBoundCond != KivaFoundation) {
                 SetupOutputVariable(
@@ -2063,6 +2066,7 @@ namespace HeatBalanceSurfaceManager {
         HGrdExtSurf = 0.0;
         TempSurfOut = 0.0;
         TempSurfInRep = 0.0;
+        TempSurfInMovInsRep = 0.0;
         QConvInReport = 0.0;
         QdotConvInRep = 0.0;
         QdotConvInRepPerArea = 0.0;
@@ -5105,6 +5109,18 @@ namespace HeatBalanceSurfaceManager {
         } // loop over zones
     }
 
+    void ReportIntMovInsInsideSurfTemp()
+    {
+        int SurfNum;
+        TempSurfInMovInsRep = TempSurfIn;
+        for (SurfNum = 1; SurfNum <= TotSurfaces; ++SurfNum) {
+            if (Surface(SurfNum).MaterialMovInsulInt > 0) {
+                if (GetCurrentScheduleValue(Surface(SurfNum).SchedMovInsulInt) > 0.0) {
+                    TempSurfInMovInsRep(SurfNum) = TempSurfInTmp(SurfNum);
+                }
+            }
+        }
+    }
     // End of Reporting subroutines for the HB Module
     // *****************************************************************************
 
@@ -6726,6 +6742,8 @@ namespace HeatBalanceSurfaceManager {
             }
         }
 
+        ReportIntMovInsInsideSurfTemp();
+        
         CalculateZoneMRT(ZoneToResimulate); // Update here so that the proper value of MRT is available to radiant systems
     }
 

--- a/src/EnergyPlus/HeatBalanceSurfaceManager.hh
+++ b/src/EnergyPlus/HeatBalanceSurfaceManager.hh
@@ -140,6 +140,8 @@ namespace HeatBalanceSurfaceManager {
     // *****************************************************************************
 
     void ReportSurfaceHeatBalance();
+    
+    void ReportIntMovInsInsideSurfTemp();
 
     // End of Reporting subroutines for the HB Module
     // *****************************************************************************

--- a/testfiles/MovableIntInsulationSimple.idf
+++ b/testfiles/MovableIntInsulationSimple.idf
@@ -497,6 +497,8 @@
 
   Output:Variable,*,Surface Inside Face Temperature,timestep;
 
+  Output:Variable,Zn001:Wall001,Surface Inside Face Interior Movable Insulation Temperature,timestep;
+
   Output:Variable,*,Surface Outside Face Temperature,timestep;
 
   Output:VariableDictionary,Regular;

--- a/tst/EnergyPlus/unit/HeatBalanceSurfaceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceSurfaceManager.unit.cc
@@ -2488,4 +2488,52 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfTempCalcHeatBalanceA
     DataHeatBalance::ZoneWinHeatGainRepEnergy.deallocate();
 }
 
+TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestReportIntMovInsInsideSurfTemp)
+{
+    
+    Real64 ExpectedResult1;
+    Real64 ExpectedResult2;
+    Real64 ExpectedResult3;
+
+    DataSurfaces::clear_state();
+    DataHeatBalSurface::clear_state();
+    
+    DataSurfaces::TotSurfaces = 3;
+    DataSurfaces::Surface.allocate(DataSurfaces::TotSurfaces);
+    DataHeatBalSurface::TempSurfIn.allocate(DataSurfaces::TotSurfaces);
+    DataHeatBalSurface::TempSurfInTmp.allocate(DataSurfaces::TotSurfaces);
+    DataHeatBalSurface::TempSurfInMovInsRep.allocate(DataSurfaces::TotSurfaces);
+
+    // Test 1 Data: Surface does NOT have movable insulation
+    DataSurfaces::Surface(1).MaterialMovInsulInt = 0;   // No material means no movable insulation
+    DataSurfaces::Surface(1).SchedMovInsulInt = 0;      // Schedule index of zero returns zero value (not scheduled)
+    DataHeatBalSurface::TempSurfIn(1) = 23.0;
+    DataHeatBalSurface::TempSurfInTmp(1) = 12.3;
+    DataHeatBalSurface::TempSurfInMovInsRep(1) = 1.23;
+    ExpectedResult1 = 23.0;                             // TempSurfInMovInsRep should be set to TempSurfIn
+    
+    // Test 2 Data: Surface does have movable insulation but it is scheduled OFF
+    DataSurfaces::Surface(2).MaterialMovInsulInt = 1;   // Material index present means there is movable insulation
+    DataSurfaces::Surface(2).SchedMovInsulInt = 0;      // Schedule index of zero returns zero value (not scheduled)
+    DataHeatBalSurface::TempSurfIn(2) = 123.0;
+    DataHeatBalSurface::TempSurfInTmp(2) = 12.3;
+    DataHeatBalSurface::TempSurfInMovInsRep(2) = 1.23;
+    ExpectedResult2 = 123.0;                             // TempSurfInMovInsRep should be set to TempSurfIn
+    
+    // Test 3 Data: Surface does have movable insulation and it is scheduled ON
+    DataSurfaces::Surface(3).MaterialMovInsulInt = 1;   // Material index present means there is movable insulation
+    DataSurfaces::Surface(3).SchedMovInsulInt = -1;     // Schedule index of -1 returns 1.0 value
+    DataHeatBalSurface::TempSurfIn(3) = 12.3;
+    DataHeatBalSurface::TempSurfInTmp(3) = 1.23;
+    DataHeatBalSurface::TempSurfInMovInsRep(3) = -9999.9;
+    ExpectedResult3 = 1.23;                             // TempSurfInMovInsRep should be set to TempSurfInTmp
+
+    // Now call the subroutine which will run all of the test cases at once and then make the comparisons
+    HeatBalanceSurfaceManager::ReportIntMovInsInsideSurfTemp();
+    EXPECT_NEAR(DataHeatBalSurface::TempSurfInMovInsRep(1),ExpectedResult1,0.00001);
+    EXPECT_NEAR(DataHeatBalSurface::TempSurfInMovInsRep(2),ExpectedResult2,0.00001);
+    EXPECT_NEAR(DataHeatBalSurface::TempSurfInMovInsRep(3),ExpectedResult3,0.00001);
+    
+}
+    
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------
When choosing interior movable insulation, there is a temperature calculated at the interface between the zone air and the interior moveable insulation as well as a temperature at the interface between the interior moveable insulation and the actual surface itself.  When the user requests the inside face temperature, they receive the temperature at the interface between the moveable insulation and the surface.  This work added the capability to also report the temperature at the interface between the zone air and the moveable insulation.  This work resolves #4432
### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue #4432 

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces