### PR TITLE
Add tolerance for high humidity OA control

### DIFF
--- a/src/EnergyPlus/DataHVACGlobals.hh
+++ b/src/EnergyPlus/DataHVACGlobals.hh
@@ -75,6 +75,7 @@ namespace DataHVACGlobals {
 
     // MODULE PARAMETER DEFINITIONS:
 
+    Real64 const SmallHumRatDiff(1.0E-7);
     extern Real64 const SmallTempDiff;
     extern Real64 const SmallMassFlow;
     extern Real64 const VerySmallMassFlow;

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -4593,7 +4593,8 @@ namespace MixedAir {
                 if (ZoneSysMoistureDemand(this->HumidistatZoneNum).TotalOutputRequired < 0.0) {
                     //     IF OAController is not allowed to modify air flow during high outdoor humrat condition, then disable modified air flow
                     //     if indoor humrat is less than or equal to outdoor humrat
-                    if (!this->ModifyDuringHighOAMoisture && Node(this->NodeNumofHumidistatZone).HumRat <= this->OAHumRat) {
+                    if (!this->ModifyDuringHighOAMoisture &&
+                        (Node(this->NodeNumofHumidistatZone).HumRat - this->OAHumRat) <= DataHVACGlobals::SmallHumRatDiff) {
                         HighHumidityOperationFlag = false;
                     } else {
                         HighHumidityOperationFlag = true;


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #7644 
 - The high humidity control option in Controller:OutdoorAir would somewhat randomly bring in excess outdoor air when the indoor and outdoor humidity ratios were essentially equal. Adding a small tolerance makes the control more consistent.
 - Diffs expected for UnitarySystem_FurnaceWithDXSystemRHControl.idf and others with this control.

### Explanation of Diffs ###
These test files have OA controller "High Humidity Control" = Yes.
FurnaceWithDXSystemRHControl, HeatPumpAirToAirWithRHControl, HPAirToAir_wSolarCollectorHWCoil, HP_wICSSolarCollector, HVACStandAloneERV_Economizer, UnitarySystem_FurnaceWithDXSystemRHControl, and UnitarySystem_WaterCoils_wMultiSpeedFan. Six of these are showing small or large eso diffs, as expected.

Looking at UnitarySystem_FurnaceWithDXSystemRHControl, for example. The following chart shows before and after, zone humidity ratio, OA humidity ratio, and "Air System Outdoor Air High Humidity Control Status". See how the high humidity control was kicking on randomly on the winter design day (left end of chart). After the fix, it stays off.

![image](https://user-images.githubusercontent.com/4991075/70472733-3b908e00-1a95-11ea-9f39-8134d4a06e1e.png)
![image](https://user-images.githubusercontent.com/4991075/70472763-49461380-1a95-11ea-90db-0ecbada125da.png)


### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [x] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [x] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
