### PR TITLE
Input file conversion utility IDF->epJSON and reverse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,8 @@ if( BUILD_TESTING )
   endif()
 endif()
 
+ADD_SUBDIRECTORY(src/ConvertInputFormat)
+
 if( BUILD_FORTRAN )
   include(CMakeAddFortranSubdirectory)
   cmake_add_fortran_subdirectory(src/ExpandObjects PROJECT ExpandObjects NO_EXTERNAL_INSTALL )

--- a/scripts/Epl-run.bat
+++ b/scripts/Epl-run.bat
@@ -316,7 +316,7 @@ IF EXIST SLABSurfaceTemps.TXT COPY "%epout%.expidf"+SLABSurfaceTemps.TXT "%epout
 IF EXIST SLABSurfaceTemps.TXT DEL SLABSurfaceTemps.TXT
 
 :  4. Execute EnergyPlus
-"%program_path%EnergyPlus" -c
+"%program_path%EnergyPlus"
 if %pausing%==Y pause
 
 :  5. Copy Post Processing Program command file(s) to working directory

--- a/src/ConvertInputFormat/CMakeLists.txt
+++ b/src/ConvertInputFormat/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.5.1)
+project(convertinputformat)
+
+set(CMAKE_CXX_STANDARD 11)
+
+# Set the CFLAGS and CXXFLAGS depending on the options the user specified.
+# Only GCC-like compilers support -Wextra, and other compilers give tons of
+# output for -Wall, so only -Wall and -Wextra on GCC.
+if (CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic")
+endif (CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
+# Detect OpenMP support in a compiler. If the compiler supports OpenMP, the
+# flags to compile with OpenMP are returned and added.
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif (OPENMP_FOUND)
+
+if (UNIX)
+  ADD_DEFINITIONS("-fPIC")
+endif()
+
+if (APPLE OR UNIX)
+  add_executable( convertinputformat main.cpp )
+else()  # windows
+  add_executable( convertinputformat main.cpp ) #  "${CMAKE_CURRENT_BINARY_DIR}/energyplus.rc" )
+endif()
+
+target_link_libraries( convertinputformat energyplusparser )
+
+if(UNIX AND NOT APPLE)
+  target_link_libraries( convertinputformat dl )
+endif()
+
+if (WIN32)
+  target_link_libraries( convertinputformat Shlwapi )
+endif()
+
+set_target_properties(convertinputformat PROPERTIES VERSION ${ENERGYPLUS_VERSION})
+
+install( TARGETS convertinputformat DESTINATION ./ )

--- a/src/ConvertInputFormat/CMakeLists.txt
+++ b/src/ConvertInputFormat/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
-project(convertinputformat)
+project(ConvertInputFormat)
 
 set(CMAKE_CXX_STANDARD 11)
 
@@ -24,21 +24,21 @@ if (UNIX)
 endif()
 
 if (APPLE OR UNIX)
-  add_executable( convertinputformat main.cpp )
+  add_executable( ConvertInputFormat main.cpp )
 else()  # windows
-  add_executable( convertinputformat main.cpp ) #  "${CMAKE_CURRENT_BINARY_DIR}/energyplus.rc" )
+  add_executable( ConvertInputFormat main.cpp ) #  "${CMAKE_CURRENT_BINARY_DIR}/energyplus.rc" )
 endif()
 
-target_link_libraries( convertinputformat energyplusparser )
+target_link_libraries( ConvertInputFormat energyplusparser )
 
 if(UNIX AND NOT APPLE)
-  target_link_libraries( convertinputformat dl )
+  target_link_libraries( ConvertInputFormat dl )
 endif()
 
 if (WIN32)
-  target_link_libraries( convertinputformat Shlwapi )
+  target_link_libraries( ConvertInputFormat Shlwapi )
 endif()
 
-set_target_properties(convertinputformat PROPERTIES VERSION ${ENERGYPLUS_VERSION})
+set_target_properties(ConvertInputFormat PROPERTIES VERSION ${ENERGYPLUS_VERSION})
 
-install( TARGETS convertinputformat DESTINATION ./ )
+install( TARGETS ConvertInputFormat DESTINATION ./ )

--- a/src/ConvertInputFormat/main.cpp
+++ b/src/ConvertInputFormat/main.cpp
@@ -1,0 +1,504 @@
+// EnergyPlus, Copyright (c) 1996-2019, The Board of Trustees of the University of Illinois,
+// The Regents of the University of California, through Lawrence Berkeley National Laboratory
+// (subject to receipt of any required approvals from the U.S. Dept. of Energy), Oak Ridge
+// National Laboratory, managed by UT-Battelle, Alliance for Sustainable Energy, LLC, and other
+// contributors. All rights reserved.
+//
+// NOTICE: This Software was developed under funding from the U.S. Department of Energy and the
+// U.S. Government consequently retains certain rights. As such, the U.S. Government has been
+// granted for itself and others acting on its behalf a paid-up, nonexclusive, irrevocable,
+// worldwide license in the Software to reproduce, distribute copies to the public, prepare
+// derivative works, and perform publicly and display publicly, and to permit others to do so.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted
+// provided that the following conditions are met:
+//
+// (1) Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//
+// (2) Redistributions in binary form must reproduce the above copyright notice, this list of
+//     conditions and the following disclaimer in the documentation and/or other materials
+//     provided with the distribution.
+//
+// (3) Neither the name of the University of California, Lawrence Berkeley National Laboratory,
+//     the University of Illinois, U.S. Dept. of Energy nor the names of its contributors may be
+//     used to endorse or promote products derived from this software without specific prior
+//     written permission.
+//
+// (4) Use of EnergyPlus(TM) Name. If Licensee (i) distributes the software in stand-alone form
+//     without changes from the version obtained under this License, or (ii) Licensee makes a
+//     reference solely to the software portion of its product, Licensee must refer to the
+//     software as "EnergyPlus version X" software, where "X" is the version number Licensee
+//     obtained under this License and may not use a different name for the software. Except as
+//     specifically required in this Section (4), Licensee shall not use in a company name, a
+//     product name, in advertising, publicity, or other promotional activities any name, trade
+//     name, trademark, logo, or other designation of "EnergyPlus", "E+", "e+" or confusingly
+//     similar designation, without the U.S. Department of Energy's prior written consent.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include <ezOptionParser.hpp>
+#include "EnergyPlus/FileSystem.hh"
+#include "EnergyPlus/DataStringGlobals.hh"
+#include "EnergyPlus/InputProcessing/IdfParser.hh"
+#include "EnergyPlus/InputProcessing/InputValidation.hh"
+#include "EnergyPlus/InputProcessing/EmbeddedEpJSONSchema.hh"
+
+using json = nlohmann::json;
+
+enum class OutputTypes {
+    Default,
+    IDF,
+    epJSON,
+    CBOR,
+    MsgPack,
+    UBJSON,
+    BSON
+};
+
+void displayMessage(std::string const & message) {
+    std::cout << message << EnergyPlus::DataStringGlobals::NL;
+}
+
+bool checkVersionMatch(json const & epJSON)
+{
+    auto it = epJSON.find("Version");
+    if (it != epJSON.end()) {
+        for (auto const &version : it.value()) {
+            std::string v = version["version_identifier"];
+            if (v.empty()) {
+                displayMessage("Input errors occurred and version ID was left blank, verify file version");
+            } else {
+                std::string::size_type const lenVer(len(EnergyPlus::DataStringGlobals::MatchVersion));
+                int Which;
+                if ((lenVer > 0) && (EnergyPlus::DataStringGlobals::MatchVersion[lenVer - 1] == '0')) {
+                    Which = static_cast<int>(index(v.substr(0, lenVer - 2), EnergyPlus::DataStringGlobals::MatchVersion.substr(0, lenVer - 2)));
+                } else {
+                    Which = static_cast<int>(index(v, EnergyPlus::DataStringGlobals::MatchVersion));
+                }
+                if (Which != 0) {
+                    displayMessage("Version: in IDF=\"" + v + "\" not the same as expected=\"" + EnergyPlus::DataStringGlobals::MatchVersion + "\"");
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+bool processErrors(std::unique_ptr<IdfParser> const & idf_parser, std::unique_ptr<Validation> const & validation)
+{
+    auto const idf_parser_errors = idf_parser->errors();
+    auto const idf_parser_warnings = idf_parser->warnings();
+
+    auto const validation_errors = validation->errors();
+    auto const validation_warnings = validation->warnings();
+
+    for (auto const &error : idf_parser_errors) {
+        displayMessage(error);
+    }
+    for (auto const &warning : idf_parser_warnings) {
+        displayMessage(warning);
+    }
+    for (auto const &error : validation_errors) {
+        displayMessage(error);
+    }
+    for (auto const &warning : validation_warnings) {
+        displayMessage(warning);
+    }
+
+    bool has_errors = validation->hasErrors() || idf_parser->hasErrors();
+
+    return has_errors;
+}
+
+void cleanEPJSON(json & epjson)
+{
+    if (epjson.type() == json::value_t::object) {
+        epjson.erase("idf_order");
+        epjson.erase("idf_max_fields");
+        epjson.erase("idf_max_extensible_fields");
+        for (auto it = epjson.begin(); it != epjson.end(); ++it) {
+            cleanEPJSON(epjson[it.key()]);
+        }
+    }
+}
+
+bool processInput(std::string const & inputFilePath, json const & schema, OutputTypes outputType, std::string outputDirectory)
+{
+    auto validation(std::unique_ptr<Validation>(new Validation(&schema)));
+    auto idf_parser(std::unique_ptr<IdfParser>(new IdfParser()));
+    json epJSON;
+
+    auto const inputFileNameOnly = EnergyPlus::FileSystem::removeFileExtension(EnergyPlus::FileSystem::getFileName(inputFilePath));
+    auto const inputDirPathName = EnergyPlus::FileSystem::getParentDirectoryPath(inputFilePath);
+
+    if (outputDirectory.empty()) {
+        outputDirectory = inputDirPathName;
+    }
+
+    auto inputFileExt = EnergyPlus::FileSystem::getFileExtension(inputFilePath);
+    std::transform(inputFileExt.begin(), inputFileExt.end(), inputFileExt.begin(), ::toupper);
+
+    bool isEpJSON = true;
+    bool isCBOR = false;
+    bool isMsgPack = false;
+    bool isUBJSON = false;
+    bool isBSON = false;
+
+    if (inputFileExt == "EPJSON" || inputFileExt == "JSON") {
+        isEpJSON = true;
+        if (outputType == OutputTypes::epJSON) {
+            displayMessage("Same output format as input format requested (epJSON). Skipping conversion and moving to next file.");
+            return false;
+        }
+    } else if (inputFileExt == "IDF" || inputFileExt == "IMF") {
+        isEpJSON = false;
+        if (outputType == OutputTypes::IDF) {
+            displayMessage("Same output format as input format requested (IDF). Skipping conversion and moving to next file.");
+            return false;
+        }
+    } else if (inputFileExt == "CBOR") {
+        isEpJSON = true;
+        isCBOR = true;
+        if (outputType == OutputTypes::CBOR) {
+            displayMessage("Same output format as input format requested (CBOR). Skipping conversion and moving to next file.");
+            return false;
+        }
+    } else if (inputFileExt == "MSGPACK") {
+        isEpJSON = true;
+        isMsgPack = true;
+        if (outputType == OutputTypes::MsgPack) {
+            displayMessage("Same output format as input format requested (MsgPack). Skipping conversion and moving to next file.");
+            return false;
+        }
+    } else if (inputFileExt == "UBJSON") {
+        isEpJSON = true;
+        isUBJSON = true;
+        if (outputType == OutputTypes::UBJSON) {
+            displayMessage("Same output format as input format requested (UBJSON). Skipping conversion and moving to next file.");
+            return false;
+        }
+    } else if (inputFileExt == "BSON") {
+        isEpJSON = true;
+        isBSON = true;
+        if (outputType == OutputTypes::BSON) {
+            displayMessage("Same output format as input format requested (BSON). Skipping conversion and moving to next file.");
+            return false;
+        }
+    } else {
+        displayMessage("ERROR: Input file must have IDF, IMF, or epJSON extension.");
+        return false;
+    }
+
+    std::ifstream input_stream(inputFilePath, std::ifstream::in);
+    if (!input_stream.is_open()) {
+        displayMessage("Input file path " + inputFilePath + " not found");
+        return false;
+    }
+
+    std::string input_file;
+    std::string line;
+    while (std::getline(input_stream, line)) {
+        input_file.append(line + EnergyPlus::DataStringGlobals::NL);
+    }
+
+    if (input_file.empty()) {
+        displayMessage("Failed to read input file: " + inputFilePath);
+        return false;
+    }
+
+    try {
+        if (!isEpJSON) {
+            bool success = true;
+            epJSON = idf_parser->decode(input_file, schema, success);
+            cleanEPJSON(epJSON);
+        } else if (isCBOR) {
+            epJSON = json::from_cbor(input_file);
+        } else if (isMsgPack) {
+            epJSON = json::from_msgpack(input_file);
+        } else if (isUBJSON) {
+            epJSON = json::from_ubjson(input_file);
+        } else if (isBSON) {
+            epJSON = json::from_bson(input_file);
+        } else {
+            epJSON = json::parse(input_file);
+        }
+    } catch (const std::exception &e) {
+        displayMessage(e.what());
+        displayMessage("Errors occurred when processing input file. Preceding condition(s) cause termination.");
+    }
+
+    bool is_valid = validation->validate(epJSON);
+    bool hasErrors = processErrors(idf_parser, validation);
+    bool versionMatch = checkVersionMatch(epJSON);
+
+    if (!is_valid || hasErrors) {
+        displayMessage("Errors occurred when validating input file. Preceding condition(s) cause termination.");
+    }
+
+    if (isEpJSON && !versionMatch) {
+        displayMessage("Skipping conversion of input file to IDF due to mismatched Version.");
+        return false;
+    }
+
+    if ((outputType == OutputTypes::Default || outputType == OutputTypes::IDF) && isEpJSON) {
+        input_file = idf_parser->encode(epJSON, schema);
+        std::string convertedEpJSON(outputDirectory + inputFileNameOnly + ".idf");
+        EnergyPlus::FileSystem::makeNativePath(convertedEpJSON);
+        std::ofstream convertedFS(convertedEpJSON, std::ofstream::out);
+        convertedFS << input_file << std::endl;
+        displayMessage("Input file converted to IDF successfully");
+    } else if ((outputType == OutputTypes::Default || outputType == OutputTypes::epJSON) && !isEpJSON) {
+        input_file = epJSON.dump(4, ' ', false, json::error_handler_t::replace);
+        std::string convertedIDF(outputDirectory + inputFileNameOnly + ".epJSON");
+        EnergyPlus::FileSystem::makeNativePath(convertedIDF);
+        std::ofstream convertedFS(convertedIDF, std::ofstream::out);
+        convertedFS << input_file << std::endl;
+        displayMessage("Input file converted to epJSON successfully");
+    } else if (outputType == OutputTypes::CBOR) {
+        std::string convertedCBOR(outputDirectory + inputFileNameOnly + ".cbor");
+        EnergyPlus::FileSystem::makeNativePath(convertedCBOR);
+        std::ofstream convertedFS(convertedCBOR, std::ofstream::out);
+        json::to_cbor(epJSON, convertedFS);
+        displayMessage("Input file converted to CBOR successfully");
+    } else if (outputType == OutputTypes::MsgPack) {
+        std::string convertedMsgPack(outputDirectory + inputFileNameOnly + ".msgpack");
+        EnergyPlus::FileSystem::makeNativePath(convertedMsgPack);
+        std::ofstream convertedFS(convertedMsgPack, std::ofstream::out);
+        json::to_msgpack(epJSON, convertedFS);
+        displayMessage("Input file converted to MsgPack successfully");
+    } else if (outputType == OutputTypes::UBJSON) {
+        std::string convertedUBJSON(outputDirectory + inputFileNameOnly + ".ubjson");
+        EnergyPlus::FileSystem::makeNativePath(convertedUBJSON);
+        std::ofstream convertedFS(convertedUBJSON, std::ofstream::out);
+        json::to_ubjson(epJSON, convertedFS);
+        displayMessage("Input file converted to UBJSON successfully");
+    } else if (outputType == OutputTypes::BSON) {
+        std::string convertedBSON(outputDirectory + inputFileNameOnly + ".bson");
+        EnergyPlus::FileSystem::makeNativePath(convertedBSON);
+        std::ofstream convertedFS(convertedBSON, std::ofstream::out);
+        json::to_bson(epJSON, convertedFS);
+        displayMessage("Input file converted to BSON successfully");
+    } else {
+        return false;
+    }
+    return true;
+}
+
+std::vector<std::string> parse_input_paths(std::string const & input_paths_file) {
+    std::ifstream input_paths_stream(input_paths_file);
+    if (!input_paths_stream.is_open()) {
+        displayMessage("Could not open file: " + input_paths_file);
+        return std::vector<std::string>();
+    }
+    std::vector<std::string> input_paths;
+    std::string line;
+    while (std::getline(input_paths_stream, line)) {
+        if (line.empty()) continue;
+        input_paths.emplace_back(line);
+    }
+    return input_paths;
+}
+
+int main(int argc, const char *argv[]) {
+
+	ez::ezOptionParser opt;
+
+    opt.overview = "Run input file conversion tool";
+    opt.syntax = "convertrinputformat [OPTIONS] input_file [input_file ..]";
+    opt.example = "convertrinputformat in.idf\n\n";
+
+    opt.add(
+        "1", // Default.
+        false, // Required?
+        1, // Number of args expected.
+        0, // Delimiter if expecting multiple args.
+        "Number of threads", // Help description.
+        "-j"     // Flag token.
+    );
+
+    opt.add(
+        "", // Default.
+        false, // Required?
+        1, // Number of args expected.
+        0, // Delimiter if expecting multiple args.
+        "Text file with list of input files to convert (newline delimited)", // Help description.
+        "-i",     // Flag token.
+        "--input"  // Flag token.
+    );
+
+    opt.add(
+        "", // Default.
+        false, // Required?
+        1, // Number of args expected.
+        0, // Delimiter if expecting multiple args.
+        "Output directory", // Help description.
+        "-o",     // Flag token.
+        "--output"  // Flag token.
+    );
+
+    const char* validOptions[] = {"default","idf","epjson","json","cbor","msgpack","ubjson","bson"};
+    auto * outputTypeValidation = new ez::ezOptionValidator(ez::ezOptionValidator::T, ez::ezOptionValidator::IN, validOptions, 8, true);
+
+    opt.add(
+        "default", // Default.
+        0, // Required?
+        1, // Number of args expected.
+        0, // Delimiter if expecting multiple args.
+        "Output format.\nDefault means IDF->epJSON or epJSON->IDF\nSelect one (case insensitive):\ndefault,idf,epjson,json,cbor,msgpack,ubjson,bson", // Help description.
+        "-f",     // Flag token.
+        "--format",     // Flag token.
+        outputTypeValidation
+  );
+
+    opt.add("", 0, 0, 0, "Display version information", "-v", "--version");
+
+    opt.add(
+        "", // Default.
+        false, // Required?
+        0, // Number of args expected.
+        0, // Delimiter if expecting multiple args.
+        "Display usage instructions.", // Help description.
+        "-h",     // Flag token.
+        "-help",  // Flag token.
+        "--help", // Flag token.
+        "--usage" // Flag token.
+    );
+
+    opt.parse(argc, argv);
+
+    std::string usage;
+    opt.getUsage(usage);
+
+    // Process standard arguments
+    if (opt.isSet("-h")) {
+        displayMessage(usage);
+        exit(EXIT_SUCCESS);
+    }
+
+    if (opt.isSet("-v")) {
+        displayMessage(EnergyPlus::DataStringGlobals::VerString);
+        exit(EXIT_SUCCESS);
+    }
+
+    int number_of_threads = 1;
+    if (opt.isSet("-j")) {
+        opt.get("-j")->getInt(number_of_threads);
+    }
+
+    std::string output_directory;
+    if (opt.isSet("-o")) {
+        opt.get("-o")->getString(output_directory);
+        if (output_directory.back() != EnergyPlus::DataStringGlobals::pathChar) {
+            output_directory.push_back(EnergyPlus::DataStringGlobals::pathChar);
+        }
+        EnergyPlus::FileSystem::makeDirectory(output_directory);
+    }
+
+    std::vector<std::string> files;
+    if (opt.isSet("-i")) {
+        std::string input_paths_file;
+        opt.get("-i")->getString(input_paths_file);
+        files = parse_input_paths(input_paths_file);
+    }
+
+    OutputTypes outputType;
+    if (opt.isSet("-f")) {
+        std::string outputTypeStr;
+        opt.get("-f")->getString(outputTypeStr);
+        std::transform(outputTypeStr.begin(), outputTypeStr.end(), outputTypeStr.begin(), ::toupper);
+        if (outputTypeStr == "EPJSON" || outputTypeStr == "JSON") {
+            outputType = OutputTypes::epJSON;
+        } else if (outputTypeStr == "IDF") {
+            outputType = OutputTypes::IDF;
+        } else if (outputTypeStr == "CBOR") {
+            outputType = OutputTypes::CBOR;
+        } else if (outputTypeStr == "MSGPACK") {
+            outputType = OutputTypes::MsgPack;
+        } else if (outputTypeStr == "UBJSON") {
+            outputType = OutputTypes::UBJSON;
+        } else if (outputTypeStr == "BSON") {
+            outputType = OutputTypes::BSON;
+        } else {
+            displayMessage("ERROR: Output type must be IDF, epJSON, CBOR, MsgPack, UBJSON, or BSON.");
+            return 1;
+        }
+    }
+
+    if (!opt.lastArgs.empty()) {
+        for (auto const & lastArg : opt.lastArgs) {
+            files.emplace_back(*lastArg);
+        }
+    } else if (opt.firstArgs.size() > 1) {
+        for (std::size_t i = 1; i < opt.firstArgs.size(); ++i) {
+            files.emplace_back(*opt.firstArgs[i]);
+        }
+    }
+
+    std::vector<std::string> badOptions;
+    if(!opt.gotRequired(badOptions)) {
+        for (auto const & badOption : badOptions) {
+            std::cerr << "ERROR: Missing required option " << badOption << ".\n\n";
+        }
+        displayMessage(usage);
+        return 1;
+    }
+
+    if(!opt.gotExpected(badOptions)) {
+        for (auto const & badOption : badOptions) {
+            std::cerr << "ERROR: Got unexpected number of arguments for option " << badOption << ".\n\n";
+        }
+        displayMessage(usage);
+        return 1;
+    }
+
+    std::vector<std::string> badArgs;
+    if(!opt.gotValid(badOptions, badArgs)) {
+        for(std::size_t i = 0; i < badOptions.size(); ++i) {
+            std::cerr << "ERROR: Got invalid argument \"" << badArgs[i] << "\" for option " << badOptions[i] << ".\n\n";
+        }
+        return 1;
+    }
+
+    auto const embeddedEpJSONSchema = EnergyPlus::EmbeddedEpJSONSchema::embeddedEpJSONSchema();
+    auto const schema = json::from_cbor(embeddedEpJSONSchema.first, embeddedEpJSONSchema.second);
+
+#ifdef _OPENMP
+    omp_set_num_threads(number_of_threads);
+#endif
+
+#ifdef _OPENMP
+#pragma omp parallel
+  {
+#pragma omp for
+    for (std::size_t i = 0; i < files.size(); ++i) {
+        bool successful = processInput(files[i], schema, outputType, output_directory);
+        if (!successful) {
+            displayMessage("Input file conversion failed.");
+        }
+    }
+  }
+#else
+    for (auto const & file : files) {
+        bool successful = processInput(file, schema, outputType, output_directory);
+        if (!successful) {
+            displayMessage("Input file conversion failed.");
+        }
+    }
+#endif
+
+    return 0;
+}

--- a/src/ConvertInputFormat/main.cpp
+++ b/src/ConvertInputFormat/main.cpp
@@ -50,16 +50,17 @@
 #include <omp.h>
 #endif
 
-#include <ezOptionParser.hpp>
-#include "EnergyPlus/FileSystem.hh"
 #include "EnergyPlus/DataStringGlobals.hh"
+#include "EnergyPlus/FileSystem.hh"
+#include "EnergyPlus/InputProcessing/EmbeddedEpJSONSchema.hh"
 #include "EnergyPlus/InputProcessing/IdfParser.hh"
 #include "EnergyPlus/InputProcessing/InputValidation.hh"
-#include "EnergyPlus/InputProcessing/EmbeddedEpJSONSchema.hh"
+#include <ezOptionParser.hpp>
 
 using json = nlohmann::json;
 
-enum class OutputTypes {
+enum class OutputTypes
+{
     Default,
     IDF,
     epJSON,
@@ -69,11 +70,12 @@ enum class OutputTypes {
     BSON
 };
 
-void displayMessage(std::string const & message) {
+void displayMessage(std::string const &message)
+{
     std::cout << message << EnergyPlus::DataStringGlobals::NL;
 }
 
-bool checkVersionMatch(json const & epJSON)
+bool checkVersionMatch(json const &epJSON)
 {
     auto it = epJSON.find("Version");
     if (it != epJSON.end()) {
@@ -99,7 +101,7 @@ bool checkVersionMatch(json const & epJSON)
     return true;
 }
 
-bool processErrors(std::unique_ptr<IdfParser> const & idf_parser, std::unique_ptr<Validation> const & validation)
+bool processErrors(std::unique_ptr<IdfParser> const &idf_parser, std::unique_ptr<Validation> const &validation)
 {
     auto const idf_parser_errors = idf_parser->errors();
     auto const idf_parser_warnings = idf_parser->warnings();
@@ -125,7 +127,7 @@ bool processErrors(std::unique_ptr<IdfParser> const & idf_parser, std::unique_pt
     return has_errors;
 }
 
-void cleanEPJSON(json & epjson)
+void cleanEPJSON(json &epjson)
 {
     if (epjson.type() == json::value_t::object) {
         epjson.erase("idf_order");
@@ -137,7 +139,7 @@ void cleanEPJSON(json & epjson)
     }
 }
 
-bool processInput(std::string const & inputFilePath, json const & schema, OutputTypes outputType, std::string outputDirectory)
+bool processInput(std::string const &inputFilePath, json const &schema, OutputTypes outputType, std::string outputDirectory)
 {
     auto validation(std::unique_ptr<Validation>(new Validation(&schema)));
     auto idf_parser(std::unique_ptr<IdfParser>(new IdfParser()));
@@ -294,7 +296,8 @@ bool processInput(std::string const & inputFilePath, json const & schema, Output
     return true;
 }
 
-std::vector<std::string> parse_input_paths(std::string const & input_paths_file) {
+std::vector<std::string> parse_input_paths(std::string const &input_paths_file)
+{
     std::ifstream input_paths_stream(input_paths_file);
     if (!input_paths_stream.is_open()) {
         displayMessage("Could not open file: " + input_paths_file);
@@ -309,69 +312,65 @@ std::vector<std::string> parse_input_paths(std::string const & input_paths_file)
     return input_paths;
 }
 
-int main(int argc, const char *argv[]) {
+int main(int argc, const char *argv[])
+{
 
-	ez::ezOptionParser opt;
+    ez::ezOptionParser opt;
 
     opt.overview = "Run input file conversion tool";
     opt.syntax = "convertrinputformat [OPTIONS] input_file [input_file ..]";
     opt.example = "convertrinputformat in.idf\n\n";
 
-    opt.add(
-        "1", // Default.
-        false, // Required?
-        1, // Number of args expected.
-        0, // Delimiter if expecting multiple args.
-        "Number of threads", // Help description.
-        "-j"     // Flag token.
+    opt.add("1",                 // Default.
+            false,               // Required?
+            1,                   // Number of args expected.
+            0,                   // Delimiter if expecting multiple args.
+            "Number of threads", // Help description.
+            "-j"                 // Flag token.
     );
 
-    opt.add(
-        "", // Default.
-        false, // Required?
-        1, // Number of args expected.
-        0, // Delimiter if expecting multiple args.
-        "Text file with list of input files to convert (newline delimited)", // Help description.
-        "-i",     // Flag token.
-        "--input"  // Flag token.
+    opt.add("",                                                                  // Default.
+            false,                                                               // Required?
+            1,                                                                   // Number of args expected.
+            0,                                                                   // Delimiter if expecting multiple args.
+            "Text file with list of input files to convert (newline delimited)", // Help description.
+            "-i",                                                                // Flag token.
+            "--input"                                                            // Flag token.
     );
 
-    opt.add(
-        "", // Default.
-        false, // Required?
-        1, // Number of args expected.
-        0, // Delimiter if expecting multiple args.
-        "Output directory. Will use input file location by default.", // Help description.
-        "-o",     // Flag token.
-        "--output"  // Flag token.
+    opt.add("",                                                           // Default.
+            false,                                                        // Required?
+            1,                                                            // Number of args expected.
+            0,                                                            // Delimiter if expecting multiple args.
+            "Output directory. Will use input file location by default.", // Help description.
+            "-o",                                                         // Flag token.
+            "--output"                                                    // Flag token.
     );
 
-    const char* validOptions[] = {"default","idf","epjson","json","cbor","msgpack","ubjson","bson"};
-    auto * outputTypeValidation = new ez::ezOptionValidator(ez::ezOptionValidator::T, ez::ezOptionValidator::IN, validOptions, 8, true);
+    const char *validOptions[] = {"default", "idf", "epjson", "json", "cbor", "msgpack", "ubjson", "bson"};
+    auto *outputTypeValidation = new ez::ezOptionValidator(ez::ezOptionValidator::T, ez::ezOptionValidator::IN, validOptions, 8, true);
 
-    opt.add(
-        "default", // Default.
-        0, // Required?
-        1, // Number of args expected.
-        0, // Delimiter if expecting multiple args.
-        "Output format.\nDefault means IDF->epJSON or epJSON->IDF\nSelect one (case insensitive):\ndefault,idf,epjson,json,cbor,msgpack,ubjson,bson", // Help description.
-        "-f",     // Flag token.
-        "--format",     // Flag token.
-        outputTypeValidation
-  );
+    opt.add("default", // Default.
+            0,         // Required?
+            1,         // Number of args expected.
+            0,         // Delimiter if expecting multiple args.
+            "Output format.\nDefault means IDF->epJSON or epJSON->IDF\nSelect one (case "
+            "insensitive):\ndefault,idf,epjson,json,cbor,msgpack,ubjson,bson", // Help description.
+            "-f",                                                              // Flag token.
+            "--format",                                                        // Flag token.
+            outputTypeValidation);
 
     opt.add("", 0, 0, 0, "Display version information", "-v", "--version");
 
-    opt.add(
-        "", // Default.
-        false, // Required?
-        0, // Number of args expected.
-        0, // Delimiter if expecting multiple args.
-        "Display usage instructions.", // Help description.
-        "-h",     // Flag token.
-        "-help",  // Flag token.
-        "--help", // Flag token.
-        "--usage" // Flag token.
+    opt.add("",                            // Default.
+            false,                         // Required?
+            0,                             // Number of args expected.
+            0,                             // Delimiter if expecting multiple args.
+            "Display usage instructions.", // Help description.
+            "-h",                          // Flag token.
+            "-help",                       // Flag token.
+            "--help",                      // Flag token.
+            "--usage"                      // Flag token.
     );
 
     opt.parse(argc, argv);
@@ -440,7 +439,7 @@ int main(int argc, const char *argv[]) {
     }
 
     if (!opt.lastArgs.empty()) {
-        for (auto const & lastArg : opt.lastArgs) {
+        for (auto const &lastArg : opt.lastArgs) {
             files.emplace_back(*lastArg);
         }
     } else if (opt.firstArgs.size() > 1) {
@@ -450,16 +449,16 @@ int main(int argc, const char *argv[]) {
     }
 
     std::vector<std::string> badOptions;
-    if(!opt.gotRequired(badOptions)) {
-        for (auto const & badOption : badOptions) {
+    if (!opt.gotRequired(badOptions)) {
+        for (auto const &badOption : badOptions) {
             std::cerr << "ERROR: Missing required option " << badOption << ".\n\n";
         }
         displayMessage(usage);
         return 1;
     }
 
-    if(!opt.gotExpected(badOptions)) {
-        for (auto const & badOption : badOptions) {
+    if (!opt.gotExpected(badOptions)) {
+        for (auto const &badOption : badOptions) {
             std::cerr << "ERROR: Got unexpected number of arguments for option " << badOption << ".\n\n";
         }
         displayMessage(usage);
@@ -467,8 +466,8 @@ int main(int argc, const char *argv[]) {
     }
 
     std::vector<std::string> badArgs;
-    if(!opt.gotValid(badOptions, badArgs)) {
-        for(std::size_t i = 0; i < badOptions.size(); ++i) {
+    if (!opt.gotValid(badOptions, badArgs)) {
+        for (std::size_t i = 0; i < badOptions.size(); ++i) {
             std::cerr << "ERROR: Got invalid argument \"" << badArgs[i] << "\" for option " << badOptions[i] << ".\n\n";
         }
         return 1;
@@ -479,34 +478,38 @@ int main(int argc, const char *argv[]) {
 
     auto number_files = files.size();
     std::size_t fileCount = 0;
+    auto newline = EnergyPlus::DataStringGlobals::NL;
 
 #ifdef _OPENMP
     omp_set_num_threads(number_of_threads);
 #endif
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(files, number_files, fileCount, schema, outputType, outputTypeStr, output_directory, std::cout, EnergyPlus::DataStringGlobals::NL)
-  {
+#pragma omp parallel default(none)                                                                                                                   \
+    shared(files, number_files, fileCount, schema, outputType, outputTypeStr, output_directory, std::cout, newline)
+    {
 #pragma omp for
-    for (std::size_t i = 0; i < number_files; ++i) {
-        bool successful = processInput(files[i], schema, outputType, output_directory);
+        for (std::size_t i = 0; i < number_files; ++i) {
+            bool successful = processInput(files[i], schema, outputType, output_directory);
 #pragma omp atomic
-        ++fileCount;
-        if (successful) {
-            std::cout << "Input file converted to " << outputTypeStr << " successfully | " << fileCount << "/" << number_files << " | " << files[i] << EnergyPlus::DataStringGlobals::NL;
-        } else {
-            std::cout << "Input file conversion failed: | " << fileCount << "/" << number_files << " | " << files[i] << EnergyPlus::DataStringGlobals::NL;
+            ++fileCount;
+            if (successful) {
+                std::cout << "Input file converted to " << outputTypeStr << " successfully | " << fileCount << "/" << number_files << " | "
+                          << files[i] << newline;
+            } else {
+                std::cout << "Input file conversion failed: | " << fileCount << "/" << number_files << " | " << files[i] << newline;
+            }
         }
     }
-  }
 #else
-    for (auto const & file : files) {
+    for (auto const &file : files) {
         bool successful = processInput(file, schema, outputType, output_directory);
         ++fileCount;
         if (successful) {
-            std::cout << "Input file converted to " << outputTypeStr << " successfully | " << fileCount << "/" << number_files << " | " << file << EnergyPlus::DataStringGlobals::NL;
+            std::cout << "Input file converted to " << outputTypeStr << " successfully | " << fileCount << "/" << number_files << " | " << file
+                      << newline;
         } else {
-            std::cout << "Input file conversion failed: | " << fileCount << "/" << number_files << " | " << file << EnergyPlus::DataStringGlobals::NL;
+            std::cout << "Input file conversion failed: | " << fileCount << "/" << number_files << " | " << file << newline;
         }
     }
 #endif

--- a/src/ConvertInputFormat/main.cpp
+++ b/src/ConvertInputFormat/main.cpp
@@ -147,7 +147,7 @@ void cleanEPJSON(json &epjson)
     }
 }
 
-bool processInput(std::string const &inputFilePath, json const &schema, OutputTypes outputType, std::string outputDirectory)
+bool processInput(std::string const &inputFilePath, json const &schema, OutputTypes outputType, std::string outputDirectory, std::string & outputTypeStr)
 {
     auto validation(std::unique_ptr<Validation>(new Validation(&schema)));
     auto idf_parser(std::unique_ptr<IdfParser>(new IdfParser()));
@@ -272,12 +272,14 @@ bool processInput(std::string const &inputFilePath, json const &schema, OutputTy
         EnergyPlus::FileSystem::makeNativePath(convertedEpJSON);
         std::ofstream convertedFS(convertedEpJSON, std::ofstream::out | std::ofstream::binary);
         convertedFS << input_file << std::endl;
+        outputTypeStr = "IDF";
     } else if ((outputType == OutputTypes::Default || outputType == OutputTypes::epJSON) && !isEpJSON) {
         auto const input_file = epJSON.dump(4, ' ', false, json::error_handler_t::replace);
         std::string convertedIDF(outputDirectory + inputFileNameOnly + ".epJSON");
         EnergyPlus::FileSystem::makeNativePath(convertedIDF);
         std::ofstream convertedFS(convertedIDF, std::ofstream::out | std::ofstream::binary);
         convertedFS << input_file << std::endl;
+        outputTypeStr = "EPJSON";
     } else if (outputType == OutputTypes::CBOR) {
         std::string convertedCBOR(outputDirectory + inputFileNameOnly + ".cbor");
         EnergyPlus::FileSystem::makeNativePath(convertedCBOR);
@@ -500,7 +502,7 @@ int main(int argc, const char *argv[])
     {
 #pragma omp for
         for (std::size_t i = 0; i < number_files; ++i) {
-            bool successful = processInput(files[i], schema, outputType, output_directory);
+            bool successful = processInput(files[i], schema, outputType, output_directory, outputTypeStr);
 #pragma omp atomic
             ++fileCount;
             if (successful) {

--- a/src/ConvertInputFormat/main.cpp
+++ b/src/ConvertInputFormat/main.cpp
@@ -514,7 +514,7 @@ int main(int argc, const char *argv[])
     }
 #else
     for (auto const &file : files) {
-        bool successful = processInput(file, schema, outputType, output_directory);
+        bool successful = processInput(file, schema, outputType, output_directory, outputTypeStr);
         ++fileCount;
         if (successful) {
             displayMessage("Input file converted to ", outputTypeStr, " successfully | ", fileCount, "/", number_files, " | ", file);

--- a/src/EnergyPlus/CMakeLists.txt
+++ b/src/EnergyPlus/CMakeLists.txt
@@ -627,6 +627,25 @@ SET( SRC
 
 CREATE_SRC_GROUPS( "${SRC}" )
 
+SET( INPUTPARSING_SRC
+  "${CMAKE_SOURCE_DIR}/third_party/milo/dtoa.h"
+  "${CMAKE_SOURCE_DIR}/third_party/milo/itoa.h"
+  "${CMAKE_SOURCE_DIR}/third_party/milo/diyfp.h"
+  "${CMAKE_SOURCE_DIR}/third_party/milo/ieee754.h"
+  "${CMAKE_CURRENT_BINARY_DIR}/DataStringGlobals.cc"
+  DataStringGlobals.hh
+  FileSystem.cc
+  FileSystem.hh
+  InputProcessing/EmbeddedEpJSONSchema.hh
+  "${CMAKE_CURRENT_BINARY_DIR}/EmbeddedEpJSONSchema.cc"
+  InputProcessing/IdfParser.cc
+  InputProcessing/IdfParser.hh
+  InputProcessing/InputValidation.cc
+  InputProcessing/InputValidation.hh
+)
+
+CREATE_SRC_GROUPS( "${INPUTPARSING_SRC}" )
+
 if (UNIX)
   ADD_DEFINITIONS("-fPIC")
 endif()
@@ -644,6 +663,16 @@ add_custom_target( GenerateEmbeddedEpJSONSchema
 add_subdirectory(AirflowNetwork)
 #message( $<TARGET_PROPERTY:airflownetworklib,INTERFACE_INCLUDE_DIRECTORIES> )
 #include_directories($<TARGET_PROPERTY:airflownetworklib,INTERFACE_INCLUDE_DIRECTORIES>)
+
+add_library( energyplusparser STATIC ${INPUTPARSING_SRC} )
+add_dependencies( energyplusparser GenerateEmbeddedEpJSONSchema )
+target_link_libraries( energyplusparser re2 )
+if(UNIX AND NOT APPLE)
+  target_link_libraries( energyplusparser dl )
+endif()
+if (WIN32)
+  target_link_libraries( energyplusparser Shlwapi )
+endif()
 
 # first we will create a static library of EnergyPlus
 # this will be linked statically to create the DLL and also the unit tests

--- a/src/EnergyPlus/CommandLineInterface.cc
+++ b/src/EnergyPlus/CommandLineInterface.cc
@@ -262,9 +262,19 @@ namespace CommandLineInterface {
         } else if (inputFileExt == "CBOR") {
             isEpJSON = true;
             isCBOR = true;
+            DisplayString("CBOR input format is experimental and unsupported.");
         } else if (inputFileExt == "MSGPACK") {
             isEpJSON = true;
             isMsgPack = true;
+            DisplayString("MsgPack input format is experimental and unsupported.");
+        } else if (inputFileExt == "UBJSON") {
+            isEpJSON = true;
+            isUBJSON = true;
+            DisplayString("UBJSON input format is experimental and unsupported.");
+        } else if (inputFileExt == "BSON") {
+            isEpJSON = true;
+            isBSON = true;
+            DisplayString("BSON input format is experimental and unsupported.");
         } else {
             DisplayString("ERROR: Input file must have IDF, IMF, or epJSON extension.");
             exit(EXIT_FAILURE);

--- a/src/EnergyPlus/CommandLineInterface.cc
+++ b/src/EnergyPlus/CommandLineInterface.cc
@@ -150,6 +150,8 @@ namespace CommandLineInterface {
 
         opt.add("", 0, 0, 0, "Output IDF->epJSON or epJSON->IDF, dependent on input file type", "-c", "--convert");
 
+        opt.add("", 0, 0, 0, "Only convert IDF->epJSON or epJSON->IDF, dependent on input file type. No simulation", "--convert-only");
+
         opt.add("L",
                 0,
                 1,
@@ -198,6 +200,8 @@ namespace CommandLineInterface {
         AnnualSimulation = opt.isSet("-a");
 
         outputEpJSONConversion = opt.isSet("-c");
+
+        outputEpJSONConversionOnly = opt.isSet("--convert-only");
 
         // Process standard arguments
         if (opt.isSet("-h")) {

--- a/src/EnergyPlus/DataGlobals.cc
+++ b/src/EnergyPlus/DataGlobals.cc
@@ -92,6 +92,8 @@ namespace DataGlobals {
     bool isEpJSON(false);
     bool isCBOR(false);
     bool isMsgPack(false);
+    bool isUBJSON(false);
+    bool isBSON(false);
     bool preserveIDFOrder(true);
 
     // MODULE PARAMETER DEFINITIONS:

--- a/src/EnergyPlus/DataGlobals.cc
+++ b/src/EnergyPlus/DataGlobals.cc
@@ -89,6 +89,7 @@ namespace DataGlobals {
     bool DDOnlySimulation(false);
     bool AnnualSimulation(false);
     bool outputEpJSONConversion(false);
+    bool outputEpJSONConversionOnly(false);
     bool isEpJSON(false);
     bool isCBOR(false);
     bool isMsgPack(false);
@@ -273,6 +274,7 @@ namespace DataGlobals {
         DDOnlySimulation = false;
         AnnualSimulation = false;
         outputEpJSONConversion = false;
+        outputEpJSONConversionOnly = false;
         isEpJSON = false;
         isCBOR = false;
         isMsgPack = false;

--- a/src/EnergyPlus/DataGlobals.hh
+++ b/src/EnergyPlus/DataGlobals.hh
@@ -67,6 +67,7 @@ namespace DataGlobals {
     extern bool DDOnlySimulation;
     extern bool AnnualSimulation;
     extern bool outputEpJSONConversion;
+    extern bool outputEpJSONConversionOnly;
     extern bool isEpJSON;
     extern bool isCBOR;
     extern bool isMsgPack;

--- a/src/EnergyPlus/DataGlobals.hh
+++ b/src/EnergyPlus/DataGlobals.hh
@@ -70,6 +70,8 @@ namespace DataGlobals {
     extern bool isEpJSON;
     extern bool isCBOR;
     extern bool isMsgPack;
+    extern bool isUBJSON;
+    extern bool isBSON;
     extern bool preserveIDFOrder;
 
     // MODULE PARAMETER DEFINITIONS:

--- a/src/EnergyPlus/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/EnergyPlusPgm.cc
@@ -456,7 +456,7 @@ int RunEnergyPlus(std::string const & filepath)
         EnergyPlus::inputProcessor = InputProcessor::factory();
         EnergyPlus::inputProcessor->processInput();
 
-        if (DataGlobals::outputEpJSONConversion) {
+        if (DataGlobals::outputEpJSONConversionOnly) {
             DisplayString("Converted input file format. Exiting.");
             return EndEnergyPlus();
         }

--- a/src/EnergyPlus/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/EnergyPlusPgm.cc
@@ -456,6 +456,11 @@ int RunEnergyPlus(std::string const & filepath)
         EnergyPlus::inputProcessor = InputProcessor::factory();
         EnergyPlus::inputProcessor->processInput();
 
+        if (DataGlobals::outputEpJSONConversion) {
+            DisplayString("Converted input file format. Exiting due to \"-c or --convert\" flag.");
+            return EndEnergyPlus();
+        }
+
         ResultsFramework::OutputSchema->setupOutputOptions();
 
         ManageSimulation();

--- a/src/EnergyPlus/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/EnergyPlusPgm.cc
@@ -457,7 +457,7 @@ int RunEnergyPlus(std::string const & filepath)
         EnergyPlus::inputProcessor->processInput();
 
         if (DataGlobals::outputEpJSONConversion) {
-            DisplayString("Converted input file format. Exiting due to \"-c or --convert\" flag.");
+            DisplayString("Converted input file format. Exiting.");
             return EndEnergyPlus();
         }
 

--- a/src/EnergyPlus/FileSystem.cc
+++ b/src/EnergyPlus/FileSystem.cc
@@ -67,14 +67,11 @@
 
 // EnergyPlus Headers
 #include <EnergyPlus/DataStringGlobals.hh>
-#include <EnergyPlus/DisplayRoutines.hh>
 #include <EnergyPlus/FileSystem.hh>
 
 namespace EnergyPlus {
 
 namespace FileSystem {
-
-    using namespace DataStringGlobals;
 
 #ifdef _WIN32
     std::string const exeExtension(".exe");
@@ -84,25 +81,25 @@ namespace FileSystem {
 
     void makeNativePath(std::string &path)
     {
-        std::replace(path.begin(), path.end(), altpathChar, pathChar);
+        std::replace(path.begin(), path.end(), DataStringGlobals::altpathChar, DataStringGlobals::pathChar);
     }
 
     std::string getFileName(std::string const &filePath)
     {
-        int pathCharPosition = filePath.find_last_of(pathChar);
+        int pathCharPosition = filePath.find_last_of(DataStringGlobals::pathChar);
         return filePath.substr(pathCharPosition + 1, filePath.size() - 1);
     }
 
     std::string getParentDirectoryPath(std::string const &path)
     {
         std::string tempPath = path;
-        if (path.at(path.size() - 1) == pathChar) tempPath = path.substr(0, path.size() - 1);
+        if (path.at(path.size() - 1) == DataStringGlobals::pathChar) tempPath = path.substr(0, path.size() - 1);
 
-        int pathCharPosition = tempPath.find_last_of(pathChar);
+        int pathCharPosition = tempPath.find_last_of(DataStringGlobals::pathChar);
         tempPath = tempPath.substr(0, pathCharPosition + 1);
 
         // If empty, then current dir, but with trailing separator too: eg `./`
-        if (tempPath == "") tempPath = {'.', pathChar};
+        if (tempPath == "") tempPath = {'.',DataStringGlobals:: pathChar};
 
         return tempPath;
     }
@@ -134,10 +131,10 @@ namespace FileSystem {
             if (pathTail.size() == 0)
                 return absoluteParentPath;
             else
-                return absoluteParentPath + pathChar + pathTail;
+                return absoluteParentPath + DataStringGlobals::pathChar + pathTail;
 
         } else {
-            DisplayString("ERROR: Could not resolve path for " + path + ".");
+            std::cout << "ERROR: Could not resolve path for " + path + "." << std::endl;
             std::exit(EXIT_FAILURE);
         }
 #endif
@@ -153,7 +150,7 @@ namespace FileSystem {
 #elif __linux__
         ssize_t len = readlink("/proc/self/exe", executableRelativePath, sizeof(executableRelativePath) - 1);
         if (len == -1) {
-            DisplayString("ERROR: Unable to locate executable.");
+            std::cout << "ERROR: Unable to locate executable." << std::endl;
             std::exit(EXIT_FAILURE);
         } else {
             executableRelativePath[len] = '\0';
@@ -182,13 +179,13 @@ namespace FileSystem {
         // Create a directory if doesn't already exist
         if (pathExists(directoryPath)) { // path already exists
             if (!directoryExists(directoryPath)) {
-                DisplayString("ERROR: " + getAbsolutePath(directoryPath) + " is not a directory.");
+                std::cout << "ERROR: " + getAbsolutePath(directoryPath) + " is not a directory." << std::endl;
                 std::exit(EXIT_FAILURE);
             }
         } else { // directory does not already exist
             std::string parentDirectoryPath = getParentDirectoryPath(directoryPath);
             if (!pathExists(parentDirectoryPath)) {
-                DisplayString("ERROR: " + getAbsolutePath(parentDirectoryPath) + " is not a directory.");
+                std::cout << "ERROR: " + getAbsolutePath(parentDirectoryPath) + " is not a directory." << std::endl;
                 std::exit(EXIT_FAILURE);
             }
 #ifdef _WIN32

--- a/src/EnergyPlus/InputProcessing/IdfParser.hh
+++ b/src/EnergyPlus/InputProcessing/IdfParser.hh
@@ -48,8 +48,8 @@
 #ifndef InputProcessing_IdfParser_hh_INCLUDED
 #define InputProcessing_IdfParser_hh_INCLUDED
 
-#include <nlohmann/json.hpp>
 #include <string>
+#include <nlohmann/json.hpp>
 #include <unordered_map>
 
 namespace EnergyPlus {

--- a/src/EnergyPlus/InputProcessing/IdfParser.hh
+++ b/src/EnergyPlus/InputProcessing/IdfParser.hh
@@ -49,6 +49,7 @@
 #define InputProcessing_IdfParser_hh_INCLUDED
 
 #include <string>
+
 #include <nlohmann/json.hpp>
 #include <unordered_map>
 

--- a/src/EnergyPlus/InputProcessing/InputProcessor.cc
+++ b/src/EnergyPlus/InputProcessing/InputProcessor.cc
@@ -298,7 +298,7 @@ void InputProcessor::processInput()
             //				ShowFatalError( "Errors occurred on processing input file. Preceding condition(s) cause termination." );
             //			}
 
-            if (DataGlobals::outputEpJSONConversion) {
+            if (DataGlobals::outputEpJSONConversion || DataGlobals::outputEpJSONConversionOnly) {
                 json epJSONClean = epJSON;
                 cleanEPJSON(epJSONClean);
                 input_file = epJSONClean.dump(4, ' ', false, json::error_handler_t::replace);
@@ -332,7 +332,7 @@ void InputProcessor::processInput()
         ShowFatalError("Errors occurred on processing input file. Preceding condition(s) cause termination.");
     }
 
-    if (DataGlobals::isEpJSON && DataGlobals::outputEpJSONConversion) {
+    if (DataGlobals::isEpJSON && (DataGlobals::outputEpJSONConversion || DataGlobals::outputEpJSONConversionOnly)) {
         if (versionMatch) {
             std::string const encoded = idf_parser->encode(epJSON, schema);
             std::string convertedEpJSON(DataStringGlobals::outputDirPathName + DataStringGlobals::inputFileNameOnly + ".idf");


### PR DESCRIPTION
Pull request overview
---------------------
Fixes #6835

This pull request adds a flag to only convert the input file (`--convert-only`) and not perform a simulation as well as adds an external input file conversion utility program.

The CLI `--convert-only` flag will now exit EnergyPlus after converting the input file format from IDF->epJSON or epJSON->IDF. This new flag reflects developer and user feedback that input file conversion should not require running a full simulation. Some output files will still be generated in this approach (for example, error file since there could still be errors during conversion).

Additionally, this PR adds a new input file conversion utility program. This program utilizes a new, small library for input parsing and validation, energyplusparser, from EnergyPlus InputProcessing code. The conversion program has a CLI that takes 1 or more input files and/or a newline delimited file of input file paths. If the code is compiled with OpenMP, this process is parallelized using a configurable number of threads. 

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
