### PR TITLE
Add a clear_state for DataReportingFlags

### DIFF
--- a/src/EnergyPlus/DataReportingFlags.cc
+++ b/src/EnergyPlus/DataReportingFlags.cc
@@ -94,6 +94,21 @@ namespace DataReportingFlags {
     bool DebugOutput(false);
     bool EvenDuringWarmup(false);
 
+    // MODULE SUBROUTINES:
+
+    // Functions
+    void clear_state() {
+        NumOfWarmupDays = 0;
+        cWarmupDay.clear();
+        DisplayPerfSimulationFlag = false;
+        DoWeatherInitReporting = false;
+        PrintEndDataDictionary = false;
+        MakeMirroredDetachedShading = true;
+        MakeMirroredAttachedShading = true;
+        DebugOutput = false;
+        EvenDuringWarmup = false;
+    }
+
 } // namespace DataReportingFlags
 
 } // namespace EnergyPlus

--- a/src/EnergyPlus/DataReportingFlags.hh
+++ b/src/EnergyPlus/DataReportingFlags.hh
@@ -76,6 +76,9 @@ namespace DataReportingFlags {
     extern bool DebugOutput;
     extern bool EvenDuringWarmup;
 
+    // Functions
+    void clear_state();
+
 } // namespace DataReportingFlags
 
 } // namespace EnergyPlus

--- a/src/EnergyPlus/StateManagement.cc
+++ b/src/EnergyPlus/StateManagement.cc
@@ -79,6 +79,7 @@
 #include <EnergyPlus/DataMoistureBalanceEMPD.hh>
 #include <EnergyPlus/DataOutputs.hh>
 #include <EnergyPlus/DataPhotovoltaics.hh>
+#include <EnergyPlus/DataReportingFlags.hh>
 #include <EnergyPlus/DataRoomAirModel.hh>
 #include <EnergyPlus/DataRuntimeLanguage.hh>
 #include <EnergyPlus/DataSizing.hh>
@@ -262,6 +263,7 @@ void EnergyPlus::clearAllStates(OutputFiles &outputFiles)
     DataOutputs::clear_state();
     DataPhotovoltaics::clear_state();
     DataPlant::clear_state();
+    DataReportingFlags::clear_state();
     DataRoomAirModel::clear_state();
     DataRuntimeLanguage::clear_state();
     DataSizing::clear_state();


### PR DESCRIPTION
hotfix for new tests failing serially following #7970 