### PR TITLE
Add FinalizeSimulation function

### DIFF
--- a/src/EnergyPlus/SimulationManager.hh
+++ b/src/EnergyPlus/SimulationManager.hh
@@ -75,6 +75,8 @@ namespace SimulationManager {
 
     void ManageSimulation();
 
+    void FinalizeSimulation();
+
     void GetProjectData();
 
     void CheckForMisMatchedEnvironmentSpecifications();


### PR DESCRIPTION
This change adds a FinalizeSimulation function. This function is useful
for external programs (such as Spawn) that are calling EnergyPlus. There
is no expected change in normal program execution. The
FinalizeSimulation function contains the code from the end of the
ManageSimulation function and simply bottles it up into a new stand
alone function. This is useful in contexts such as spawn where the
client may end the simulation before the run period is complete.


