### PR TITLE
Fix Python Plugin DLL path issues when EnergyPlus is called through a symlink

### DIFF
--- a/src/EnergyPlus/FileSystem.cc
+++ b/src/EnergyPlus/FileSystem.cc
@@ -106,6 +106,13 @@ namespace FileSystem {
 
     std::string getAbsolutePath(std::string const &path)
     {
+        /*
+         * Returns the absolute path for a given relative path.
+         *
+         * If the relative path points to a symlink, the symlink will
+         * be resolved, and this function will return the absolute path
+         * of the link.
+         */
 
 #ifdef _WIN32
         char absolutePath[1024];
@@ -142,6 +149,11 @@ namespace FileSystem {
 
     std::string getProgramPath()
     {
+        /*
+         * Returns the relative path to the executable file (including symlinks).
+         *
+         * To resolve symlinks, wrap this call in getAbsolutePath().
+         */
         char executableRelativePath[1024];
 
 #ifdef __APPLE__

--- a/src/EnergyPlus/PluginManager.cc
+++ b/src/EnergyPlus/PluginManager.cc
@@ -127,7 +127,7 @@ namespace PluginManagement {
         // In this case, the current executable path will be the E+ install root
         // Which is where we find the Python Wrapper Shared Library
         if (wrapperDLLHandle) return; // already found
-        std::string programPath = FileSystem::getProgramPath();
+        std::string programPath = FileSystem::getAbsolutePath(FileSystem::getProgramPath());
         std::string programDir = FileSystem::getParentDirectoryPath(programPath);
         std::string sanitizedProgramDir = PluginManager::sanitizedPath(programDir);
         // set the path to the python library


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8037
 
Resolves symlink path for executable in Python Plugin code.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process


### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
