### PR TITLE
Fix default for SimulationControl Maximum Number of HVAC Sizing Simulation Passes

### DIFF
--- a/tst/EnergyPlus/unit/SimulationManager.unit.cc
+++ b/tst/EnergyPlus/unit/SimulationManager.unit.cc
@@ -479,3 +479,25 @@ TEST_F(EnergyPlusFixture, SimulationManager_OutputDiagnostics_HasEmpty)
     });
     EXPECT_TRUE(compare_err_stream(expectedError, true));
 }
+
+TEST_F(EnergyPlusFixture, SimulationManager_HVACSizingSimulationChoiceTest)
+{
+    std::string const idf_objects = delimited_string({
+        "  SimulationControl,",
+        "    No,                      !- Do Zone Sizing Calculation",
+        "    No,                      !- Do System Sizing Calculation",
+        "    No,                      !- Do Plant Sizing Calculation",
+        "    No,                      !- Run Simulation for Sizing Periods",
+        "    Yes,                     !- Run Simulation for Weather File Run Periods",
+        "    Yes;                     !- Do HVAC Sizing Simulation for Sizing Periods",
+    });
+
+    EXPECT_TRUE(process_idf(idf_objects));
+
+    SimulationManager::GetProjectData(state, state.outputFiles);
+
+    EXPECT_TRUE(DataGlobals::DoHVACSizingSimulation);
+    // get a default value
+    EXPECT_EQ(DataGlobals::HVACSizingSimMaxIterations, 1);   
+
+}


### PR DESCRIPTION
Pull request overview
---------------------
Fixes #8146
In SimulationControl, if the field "Maximum Number of HVAC Sizing Simulation Passes" is left blank, the default of 1 is now correctly applied. Previously the HVAC Sizing Simulation did not run for a SimulationControl object like this:

```
SimulationControl,
  Yes,                                    !- Do Zone Sizing Calculation
  Yes,                                    !- Do System Sizing Calculation
  Yes,                                    !- Do Plant Sizing Calculation
  Yes,                                    !- Run Simulation for Sizing Periods
  No,                                     !- Run Simulation for Weather File Run Periods
  Yes;                                    !- Do HVAC Sizing Simulation for Sizing Periods
```

This fixes missing output for central plant equipment in the Equipment Summary table output, as well as other missing columns related sizing outputs.
 

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [x] Perform a Code Review on GitHub
 - [x] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] ~If feature, test running new feature, try creative ways to break it~
 - [x] CI status: all green or justified
 - [x] Check that performance is not impacted (CI Linux results include performance check)
 - [x] Run Unit Test(s) locally
 - [ ] ~Check any new function arguments for performance impacts~
 - [ ] ~Verify IDF naming conventions and styles, memos and notes and defaults~
 - [ ] ~If new idf included, locally check the err file and other outputs~
