### PR TITLE
Fix formatting warnings and also formatting checker

### DIFF
--- a/scripts/dev/verify_file_formatting.sh
+++ b/scripts/dev/verify_file_formatting.sh
@@ -13,7 +13,7 @@ grep -q -P "^ *\t *" "$1"
 
 if [ $? -eq 0 ]
 then
-  diff -I "^ *\S\+.*" --unchanged-line-format="" --new-line-format="" --old-line-format="{ \"filename\": \"$1\", \"line\": %dn, \"messagetype\": \"warning\", \"message\": \"Formatting does not meet standards, See .clang_format and apply formatting.\", \"tool\": \"format-checker\" }%c'\012'" "$1" <(clang-format "$1")
+  diff -I "^ *\S\+.*" --unchanged-line-format="" --new-line-format="" --old-line-format="{ \"file\": \"$1\", \"line\": %dn, \"messagetype\": \"warning\", \"message\": \"Formatting does not meet standards, See .clang_format and apply formatting.\", \"tool\": \"format-checker\" }%c'\012'" "$1" <(clang-format "$1")
 fi
 
 

--- a/tst/EnergyPlus/unit/Psychrometrics.unit.cc
+++ b/tst/EnergyPlus/unit/Psychrometrics.unit.cc
@@ -228,46 +228,46 @@ TEST_F(EnergyPlusFixture, Psychrometrics_PsyWFnTdpPb_Test)
 }
 
 inline Real64 PsyCpAirFnWTdb(Real64 const dw, // humidity ratio {kgWater/kgDryAir}
-                      Real64 const T   // input temperature {Celsius}
+                             Real64 const T   // input temperature {Celsius}
 )
 {
 
-	//// NOTE: THIS FUNCTION IS DEPRECATED AND USED FOR TESTING PURPOSES ONLY
+    //// NOTE: THIS FUNCTION IS DEPRECATED AND USED FOR TESTING PURPOSES ONLY
 
-	// FUNCTION INFORMATION:
-	//       AUTHOR         J. C. VanderZee
-	//       DATE WRITTEN   Feb. 1994
-	//       MODIFIED       na
-	//       RE-ENGINEERED  na
+    // FUNCTION INFORMATION:
+    //       AUTHOR         J. C. VanderZee
+    //       DATE WRITTEN   Feb. 1994
+    //       MODIFIED       na
+    //       RE-ENGINEERED  na
 
-	// PURPOSE OF THIS FUNCTION:
-	// This function provides the heat capacity of air {J/kg-C} as function of humidity ratio.
+    // PURPOSE OF THIS FUNCTION:
+    // This function provides the heat capacity of air {J/kg-C} as function of humidity ratio.
 
-	// METHODOLOGY EMPLOYED:
-	// take numerical derivative of PsyHFnTdbW function
+    // METHODOLOGY EMPLOYED:
+    // take numerical derivative of PsyHFnTdbW function
 
-	// REFERENCES:
-	// see PsyHFnTdbW ref. to ASHRAE Fundamentals
-	// USAGE:  cpa = PsyCpAirFnWTdb(w,T)
+    // REFERENCES:
+    // see PsyHFnTdbW ref. to ASHRAE Fundamentals
+    // USAGE:  cpa = PsyCpAirFnWTdb(w,T)
 
-	// Static locals
-	static Real64 dwSave(-100.0);
-	static Real64 Tsave(-100.0);
-	static Real64 cpaSave(-100.0);
+    // Static locals
+    static Real64 dwSave(-100.0);
+    static Real64 Tsave(-100.0);
+    static Real64 cpaSave(-100.0);
 
-	// check if last call had the same input and if it did just use the saved output
-	if ((Tsave == T) && (dwSave == dw)) return cpaSave;
+    // check if last call had the same input and if it did just use the saved output
+    if ((Tsave == T) && (dwSave == dw)) return cpaSave;
 
-	// compute heat capacity of air
-	Real64 const w(max(dw, 1.0e-5));
-	Real64 const cpa((PsyHFnTdbW(T + 0.1, w) - PsyHFnTdbW(T, w)) * 10.0); // result => heat capacity of air {J/kg-C}
+    // compute heat capacity of air
+    Real64 const w(max(dw, 1.0e-5));
+    Real64 const cpa((PsyHFnTdbW(T + 0.1, w) - PsyHFnTdbW(T, w)) * 10.0); // result => heat capacity of air {J/kg-C}
 
-	// save values for next call
-	dwSave = dw;
-	Tsave = T;
-	cpaSave = cpa;
+    // save values for next call
+    dwSave = dw;
+    Tsave = T;
+    cpaSave = cpa;
 
-	return cpa;
+    return cpa;
 }
 
 TEST_F(EnergyPlusFixture, Psychrometrics_PsyCpAirFn_Test)
@@ -353,7 +353,7 @@ TEST_F(EnergyPlusFixture, Psychrometrics_CpAirValue_Test)
     Real64 T2 = 20.0;
 
     // Dry Cooling Test
-    Real64 MassFlowRate = 5.0;  // kgDryAir/s
+    Real64 MassFlowRate = 5.0;                 // kgDryAir/s
     Real64 CpAir = 1.00484e3 + W1 * 1.85895e3; // PsyCpAirFnW per cp = dh/dT
     Real64 CpAir1 = PsyCpAirFnW(W1);           // PsyCpAirFnW per cp = dh/dT
     Real64 CpAir2 = PsyCpAirFnW(W2);           // PsyCpAirFnW per cp = dh/dT
@@ -365,8 +365,8 @@ TEST_F(EnergyPlusFixture, Psychrometrics_CpAirValue_Test)
     Real64 Qfrom_mdot_CpAir_DeltaT = MassFlowRate * CpAir * (T1 - T2);
 
     // get enthalpy at state 1 and 2
-    Real64 H1 = PsyHFnTdbW(T1, W1);         // enthaly ait state 1
-    Real64 H2 = PsyHFnTdbW(T2, W2);         // enthaly ait state 2
+    Real64 H1 = PsyHFnTdbW(T1, W1); // enthaly ait state 1
+    Real64 H2 = PsyHFnTdbW(T2, W2); // enthaly ait state 2
     Real64 Qfrom_mdot_DeltaH = MassFlowRate * (H1 - H2);
 
     // check heat rate
@@ -378,8 +378,8 @@ TEST_F(EnergyPlusFixture, Psychrometrics_CpAirValue_Test)
     CpAir = 1.00484e3 + W1 * 1.85895e3;
     Qfrom_mdot_CpAir_DeltaT = MassFlowRate * CpAir * (T2 - T1);
 
-    H1 = PsyHFnTdbW(T1, W1);         // enthaly ait state 1
-    H2 = PsyHFnTdbW(T2, W2);         // enthaly ait state 2
+    H1 = PsyHFnTdbW(T1, W1); // enthaly ait state 1
+    H2 = PsyHFnTdbW(T2, W2); // enthaly ait state 2
     Qfrom_mdot_DeltaH = MassFlowRate * (H2 - H1);
 
     // check heat transfer rate calc method for heating


### PR DESCRIPTION
Formatting warnings were just because tabs were found in a unit test file.  These are fixed here.

I found that the format checker was reporting out messages to CI, but using "filename" instead of just "file".  I fixed that here as well, and now it should properly point developers to the exact line that was problematic.

Reviewer: If you want to run this locally, just make sure you have clang-format installed, and from the root of the repository, run `./scripts/dev/verify_formatting.sh`.  It shouldn't report anything.  Then add a tab character to a src or tst file and re-run.  It should report a JSON warning about the character.