### PR TITLE
Clean up compiler warnings from GCC 9.3

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -95,9 +95,9 @@ ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
     ADD_CXX_DEFINITIONS("-pipe") # Faster compiler processing
     ADD_CXX_DEFINITIONS("-std=c++11") # Enable C++11 features in g++
     ADD_CXX_DEFINITIONS("-pedantic") # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
-    ADD_CXX_DEFINITIONS("-ffor-scope")
     ADD_CXX_DEFINITIONS("-Wall -Wextra") # Turn on warnings
     ADD_CXX_DEFINITIONS("-Wno-unknown-pragmas")
+    ADD_CXX_DEFINITIONS("-Wno-deprecated-copy")
     ADD_CXX_DEFINITIONS("-Wno-attributes") # Don't warn on attributes Clang doesn't know
     ADD_CXX_DEFINITIONS("-Wno-delete-non-virtual-dtor")
     ADD_CXX_DEFINITIONS("-Wno-missing-braces")

--- a/third_party/ObjexxFCL/CMakeLists.txt
+++ b/third_party/ObjexxFCL/CMakeLists.txt
@@ -1,7 +1,7 @@
 set( target_name objexx )
 
 if (UNIX)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wno-sign-compare")
 endif()
 
 set(src

--- a/third_party/Windows-CalcEngine/cmake/WCECompilerFlags.cmake
+++ b/third_party/Windows-CalcEngine/cmake/WCECompilerFlags.cmake
@@ -18,8 +18,8 @@ IF ( CMAKE_COMPILER_IS_GNUCXX OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" ) 
         ADD_CXX_DEFINITIONS("-fPIC")
     endif()
     ADD_CXX_DEFINITIONS("-pedantic") # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
-    ADD_CXX_DEFINITIONS("-ffor-scope")
-    ADD_CXX_DEFINITIONS("-Wall -Wextra") # Turn on warnings
+    #ADD_CXX_DEFINITIONS("-ffor-scope")
+    #ADD_CXX_DEFINITIONS("-Wall -Wextra") # Turn on warnings
     ADD_CXX_DEFINITIONS("-Wno-unknown-pragmas")
     if( CMAKE_COMPILER_IS_GNUCXX ) # g++
       ADD_CXX_DEFINITIONS("-Wno-unused-but-set-parameter -Wno-unused-but-set-variable") # Suppress unused-but-set warnings until more serious ones are addressed

--- a/third_party/eigen/CMakeLists.txt
+++ b/third_party/eigen/CMakeLists.txt
@@ -156,7 +156,7 @@ if(NOT MSVC)
   endif()
   ei_add_cxx_compiler_flag("-pedantic")
   ei_add_cxx_compiler_flag("-Wall")
-  ei_add_cxx_compiler_flag("-Wextra")
+  #ei_add_cxx_compiler_flag("-Wextra")
   #ei_add_cxx_compiler_flag("-Weverything")              # clang
 
   ei_add_cxx_compiler_flag("-Wundef")

--- a/third_party/penumbra/cmake/compiler-flags.cmake
+++ b/third_party/penumbra/cmake/compiler-flags.cmake
@@ -57,7 +57,7 @@ ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleC
     ADD_CXX_DEFINITIONS("-pipe") # Faster compiler processing
     ADD_CXX_DEFINITIONS("-std=c++11") # Enable C++11 features in g++
     ADD_CXX_DEFINITIONS("-pedantic") # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
-    ADD_CXX_DEFINITIONS("-ffor-scope")
+    #ADD_CXX_DEFINITIONS("-ffor-scope")
     ADD_CXX_DEFINITIONS("-Wall -Wextra") # Turn on warnings
     ADD_CXX_DEFINITIONS("-Wno-unknown-pragmas")
     if ( CMAKE_COMPILER_IS_GNUCXX ) # g++


### PR DESCRIPTION
Pull request overview
---------------------
I installed Ubuntu 20.04 today and GCC 9.3 came with it.  Building EnergyPlus revealed some warnings that need to be tidied.  The primary things are:

- All -ffor-scope flags need to be eliminated, it is deprecated and is now warning about the flag being there.
- There are some deprecated copy warnings coming out that are emitted if the user has a user defined copy constructor without a user defined assignment constructor, vice versa, or one of the user defined constructors have been made private so it appears to be missing.  For our case, I think it is fine to just mute the warning.
- There is a sign comparison warning from assertions inside ObjexxFCL Array1D.

