### PR TITLE
Quick attempts to fix integration failures

### DIFF
--- a/testfiles/PythonPluginPlantOperation_largeOff.idf
+++ b/testfiles/PythonPluginPlantOperation_largeOff.idf
@@ -7708,116 +7708,30 @@
     Boiler:HotWater,         !- Equipment 1 Object Type
     HeatSys1 Boiler;         !- Equipment 1 Name
 
-!  EnergyManagementSystem:ProgramCallingManager,
-!    Heating_dispatch,        !- Name
-!    UserDefinedComponentModel,  !- EnergyPlus Model Calling Point
-!    Heating_dispatch_Values; !- Program Name 1
-
   PythonPlugin:Instance,
     Heating_dispatch,                  !- Name
     Yes,                                    !- Run During Warmup Days
     PythonPluginPlantOperation_largeOff,    !- Python Module Name
-    Heating_dispatch_Values;           !- Plugin Class Name
-
-!  EnergyManagementSystem:Program,
-!    Heating_dispatch_Values, !- Name
-!    IF HeatSys1_LoopDmnd > 0.0,  !- Program Line 1
-!    SET Boiler_Disptch = HeatSys1_LoopDmnd,  !- Program Line 2
-!    ELSE,                    !- <none>
-!    SET Boiler_Disptch = 0.0,!- <none>
-!    ENDIF;                   !- <none>
-
-!  EnergyManagementSystem:InternalVariable,
-!    HeatSys1_LoopDmnd,       !- Name
-!    HeatSys1 Operation Scheme,  !- Internal Data Index Key Name
-!    Supply Side Current Demand Rate;  !- Internal Data Type
-
-!  EnergyManagementSystem:Actuator,
-!    Boiler_Disptch,          !- Name
-!    HeatSys1 Operation Scheme:HeatSys1 Boiler,  !- Actuated Component Unique Name
-!    Plant Equipment Operation,  !- Actuated Component Type
-!    Distributed Load Rate;   !- Actuated Component Control Type
+    HeatingDispatchValues;           !- Plugin Class Name
 
   PlantEquipmentOperation:UserDefined,
     CoolSys1 Operation Scheme,  !- Name
     Cooling_dispatch,        !- Main Model Program Calling Manager Name
-    Init_Chiller_Capacity,   !- Initialization Program Calling Manager Name
+    ,   !- Initialization Program Calling Manager Name
     Chiller:Electric:ReformulatedEIR,  !- Equipment 1 Object Type
     CoolSys1 Chiller 1,      !- Equipment 1 Name
     Chiller:Electric:ReformulatedEIR,  !- Equipment 2 Object Type
     CoolSys1 Chiller 2;      !- Equipment 2 Name
 
- ! EnergyManagementSystem:ProgramCallingManager,
- !   Init_Chiller_Capacity,         !- Name
- !   UserDefinedComponentModel,     !- EnergyPlus Model Calling Point
- !   Init_Chiller_Capacity_Values;  !- Program Name 1
-
-  PythonPlugin:Instance,
-    Init_Chiller_Capacity,                              !- Name
-    Yes,                                                !- Run During Warmup Days
-    PythonPluginPlantOperation_largeOff,                !- Python Module Name
-    Init_Chiller_Capacity_and_Cooling_dispatch_Values;  !- Plugin Class Name
-
   PythonPlugin:Variables,
     PythonGlobalVars,           !- Name
     totChilCap;     !- Variable Name 1
-
-!  EnergyManagementSystem:Program,
-!    Init_Chiller_Capacity_Values,  !- Name
-!    Set totChilCap = Chil1_Cap + Chil2_Cap;  !- Program Line 1
-
-!  EnergyManagementSystem:GlobalVariable,
-!    totChilCap;              !- Erl Variable 1 Name
-
-!  EnergyManagementSystem:ProgramCallingManager,
-!    Cooling_dispatch,        !- Name
-!    UserDefinedComponentModel,  !- EnergyPlus Model Calling Point
-!    Cooling_dispatch_Values; !- Program Name 1
 
   PythonPlugin:Instance,
     Cooling_dispatch,                                   !- Name
     Yes,                                                !- Run During Warmup Days
     PythonPluginPlantOperation_largeOff,                !- Python Module Name
