### PR TITLE
ZoneHVAC:PackagedTerminalAirConditioner with autosized steam coil terminates with fatal error

### DIFF
--- a/src/EnergyPlus/BoilerSteam.cc
+++ b/src/EnergyPlus/BoilerSteam.cc
@@ -394,7 +394,7 @@ namespace BoilerSteam {
                 ErrorsFound = true;
             }
 
-            if (rNumericArgs(5) == 0.0) {
+            if (rNumericArgs(5) < 0.0) {
                 ShowSevereError(RoutineName + cCurrentModuleObject + "=\"" + cAlphaArgs(1) + "\",");
                 ShowContinueError("Invalid " + cNumericFieldNames(5) + '=' + RoundSigDigits(rNumericArgs(5), 3));
                 ErrorsFound = true;

--- a/tst/EnergyPlus/unit/PackagedTerminalHeatPump.unit.cc
+++ b/tst/EnergyPlus/unit/PackagedTerminalHeatPump.unit.cc
@@ -538,6 +538,8 @@ TEST_F(EnergyPlusFixture, PackagedTerminalHP_VSCoils_Sizing)
     Real64 OnOffAirFlowRatio(1.0); // ratio of compressor ON airflow to average airflow over timestep
     Real64 ZoneLoad(0.0);          // cooling or heating needed by zone [watts]
 
+    // Also set BeginEnvrnFlag so code is tested for coil initialization and does not crash
+    DataGlobals::BeginEnvrnFlag = true;
     InitPTUnit(1, DataSizing::CurZoneEqNum, true, OnOffAirFlowRatio, ZoneLoad);
 
     // check that an intermediate speed has the correct flow ratio


### PR DESCRIPTION
Pull request overview
---------------------
This fixes #7480. When a steam coil is used as the heating coil in ZoneHVAC:PackagedTerminalAirConditioner and the steam heating coil Max Steam Flow Rate is autosized, the simulation terminates with a fatal error that a water coil could not be found.

Work around: Manually size the steam coil Max Steam Flow Rate.

### Work Checklist
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] At least one of the following appropriate labels must be added to this PR to be consumed into the changelog:
   - Defect: This pull request repairs a github defect issue.  The github issue should be referenced in the PR description
   - Refactoring: This pull request includes code changes that don't change the functionality of the program, just perform refactoring
   - NewFeature: This pull request includes code to add a new feature to EnergyPlus
   - Performance: This pull request includes code changes that are directed at improving the runtime performance of EnergyPlus
   - DoNoPublish: This pull request includes changes that shouldn't be included in the changelog

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [ ] Functional code review (it has to work!)
 - [ ] If defect, results of running current develop vs this branch should exhibit the fix
 - [ ] CI status: all green or justified
 - [ ] Performance: CI Linux results include performance check
 - [ ] Unit Test(s)
 - C++ checks:
   - [ ] Argument types
   - [ ] If any virtual classes, ensure virtual destructor included, other things
 - IDD changes:
   - [ ] Verify naming conventions and styles, memos and notes and defaults
   - [ ] Open windows IDF Editor with modified IDD to check for errors
   - [ ] If transition, add to input rules file for interfaces
   - [ ] If transition, add transition source
   - [ ] If transition, update idfs
 - [ ] If new idf included, locally check the err file and other outputs
 - [ ] Required documentation updates?
 - [ ] ExpandObjects changes?
 - [ ] If output changes, including tabular output structure, add to output rules file for interfaces
