### PR TITLE
Corrected CapFTemp curve index used in multi-speed DX coils for capacity sizing

### DIFF
--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -14876,7 +14876,7 @@ namespace DXCoils {
                     (SELECT_CASE_var == CoilDX_HeatingEmpirical) || (SELECT_CASE_var == CoilDX_CoolingTwoStageWHumControl)) {
                     CapFTCurveIndex = DXCoil(CoilIndex).CCapFTemp(1);
                 } else if ((SELECT_CASE_var == CoilDX_MultiSpeedCooling) || (SELECT_CASE_var == CoilDX_MultiSpeedHeating)) {
-                    CapFTCurveIndex = DXCoil(CoilIndex).MSCCapFTemp(1);
+                    CapFTCurveIndex = DXCoil(CoilIndex).MSCCapFTemp(DXCoil(CoilIndex).NumOfSpeeds);
                 } else if (SELECT_CASE_var == CoilVRF_Heating) {
                     CapFTCurveIndex = DXCoil(CoilIndex).CCapFTemp(1);
                 } else {

--- a/tst/EnergyPlus/unit/DXCoils.unit.cc
+++ b/tst/EnergyPlus/unit/DXCoils.unit.cc
@@ -3833,4 +3833,141 @@ TEST_F(EnergyPlusFixture, TestMultiSpeedCoolingCoilPartialAutoSizeOutput)
     EXPECT_EQ(1.75, DXCoil(1).MSRatedAirVolFlowRate(2));
     EXPECT_EQ(0.875, DXCoil(1).MSRatedAirVolFlowRate(1));
 }
