### PR TITLE
Fix up a couple paper cuts

### DIFF
--- a/.decent_ci-Linux.yaml
+++ b/.decent_ci-Linux.yaml
@@ -49,8 +49,8 @@ compilers:
     cmake_extra_flags: -DBUILD_FORTRAN=ON -DBUILD_TESTING:BOOL=ON -DENABLE_REGRESSION_TESTING:BOOL=OFF -DCOMMIT_SHA=$COMMIT_SHA -DENABLE_COVERAGE:BOOL=ON -DENABLE_GTEST_DEBUG_MODE:BOOL=OFF
     coverage_enabled: true
     coverage_base_dir: src/EnergyPlus
-    coverage_pass_limit: 68.4
-    coverage_warn_limit: 68.0
+    coverage_pass_limit: 68.0
+    coverage_warn_limit: 67.9
     coverage_s3_bucket: energyplus
     build_tag: IntegrationCoverage
     ctest_filter: -R "integration.*"

--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -4116,7 +4116,7 @@ namespace SingleDuct {
         // na
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-        Real64 MassFlow; // [kg/sec]   Total Mass Flow Rate from Hot & Cold Inlets
+        Real64 MassFlow = 0; // [kg/sec]   Total Mass Flow Rate from Hot & Cold Inlets
         Real64 QTotLoad; // [Watts]
         // unused  REAL(r64) :: QZnReq      ! [Watts]
         Real64 CpAirZn;


### PR DESCRIPTION
A couple tiny things are causing the dashboard to be more yellow than usual.
1. An uninitialized variable warning is appearing on Mac.  I believe the variable is actually initialized, the compiler just doesn't see that the uninitialized paths are not actually going to continue.  Anyway, I initialized it to zero, I think it will be perfectly fine.
2. The integration coverage dipped very slightly below the warn limit.  This is because over the past couple months, we've been refactoring plant components and reduced the number of lines in each object usually quite significantly.  Since these components are covered by varying amounts of unit tests, we ended up dropping the number of covered lines.  I just dropped the limit very slightly so it won't warn anymore.

CI should come back clean with no diffs due to the initialized variable thing and all green on integration coverage as well. -- except for the ever-present timeout file, that is.  If that's all good, this can drop in.