### PR TITLE
Schedules which change pattern during Daylight Savings Time cause incorrect results at hour 23

### DIFF
--- a/src/EnergyPlus/ScheduleManager.cc
+++ b/src/EnergyPlus/ScheduleManager.cc
@@ -2833,30 +2833,35 @@ namespace ScheduleManager {
 
         for (ScheduleIndex = 1; ScheduleIndex <= NumSchedules; ++ScheduleIndex) {
 
-            // Determine which Week Schedule is used
-            //  Cant use stored day of year because of leap year inconsistency
-            WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule);
-
-            // Now, which day?
-            if (DayOfWeek <= 7 && HolidayIndex > 0) {
-                DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+            if (Schedule(ScheduleIndex).EMSActuatedOn) {
+                Schedule(ScheduleIndex).CurrentValue = Schedule(ScheduleIndex).EMSValue;
             } else {
-                DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
-            }
-
-            // Hourly Value
-            if (WhichHour <= 24) {
-                Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour);
-            } else if (TimeStep <= NumOfTimeStepInHour) {
-                WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule + 1);
-                if (DayOfWeek <= 7 && HolidayIndex > 0) {
-                    DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                // Hourly Value
+                if (WhichHour <= 24) {
+                    WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule);
+                    if (DayOfWeek <= 7 && HolidayIndex > 0) {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                    } else {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                    }
+                    Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour);
+                } else if (TimeStep <= NumOfTimeStepInHour) {
+                    WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule + 1);
+                    if (DayOfWeek <= 7 && HolidayIndex > 0) {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                    } else {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                    }
+                    Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour - 24);
                 } else {
-                    DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                    WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule + 1);
+                    if (DayOfWeek <= 7 && HolidayIndex > 0) {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                    } else {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                    }
+                    Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(NumOfTimeStepInHour, WhichHour - 24);
                 }
-                Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour - 24);
-            } else {
-                Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(NumOfTimeStepInHour, WhichHour - 24);
             }
         }
     }
@@ -4976,34 +4981,36 @@ namespace ScheduleManager {
 
         WhichHour = HourOfDay + DSTIndicator;
         for (ScheduleIndex = 1; ScheduleIndex <= NumSchedules; ++ScheduleIndex) {
-            // Determine which Week Schedule is used
-            //  Cant use stored day of year because of leap year inconsistency
-            WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule);
-
-            // Now, which day?
-            if (DayOfWeek <= 7 && HolidayIndex > 0) {
-                DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
-            } else {
-                DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
-            }
-
-            // Hourly Value
-            if (WhichHour <= 24) {
-                Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour);
-            } else if (TimeStep <= NumOfTimeStepInHour) {
-                WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule + 1);
-                if (DayOfWeek <= 7 && HolidayIndex > 0) {
-                    DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
-                } else {
-                    DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
-                }
-                Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour - 24);
-            } else {
-                Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(NumOfTimeStepInHour, WhichHour - 24);
-            }
 
             if (Schedule(ScheduleIndex).EMSActuatedOn) {
                 Schedule(ScheduleIndex).CurrentValue = Schedule(ScheduleIndex).EMSValue;
+            } else {
+                // Hourly Value
+                if (WhichHour <= 24) {
+                    WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule);
+                    if (DayOfWeek <= 7 && HolidayIndex > 0) {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                    } else {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                    }
+                    Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour);
+                } else if (TimeStep <= NumOfTimeStepInHour) {
+                    WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule + 1);
+                    if (DayOfWeek <= 7 && HolidayIndex > 0) {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                    } else {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                    }
+                    Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour - 24);
+                } else {
+                    WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule + 1);
+                    if (DayOfWeek <= 7 && HolidayIndex > 0) {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                    } else {
+                        DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                    }
+                    Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(NumOfTimeStepInHour, WhichHour - 24);
+                }
             }
         }
     }