-    Init_Chiller_Capacity_and_Cooling_dispatch_Values;  !- Plugin Class Name
-
-!  EnergyManagementSystem:Program,
-!    Cooling_dispatch_Values, !- Name
-!    IF CoolSys1_LoopDmnd < 0.0,  !- Program Line 1
-!    Set UniformPLR  = CoolSys1_LoopDmnd / totChilCap,  !- Program Line 2
-!    Set UniformPLR  =  @min UniformPLR 1.0,  !- <none>
-!    SET Chil1_Disptch = UniformPLR*Chil1_Cap,  !- <none>
-!    SET Chil2_Disptch = UniformPLR*Chil2_Cap,  !- <none>
-!    ELSE,                    !- <none>
-!    SET Chil1_Disptch = 0.0, !- <none>
-!    SET Chil2_Disptch = 0.0, !- <none>
-!    ENDIF;                   !- <none>
-
-!  EnergyManagementSystem:InternalVariable,
-!    CoolSys1_LoopDmnd,       !- Name
-!    CoolSys1 Operation Scheme,  !- Internal Data Index Key Name
-!    Supply Side Current Demand Rate;  !- Internal Data Type
-
-!  EnergyManagementSystem:InternalVariable,
-!    Chil1_Cap,               !- Name
-!    CoolSys1 Chiller 1,      !- Internal Data Index Key Name
-!    Chiller Nominal Capacity;!- Internal Data Type
-
-!  EnergyManagementSystem:InternalVariable,
-!    Chil2_Cap,               !- Name
-!    CoolSys1 Chiller 2,      !- Internal Data Index Key Name
-!    Chiller Nominal Capacity;!- Internal Data Type
-
-!  EnergyManagementSystem:Actuator,
-!    Chil1_Disptch,           !- Name
-!    CoolSys1 Operation Scheme:CoolSys1 Chiller 1,  !- Actuated Component Unique Name
-!    Plant Equipment Operation,  !- Actuated Component Type
-!    Distributed Load Rate;   !- Actuated Component Control Type
-
-!  EnergyManagementSystem:Actuator,
-!    Chil2_Disptch,           !- Name
-!    CoolSys1 Operation Scheme:CoolSys1 Chiller 2,  !- Actuated Component Unique Name
-!    Plant Equipment Operation,  !- Actuated Component Type
-!    Distributed Load Rate;   !- Actuated Component Control Type
+    InitChillerCapacityAndCoolingDispatchValues;  !- Plugin Class Name
 
   PlantEquipmentOperation:UserDefined,
     TowerWaterSys Operation Scheme,  !- Name
@@ -7826,37 +7740,11 @@
     CoolingTower:SingleSpeed,!- Equipment 1 Object Type
     TowerWaterSys CoolTower; !- Equipment 1 Name
 
-!  EnergyManagementSystem:ProgramCallingManager,
-!    Tower_dispatch,             !- Name
-!    UserDefinedComponentModel,  !- EnergyPlus Model Calling Point
-!    Tower_dispatch_Values;      !- Program Name 1
-
   PythonPlugin:Instance,
     Tower_dispatch,             !- Name
     Yes,                                    !- Run During Warmup Days
     PythonPluginPlantOperation_largeOff,    !- Python Module Name
-    Tower_dispatch_Values;                  !- Plugin Class Name
-
-!  EnergyManagementSystem:Program,
-!    Tower_dispatch_Values,   !- Name
-!    IF TowerWaterSys_LoopDmnd < 0.0,  !- Program Line 1
-!    SET Tower_Disptch = TowerWaterSys_LoopDmnd,  !- Program Line 2
-!    ELSE,                    !- <none>
-!    SET Tower_Disptch = 0.0, !- <none>
-!    ENDIF;                   !- <none>
-
-!  EnergyManagementSystem:InternalVariable,
-!    TowerWaterSys_LoopDmnd,  !- Name
-!    TowerWaterSys Operation Scheme,  !- Internal Data Index Key Name
-!    Supply Side Current Demand Rate;  !- Internal Data Type
-
-!  EnergyManagementSystem:Actuator,
-!    Tower_Disptch,           !- Name
-!    TowerWaterSys Operation Scheme:TowerWaterSys CoolTower,  !- Actuated Component Unique Name
-!    Plant Equipment Operation,  !- Actuated Component Type
-!    Distributed Load Rate;   !- Actuated Component Control Type
-
-! ***LOOPS***
+    TowerDispatchValues;                  !- Plugin Class Name
 
   PlantLoop,
     CoolSys1,                !- Name

