### PR TITLE
Apply clang-format to clean up custom_check errors

### DIFF
--- a/src/EnergyPlus/Coils/CoilCoolingDX.hh
+++ b/src/EnergyPlus/Coils/CoilCoolingDX.hh
@@ -45,7 +45,6 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #ifndef ENERGYPLUS_COILS_COILCOOLINGDX
 #define ENERGYPLUS_COILS_COILCOOLINGDX
 
@@ -74,23 +73,23 @@ struct CoilCoolingDXInputSpecification
 struct CoilCoolingDX
 {
     CoilCoolingDX() = default;
-    static int factory(std::string const & coilName);
+    static int factory(std::string const &coilName);
     static void getInput();
     static void clear_state();
-    void instantiateFromInputSpec(const CoilCoolingDXInputSpecification& input_data);
+    void instantiateFromInputSpec(const CoilCoolingDXInputSpecification &input_data);
     void oneTimeInit();
     void simulate(bool useAlternateMode, Real64 PLR, int speedNum, Real64 speedRatio, int fanOpMode);
     void setData(int fanIndex, int fanType, std::string const &fanName, int airLoopNum);
     void getFixedData(int &evapInletNodeIndex,
-                 int &evapOutletNodeIndex,
-                 int &condInletNodeIndex,
-                 int &normalModeNumSpeeds,
-                 CoilCoolingDXCurveFitPerformance::CapControlMethod &capacityControlMethod,
-                 Real64 &minOutdoorDryBulb);
+                      int &evapOutletNodeIndex,
+                      int &condInletNodeIndex,
+                      int &normalModeNumSpeeds,
+                      CoilCoolingDXCurveFitPerformance::CapControlMethod &capacityControlMethod,
+                      Real64 &minOutdoorDryBulb);
     void getDataAfterSizing(Real64 &normalModeRatedEvapAirFlowRate,
-                      Real64 &normalModeRatedCapacity,
-                      std::vector<Real64> &normalModeFlowRates, 
-                      std::vector<Real64> &normalModeRatedCapacities);
+                            Real64 &normalModeRatedCapacity,
+                            std::vector<Real64> &normalModeFlowRates,
+                            std::vector<Real64> &normalModeRatedCapacities);
     static void inline passThroughNodeData(DataLoopNode::NodeData &in, DataLoopNode::NodeData &out);
     void size();
 
@@ -100,7 +99,7 @@ struct CoilCoolingDX
     int evapInletNodeIndex = 0;
     int evapOutletNodeIndex = 0;
     int availScheduleIndex = 0;
-    //int condZoneIndex = 0;
+    // int condZoneIndex = 0;
     int condInletNodeIndex = 0;
     int condOutletNodeIndex = 0;
     CoilCoolingDXCurveFitPerformance performance;
@@ -111,9 +110,9 @@ struct CoilCoolingDX
     int evaporativeCondSupplyTankIndex = 0;
     int evaporativeCondSupplyTankARRID = 0;
     Real64 evaporativeCondSupplyTankVolumeFlow = 0.0;
-    //Real64 evaporativeCondSupplyTankVolumeConsumption = 0.0;
-	Real64 evapCondPumpElecPower = 0.0;
-	Real64 evapCondPumpElecConsumption = 0.0;
+    // Real64 evaporativeCondSupplyTankVolumeConsumption = 0.0;
+    Real64 evapCondPumpElecPower = 0.0;
+    Real64 evapCondPumpElecConsumption = 0.0;
     int airLoopNum = 0; // Add for AFN compatibility, revisit at a later date
     int supplyFanIndex = 0;
     int supplyFanType = 0;
@@ -143,7 +142,6 @@ struct CoilCoolingDX
     Real64 speedRatioReport = 0.0;
     Real64 wasteHeatEnergyRate = 0.0;
     Real64 wasteHeatEnergy = 0.0;
-
 };
 
 extern std::vector<CoilCoolingDX> coilCoolingDXs;

--- a/src/EnergyPlus/Coils/CoilCoolingDXCurveFitPerformance.hh
+++ b/src/EnergyPlus/Coils/CoilCoolingDXCurveFitPerformance.hh
@@ -45,19 +45,18 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #ifndef ENERGYPLUS_COILS_COILCOOLINGDXCURVEFITPERFORMANCE
 #define ENERGYPLUS_COILS_COILCOOLINGDXCURVEFITPERFORMANCE
 
 #include <string>
 #include <vector>
 
-#include <EnergyPlus/EnergyPlus.hh>
 #include <EnergyPlus/Coils/CoilCoolingDXCurveFitOperatingMode.hh>
 #include <EnergyPlus/DataLoopNode.hh>
+#include <EnergyPlus/EnergyPlus.hh>
 
 namespace EnergyPlus {
-    class OutputFiles;
+class OutputFiles;
 
 struct CoilCoolingDXCurveFitPerformanceInputSpecification
 {
@@ -78,7 +77,7 @@ struct CoilCoolingDXCurveFitPerformanceInputSpecification
 struct CoilCoolingDXCurveFitPerformance
 {
     std::string object_name = "Coil:Cooling:DX:CurveFit:Performance";
-    void instantiateFromInputSpec(const CoilCoolingDXCurveFitPerformanceInputSpecification& input_data);
+    void instantiateFromInputSpec(const CoilCoolingDXCurveFitPerformanceInputSpecification &input_data);
     void simulate(const DataLoopNode::NodeData &inletNode,
                   DataLoopNode::NodeData &outletNode,
                   bool useAlternateMode,
@@ -98,11 +97,12 @@ struct CoilCoolingDXCurveFitPerformance
                    int &fanOpMode,
                    DataLoopNode::NodeData &condInletNode,
                    DataLoopNode::NodeData &condOutletNode);
-    void calcStandardRatings(int supplyFanIndex, int supplyFanType, std::string const &supplyFanName, int condInletNodeIndex, EnergyPlus::OutputFiles &outputFiles);
+    void calcStandardRatings(
+        int supplyFanIndex, int supplyFanType, std::string const &supplyFanName, int condInletNodeIndex, EnergyPlus::OutputFiles &outputFiles);
     Real64 calcIEERResidual(Real64 const SupplyAirMassFlowRate, std::vector<Real64> const &Par);
     CoilCoolingDXCurveFitPerformanceInputSpecification original_input_specs;
     CoilCoolingDXCurveFitPerformance() = default;
-	explicit CoilCoolingDXCurveFitPerformance(const std::string& name);
+    explicit CoilCoolingDXCurveFitPerformance(const std::string &name);
     void size();
 
     std::string name;
@@ -114,18 +114,18 @@ struct CoilCoolingDXCurveFitPerformance
     Real64 unitStatic = 0.0;
     bool mySizeFlag = true;
 
-	enum CapControlMethod
-	{
-            CONTINUOUS,
-            DISCRETE
-        };
-	CapControlMethod capControlMethod = CapControlMethod::DISCRETE;
+    enum CapControlMethod
+    {
+        CONTINUOUS,
+        DISCRETE
+    };
+    CapControlMethod capControlMethod = CapControlMethod::DISCRETE;
 
     Real64 evapCondBasinHeatCap = 0.0;
     Real64 evapCondBasinHeatSetpoint = 0.0;
     int evapCondBasinHeatSchedulIndex = 0;
-	Real64 basinHeaterElectricityConsumption = 0.0;
-	Real64 basinHeaterPower = 0.0;
+    Real64 basinHeaterElectricityConsumption = 0.0;
+    Real64 basinHeaterPower = 0.0;
     Real64 powerUse = 0.0;
     Real64 electricityConsumption = 0.0;
     Real64 RTF = 0.0;

--- a/src/EnergyPlus/DataHVACGlobals.cc
+++ b/src/EnergyPlus/DataHVACGlobals.cc
@@ -314,7 +314,7 @@ namespace DataHVACGlobals {
                                             "",
                                             "Coil:Cooling:DX:VariableRefrigerantFlow:FluidTemperatureControl",
                                             "",
-					    "Coil:Cooling:DX"});
+                                            "Coil:Cooling:DX"});
 
     Array1D_string const cHeatingCoilTypes(NumAllCoilTypes,
                                            {"",
@@ -351,7 +351,7 @@ namespace DataHVACGlobals {
                                             "Coil:WaterHeating:AirToWaterHeatPump:VariableSpeed",
                                             "",
                                             "Coil:Heating:DX:VariableRefrigerantFlow:FluidTemperatureControl",
-					    ""});
+                                            ""});
 
     // Water to air HP coil types
     int const WatertoAir_Simple(1);