--- a/src/EnergyPlus/ScheduleManager.cc
+++ b/src/EnergyPlus/ScheduleManager.cc
@@ -2848,6 +2848,12 @@ namespace ScheduleManager {
             if (WhichHour <= 24) {
                 Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour);
             } else if (TimeStep <= NumOfTimeStepInHour) {
+                WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule + 1);
+                if (DayOfWeek <= 7 && HolidayIndex > 0) {
+                    DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                } else {
+                    DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                }
                 Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour - 24);
             } else {
                 Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(NumOfTimeStepInHour, WhichHour - 24);
@@ -4985,6 +4991,12 @@ namespace ScheduleManager {
             if (WhichHour <= 24) {
                 Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour);
             } else if (TimeStep <= NumOfTimeStepInHour) {
+                WeekSchedulePointer = Schedule(ScheduleIndex).WeekSchedulePointer(DayOfYear_Schedule + 1);
+                if (DayOfWeek <= 7 && HolidayIndex > 0) {
+                    DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(7 + HolidayIndex);
+                } else {
+                    DaySchedulePointer = WeekSchedule(WeekSchedulePointer).DaySchedulePointer(DayOfWeek);
+                }
                 Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(TimeStep, WhichHour - 24);
             } else {
                 Schedule(ScheduleIndex).CurrentValue = DaySchedule(DaySchedulePointer).TSValue(NumOfTimeStepInHour, WhichHour - 24);

--- a/tst/EnergyPlus/unit/ScheduleManager.unit.cc
+++ b/tst/EnergyPlus/unit/ScheduleManager.unit.cc
@@ -83,6 +83,97 @@ TEST_F(EnergyPlusFixture, ScheduleManager_isMinuteMultipleOfTimestep)
     EXPECT_FALSE(isMinuteMultipleOfTimestep(53, 12));
 }
 
+TEST_F(EnergyPlusFixture, ScheduleManager_UpdateScheduleValues)
+{
+
+    ScheduleInputProcessed = true;
+    DataEnvironment::DSTIndicator = 0;
+    ScheduleManager::NumSchedules = 1;
+    ScheduleManager::Schedule.allocate(1);
+    Schedule(1).WeekSchedulePointer.allocate(367);
+    WeekSchedule.allocate(3);
+    WeekSchedule(1).DaySchedulePointer.allocate(12);
+    WeekSchedule(2).DaySchedulePointer.allocate(12);
+    WeekSchedule(3).DaySchedulePointer.allocate(12);
+    DataGlobals::NumOfTimeStepInHour = 1;
+    DaySchedule.allocate(3);
+    DaySchedule(1).TSValue.allocate(1, 24);
+    DaySchedule(2).TSValue.allocate(1, 24);
+    DaySchedule(3).TSValue.allocate(1, 24);
+
+    for (int ScheduleIndex = 1; ScheduleIndex <= ScheduleManager::NumSchedules; ScheduleIndex++) {
+        for (int i = 1; i <= 366; i++) {
+            int x = 1;
+            if (i > 250) {
+                x = 3;
+            } else if (i > 249) {
+                x = 2;
+            }
+            Schedule(ScheduleIndex).WeekSchedulePointer(i) = x;
+        }
+    }
+    for (int WeekSchedulePointer = 1; WeekSchedulePointer <= 3; WeekSchedulePointer++) {
+        for (int dayOfWeek = 1; dayOfWeek <= 12; dayOfWeek++) {
+            int y = 1;
+            if (WeekSchedulePointer == 2) y = 2;
+            if (WeekSchedulePointer == 3) y = 3;
+            WeekSchedule(WeekSchedulePointer).DaySchedulePointer(dayOfWeek) = y;
+        }
+    }
+    for (int daySchedulePointer = 1; daySchedulePointer <= 3; daySchedulePointer++) {
+        for (int whichHour = 1; whichHour <= 24; whichHour++) {
+            Real64 schVal = 1.0;
+            if (daySchedulePointer == 2) schVal = 2.0;
+            if (daySchedulePointer == 3) schVal = 3.0;
+            DaySchedule(daySchedulePointer).TSValue(1, whichHour) = schVal;
+        }
+    }
+
+    DataEnvironment::HolidayIndex = 0;
+    DataEnvironment::DayOfWeek = 1;
+    DataGlobals::TimeStep = 1;
+    DataGlobals::HourOfDay = 1;
+
+    // check day schedules
+    EXPECT_EQ(DaySchedule(1).TSValue(1, 1), 1.0); // day < 250 points to this schedule
+    EXPECT_EQ(DaySchedule(1).TSValue(1, 24), 1.0);
+
+    EXPECT_EQ(DaySchedule(2).TSValue(1, 1), 2.0); // day = 250 points to this schedule
+    EXPECT_EQ(DaySchedule(2).TSValue(1, 24), 2.0);
+
+    EXPECT_EQ(DaySchedule(3).TSValue(1, 1), 3.0); // day > 250 points to this schedule
+    EXPECT_EQ(DaySchedule(3).TSValue(1, 24), 3.0);
+
+    // schedule values are 1 through day 249, 2 for day 250, and 3 for remainder of year
+    DataEnvironment::DayOfYear_Schedule = 1;
+    UpdateScheduleValues();
+    // expect 1.0 on day 1
+    EXPECT_EQ(Schedule(1).CurrentValue, 1.0);
+
+    DataEnvironment::DayOfYear_Schedule = 250;
+    UpdateScheduleValues();
+    // expect 2.0 on day 250
+    EXPECT_EQ(Schedule(1).CurrentValue, 2.0);
+
+    // test end of day 250 with daylight savings time active
+    DataGlobals::HourOfDay = 24;
+    DataEnvironment::DSTIndicator = 1;
+    UpdateScheduleValues();
+    // expect a 3 on day 251, which on day 250 at midnight with DST of hour 1 of day 251
+    EXPECT_EQ(Schedule(1).CurrentValue, 3.0);
+
+    DataGlobals::HourOfDay = 2;
+    DataEnvironment::DSTIndicator = 0;
+    DataEnvironment::DayOfYear_Schedule = 251;
+    UpdateScheduleValues();
+    // expect 3.0 for remainder of year regardless of DST
+    EXPECT_EQ(Schedule(1).CurrentValue, 3.0);
+    DataGlobals::HourOfDay = 24;
+    DataEnvironment::DSTIndicator = 1;
+    UpdateScheduleValues();
+    EXPECT_EQ(Schedule(1).CurrentValue, 3.0);
+}
+
 TEST_F(EnergyPlusFixture, ScheduleAnnualFullLoadHours_test)
 {
     // J.Glazer - August 2017


### PR DESCRIPTION
Pull request overview
---------------------
Fixes #5155. When a schedule is used when DST is active, the program will look at hour 1 of the schedule when time of day = 24. This change looks to the next day's schedule for hour 1.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