--- a/testfiles/PythonPluginPlantOperation_largeOff.py
+++ b/testfiles/PythonPluginPlantOperation_largeOff.py
@@ -1,14 +1,15 @@
 from pyenergyplus.plugin import EnergyPlusPlugin
 
-class Heating_dispatch_Values(EnergyPlusPlugin):
+
+class HeatingDispatchValues(EnergyPlusPlugin):
 
     def __init__(self):
         # init parent class
         super().__init__()
         self.need_to_get_handles = True
 
-        self.HeatSys1_LoopDmnd_handle = None
-        self.Boiler_Disptch_handle = None
+        self.heat_sys_1_loop_demand_handle = None
+        self.boiler_dispatch_handle = None
 
     def on_user_defined_component_model(self) -> int:
 
@@ -17,24 +18,23 @@ class Heating_dispatch_Values(EnergyPlusPlugin):
 
             # get variable handles if needed
             if self.need_to_get_handles:
-
-                self.HeatSys1_LoopDmnd_handle = self.api.exchange.get_internal_variable_handle(
+                self.heat_sys_1_loop_demand_handle = self.api.exchange.get_internal_variable_handle(
                     "Supply Side Current Demand Rate",
                     "HeatSys1 Operation Scheme"
                 )
-
-                self.Boiler_Disptch_handle = self.api.exchange.get_actuator_handle(
+                self.boiler_dispatch_handle = self.api.exchange.get_actuator_handle(
                     "Plant Equipment Operation",
                     "Distributed Load Rate",
                     "HeatSys1 Operation Scheme:HeatSys1 Boiler"
                 )
+                self.need_to_get_handles = False
 
             # calculation
-            HeatSys1_LoopDmnd = self.api.exchange.get_internal_variable_value(self.HeatSys1_LoopDmnd_handle)
-            if HeatSys1_LoopDmnd > 0.0:
-                self.api.exchange.set_actuator_value(self.Boiler_Disptch_handle, HeatSys1_LoopDmnd)
+            heat_sys_1_loop_demand = self.api.exchange.get_internal_variable_value(self.heat_sys_1_loop_demand_handle)
+            if heat_sys_1_loop_demand > 0.0:
+                self.api.exchange.set_actuator_value(self.boiler_dispatch_handle, heat_sys_1_loop_demand)
             else:
-                self.api.exchange.set_actuator_value(self.Boiler_Disptch_handle, 0.0)
+                self.api.exchange.set_actuator_value(self.boiler_dispatch_handle, 0.0)
 
             return 0
 
@@ -42,19 +42,20 @@ class Heating_dispatch_Values(EnergyPlusPlugin):
             # api not ready, return
             return 0
 
-class Init_Chiller_Capacity_and_Cooling_dispatch_Values(EnergyPlusPlugin):
+
+class InitChillerCapacityAndCoolingDispatchValues(EnergyPlusPlugin):
 
     def __init__(self):
         # init parent class
         super().__init__()
         self.need_to_get_handles = True
 
-        self.totChilCap_handle = None
-        self.Chil1_Cap_handle = None
-        self.Chil2_Cap_handle = None
-        self.CoolSys1_LoopDmnd_handle = None
-        self.Chil1_Disptch_handle = None
-        self.Chil2_Disptch_handle = None
+        self.total_chiller_capacity_handle = None
+        self.chiller_1_capacity_handle = None
+        self.chiller_2_capacity_handle = None
+        self.cool_sys_1_loop_demand_handle = None
+        self.chiller_1_dispatch_handle = None
+        self.chiller_2_dispatch_handle = None
 
     def on_user_defined_component_model(self) -> int:
 
@@ -63,51 +64,46 @@ class Init_Chiller_Capacity_and_Cooling_dispatch_Values(EnergyPlusPlugin):
 
             # get variable handles if needed
             if self.need_to_get_handles:
-
-                self.totChilCap_handle = self.api.exchange.get_global_handle("totChilCap")
-
-                self.Chil1_Cap_handle = self.api.exchange.get_internal_variable_handle(
+                self.total_chiller_capacity_handle = self.api.exchange.get_global_handle("totChilCap")
+                self.chiller_1_capacity_handle = self.api.exchange.get_internal_variable_handle(
                     "Chiller Nominal Capacity",
                     "CoolSys1 Chiller 1"
                 )
-
-                self.Chil2_Cap_handle = self.api.exchange.get_internal_variable_handle(
+                self.chiller_2_capacity_handle = self.api.exchange.get_internal_variable_handle(
                     "Chiller Nominal Capacity",
                     "CoolSys1 Chiller 2"
                 )
-
-                self.CoolSys1_LoopDmnd_handle = self.api.exchange.get_internal_variable_handle(
+                self.cool_sys_1_loop_demand_handle = self.api.exchange.get_internal_variable_handle(
                     "Supply Side Current Demand Rate",
                     "CoolSys1 Operation Scheme"
                 )
-
-                self.Chil1_Disptch_handle = self.api.exchange.get_actuator_handle(
+                self.chiller_1_dispatch_handle = self.api.exchange.get_actuator_handle(
                     "Plant Equipment Operation",
                     "Distributed Load Rate",
                     "CoolSys1 Operation Scheme:CoolSys1 Chiller 1"
                 )
-
-                self.Chil2_Disptch_handle = self.api.exchange.get_actuator_handle(
+                self.chiller_2_dispatch_handle = self.api.exchange.get_actuator_handle(
                     "Plant Equipment Operation",
                     "Distributed Load Rate",
                     "CoolSys1 Operation Scheme:CoolSys1 Chiller 2"
                 )
+                self.need_to_get_handles = False
 
             # calculation: Init_Chiller_Capacity_Values
-            Chil1_Cap = self.api.exchange.get_internal_variable_value(self.Chil1_Cap_handle)
-            Chil2_Cap = self.api.exchange.get_internal_variable_value(self.Chil2_Cap_handle)
-            self.api.exchange.set_global_value(self.totChilCap_handle, Chil1_Cap + Chil2_Cap)
+            chiller_1_capacity = self.api.exchange.get_internal_variable_value(self.chiller_1_capacity_handle)
+            chiller_2_capacity = self.api.exchange.get_internal_variable_value(self.chiller_2_capacity_handle)
+            total_chiller_capacity = chiller_1_capacity + chiller_2_capacity
+            self.api.exchange.set_global_value(self.total_chiller_capacity_handle, total_chiller_capacity)
 
             # calculation: Cooling_dispatch_Values
-            CoolSys1_LoopDmnd = self.api.exchange.get_internal_variable_value(self.CoolSys1_LoopDmnd_handle)
-            totChilCap = self.api.exchange.get_global_value(self.totChilCap_handle)
-            if CoolSys1_LoopDmnd < 0.0:
-                UniformPLR = min(CoolSys1_LoopDmnd / totChilCap, 1.0)
-                self.api.exchange.set_actuator_value(self.Chil1_Disptch_handle, UniformPLR * Chil1_Cap)
-                self.api.exchange.set_actuator_value(self.Chil2_Disptch_handle, UniformPLR * Chil2_Cap)
+            cool_sys_1_loop_demand = self.api.exchange.get_internal_variable_value(self.cool_sys_1_loop_demand_handle)
+            if cool_sys_1_loop_demand < 0.0:
+                uniform_plr = min(cool_sys_1_loop_demand / total_chiller_capacity, 1.0)
+                self.api.exchange.set_actuator_value(self.chiller_1_dispatch_handle, uniform_plr * chiller_1_capacity)
+                self.api.exchange.set_actuator_value(self.chiller_2_dispatch_handle, uniform_plr * chiller_2_capacity)
             else:
-                self.api.exchange.set_actuator_value(self.Chil1_Disptch_handle, 0)
-                self.api.exchange.set_actuator_value(self.Chil2_Disptch_handle, 0)
+                self.api.exchange.set_actuator_value(self.chiller_1_dispatch_handle, 0)
+                self.api.exchange.set_actuator_value(self.chiller_2_dispatch_handle, 0)
 
             return 0
 
@@ -115,15 +111,16 @@ class Init_Chiller_Capacity_and_Cooling_dispatch_Values(EnergyPlusPlugin):
             # api not ready, return
             return 0
 
-class Tower_dispatch_Values(EnergyPlusPlugin):
+
+class TowerDispatchValues(EnergyPlusPlugin):
 
     def __init__(self):
         # init parent class
         super().__init__()
         self.need_to_get_handles = True
 
-        self.TowerWaterSys_LoopDmnd_handle = None
-        self.Tower_Disptch_handle = None
+        self.tower_water_sys_loop_demand_handle = None
+        self.tower_dispatch_handle = None
 
     def on_user_defined_component_model(self) -> int:
 
@@ -132,24 +129,25 @@ class Tower_dispatch_Values(EnergyPlusPlugin):
 
             # get variable handles if needed
             if self.need_to_get_handles:
-
-                self.TowerWaterSys_LoopDmnd_handle = self.api.exchange.get_internal_variable_handle(
+                self.tower_water_sys_loop_demand_handle = self.api.exchange.get_internal_variable_handle(
                     "Supply Side Current Demand Rate",
                     "TowerWaterSys Operation Scheme"
                 )
-
-                self.Tower_Disptch_handle = self.api.exchange.get_actuator_handle(
+                self.tower_dispatch_handle = self.api.exchange.get_actuator_handle(
                     "Plant Equipment Operation",
                     "Distributed Load Rate",
                     "TowerWaterSys Operation Scheme:TowerWaterSys CoolTower"
                 )
-
+                self.need_to_get_handles = False
+                
             # calculation
-            TowerWaterSys_LoopDmnd = self.api.exchange.get_internal_variable_value(self.TowerWaterSys_LoopDmnd_handle)
-            if TowerWaterSys_LoopDmnd < 0.0:
-                self.api.exchange.set_actuator_value(self.Tower_Disptch_handle, TowerWaterSys_LoopDmnd)
+            tower_water_sys_loop_demand = self.api.exchange.get_internal_variable_value(
+                self.tower_water_sys_loop_demand_handle
+            )
+            if tower_water_sys_loop_demand < 0.0:
+                self.api.exchange.set_actuator_value(self.tower_dispatch_handle, tower_water_sys_loop_demand)
             else:
-                self.api.exchange.set_actuator_value(self.Tower_Disptch_handle, 0.0)
+                self.api.exchange.set_actuator_value(self.tower_dispatch_handle, 0.0)
 
             return 0
 

--- a/testfiles/PythonPluginPlantOperation_largeOff.py
+++ b/testfiles/PythonPluginPlantOperation_largeOff.py
@@ -139,7 +139,7 @@ class TowerDispatchValues(EnergyPlusPlugin):
                     "TowerWaterSys Operation Scheme:TowerWaterSys CoolTower"
                 )
                 self.need_to_get_handles = False
-                
+
             # calculation
             tower_water_sys_loop_demand = self.api.exchange.get_internal_variable_value(
                 self.tower_water_sys_loop_demand_handle


### PR DESCRIPTION
In a recent commit, I found not one, but two files timing out in the linux integration debug build.  These days about half the time the files all pass, but that's not nearly enough.  We need all these files to pass fully so that something real doesn't slip through the cracks.

HospitalLowEnergy definitely needs some love, the HVAC system has lots of iteration problems, etc.  But in the meantime, I just put the timestep from 10 minutes to 15 minutes, and as expected, it cut the runtime down, and it should start passing here.  The file has "big" diffs, but the meter diffs were actually on the order of small fractions of a percent change.  If someone wants to really dig in to that file and get it working right at the 10 minute timestep level, that's fine, but in the meantime, we need to get it at least running consistently on CI.  Otherwise we might as well just not test it.

A python plugin file timed out, and with a quick cleanup, I found an initialization flag was never being set in the Python code, and so the code was looking for handles to actuators and variables every - single - time it ran.  Many, many, string searches going on.  Once I changed that the file runtime went from 42 seconds to about 2.75 seconds, on a local release build.

I'm open to discussion on the HospitalLowEnergy change, but if no one has the time to dig in to the shenanigans in that file, we should at least just use this slight change to the time step to get it running reliably.