@@ -502,12 +502,12 @@ namespace DataHVACGlobals {
     Real64 deviationFromSetPtThresholdHtg(-0.2); // heating threshold for reporting setpoint deviation
     Real64 deviationFromSetPtThresholdClg(0.2);  // cooling threshold for reporting setpoint deviation
 
-    bool SimAirLoopsFlag;          // True when the air loops need to be (re)simulated
-    bool SimElecCircuitsFlag;      // True when electic circuits need to be (re)simulated
-    bool SimPlantLoopsFlag;        // True when the main plant loops need to be (re)simulated
-    bool SimZoneEquipmentFlag;     // True when zone equipment components need to be (re)simulated
-    bool SimNonZoneEquipmentFlag;  // True when non-zone equipment components need to be (re)simulated
-    bool ZoneMassBalanceHVACReSim; // True when zone air mass flow balance and air loop needs (re)simulated
+    bool SimAirLoopsFlag;                  // True when the air loops need to be (re)simulated
+    bool SimElecCircuitsFlag;              // True when electic circuits need to be (re)simulated
+    bool SimPlantLoopsFlag;                // True when the main plant loops need to be (re)simulated
+    bool SimZoneEquipmentFlag;             // True when zone equipment components need to be (re)simulated
+    bool SimNonZoneEquipmentFlag;          // True when non-zone equipment components need to be (re)simulated
+    bool ZoneMassBalanceHVACReSim;         // True when zone air mass flow balance and air loop needs (re)simulated
     int MinAirLoopIterationsAfterFirst(1); // minimum number of HVAC iterations after FirstHVACIteration
 
     int const NumZoneHVACTerminalTypes(37);

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -3811,7 +3811,8 @@ namespace OutputReportTabular {
                     tbl_stream << "<br><a href=\"#" << MakeAnchorName(Initialization_Summary, Entire_Facility) << "\">Initialization Summary</a>\n";
                 }
                 if (displayHeatEmissionsSummary) {
-                    tbl_stream << "<br><a href=\"#" << MakeAnchorName(Annual_Heat_Emissions_Summary, Entire_Facility) << "\">Annual Heat Emissions Summary</a>\n";
+                    tbl_stream << "<br><a href=\"#" << MakeAnchorName(Annual_Heat_Emissions_Summary, Entire_Facility)
+                               << "\">Annual Heat Emissions Summary</a>\n";
                 }
                 for (kReport = 1; kReport <= numReportName; ++kReport) {
                     if (reportName(kReport).show) {
@@ -3965,8 +3966,10 @@ namespace OutputReportTabular {
             if (gatherThisTime) {
                 for (jTable = 1; jTable <= curNumTables; ++jTable) {
                     repIndex = curResIndex + (jTable - 1);
-                    if (((curStepType == OutputProcessor::TimeStepType::TimeStepZone) && (t_timeStepType == OutputProcessor::TimeStepType::TimeStepZone)) ||
-                        ((curStepType == OutputProcessor::TimeStepType::TimeStepSystem) && (t_timeStepType == OutputProcessor::TimeStepType::TimeStepSystem))) {
+                    if (((curStepType == OutputProcessor::TimeStepType::TimeStepZone) &&
+                         (t_timeStepType == OutputProcessor::TimeStepType::TimeStepZone)) ||
+                        ((curStepType == OutputProcessor::TimeStepType::TimeStepSystem) &&
+                         (t_timeStepType == OutputProcessor::TimeStepType::TimeStepSystem))) {
                         // put actual value from OutputProcesser arrays
                         curValue = GetInternalVariableValue(curTypeOfVar, BinObjVarID(repIndex).varMeterNum);
                         // per MJW when a summed variable is used divide it by the length of the time step
@@ -4126,8 +4129,10 @@ namespace OutputReportTabular {
                 curCol = jColumn + curFirstColumn - 1;
                 curTypeOfVar = MonthlyColumnsTypeOfVar(curCol);
                 curStepType = MonthlyColumnsStepType(curCol);
-                if (((curStepType == OutputProcessor::TimeStepType::TimeStepZone) && (t_timeStepType == OutputProcessor::TimeStepType::TimeStepZone)) ||
-                    ((curStepType == OutputProcessor::TimeStepType::TimeStepSystem) && (t_timeStepType == OutputProcessor::TimeStepType::TimeStepSystem))) {
+                if (((curStepType == OutputProcessor::TimeStepType::TimeStepZone) &&
+                     (t_timeStepType == OutputProcessor::TimeStepType::TimeStepZone)) ||
+                    ((curStepType == OutputProcessor::TimeStepType::TimeStepSystem) &&
+                     (t_timeStepType == OutputProcessor::TimeStepType::TimeStepSystem))) {
                     //  the above condition used to include the following prior to new scan method
                     //  (MonthlyColumns(curCol)%aggType .EQ. aggTypeValueWhenMaxMin)
                     curVarNum = MonthlyColumnsVarNum(curCol);
@@ -4144,8 +4149,8 @@ namespace OutputReportTabular {
                     // the current timestamp
                     minuteCalculated = DetermineMinuteForReporting(t_timeStepType);
                     //      minuteCalculated = (CurrentTime - INT(CurrentTime))*60
-                    //      IF (t_timeStepType .EQ. OutputProcessor::TimeStepType::TimeStepSystem) minuteCalculated = minuteCalculated + SysTimeElapsed * 60
-                    //      minuteCalculated = INT((TimeStep-1) * TimeStepZone * 60) + INT((SysTimeElapsed + TimeStepSys) * 60)
+                    //      IF (t_timeStepType .EQ. OutputProcessor::TimeStepType::TimeStepSystem) minuteCalculated = minuteCalculated +
+                    //      SysTimeElapsed * 60 minuteCalculated = INT((TimeStep-1) * TimeStepZone * 60) + INT((SysTimeElapsed + TimeStepSys) * 60)
                     EncodeMonDayHrMin(timestepTimeStamp, Month, DayOfMonth, HourOfDay, minuteCalculated);
                     // perform the selected aggregation type
                     // use next lines since it is faster was: SELECT CASE (MonthlyColumns(curCol)%aggType)
@@ -4834,8 +4839,8 @@ namespace OutputReportTabular {
         using PlantChillers::NumElectricChillers;
         using PlantChillers::NumEngineDrivenChillers;
         using PlantChillers::NumGTChillers;
-        using RefrigeratedCase::RefrigRack;
         using RefrigeratedCase::Condenser;
+        using RefrigeratedCase::RefrigRack;
         using VariableSpeedCoils::NumVarSpeedCoils;
         using VariableSpeedCoils::VarSpeedCoil;
         using WaterThermalTanks::WaterThermalTank;
@@ -4874,14 +4879,13 @@ namespace OutputReportTabular {
 
         // Condenser water loop
         for (iCooler = 1; iCooler <= NumSimpleTowers; ++iCooler) {
-            SysTotalHVACRejectHeatLoss += towers(iCooler).Qactual * TimeStepSysSec + towers(iCooler).FanEnergy +
-                                          towers(iCooler).BasinHeaterConsumption;
+            SysTotalHVACRejectHeatLoss +=
+                towers(iCooler).Qactual * TimeStepSysSec + towers(iCooler).FanEnergy + towers(iCooler).BasinHeaterConsumption;
         }
         for (iCooler = 1; iCooler <= NumSimpleEvapFluidCoolers; ++iCooler) {
-            SysTotalHVACRejectHeatLoss +=
-                    SimpleEvapFluidCooler(iCooler).Qactual * TimeStepSysSec + SimpleEvapFluidCooler(iCooler).FanEnergy;
+            SysTotalHVACRejectHeatLoss += SimpleEvapFluidCooler(iCooler).Qactual * TimeStepSysSec + SimpleEvapFluidCooler(iCooler).FanEnergy;
         }
-        for (auto & cooler : SimpleFluidCooler) {
+        for (auto &cooler : SimpleFluidCooler) {
             SysTotalHVACRejectHeatLoss += cooler.Qactual * TimeStepSysSec + cooler.FanEnergy;
         }
 
@@ -4919,8 +4923,7 @@ namespace OutputReportTabular {
 
         // Water / steam boiler
         for (iBoiler = 1; iBoiler <= NumBoilers; ++iBoiler) {
-            SysTotalHVACRejectHeatLoss +=
-                Boiler(iBoiler).FuelConsumed + Boiler(iBoiler).ParasiticElecConsumption - Boiler(iBoiler).BoilerEnergy;
+            SysTotalHVACRejectHeatLoss += Boiler(iBoiler).FuelConsumed + Boiler(iBoiler).ParasiticElecConsumption - Boiler(iBoiler).BoilerEnergy;
         }
 
         // DX Coils air to air
@@ -8444,7 +8447,7 @@ namespace OutputReportTabular {
             rowHead.allocate(numRows);
             columnHead.allocate(7);
             columnWidth.allocate(7);
-            columnWidth = 14; // array assignment - same for all columns
+            columnWidth = 14;               // array assignment - same for all columns
             tableBody.allocate(7, numRows); // TODO: this appears to be (column, row)...
             rowHead = "";
             tableBody = "";
@@ -8532,16 +8535,24 @@ namespace OutputReportTabular {
                 }
 
                 // Erase the SubCategory (first column), using slicing
-                Array2D_string tableBodyTemp(tableBody({2, _, _ }, {_, _, _}));
-                Array1D_string columnHeadTemp(columnHead({2, _, _ }));
+                Array2D_string tableBodyTemp(tableBody({2, _, _}, {_, _, _}));
+                Array1D_string columnHeadTemp(columnHead({2, _, _}));
 
                 if (sqlite) {
-                    sqlite->createSQLiteTabularDataRecords(
-                        tableBodyTemp, rowHeadTemp, columnHeadTemp, "AnnualBuildingUtilityPerformanceSummary", "Entire Facility", "End Uses By Subcategory");
+                    sqlite->createSQLiteTabularDataRecords(tableBodyTemp,
+                                                           rowHeadTemp,
+                                                           columnHeadTemp,
+                                                           "AnnualBuildingUtilityPerformanceSummary",
+                                                           "Entire Facility",
+                                                           "End Uses By Subcategory");
                 }
                 if (ResultsFramework::OutputSchema->timeSeriesAndTabularEnabled()) {
-                    ResultsFramework::OutputSchema->TabularReportsCollection.addReportTable(
-                        tableBodyTemp, rowHeadTemp, columnHeadTemp, "Annual Building Utility Performance Summary", "Entire Facility", "End Uses By Subcategory");
+                    ResultsFramework::OutputSchema->TabularReportsCollection.addReportTable(tableBodyTemp,
+                                                                                            rowHeadTemp,
+                                                                                            columnHeadTemp,
+                                                                                            "Annual Building Utility Performance Summary",
+                                                                                            "Entire Facility",
+                                                                                            "End Uses By Subcategory");
                 }
                 rowHeadTemp.deallocate();
                 tableBodyTemp.deallocate();
@@ -9286,7 +9297,6 @@ namespace OutputReportTabular {
                                                                                         "Source Energy End Use Components Summary");
             }
 
-
             // Normalized by Area tables
 
             {
@@ -9340,12 +9350,13 @@ namespace OutputReportTabular {
                                                            "Source Energy End Use Component Per Conditioned Floor Area");
                 }
                 if (ResultsFramework::OutputSchema->timeSeriesAndTabularEnabled()) {
-                    ResultsFramework::OutputSchema->TabularReportsCollection.addReportTable(tableBody,
-                                                                                            rowHead,
-                                                                                            columnHead,
-                                                                                            "Source Energy End Use Components Summary",
-                                                                                            "Entire Facility",
-                                                                                            "Source Energy End Use Component Per Conditioned Floor Area");
+                    ResultsFramework::OutputSchema->TabularReportsCollection.addReportTable(
+                        tableBody,
+                        rowHead,
+                        columnHead,
+                        "Source Energy End Use Components Summary",
+                        "Entire Facility",
+                        "Source Energy End Use Component Per Conditioned Floor Area");
                 }
             } // End of Normalized by Conditioned Area
 
@@ -9877,8 +9888,8 @@ namespace OutputReportTabular {
             }
 
             // Erase the SubCategory (first column), using slicing
-            Array2D_string tableBodyTemp(tableBody({2, _, _ }, {_, _, _}));
-            Array1D_string columnHeadTemp(columnHead({2, _, _ }));
+            Array2D_string tableBodyTemp(tableBody({2, _, _}, {_, _, _}));
+            Array1D_string columnHeadTemp(columnHead({2, _, _}));
 
             if (sqlite) {
                 sqlite->createSQLiteTabularDataRecords(
@@ -10587,8 +10598,9 @@ namespace OutputReportTabular {
                                     }
                                 }
                                 if (DetailedWWR) {
-                                    ObjexxFCL::gio::write(OutputFileDebug, fmtA) << Surface(iSurf).Name + ",Wall," + RoundSigDigits(curArea * mult, 1) + ',' +
-                                                                             RoundSigDigits(Surface(iSurf).Tilt, 1);
+                                    ObjexxFCL::gio::write(OutputFileDebug, fmtA) << Surface(iSurf).Name + ",Wall," +
+                                                                                        RoundSigDigits(curArea * mult, 1) + ',' +
+                                                                                        RoundSigDigits(Surface(iSurf).Tilt, 1);
                                 }
                             } else if ((SELECT_CASE_var == SurfaceClass_Window) || (SELECT_CASE_var == SurfaceClass_TDD_Dome)) {
                                 mult = Zone(zonePt).Multiplier * Zone(zonePt).ListMultiplier * Surface(iSurf).Multiplier;
@@ -10609,8 +10621,9 @@ namespace OutputReportTabular {
                                     curArea * Surface(iSurf).Multiplier; // total window opening area for each zone (glass plus frame area)
                                 zoneGlassArea(zonePt) += Surface(iSurf).GrossArea * Surface(iSurf).Multiplier;
                                 if (DetailedWWR) {
-                                    ObjexxFCL::gio::write(OutputFileDebug, fmtA) << Surface(iSurf).Name + ",Window," + RoundSigDigits(curArea * mult, 1) + ',' +
-                                                                             RoundSigDigits(Surface(iSurf).Tilt, 1);
+                                    ObjexxFCL::gio::write(OutputFileDebug, fmtA) << Surface(iSurf).Name + ",Window," +
+                                                                                        RoundSigDigits(curArea * mult, 1) + ',' +
+                                                                                        RoundSigDigits(Surface(iSurf).Tilt, 1);
                                 }
                             }
                         }
@@ -10622,15 +10635,17 @@ namespace OutputReportTabular {
                                 mult = Zone(zonePt).Multiplier * Zone(zonePt).ListMultiplier;
                                 roofArea += curArea * mult;
                                 if (DetailedWWR) {
-                                    ObjexxFCL::gio::write(OutputFileDebug, fmtA) << Surface(iSurf).Name + ",Roof," + RoundSigDigits(curArea * mult, 1) + ',' +
-                                                                             RoundSigDigits(Surface(iSurf).Tilt, 1);
+                                    ObjexxFCL::gio::write(OutputFileDebug, fmtA) << Surface(iSurf).Name + ",Roof," +
+                                                                                        RoundSigDigits(curArea * mult, 1) + ',' +
+                                                                                        RoundSigDigits(Surface(iSurf).Tilt, 1);
                                 }
                             } else if ((SELECT_CASE_var == SurfaceClass_Window) || (SELECT_CASE_var == SurfaceClass_TDD_Dome)) {
                                 mult = Zone(zonePt).Multiplier * Zone(zonePt).ListMultiplier * Surface(iSurf).Multiplier;
                                 skylightArea += curArea * mult;
                                 if (DetailedWWR) {
-                                    ObjexxFCL::gio::write(OutputFileDebug, fmtA) << Surface(iSurf).Name + ",Skylight," + RoundSigDigits(curArea * mult, 1) +
-                                                                             ',' + RoundSigDigits(Surface(iSurf).Tilt, 1);
+                                    ObjexxFCL::gio::write(OutputFileDebug, fmtA) << Surface(iSurf).Name + ",Skylight," +
+                                                                                        RoundSigDigits(curArea * mult, 1) + ',' +
+                                                                                        RoundSigDigits(Surface(iSurf).Tilt, 1);
                                 }
                             }
                         }
@@ -10648,11 +10663,11 @@ namespace OutputReportTabular {
                 ObjexxFCL::gio::write(OutputFileDebug, fmtA) << "TotalWallArea,WallAreaN,WallAreaS,WallAreaE,WallAreaW";
                 ObjexxFCL::gio::write(OutputFileDebug, fmtA) << "TotalWindowArea,WindowAreaN,WindowAreaS,WindowAreaE,WindowAreaW";
                 ObjexxFCL::gio::write(OutputFileDebug, fmtA) << RoundSigDigits(TotalWallArea, 2) + ',' + RoundSigDigits(wallAreaN, 2) + ',' +
-                                                         RoundSigDigits(wallAreaS, 2) + ',' + RoundSigDigits(wallAreaE, 2) + ',' +
-                                                         RoundSigDigits(wallAreaW, 2);
+                                                                    RoundSigDigits(wallAreaS, 2) + ',' + RoundSigDigits(wallAreaE, 2) + ',' +
+                                                                    RoundSigDigits(wallAreaW, 2);
                 ObjexxFCL::gio::write(OutputFileDebug, fmtA) << RoundSigDigits(TotalWindowArea, 2) + ',' + RoundSigDigits(windowAreaN, 2) + ',' +
-                                                         RoundSigDigits(windowAreaS, 2) + ',' + RoundSigDigits(windowAreaE, 2) + ',' +
-                                                         RoundSigDigits(windowAreaW, 2);
+                                                                    RoundSigDigits(windowAreaS, 2) + ',' + RoundSigDigits(windowAreaE, 2) + ',' +
+                                                                    RoundSigDigits(windowAreaW, 2);
             }
 
             tableBody = "";
@@ -12277,8 +12292,9 @@ namespace OutputReportTabular {
 
         if (ShowDecayCurvesInEIO) {
             // show the line definition for the decay curves
-            print(outputFiles.eio,  "! <Radiant to Convective Decay Curves for Cooling>,Zone Name, Surface Name, Time "
-                                    "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36");
+            print(outputFiles.eio,
+                  "! <Radiant to Convective Decay Curves for Cooling>,Zone Name, Surface Name, Time "
+                  "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36");
             // Put the decay curve into the EIO file
             for (int iZone = 1; iZone <= NumOfZones; ++iZone) {
                 ZoneData &zd(Zone(iZone));
@@ -12767,7 +12783,6 @@ namespace OutputReportTabular {
                     // We delay the potential application of SI to IP conversion and actual output until after both the AirLoopComponentLoadSummary
                     // and FacilityComponentLoadSummary have been processed because below we try to retrieve the info directly when the timestamp
                     // would match (cf #7356), and if we converted right now, we would apply the conversion twice
-
                 }
             }
         }
@@ -13042,7 +13057,6 @@ namespace OutputReportTabular {
 
             OutputCompLoadSummary(facilityOutput, FacilityCoolCompLoadTables, FacilityHeatCompLoadTables, 0);
         }
-
 
         // ZoneComponentLoadSummary: Now we convert and Display
         if (displayZoneComponentLoadSummary) {
@@ -14137,12 +14151,12 @@ namespace OutputReportTabular {
                     rowHead(6) = "Number of People";
                 }
 
-	            tableBody(1, 1) = fmt::format("{:.{}f}", curCompLoad.outsideAirRatio, 4);   // outside Air
-	            tableBody(1, 2) = fmt::format("{:0.3E}", curCompLoad.airflowPerFlrArea); // airflow per floor area
-	            tableBody(1, 3) = fmt::format("{:0.3E}", curCompLoad.airflowPerTotCap);  // airflow per total capacity
-	            tableBody(1, 4) = fmt::format("{:0.3E}", curCompLoad.areaPerTotCap);     // area per total capacity
-	            tableBody(1, 5) = fmt::format("{:0.3E}", curCompLoad.totCapPerArea);     // total capacity per area
-	            tableBody(1, 6) = fmt::format("{:.{}f}", curCompLoad.numPeople, 1); // number of people
+                tableBody(1, 1) = fmt::format("{:.{}f}", curCompLoad.outsideAirRatio, 4); // outside Air
+                tableBody(1, 2) = fmt::format("{:0.3E}", curCompLoad.airflowPerFlrArea);  // airflow per floor area
+                tableBody(1, 3) = fmt::format("{:0.3E}", curCompLoad.airflowPerTotCap);   // airflow per total capacity
+                tableBody(1, 4) = fmt::format("{:0.3E}", curCompLoad.areaPerTotCap);      // area per total capacity
+                tableBody(1, 5) = fmt::format("{:0.3E}", curCompLoad.totCapPerArea);      // total capacity per area
+                tableBody(1, 6) = fmt::format("{:.{}f}", curCompLoad.numPeople, 1);       // number of people
 
                 WriteSubtitle(engineeringCheckName);
                 WriteTable(tableBody, rowHead, columnHead, columnWidth);
@@ -15089,7 +15103,7 @@ namespace OutputReportTabular {
         }
     }
 
-    void FillRowHead(Array1D_string & rowHead)
+    void FillRowHead(Array1D_string &rowHead)
     {
         // Forward fill the blanks in rowHead (eg End use column)
         std::string currentEndUseName;
@@ -15102,7 +15116,6 @@ namespace OutputReportTabular {
             }
         }
     }
-
 
     //======================================================================================================================
     //======================================================================================================================
@@ -15584,18 +15597,18 @@ namespace OutputReportTabular {
 
         // FUNCTION PARAMETER DEFINITIONS:
         static Array1D<ObjexxFCL::gio::Fmt> formDigits({0, 9},
-                                            {"(F12.0)",
-                                             "(F12.1)",
-                                             "(F12.2)",
-                                             "(F12.3)",
-                                             "(F12.4)",
-                                             "(F12.5)",
-                                             "(F12.6)",
-                                             "(F12.7)",
-                                             "(F12.8)",
-                                             "(F12.9)"}); // formDigits(0) | formDigits(1) | formDigits(2) | formDigits(3) |
-                                                          // formDigits(4) | formDigits(5) | formDigits(6) | formDigits(7) |
-                                                          // formDigits(8) | formDigits(9)
+                                                       {"(F12.0)",
+                                                        "(F12.1)",
+                                                        "(F12.2)",
+                                                        "(F12.3)",
+                                                        "(F12.4)",
+                                                        "(F12.5)",
+                                                        "(F12.6)",
+                                                        "(F12.7)",
+                                                        "(F12.8)",
+                                                        "(F12.9)"}); // formDigits(0) | formDigits(1) | formDigits(2) | formDigits(3) |
+                                                                     // formDigits(4) | formDigits(5) | formDigits(6) | formDigits(7) |
+                                                                     // formDigits(8) | formDigits(9)
         static Array1D<Real64> const maxvalDigits({0, 9},
                                                   {9999999999.0,
                                                    999999999.0,
@@ -15943,7 +15956,7 @@ namespace OutputReportTabular {
         UnitConv(69).siName = "W";
         UnitConv(70).siName = "W";
         UnitConv(71).siName = "W/KG";
-        UnitConv(72).siName = "W/KG H2O";   // TODO: replace with W/kgWater? or rather just remove
+        UnitConv(72).siName = "W/KG H2O"; // TODO: replace with W/kgWater? or rather just remove
         UnitConv(73).siName = "W/K";
         UnitConv(74).siName = "W/M2";
         UnitConv(75).siName = "W/M2";

--- a/src/EnergyPlus/SystemReports.cc
+++ b/src/EnergyPlus/SystemReports.cc
@@ -70,7 +70,6 @@
 #include <EnergyPlus/DataHeatBalFanSys.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
 #include <EnergyPlus/DataLoopNode.hh>
-#include <EnergyPlus/Plant/DataPlant.hh>
 #include <EnergyPlus/DataPrecisionGlobals.hh>
 #include <EnergyPlus/DataSizing.hh>
 #include <EnergyPlus/DataZoneEnergyDemands.hh>
@@ -81,6 +80,7 @@
 #include <EnergyPlus/OutdoorAirUnit.hh>
 #include <EnergyPlus/OutputProcessor.hh>
 #include <EnergyPlus/PackagedTerminalHeatPump.hh>
+#include <EnergyPlus/Plant/DataPlant.hh>
 #include <EnergyPlus/Psychrometrics.hh>
 #include <EnergyPlus/PurchasedAirManager.hh>
 #include <EnergyPlus/SplitterComponent.hh>
@@ -2479,16 +2479,16 @@ namespace SystemReports {
         bool IsParent;
 
         // Dimension GetMeteredVariables arrays
-        Array1D_int VarIndexes;                     // Variable Numbers
-        Array1D_int VarTypes;                       // Variable Types (1=integer, 2=real, 3=meter)
-        Array1D_string UnitsStrings;                // UnitsStrings for each variable
+        Array1D_int VarIndexes;                            // Variable Numbers
+        Array1D_int VarTypes;                              // Variable Types (1=integer, 2=real, 3=meter)
+        Array1D_string UnitsStrings;                       // UnitsStrings for each variable
         Array1D<OutputProcessor::TimeStepType> IndexTypes; // Variable Idx Types (1=Zone,2=HVAC)
-        Array1D<OutputProcessor::Unit> unitsForVar; // units from enum for each variable
-        Array1D_int ResourceTypes;                  // ResourceTypes for each variable
-        Array1D_string EndUses;                     // EndUses for each variable
-        Array1D_string Groups;                      // Groups for each variable
-        Array1D_string Names;                       // Variable Names for each variable
-        int NumFound;                               // Number Found
+        Array1D<OutputProcessor::Unit> unitsForVar;        // units from enum for each variable
+        Array1D_int ResourceTypes;                         // ResourceTypes for each variable
+        Array1D_string EndUses;                            // EndUses for each variable
+        Array1D_string Groups;                             // Groups for each variable
+        Array1D_string Names;                              // Variable Names for each variable
+        int NumFound;                                      // Number Found
         int NumVariables;
         int NumLeft; // Counter for deeper components
 
@@ -3862,7 +3862,7 @@ namespace SystemReports {
             AIRTERMINAL_SINGLEDUCT_VAV_REHEAT,
             AIRTERMINAL_SINGLEDUCT_VAV_REHEAT_VARIABLESPEEDFAN,
             COIL_COOLING_DX,
-	        COIL_COOLING_DX_MULTISPEED,
+            COIL_COOLING_DX_MULTISPEED,
             COIL_COOLING_DX_SINGLESPEED,
             COIL_COOLING_DX_SINGLESPEED_THERMALSTORAGE,
             COIL_COOLING_DX_TWOSPEED,
@@ -3956,7 +3956,7 @@ namespace SystemReports {
             {"AIRTERMINAL:SINGLEDUCT:VAV:REHEAT", AIRTERMINAL_SINGLEDUCT_VAV_REHEAT},
             {"AIRTERMINAL:SINGLEDUCT:VAV:REHEAT:VARIABLESPEEDFAN", AIRTERMINAL_SINGLEDUCT_VAV_REHEAT_VARIABLESPEEDFAN},
             {"COIL:COOLING:DX", COIL_COOLING_DX},
-	        {"COIL:COOLING:DX:MULTISPEED", COIL_COOLING_DX_MULTISPEED},
+            {"COIL:COOLING:DX:MULTISPEED", COIL_COOLING_DX_MULTISPEED},
             {"COIL:COOLING:DX:SINGLESPEED", COIL_COOLING_DX_SINGLESPEED},
             {"COIL:COOLING:DX:SINGLESPEED:THERMALSTORAGE", COIL_COOLING_DX_SINGLESPEED_THERMALSTORAGE},
             {"COIL:COOLING:DX:TWOSPEED", COIL_COOLING_DX_TWOSPEED},
@@ -4009,9 +4009,9 @@ namespace SystemReports {
             {"SOLARCOLLECTOR:FLATPLATE:PHOTOVOLTAICTHERMAL", SOLARCOLLECTOR_FLATPLATE_PHOTOVOLTAICTHERMAL},
             {"SOLARCOLLECTOR:UNGLAZEDTRANSPIRED", SOLARCOLLECTOR_UNGLAZEDTRANSPIRED},
             {"ZONEHVAC:AIRDISTRIBUTIONUNIT", ZONEHVAC_AIRDISTRIBUTIONUNIT},
-            {"ZONEHVAC:TERMINALUNIT:VARIABLEREFRIGERANTFLOW",ZONEHVAC_TERMINALUNIT_VRF},
-            {"COIL:COOLING:DX:VARIABLEREFRIGERANTFLOW",COIL_COOLING_VRF},
-            {"COIL:HEATING:DX:VARIABLEREFRIGERANTFLOW",COIL_HEATING_VRF},
+            {"ZONEHVAC:TERMINALUNIT:VARIABLEREFRIGERANTFLOW", ZONEHVAC_TERMINALUNIT_VRF},
+            {"COIL:COOLING:DX:VARIABLEREFRIGERANTFLOW", COIL_COOLING_VRF},
+            {"COIL:HEATING:DX:VARIABLEREFRIGERANTFLOW", COIL_HEATING_VRF},
             {"COIL:COOLING:DX:VARIABLEREFRIGERANTFLOW:FLUIDTEMPERATURECONTROL", COIL_COOLING_VRF_FTC},
             {"COIL:HEATING:DX:VARIABLEREFRIGERANTFLOW:FLUIDTEMPERATURECONTROL", COIL_HEATING_VRF_FTC}};
         assert(component_map.size() == n_ComponentTypes);
@@ -5104,16 +5104,21 @@ namespace SystemReports {
         static ObjexxFCL::gio::Fmt Format_707("(1X,A)");
         static ObjexxFCL::gio::Fmt Format_708(
             "('! <AirLoopHVAC>,<Air Loop Name>,<# Return Nodes>,<# Supply Nodes>,','<# Zones Cooled>,<# Zones Heated>,<Outdoor Air Used>')");
-        static ObjexxFCL::gio::Fmt Format_709("('! <AirLoop Return Connections>,<Connection Count>,<AirLoopHVAC Name>,','<Zn Eqp Return Node #>,<Zn Eqp Return "
-                                   "Node Name>,','<AirLoop Return Node #>,<Air Loop Return Node Name>')");
-        static ObjexxFCL::gio::Fmt Format_710("('! <AirLoop Supply Connections>,<Connection Count>,<AirLoopHVAC Name>,','<Zn Eqp Supply Node #>,<Zn Eqp Supply "
-                                   "Node Name>,','<AirLoop Supply Node #>,<Air Loop Supply Node Name>')");
-        static ObjexxFCL::gio::Fmt Format_711("('! <Cooled Zone Info>,<Cooled Zone Count>,<Cooled Zone Name>,','<Cooled Zone Inlet Node #>,<Cooled Zone Inlet "
-                                   "Node Name>,<AirLoopHVAC Name>')");
-        static ObjexxFCL::gio::Fmt Format_712("('! <Heated Zone Info>,<Heated Zone Count>,<Heated Zone Name>,','<Heated Zone Inlet Node #>,<Heated Zone Inlet "
-                                   "Node Name>,<AirLoopHVAC Name>')");
-        static ObjexxFCL::gio::Fmt Format_714("('! <Outdoor Air Connections>,<OA Inlet Node #>,<OA Return Air Inlet Node Name>,','<OA Outlet Node #>,<OA Mixed "
-                                   "Air Outlet Node Name>,<AirLoopHVAC Name>'s)");
+        static ObjexxFCL::gio::Fmt Format_709(
+            "('! <AirLoop Return Connections>,<Connection Count>,<AirLoopHVAC Name>,','<Zn Eqp Return Node #>,<Zn Eqp Return "
+            "Node Name>,','<AirLoop Return Node #>,<Air Loop Return Node Name>')");
+        static ObjexxFCL::gio::Fmt Format_710(
+            "('! <AirLoop Supply Connections>,<Connection Count>,<AirLoopHVAC Name>,','<Zn Eqp Supply Node #>,<Zn Eqp Supply "
+            "Node Name>,','<AirLoop Supply Node #>,<Air Loop Supply Node Name>')");
+        static ObjexxFCL::gio::Fmt Format_711(
+            "('! <Cooled Zone Info>,<Cooled Zone Count>,<Cooled Zone Name>,','<Cooled Zone Inlet Node #>,<Cooled Zone Inlet "
+            "Node Name>,<AirLoopHVAC Name>')");
+        static ObjexxFCL::gio::Fmt Format_712(
+            "('! <Heated Zone Info>,<Heated Zone Count>,<Heated Zone Name>,','<Heated Zone Inlet Node #>,<Heated Zone Inlet "
+            "Node Name>,<AirLoopHVAC Name>')");
+        static ObjexxFCL::gio::Fmt Format_714(
+            "('! <Outdoor Air Connections>,<OA Inlet Node #>,<OA Return Air Inlet Node Name>,','<OA Outlet Node #>,<OA Mixed "
+            "Air Outlet Node Name>,<AirLoopHVAC Name>'s)");
         static ObjexxFCL::gio::Fmt Format_713("(A)");
 
         ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << "! ===============================================================";
@@ -5128,10 +5133,12 @@ namespace SystemReports {
         ObjexxFCL::gio::write(OutputFileBNDetails, Format_714);
         ObjexxFCL::gio::write(OutputFileBNDetails, Format_713)
             << "! <AirLoopHVAC Connector>,<Connector Type>,<Connector Name>,<Loop Name>,<Loop Type>,<Number of Inlets/Outlets>";
-        ObjexxFCL::gio::write(OutputFileBNDetails, Format_713) << "! <AirLoopHVAC Connector Branches>,<Connector Node Count>,<Connector Type>,<Connector "
-                                                       "Name>,<Inlet Branch>,<Outlet Branch>,<Loop Name>,<Loop Type>";
-        ObjexxFCL::gio::write(OutputFileBNDetails, Format_713) << "! <AirLoopHVAC Connector Nodes>,<Connector Node Count>,<Connector Type>,<Connector "
-                                                       "Name>,<Inlet Node>,<Outlet Node>,<Loop Name>,<Loop Type>";
+        ObjexxFCL::gio::write(OutputFileBNDetails, Format_713)
+            << "! <AirLoopHVAC Connector Branches>,<Connector Node Count>,<Connector Type>,<Connector "
+               "Name>,<Inlet Branch>,<Outlet Branch>,<Loop Name>,<Loop Type>";
+        ObjexxFCL::gio::write(OutputFileBNDetails, Format_713)
+            << "! <AirLoopHVAC Connector Nodes>,<Connector Node Count>,<Connector Type>,<Connector "
+               "Name>,<Inlet Node>,<Outlet Node>,<Loop Name>,<Loop Type>";
         for (Count = 1; Count <= NumPrimaryAirSys; ++Count) {
             ObjexxFCL::gio::write(ChrOut, fmtLD) << AirToZoneNodeInfo(Count).NumReturnNodes;
             ObjexxFCL::gio::write(ChrOut2, fmtLD) << AirToZoneNodeInfo(Count).NumSupplyNodes;
@@ -5146,8 +5153,8 @@ namespace SystemReports {
             } else {
                 ChrOut5 = "No";
             }
-            ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << " AirLoopHVAC," + AirToZoneNodeInfo(Count).AirLoopName + ',' + ChrOut + ',' + ChrOut2 +
-                                                               ',' + ChrOut3 + ',' + ChrOut4 + ',' + ChrOut5;
+            ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << " AirLoopHVAC," + AirToZoneNodeInfo(Count).AirLoopName + ',' + ChrOut + ',' +
+                                                                          ChrOut2 + ',' + ChrOut3 + ',' + ChrOut4 + ',' + ChrOut5;
             for (Count1 = 1; Count1 <= AirToZoneNodeInfo(Count).NumReturnNodes; ++Count1) {
                 ObjexxFCL::gio::write(ChrOut, fmtLD) << Count1;
                 if (AirToZoneNodeInfo(Count).ZoneEquipReturnNodeNum(Count1) > 0) {
@@ -5184,7 +5191,8 @@ namespace SystemReports {
                     }
                 }
                 if (ChrOut3 != errstring) {
-                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << ChrOut3 + ',' + NodeID(AirToZoneNodeInfo(Count).AirLoopReturnNodeNum(Count1));
+                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701)
+                        << ChrOut3 + ',' + NodeID(AirToZoneNodeInfo(Count).AirLoopReturnNodeNum(Count1));
                 } else {
                     ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << errstring + ',' + errstring;
                 }
@@ -5225,7 +5233,8 @@ namespace SystemReports {
                     }
                 }
                 if (ChrOut3 != errstring) {
-                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << ChrOut3 + ',' + NodeID(AirToZoneNodeInfo(Count).AirLoopSupplyNodeNum(Count1));
+                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701)
+                        << ChrOut3 + ',' + NodeID(AirToZoneNodeInfo(Count).AirLoopSupplyNodeNum(Count1));
                 } else {
                     ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << errstring + ',' + errstring;
                 }
@@ -5251,7 +5260,8 @@ namespace SystemReports {
                     ObjexxFCL::gio::write(OutputFileBNDetails, Format_701)
                         << ChrOut2 + ',' + NodeID(AirToZoneNodeInfo(Count).CoolZoneInletNodes(Count1)) + ',' + AirToZoneNodeInfo(Count).AirLoopName;
                 } else {
-                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << errstring + ',' + errstring + ',' + AirToZoneNodeInfo(Count).AirLoopName;
+                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701)
+                        << errstring + ',' + errstring + ',' + AirToZoneNodeInfo(Count).AirLoopName;
                 }
             }
             for (Count1 = 1; Count1 <= AirToZoneNodeInfo(Count).NumZonesHeated; ++Count1) {
@@ -5274,7 +5284,8 @@ namespace SystemReports {
                     ObjexxFCL::gio::write(OutputFileBNDetails, Format_701)
                         << ChrOut2 + ',' + NodeID(AirToZoneNodeInfo(Count).HeatZoneInletNodes(Count1)) + ',' + AirToZoneNodeInfo(Count).AirLoopName;
                 } else {
-                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << errstring + ',' + errstring + ',' + AirToZoneNodeInfo(Count).AirLoopName;
+                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701)
+                        << errstring + ',' + errstring + ',' + AirToZoneNodeInfo(Count).AirLoopName;
                 }
             }
             if (AirToOANodeInfo(Count).OASysExists) {
@@ -5312,14 +5323,16 @@ namespace SystemReports {
                     ObjexxFCL::gio::write(OutputFileBNDetails, Format_701)
                         << ChrOut2 + ',' + NodeID(AirToOANodeInfo(Count).OASysOutletNodeNum) + ',' + AirToZoneNodeInfo(Count).AirLoopName;
                 } else {
-                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << errstring + ',' + errstring + ',' + AirToZoneNodeInfo(Count).AirLoopName;
+                    ObjexxFCL::gio::write(OutputFileBNDetails, Format_701)
+                        << errstring + ',' + errstring + ',' + AirToZoneNodeInfo(Count).AirLoopName;
                 }
             }
             //  Report HVAC Air Loop Splitter to BND file
             if (PrimaryAirSystem(Count).Splitter.Exists) {
                 ObjexxFCL::gio::write(ChrOut, fmtLD) << PrimaryAirSystem(Count).Splitter.TotalOutletNodes;
-                ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << "   AirLoopHVAC Connector,Splitter," + PrimaryAirSystem(Count).Splitter.Name + ',' +
-                                                                   PrimaryAirSystem(Count).Name + ",Air," + stripped(ChrOut);
+                ObjexxFCL::gio::write(OutputFileBNDetails, Format_701) << "   AirLoopHVAC Connector,Splitter," +
+                                                                              PrimaryAirSystem(Count).Splitter.Name + ',' +
+                                                                              PrimaryAirSystem(Count).Name + ",Air," + stripped(ChrOut);
                 for (Count1 = 1; Count1 <= PrimaryAirSystem(Count).Splitter.TotalOutletNodes; ++Count1) {
                     ObjexxFCL::gio::write(ChrOut, fmtLD) << Count1;
                     if (PrimaryAirSystem(Count).Splitter.BranchNumIn <= 0) {
@@ -5370,4 +5383,3 @@ namespace SystemReports {
 } // namespace SystemReports
 
 } // namespace EnergyPlus
-

--- a/src/EnergyPlus/UnitarySystem.cc
+++ b/src/EnergyPlus/UnitarySystem.cc
@@ -50,16 +50,15 @@
 #include <EnergyPlus/AirflowNetwork/include/AirflowNetwork/Elements.hpp>
 #include <EnergyPlus/BranchInputManager.hh>
 #include <EnergyPlus/BranchNodeConnections.hh>
-#include <EnergyPlus/CurveManager.hh>
 #include <EnergyPlus/Coils/CoilCoolingDX.hh>
+#include <EnergyPlus/CurveManager.hh>
 #include <EnergyPlus/DXCoils.hh>
 #include <EnergyPlus/DataAirLoop.hh>
 #include <EnergyPlus/DataGlobals.hh>
-#include <EnergyPlus/DataHVACSystems.hh>
 #include <EnergyPlus/DataHVACControllers.hh>
+#include <EnergyPlus/DataHVACSystems.hh>
 #include <EnergyPlus/DataHeatBalFanSys.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
-#include <EnergyPlus/Plant/DataPlant.hh>
 #include <EnergyPlus/DataSizing.hh>
 #include <EnergyPlus/DataZoneControls.hh>
 #include <EnergyPlus/DataZoneEnergyDemands.hh>
@@ -77,6 +76,7 @@
 #include <EnergyPlus/NodeInputManager.hh>
 #include <EnergyPlus/OutdoorAirUnit.hh>
 #include <EnergyPlus/PackagedThermalStorageCoil.hh>
+#include <EnergyPlus/Plant/DataPlant.hh>
 #include <EnergyPlus/PlantUtilities.hh>
 #include <EnergyPlus/Psychrometrics.hh>
 #include <EnergyPlus/ReportCoilSelection.hh>
@@ -175,10 +175,9 @@ namespace UnitarySystems {
           m_VarSpeedHeatingCoil(false), m_SystemHeatControlNodeNum(0), m_CoolCoilExists(false), m_CoolingCoilType_Num(0), m_NumOfSpeedCooling(0),
           m_CoolingCoilAvailSchPtr(0), m_DesignCoolingCapacity(0.0), m_MaxCoolAirVolFlow(0.0), m_CondenserNodeNum(0), m_CondenserType(0),
           m_CoolingCoilIndex(0), m_HeatPump(false), m_ActualDXCoilIndexForHXAssisted(0), m_DiscreteSpeedCoolingCoil(false),
-          m_ContSpeedCoolingCoil(false),
-          m_SystemCoolControlNodeNum(0), m_WaterCyclingMode(0), m_ISHundredPercentDOASDXCoil(false), m_RunOnSensibleLoad(false),
-          m_RunOnLatentLoad(false), m_RunOnLatentOnlyWithSensible(false), m_DehumidificationMode(0), m_SuppHeatCoilType_Num(0),
-          m_SuppCoilExists(false), m_DesignSuppHeatingCapacity(0.0), m_SuppCoilAirInletNode(0), m_SuppCoilAirOutletNode(0),
+          m_ContSpeedCoolingCoil(false), m_SystemCoolControlNodeNum(0), m_WaterCyclingMode(0), m_ISHundredPercentDOASDXCoil(false),
+          m_RunOnSensibleLoad(false), m_RunOnLatentLoad(false), m_RunOnLatentOnlyWithSensible(false), m_DehumidificationMode(0),
+          m_SuppHeatCoilType_Num(0), m_SuppCoilExists(false), m_DesignSuppHeatingCapacity(0.0), m_SuppCoilAirInletNode(0), m_SuppCoilAirOutletNode(0),
           m_SuppCoilFluidInletNode(0), m_MaxSuppCoilFluidFlow(0.0), m_SuppHeatCoilIndex(0), m_SuppHeatControlNodeNum(0), m_SupHeaterLoad(0.0),
           m_CoolingSAFMethod(0), m_HeatingSAFMethod(0), m_NoCoolHeatSAFMethod(0), m_MaxNoCoolHeatAirVolFlow(0.0),
           m_AirFlowControl(UseCompFlow::FlowNotYetSet), m_CoolingCoilUpstream(true), m_MaxOATSuppHeat(0.0), m_MinOATCompressorCooling(0.0),
@@ -1107,7 +1106,7 @@ namespace UnitarySystems {
                 //     simulate water coil to find operating capacity
                 WaterCoils::SimulateWaterCoilComponents(
                     this->m_CoolingCoilName, FirstHVACIteration, this->m_CoolingCoilIndex, initUnitarySystemsQActual);
-                    this->m_DesignCoolingCapacity = initUnitarySystemsQActual;
+                this->m_DesignCoolingCapacity = initUnitarySystemsQActual;
 
             } // from IF(UnitarySystem(UnitarySysNum)%CoolingCoilType_Num == Coil_CoolingWater .OR. Coil_CoolingWaterDetailed
             if (this->m_HeatingCoilType_Num == DataHVACGlobals::Coil_HeatingWater) {
@@ -1505,7 +1504,7 @@ namespace UnitarySystems {
 
         bool anyEMSRan;
         EMSManager::ManageEMS(DataGlobals::emsCallFromUnitarySystemSizing, anyEMSRan); // calling point
-        bool HardSizeNoDesRun;                  // Indicator to a hard-sized field with no design sizing data
+        bool HardSizeNoDesRun;                                                         // Indicator to a hard-sized field with no design sizing data
 
         // Initiate all reporting variables
         if (DataSizing::SysSizingRunDone || DataSizing::ZoneSizingRunDone) {
@@ -1656,9 +1655,9 @@ namespace UnitarySystems {
                 EqSizing.CoolingCapacity = true;
                 EqSizing.DesCoolingLoad = CoolCapAtPeak;
             } else {
-                if ( !HardSizeNoDesRun && (CoolingSAFlowMethod != FlowPerCoolingCapacity && this->m_DesignCoolingCapacity > 0.0)) {
-                    if ( this->m_CoolingCoilType_Num == DataHVACGlobals::CoilDX_MultiSpeedCooling ) {
-                        DataSizing::DataTotCapCurveIndex = DXCoils::GetDXCoilCapFTCurveIndex( this->m_CoolingCoilIndex, ErrFound );
+                if (!HardSizeNoDesRun && (CoolingSAFlowMethod != FlowPerCoolingCapacity && this->m_DesignCoolingCapacity > 0.0)) {
+                    if (this->m_CoolingCoilType_Num == DataHVACGlobals::CoilDX_MultiSpeedCooling) {
+                        DataSizing::DataTotCapCurveIndex = DXCoils::GetDXCoilCapFTCurveIndex(this->m_CoolingCoilIndex, ErrFound);
                         DataSizing::DataIsDXCoil = true;
                     }
                     if (this->m_CoolingCoilType_Num == DataHVACGlobals::Coil_CoolingAirToAirVariableSpeed) {
@@ -1756,8 +1755,8 @@ namespace UnitarySystems {
                 EqSizing.HeatingCapacity = true;
                 EqSizing.DesHeatingLoad = HeatCapAtPeak;
             } else {
-                if ( !HardSizeNoDesRun && (HeatingSAFlowMethod != FlowPerHeatingCapacity && this->m_DesignHeatingCapacity != DataSizing::AutoSize)) {
-                    if ( this->m_HeatingCoilType_Num == DataHVACGlobals::CoilDX_MultiSpeedHeating ) {
+                if (!HardSizeNoDesRun && (HeatingSAFlowMethod != FlowPerHeatingCapacity && this->m_DesignHeatingCapacity != DataSizing::AutoSize)) {
+                    if (this->m_HeatingCoilType_Num == DataHVACGlobals::CoilDX_MultiSpeedHeating) {
                         SizingMethod = DataHVACGlobals::HeatingCapacitySizing;
                         DataSizing::DataFlowUsedForSizing = EqSizing.HeatingAirVolFlow;
                         TempSize = DataSizing::AutoSize;
@@ -1766,7 +1765,7 @@ namespace UnitarySystems {
                         DataSizing::DataIsDXCoil = true;
                         if (DataSizing::CurSysNum > 0)
                             DataAirLoop::AirLoopControlInfo(AirLoopNum).UnitarySysSimulating =
-                            false; // set to false to allow calculation of actual heating capacity
+                                false; // set to false to allow calculation of actual heating capacity
                         ReportSizingManager::RequestSizing(CompType, CompName, SizingMethod, SizingString, TempSize, PrintFlag, RoutineName);
                         if (DataSizing::CurSysNum > 0) DataAirLoop::AirLoopControlInfo(AirLoopNum).UnitarySysSimulating = true;
                         HeatCapAtPeak = TempSize;
@@ -1774,7 +1773,7 @@ namespace UnitarySystems {
                         EqSizing.DesHeatingLoad = HeatCapAtPeak;
                     }
                 } else {
-                   HeatCapAtPeak = this->m_DesignHeatingCapacity;
+                    HeatCapAtPeak = this->m_DesignHeatingCapacity;
                 }
             }
             //			if ( ! UnitarySystem( UnitarySysNum ).CoolCoilExists )DXCoolCap = HeatCapAtPeak;
@@ -1920,14 +1919,16 @@ namespace UnitarySystems {
                 SizingMethod = DataHVACGlobals::AutoCalculateSizing;
                 this->m_MaxNoCoolHeatAirVolFlow = DataSizing::AutoSize;
             } else if (this->m_NoCoolHeatSAFMethod == FlowPerCoolingCapacity) {
-                if ( EqSizing.DesCoolingLoad <= 0.0) {
+                if (EqSizing.DesCoolingLoad <= 0.0) {
                     // water coils not sizing yet
-                    if ( this->m_CoolingCoilType_Num == DataHVACGlobals::Coil_CoolingWater ||
-                        this->m_CoolingCoilType_Num == DataHVACGlobals::Coil_CoolingWaterDetailed ) {
+                    if (this->m_CoolingCoilType_Num == DataHVACGlobals::Coil_CoolingWater ||
+                        this->m_CoolingCoilType_Num == DataHVACGlobals::Coil_CoolingWaterDetailed) {
                         WaterCoils::SimulateWaterCoilComponents(
-                            this->m_CoolingCoilName, FirstHVACIteration, this->m_CoolingCoilIndex, QActual, this->m_FanOpMode, 1.0 );
+                            this->m_CoolingCoilName, FirstHVACIteration, this->m_CoolingCoilIndex, QActual, this->m_FanOpMode, 1.0);
                         EqSizing.DesCoolingLoad = WaterCoils::GetWaterCoilCapacity(
-                            UtilityRoutines::MakeUPPERCase( DataHVACGlobals::cAllCoilTypes( this->m_CoolingCoilType_Num ) ), this->m_CoolingCoilName, ErrFound );
+                            UtilityRoutines::MakeUPPERCase(DataHVACGlobals::cAllCoilTypes(this->m_CoolingCoilType_Num)),
+                            this->m_CoolingCoilName,
+                            ErrFound);
                     }
                 }
                 this->m_MaxNoCoolHeatAirVolFlow *= EqSizing.DesCoolingLoad;
@@ -1936,13 +1937,15 @@ namespace UnitarySystems {
                 SizingMethod = DataHVACGlobals::AutoCalculateSizing;
                 this->m_MaxNoCoolHeatAirVolFlow = DataSizing::AutoSize;
             } else if (this->m_NoCoolHeatSAFMethod == FlowPerHeatingCapacity) {
-                if ( EqSizing.DesHeatingLoad <= 0.0 ) {
+                if (EqSizing.DesHeatingLoad <= 0.0) {
                     // water coil not sizing yet
-                    if ( this->m_HeatingCoilType_Num == DataHVACGlobals::Coil_HeatingWater ) {
+                    if (this->m_HeatingCoilType_Num == DataHVACGlobals::Coil_HeatingWater) {
                         WaterCoils::SimulateWaterCoilComponents(
-                            this->m_HeatingCoilName, FirstHVACIteration, this->m_HeatingCoilIndex, QActual, this->m_FanOpMode, 1.0 );
+                            this->m_HeatingCoilName, FirstHVACIteration, this->m_HeatingCoilIndex, QActual, this->m_FanOpMode, 1.0);
                         EqSizing.DesHeatingLoad = WaterCoils::GetWaterCoilCapacity(
-                            UtilityRoutines::MakeUPPERCase( DataHVACGlobals::cAllCoilTypes( this->m_HeatingCoilType_Num ) ), this->m_HeatingCoilName, ErrFound );
+                            UtilityRoutines::MakeUPPERCase(DataHVACGlobals::cAllCoilTypes(this->m_HeatingCoilType_Num)),
+                            this->m_HeatingCoilName,
+                            ErrFound);
                     }
                 }
                 this->m_MaxNoCoolHeatAirVolFlow *= EqSizing.DesHeatingLoad;
@@ -2093,7 +2096,7 @@ namespace UnitarySystems {
             newCoil.size();
             for (Iter = 1; Iter <= this->m_NumOfSpeedCooling; ++Iter) {
                 // Need to size each speed here, so call once for each speed - probably need to call each mode too when fully implemented?
-                //newCoil.simulate(this->m_DehumidificationMode, this->m_CoolingPartLoadFrac, Iter, this->m_CoolingSpeedRatio, this->m_FanOpMode);
+                // newCoil.simulate(this->m_DehumidificationMode, this->m_CoolingPartLoadFrac, Iter, this->m_CoolingSpeedRatio, this->m_FanOpMode);
                 this->m_CoolVolumeFlowRate[Iter] = newCoil.performance.normalMode.speeds[Iter - 1].evap_air_flow_rate;
                 this->m_CoolMassFlowRate[Iter] = this->m_CoolVolumeFlowRate[Iter] * DataEnvironment::StdRhoAir;
                 // it seems the ratio should reference the actual flow rates, not the fan flow ???
@@ -2132,11 +2135,11 @@ namespace UnitarySystems {
                 EqSizing.CoolingAirVolFlow *
                 DataEnvironment::StdRhoAir; // doesn't matter what this value is since only coil size is needed and CompOn = 0 here
             DXCoils::SimDXCoilMultiSpeed(blankString, 1.0, 1.0, this->m_CoolingCoilIndex, 0, 0, 0);
-            if ( !HardSizeNoDesRun && EqSizing.Capacity ) {
+            if (!HardSizeNoDesRun && EqSizing.Capacity) {
                 // do nothing, the vars EqSizing.DesCoolingLoad and DataSizing::DXCoolCap are already set earlier and the values could be max of the
                 // cooling and heating austosized values. Thus reseting them here to user specified value may not be the design size used else where
             } else {
-                DataSizing::DXCoolCap = DXCoils::GetCoilCapacityByIndexType( this->m_CoolingCoilIndex, this->m_CoolingCoilType_Num, ErrFound );
+                DataSizing::DXCoolCap = DXCoils::GetCoilCapacityByIndexType(this->m_CoolingCoilIndex, this->m_CoolingCoilType_Num, ErrFound);
                 EqSizing.DesCoolingLoad = DataSizing::DXCoolCap;
             }
             MSHPIndex = this->m_DesignSpecMSHPIndex;
@@ -2528,7 +2531,7 @@ namespace UnitarySystems {
             DataSizing::DataHeatSizeRatio = 1.0;
         }
 
-        if ( !HardSizeNoDesRun && (EqSizing.Capacity && EqSizing.DesHeatingLoad > 0.0)) {
+        if (!HardSizeNoDesRun && (EqSizing.Capacity && EqSizing.DesHeatingLoad > 0.0)) {
             // vars EqSizing.DesHeatingLoad is already set earlier and supplemental heating coil should
             // be sized to design value instead of user specified value if HardSizeNoDesRun is false
             DataSizing::UnitaryHeatCap = EqSizing.DesHeatingLoad;
@@ -6402,10 +6405,9 @@ namespace UnitarySystems {
                 } else if (thisSys.m_CoolingCoilType_Num == DataHVACGlobals::CoilDX_CoolingTwoStageWHumControl) {
                     thisSys.m_MinOATCompressorCooling = DXCoils::GetMinOATCompressor(loc_coolingCoilType, loc_m_CoolingCoilName, errFlag);
                 } else if (thisSys.m_CoolingCoilType_Num == DataHVACGlobals::Coil_CoolingAirToAirVariableSpeed) {
-					thisSys.m_MinOATCompressorCooling = VariableSpeedCoils::GetVSCoilMinOATCompressor(
-							loc_m_CoolingCoilName, errFlag);
-				} else if (thisSys.m_CoolingCoilType_Num == DataHVACGlobals::CoilDX_Cooling) {
-                	// TODO: Set thisSys.m_minOATCompressorCooling
+                    thisSys.m_MinOATCompressorCooling = VariableSpeedCoils::GetVSCoilMinOATCompressor(loc_m_CoolingCoilName, errFlag);
+                } else if (thisSys.m_CoolingCoilType_Num == DataHVACGlobals::CoilDX_Cooling) {
+                    // TODO: Set thisSys.m_minOATCompressorCooling
                 } else {
                     thisSys.m_MinOATCompressorCooling = -1000.0;
                 }
@@ -6435,7 +6437,7 @@ namespace UnitarySystems {
                 errFlag = false;
                 if (thisSys.m_CoolingCoilType_Num == DataHVACGlobals::CoilDX_CoolingSingleSpeed) {
                     thisSys.m_CondenserNodeNum = DXCoils::GetCoilCondenserInletNode(loc_coolingCoilType, loc_m_CoolingCoilName, errFlag);
-               		// TODO: Should we add a block for the new DX Coil?
+                    // TODO: Should we add a block for the new DX Coil?
                 } else if (thisSys.m_CoolingCoilType_Num == DataHVACGlobals::Coil_CoolingAirToAirVariableSpeed) {
                     thisSys.m_CondenserNodeNum = VariableSpeedCoils::GetVSCoilCondenserInletNode(loc_m_CoolingCoilName, errFlag);
                 } else if (thisSys.m_CoolingCoilType_Num == DataHVACGlobals::CoilDX_CoolingHXAssisted) {
@@ -12894,8 +12896,7 @@ namespace UnitarySystems {
                 }
             }
             bool useDehumMode = (this->m_DehumidificationMode == 1);
-            coilCoolingDXs[this->m_CoolingCoilIndex].simulate(
-                useDehumMode, CycRatio, this->m_CoolingSpeedNum, SpeedRatio, this->m_FanOpMode);
+            coilCoolingDXs[this->m_CoolingCoilIndex].simulate(useDehumMode, CycRatio, this->m_CoolingSpeedNum, SpeedRatio, this->m_FanOpMode);
 
         } else if (CoilTypeNum == DataHVACGlobals::Coil_CoolingAirToAirVariableSpeed) {
 
@@ -15014,12 +15015,11 @@ namespace UnitarySystems {
         } else {
 
             DataLoopNode::Node(AirControlNode).MassFlowRate = airMdot;
-            if ( lowSpeedRatio != 1.0 ) {
+            if (lowSpeedRatio != 1.0) {
                 // division by zero when lowSpeedRatio == 1.0
                 thisSys.FanPartLoadRatio =
-                    max( 0.0, ((airMdot - (systemMaxAirFlowRate * lowSpeedRatio)) / ((1.0 - lowSpeedRatio) * systemMaxAirFlowRate)) );
-            }
-            else {
+                    max(0.0, ((airMdot - (systemMaxAirFlowRate * lowSpeedRatio)) / ((1.0 - lowSpeedRatio) * systemMaxAirFlowRate)));
+            } else {
                 thisSys.FanPartLoadRatio = 1.0;
             }
             if (WaterControlNode > 0) {
@@ -15259,14 +15259,15 @@ namespace UnitarySystems {
         }
     }
 
-    int UnitarySys::getAirInNode(std::string const &UnitarySysName, int const ZoneOAUnitNum) {
+    int UnitarySys::getAirInNode(std::string const &UnitarySysName, int const ZoneOAUnitNum)
+    {
         if (UnitarySystems::getInputOnceFlag) {
             getUnitarySystemInput(UnitarySysName, false, ZoneOAUnitNum);
             UnitarySystems::getInputOnceFlag = false;
         }
         int airNode = 0;
         for (int UnitarySysNum = 0; UnitarySysNum < numUnitarySystems; ++UnitarySysNum) {
-            if (UtilityRoutines::SameString(UnitarySysName, unitarySys[ UnitarySysNum ].Name)) {
+            if (UtilityRoutines::SameString(UnitarySysName, unitarySys[UnitarySysNum].Name)) {
                 airNode = this->AirInNode;
                 break;
             }
@@ -15274,14 +15275,15 @@ namespace UnitarySystems {
         return airNode;
     }
 
-    int UnitarySys::getAirOutNode(std::string const &UnitarySysName, int const ZoneOAUnitNum) {
+    int UnitarySys::getAirOutNode(std::string const &UnitarySysName, int const ZoneOAUnitNum)
+    {
         if (UnitarySystems::getInputOnceFlag) {
             getUnitarySystemInput(UnitarySysName, false, ZoneOAUnitNum);
             UnitarySystems::getInputOnceFlag = false;
         }
         int airNode = 0;
         for (int UnitarySysNum = 0; UnitarySysNum < numUnitarySystems; ++UnitarySysNum) {
-            if (UtilityRoutines::SameString(UnitarySysName, unitarySys[ UnitarySysNum ].Name)) {
+            if (UtilityRoutines::SameString(UnitarySysName, unitarySys[UnitarySysNum].Name)) {
                 airNode = this->AirOutNode;
                 break;
             }

--- a/tst/EnergyPlus/unit/Coils/CoilCoolingDXFixture.hh
+++ b/tst/EnergyPlus/unit/Coils/CoilCoolingDXFixture.hh
@@ -54,164 +54,161 @@
 class CoilCoolingDXTest : public EnergyPlus::EnergyPlusFixture
 {
 public:
-
 protected:
-	void SetUp() override
-	{
-		EnergyPlus::EnergyPlusFixture::SetUp(); // Sets up the base fixture first.
-	}
+    void SetUp() override
+    {
+        EnergyPlus::EnergyPlusFixture::SetUp(); // Sets up the base fixture first.
+    }
 
-	std::string getSpeedObjectString(const std::string &speedObjectName) {
-		std::string const idf_objects = delimited_string( {
-		        "Coil:Cooling:DX:CurveFit:Speed, ",
-				" " + speedObjectName + ",       ",
-				" 0.8,                           ",
-				" 0.745,                         ",
-				" 3.1415926,                     ",
-				" 0.9,                           ",
-				" 0.9,                           ",
-				" 0.5,                           ",
-				" 300,                           ",
-				" 6.9,                           ",
-				" 0.8,                           ",
-				" " + speedObjectName + "CapFT,  ",
-				" " + speedObjectName + "CapFF,  ",
-				" " + speedObjectName + "EIRFT,  ",
-				" " + speedObjectName + "EIRFF,  ",
-				" " + speedObjectName + "PLFCurveName, ",
-				" 0.6,                           ",
-				" " + speedObjectName + "WasteHeatFunctionCurve, ",
-				" " + speedObjectName + "SHRFT,  ",
-				" " + speedObjectName + "SHRFF;  ",
-				"Curve:Biquadratic,              ",
-				" " + speedObjectName + "CapFT,  ",
-				" 1, 0, 0, 0, 0, 0,              ",
-				" 0, 1, 0, 1;                    ",
-				"Curve:Linear,                   ",
-				" " + speedObjectName + "CapFF,  ",
-				" 1, 0,                          ",
-				" 0, 1;                          ",
-				"Curve:Biquadratic,              ",
-				" " + speedObjectName + "EIRFT,  ",
-				" 1, 0, 0, 0, 0, 0,              ",
-				" 0, 1, 0, 1;                    ",
-				"Curve:Linear,                   ",
-				" " + speedObjectName + "EIRFF,  ",
-				" 1, 0,                          ",
-				" 0, 1;                          ",
-				"Curve:Linear,                   ",
-				" " + speedObjectName + "PLFCurveName, ",
-				" 0.85, 0.15,                    ",
-				" 0, 1;                          ",
-				"Curve:Biquadratic,              ",
-				" " + speedObjectName + "WasteHeatFunctionCurve, ",
-				" 1, 0, 0, 0, 0, 0,              ",
-				" 0, 1, 0, 1;                    ",
-				"Curve:Biquadratic,              ",
-				" " + speedObjectName + "SHRFT,  ",
-				" 1, 0, 0, 0, 0, 0,              ",
-				" 0, 1, 0, 1;                    ",
-				"Curve:Linear,                   ",
-				" " + speedObjectName + "SHRFF,  ",
-				" 1, 0,                          ",
-				" 0, 1;                          ",
-				" "});
-		return idf_objects + '\n';
-	}
+    std::string getSpeedObjectString(const std::string &speedObjectName)
+    {
+        std::string const idf_objects = delimited_string({"Coil:Cooling:DX:CurveFit:Speed, ",
+                                                          " " + speedObjectName + ",       ",
+                                                          " 0.8,                           ",
+                                                          " 0.745,                         ",
+                                                          " 3.1415926,                     ",
+                                                          " 0.9,                           ",
+                                                          " 0.9,                           ",
+                                                          " 0.5,                           ",
+                                                          " 300,                           ",
+                                                          " 6.9,                           ",
+                                                          " 0.8,                           ",
+                                                          " " + speedObjectName + "CapFT,  ",
+                                                          " " + speedObjectName + "CapFF,  ",
+                                                          " " + speedObjectName + "EIRFT,  ",
+                                                          " " + speedObjectName + "EIRFF,  ",
+                                                          " " + speedObjectName + "PLFCurveName, ",
+                                                          " 0.6,                           ",
+                                                          " " + speedObjectName + "WasteHeatFunctionCurve, ",
+                                                          " " + speedObjectName + "SHRFT,  ",
+                                                          " " + speedObjectName + "SHRFF;  ",
+                                                          "Curve:Biquadratic,              ",
+                                                          " " + speedObjectName + "CapFT,  ",
+                                                          " 1, 0, 0, 0, 0, 0,              ",
+                                                          " 0, 1, 0, 1;                    ",
+                                                          "Curve:Linear,                   ",
+                                                          " " + speedObjectName + "CapFF,  ",
+                                                          " 1, 0,                          ",
+                                                          " 0, 1;                          ",
+                                                          "Curve:Biquadratic,              ",
+                                                          " " + speedObjectName + "EIRFT,  ",
+                                                          " 1, 0, 0, 0, 0, 0,              ",
+                                                          " 0, 1, 0, 1;                    ",
+                                                          "Curve:Linear,                   ",
+                                                          " " + speedObjectName + "EIRFF,  ",
+                                                          " 1, 0,                          ",
+                                                          " 0, 1;                          ",
+                                                          "Curve:Linear,                   ",
+                                                          " " + speedObjectName + "PLFCurveName, ",
+                                                          " 0.85, 0.15,                    ",
+                                                          " 0, 1;                          ",
+                                                          "Curve:Biquadratic,              ",
+                                                          " " + speedObjectName + "WasteHeatFunctionCurve, ",
+                                                          " 1, 0, 0, 0, 0, 0,              ",
+                                                          " 0, 1, 0, 1;                    ",
+                                                          "Curve:Biquadratic,              ",
+                                                          " " + speedObjectName + "SHRFT,  ",
+                                                          " 1, 0, 0, 0, 0, 0,              ",
+                                                          " 0, 1, 0, 1;                    ",
+                                                          "Curve:Linear,                   ",
+                                                          " " + speedObjectName + "SHRFF,  ",
+                                                          " 1, 0,                          ",
+                                                          " 0, 1;                          ",
+                                                          " "});
+        return idf_objects + '\n';
+    }
 
-	std::string getModeObjectString(std::string modeName, int numSpeeds) {
-		std::vector<std::string> mode_object_lines =
-				{
-						"Coil:Cooling:DX:CurveFit:OperatingMode, ",
-						" " + modeName + ",                      ", // name
-						" 12000,                                 ", // rated gross total cooling capacity
-						" 1,                                     ", // rated evap air flow rate
-						" 2,                                     ", // rated condenser air flow rate
-						" 2.5,                                   ", // maximum cycling rate
-						" 0.5,                                   ", // ratio for latent cycling
-						" 100,                                   ", // latent time constant
-						" 300,                                   ", // latent time for removal to begin
-						" Yes,                                   ", // apply latent in higher speeds than 1
-						" EvaporativelyCooled,                   ", // condenser type
-						" 200,                                   ", // evap condenser pump power
-						" 5,                                     " // nominal speed num
-				};
-		std::vector<std::string> speedObjects;
-		for (int speedNum = 1; speedNum <= numSpeeds; speedNum++) {
-			if (speedNum < numSpeeds) {
-				mode_object_lines.push_back(" " + modeName + "Speed" + std::to_string(speedNum) + ",");
-			} else {
-				mode_object_lines.push_back(" " + modeName + "Speed" + std::to_string(speedNum) + ";");
-			}
-			speedObjects.push_back(this->getSpeedObjectString(modeName + "Speed" + std::to_string(speedNum)));
-		}
-		std::string const mode_object = delimited_string(mode_object_lines);
+    std::string getModeObjectString(std::string modeName, int numSpeeds)
+    {
+        std::vector<std::string> mode_object_lines = {
+            "Coil:Cooling:DX:CurveFit:OperatingMode, ",
+            " " + modeName + ",                      ", // name
+            " 12000,                                 ", // rated gross total cooling capacity
+            " 1,                                     ", // rated evap air flow rate
+            " 2,                                     ", // rated condenser air flow rate
+            " 2.5,                                   ", // maximum cycling rate
+            " 0.5,                                   ", // ratio for latent cycling
+            " 100,                                   ", // latent time constant
+            " 300,                                   ", // latent time for removal to begin
+            " Yes,                                   ", // apply latent in higher speeds than 1
+            " EvaporativelyCooled,                   ", // condenser type
+            " 200,                                   ", // evap condenser pump power
+            " 5,                                     "  // nominal speed num
+        };
+        std::vector<std::string> speedObjects;
+        for (int speedNum = 1; speedNum <= numSpeeds; speedNum++) {
+            if (speedNum < numSpeeds) {
+                mode_object_lines.push_back(" " + modeName + "Speed" + std::to_string(speedNum) + ",");
+            } else {
+                mode_object_lines.push_back(" " + modeName + "Speed" + std::to_string(speedNum) + ";");
+            }
+            speedObjects.push_back(this->getSpeedObjectString(modeName + "Speed" + std::to_string(speedNum)));
+        }
+        std::string const mode_object = delimited_string(mode_object_lines);
 
-		std::string fullObject;
-		fullObject = mode_object;
-		for (auto & speedObj : speedObjects) {
-			fullObject += speedObj;
-		}
-		return fullObject;
-	}
+        std::string fullObject;
+        fullObject = mode_object;
+        for (auto &speedObj : speedObjects) {
+            fullObject += speedObj;
+        }
+        return fullObject;
+    }
 
-	std::string getPerformanceObjectString(std::string const performanceName, bool addAlternateMode, int numSpeedsPerMode) {
-		std::vector<std::string> performance_object_lines =
-				{
-						"Coil:Cooling:DX:CurveFit:Performance, ",
-						" " + performanceName + ",             ",  // name
-						" 100,                                 ",  // crankcase heater capacity
-						" 0,                                   ",  // min OAT for compressor
-						" 1,                                   ",  // max OAT for basin heater
-						" 100,                                 ",  // static pressure
-						" Continuous,                          ",  // capacity control method
-						" 100,                                 ",  // basin heater capacity
-						" 400,                                 ",  // basin heater setpoint temp
-						" ,                                    ",  // basin heater operating schedule name
-						" Electricity,                         ",  // compressor fuel type
-						" BaseOperatingMode,                   "   // base operating mode name
-				};
+    std::string getPerformanceObjectString(std::string const performanceName, bool addAlternateMode, int numSpeedsPerMode)
+    {
+        std::vector<std::string> performance_object_lines = {
+            "Coil:Cooling:DX:CurveFit:Performance, ",
+            " " + performanceName + ",             ", // name
+            " 100,                                 ", // crankcase heater capacity
+            " 0,                                   ", // min OAT for compressor
+            " 1,                                   ", // max OAT for basin heater
+            " 100,                                 ", // static pressure
+            " Continuous,                          ", // capacity control method
+            " 100,                                 ", // basin heater capacity
+            " 400,                                 ", // basin heater setpoint temp
+            " ,                                    ", // basin heater operating schedule name
+            " Electricity,                         ", // compressor fuel type
+            " BaseOperatingMode,                   "  // base operating mode name
+        };
 
-		std::vector<std::string> modeObjects;
-		modeObjects.push_back(this->getModeObjectString("BaseOperatingMode", numSpeedsPerMode));
-		if (addAlternateMode) {
-			performance_object_lines.emplace_back(" AlternateOperatingMode;");
-			modeObjects.push_back(this->getModeObjectString("AlternateOperatingMode", numSpeedsPerMode));
-		} else {
-			performance_object_lines.emplace_back(";");
-		}
-		std::string const performanceObject = delimited_string(performance_object_lines);
+        std::vector<std::string> modeObjects;
+        modeObjects.push_back(this->getModeObjectString("BaseOperatingMode", numSpeedsPerMode));
+        if (addAlternateMode) {
+            performance_object_lines.emplace_back(" AlternateOperatingMode;");
+            modeObjects.push_back(this->getModeObjectString("AlternateOperatingMode", numSpeedsPerMode));
+        } else {
+            performance_object_lines.emplace_back(";");
+        }
+        std::string const performanceObject = delimited_string(performance_object_lines);
 
-		std::string fullObject = performanceObject;
-		for (auto & modeObject : modeObjects) {
-			fullObject += modeObject;
-		}
-		return fullObject;
-	}
+        std::string fullObject = performanceObject;
+        for (auto &modeObject : modeObjects) {
+            fullObject += modeObject;
+        }
+        return fullObject;
+    }
 
-	std::string getCoilObjectString(std::string const coilName, bool addAlternateMode, int numSpeedsPerMode) {
-		std::string coilObject = delimited_string(
-				{
-						"Coil:Cooling:DX,                     ",
-						" " + coilName + ",                   ",  // name
-						" EvapInletNode,                      ",  // evap inlet node
-						" EvapOutletNode,                     ",  // evap outlet node
-						" AvailSchedule,                      ",  // availability schedule name
-						" ZoneNameForCondenser,               ",  // condenser zone name
-						" CondenserInletNode,                 ",  // condenser inlet node
-						" CondenserOutletNode,                ",  // condenser outlet node
-						" PerformanceObjectName,              ",  // performance object name
-						" ,!CondensateCollectionTankName,       ",  // condensate storage tank name
-						" ;!EvaporativeCondenserSupplyTankName; ",  // evaporative condenser supply tank name
-						"Schedule:Constant,AvailSchedule,,1;  "
-				});
-		std::string performanceObject = this->getPerformanceObjectString("PerformanceObjectName", addAlternateMode, numSpeedsPerMode);
-		std::string fullObject = coilObject + performanceObject;
-		return fullObject;
-	}
+    std::string getCoilObjectString(std::string const coilName, bool addAlternateMode, int numSpeedsPerMode)
+    {
+        std::string coilObject = delimited_string({"Coil:Cooling:DX,                     ",
+                                                   " " + coilName + ",                   ",   // name
+                                                   " EvapInletNode,                      ",   // evap inlet node
+                                                   " EvapOutletNode,                     ",   // evap outlet node
+                                                   " AvailSchedule,                      ",   // availability schedule name
+                                                   " ZoneNameForCondenser,               ",   // condenser zone name
+                                                   " CondenserInletNode,                 ",   // condenser inlet node
+                                                   " CondenserOutletNode,                ",   // condenser outlet node
+                                                   " PerformanceObjectName,              ",   // performance object name
+                                                   " ,!CondensateCollectionTankName,       ", // condensate storage tank name
+                                                   " ;!EvaporativeCondenserSupplyTankName; ", // evaporative condenser supply tank name
+                                                   "Schedule:Constant,AvailSchedule,,1;  "});
+        std::string performanceObject = this->getPerformanceObjectString("PerformanceObjectName", addAlternateMode, numSpeedsPerMode);
+        std::string fullObject = coilObject + performanceObject;
+        return fullObject;
+    }
 
-	void TearDown() override
-	{
-		EnergyPlus::EnergyPlusFixture::TearDown(); // Remember to tear down the base fixture after cleaning up derived fixture!
-	}
+    void TearDown() override
+    {
+        EnergyPlus::EnergyPlusFixture::TearDown(); // Remember to tear down the base fixture after cleaning up derived fixture!
+    }
 };


### PR DESCRIPTION
Quick fix, applying clang-format to recently changed files.  Looks to be pretty much just indentation and spacing changes.