### PR TITLE
Mute unrecognized warnings so we can still emit them on newer compilers

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -97,8 +97,9 @@ ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
     ADD_CXX_DEFINITIONS("-pedantic") # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
     ADD_CXX_DEFINITIONS("-Wall -Wextra") # Turn on warnings
     ADD_CXX_DEFINITIONS("-Wno-unknown-pragmas")
-    ADD_CXX_DEFINITIONS("-Wno-deprecated-copy")
-    ADD_CXX_DEFINITIONS("-Wno-unknown-warning") # allow warning about things on newer compilers without affecting older ones
+    if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0)
+      ADD_CXX_DEFINITIONS("-Wno-deprecated-copy")
+    endif()
     ADD_CXX_DEFINITIONS("-Wno-attributes") # Don't warn on attributes Clang doesn't know
     ADD_CXX_DEFINITIONS("-Wno-delete-non-virtual-dtor")
     ADD_CXX_DEFINITIONS("-Wno-missing-braces")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -98,6 +98,7 @@ ELSEIF ( CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
     ADD_CXX_DEFINITIONS("-Wall -Wextra") # Turn on warnings
     ADD_CXX_DEFINITIONS("-Wno-unknown-pragmas")
     ADD_CXX_DEFINITIONS("-Wno-deprecated-copy")
+    ADD_CXX_DEFINITIONS("-Wno-unknown-warning") # allow warning about things on newer compilers without affecting older ones
     ADD_CXX_DEFINITIONS("-Wno-attributes") # Don't warn on attributes Clang doesn't know
     ADD_CXX_DEFINITIONS("-Wno-delete-non-virtual-dtor")
     ADD_CXX_DEFINITIONS("-Wno-missing-braces")


### PR DESCRIPTION
Followup to #7959 where the result ended up causing lots of warnings on some machines.  With this change, new unknown warnings do not cause problems with older compilers, so that we can still emit them with newer compilers.  This flag has an interesting behavior however, in that if any other problem arises during building, the muted warning should be called out, just in case it was hiding a problem.