+
+TEST_F(EnergyPlusFixture, DXCoils_GetDXCoilCapFTCurveIndexTest)
+{
+    using CurveManager::BiQuadratic;
+    using CurveManager::NumCurves;
+    using CurveManager::Quadratic;
+    int DXCoilNum;
+    int CurveNum;
+
+    NumDXCoils = 2;
+    DXCoil.allocate(NumDXCoils);
+    DXCoil(1).DXCoilType_Num = CoilDX_MultiSpeedCooling;
+    DXCoil(1).DXCoilType = "Coil:Cooling:DX:MultiSpeed";
+    DXCoil(2).DXCoilType_Num = CoilDX_MultiSpeedHeating;
+    DXCoil(2).DXCoilType = "Coil:Heating:DX:MultiSpeed";
+
+
+    for (DXCoilNum = 1; DXCoilNum <= 2; ++DXCoilNum) {
+        DXCoil(DXCoilNum).NumOfSpeeds = 2;
+        DXCoil(DXCoilNum).MSRatedTotCap.allocate(DXCoil(DXCoilNum).NumOfSpeeds);
+        DXCoil(DXCoilNum).MSCCapFTemp.allocate(DXCoil(DXCoilNum).NumOfSpeeds);
+    }
+
+    NumCurves = 4;
+    PerfCurve.allocate(NumCurves);
+
+    CurveNum = 1;
+    PerfCurve(CurveNum).Name = "HP_Cool-Cap-fT-SP1";
+    PerfCurve(CurveNum).CurveType = BiQuadratic;
+    PerfCurve(CurveNum).ObjectType = "Curve:Biquadratic";
+    PerfCurve(CurveNum).InterpolationType = EvaluateCurveToLimits;
+    PerfCurve(CurveNum).Coeff1 = 1.658788451;
+    PerfCurve(CurveNum).Coeff2 = -0.0834530076;
+    PerfCurve(CurveNum).Coeff3 = 0.00342409032;
+    PerfCurve(CurveNum).Coeff4 = 0.0024332436;
+    PerfCurve(CurveNum).Coeff5 = -4.5036e-005;
+    PerfCurve(CurveNum).Coeff6 = -0.00053367984;
+    PerfCurve(CurveNum).Var1Min = 13.88;
+    PerfCurve(CurveNum).Var1Max = 23.88;
+    PerfCurve(CurveNum).Var2Min = 18.33;
+    PerfCurve(CurveNum).Var2Max = 51.66;
+
+    CurveNum = 2;
+    PerfCurve(CurveNum).Name = "HP_Cool-Cap-fT-SP2";
+    PerfCurve(CurveNum).CurveType = BiQuadratic;
+    PerfCurve(CurveNum).ObjectType = "Curve:Biquadratic";
+    PerfCurve(CurveNum).InterpolationType = EvaluateCurveToLimits;
+    PerfCurve(CurveNum).Coeff1 = 1.472738138;
+    PerfCurve(CurveNum).Coeff2 = -0.0672218352;
+    PerfCurve(CurveNum).Coeff3 = 0.0029199042;
+    PerfCurve(CurveNum).Coeff4 = 5.16005999999982e-005;
+    PerfCurve(CurveNum).Coeff5 = -2.97756e-005;
+    PerfCurve(CurveNum).Coeff6 = -0.00035908596;
+    PerfCurve(CurveNum).Var1Min = 13.88;
+    PerfCurve(CurveNum).Var1Max = 23.88;
+    PerfCurve(CurveNum).Var2Min = 18.33;
+    PerfCurve(CurveNum).Var2Max = 51.66;
+
+    CurveNum = 3;
+    PerfCurve(CurveNum).Name = "HP_Heat-Cap-fT-SP1";
+    PerfCurve(CurveNum).CurveType = BiQuadratic;
+    PerfCurve(CurveNum).ObjectType = "Curve:Biquadratic";
+    PerfCurve(CurveNum).InterpolationType = EvaluateCurveToLimits;
+    PerfCurve(CurveNum).Coeff1 = 0.84077409;
+    PerfCurve(CurveNum).Coeff2 = -0.0014336586;
+    PerfCurve(CurveNum).Coeff3 = -0.000150336;
+    PerfCurve(CurveNum).Coeff4 = 0.029628603;
+    PerfCurve(CurveNum).Coeff5 = 0.000161676;
+    PerfCurve(CurveNum).Coeff6 = -2.349e-005;
+    PerfCurve(CurveNum).Var1Min = -100.0;
+    PerfCurve(CurveNum).Var1Max = 100.0;
+    PerfCurve(CurveNum).Var2Min = -100.0;
+    PerfCurve(CurveNum).Var2Max = 100.0;
+
+    CurveNum = 4;
+    PerfCurve(CurveNum).Name = "HP_Heat-Cap-fT-SP2";
+    PerfCurve(CurveNum).CurveType = BiQuadratic;
+    PerfCurve(CurveNum).ObjectType = "Curve:Biquadratic";
+    PerfCurve(CurveNum).InterpolationType = EvaluateCurveToLimits;
+    PerfCurve(CurveNum).Coeff1 = 0.831506971;
+    PerfCurve(CurveNum).Coeff2 = 0.0018392166;
+    PerfCurve(CurveNum).Coeff3 = -0.000187596;
+    PerfCurve(CurveNum).Coeff4 = 0.0266002056;
+    PerfCurve(CurveNum).Coeff5 = 0.000191484;
+    PerfCurve(CurveNum).Coeff6 = -6.5772e-005;
+    PerfCurve(CurveNum).Var1Min = -100.0;
+    PerfCurve(CurveNum).Var1Max = 100.0;
+    PerfCurve(CurveNum).Var2Min = -100.0;
+    PerfCurve(CurveNum).Var2Max = 100.0;
+
+    DXCoil(1).MSCCapFTemp(1) = 1;
+    DXCoil(1).MSCCapFTemp(2) = 2;
+
+    DXCoilNum = 2;
+    DXCoil(DXCoilNum).MSCCapFTemp(1) = 3;
+    DXCoil(DXCoilNum).MSCCapFTemp(2) = 4;
+
+    bool ErrorsFound;
+    int DataTotCapCurveIndex = 0;
+
+    DXCoils::GetCoilsInputFlag = false;
+
+    // dx cooling coil 
+    int CoilIndex = 1;
+    EXPECT_EQ(DXCoil(CoilIndex).DXCoilType, "Coil:Cooling:DX:MultiSpeed");
+    DataTotCapCurveIndex = DXCoils::GetDXCoilCapFTCurveIndex( CoilIndex, ErrorsFound );
+    EXPECT_EQ(2, DataTotCapCurveIndex);
+    // evaluate dx cooling coil curves to show impacts of incorrect curve index
+    Real64 TotCapTempModFac_lowestSpeed = CurveValue(1, 19.4, 30.0);
+    Real64 TotCapTempModFac_designSpeed = CurveValue(DataTotCapCurveIndex, 19.4, 30.0);
+    EXPECT_DOUBLE_EQ(1.0503539775151995, TotCapTempModFac_lowestSpeed);
+    EXPECT_DOUBLE_EQ(1.0333316291120003, TotCapTempModFac_designSpeed);
+    // apply dx cooling coil capacity curve correction
+    Real64 PeakCoilCoolingLoad = 10000.0;
+    Real64 NominalCoolingDesignCapacity_lowestSpeed = PeakCoilCoolingLoad / TotCapTempModFac_lowestSpeed;
+    Real64 NominalCoolingDesignCapacity_designSpeed = PeakCoilCoolingLoad / TotCapTempModFac_designSpeed;
+    EXPECT_DOUBLE_EQ(9520.5999254239905, NominalCoolingDesignCapacity_lowestSpeed);
+    EXPECT_DOUBLE_EQ(9677.4353153145621, NominalCoolingDesignCapacity_designSpeed);
+
+    // dx heating coil 
+    CoilIndex = 2;
+    EXPECT_EQ(DXCoil(CoilIndex).DXCoilType, "Coil:Heating:DX:MultiSpeed");
+    DataTotCapCurveIndex = DXCoils::GetDXCoilCapFTCurveIndex( CoilIndex, ErrorsFound );
+    EXPECT_EQ(4, DataTotCapCurveIndex);
+    // evaluate dx heating coil curves to show impacts of incorrect curve index
+    TotCapTempModFac_lowestSpeed = CurveValue(3, 5.0, 10.0);
+    TotCapTempModFac_designSpeed = CurveValue(DataTotCapCurveIndex, 5.0, 10.0);
+    EXPECT_DOUBLE_EQ(1.1411265269999999, TotCapTempModFac_lowestSpeed);
+    EXPECT_DOUBLE_EQ(1.1178750099999999, TotCapTempModFac_designSpeed);
+    // apply dx heating coil capacity curve correction
+    Real64 PeakCoilHeatingLoad = 10000.0;
+    Real64 NominalHeatingDesignCapacity_lowestSpeed = PeakCoilHeatingLoad / TotCapTempModFac_lowestSpeed;
+    Real64 NominalHeatingDesignCapacity_designSpeed = PeakCoilHeatingLoad / TotCapTempModFac_designSpeed;
+    EXPECT_DOUBLE_EQ(8763.2701224550547, NominalHeatingDesignCapacity_lowestSpeed);
+    EXPECT_DOUBLE_EQ(8945.5439208717980, NominalHeatingDesignCapacity_designSpeed);
+}
+
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #7625
 - Sets the corrects capacity function of temperature curve index used for adjusting the coil load to coil design capacity for multi-speed DX cooling and heating coils.  Prior to this fix, the lowest speed (speed 1) curve index was used. This is a defect.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally

