### PR TITLE
Output to stdout if no edd output file is requested

### DIFF
--- a/src/EnergyPlus/IOFiles.cc
+++ b/src/EnergyPlus/IOFiles.cc
@@ -226,7 +226,9 @@ std::string InputOutputFile::get_output()
     }
 }
 
-InputOutputFile::InputOutputFile(std::string FileName) : fileName(std::move(FileName))
+InputOutputFile::InputOutputFile(std::string FileName, const bool DefaultToStdout) 
+  : fileName{std::move(FileName)},
+    defaultToStdOut{DefaultToStdout}
 {
 }
 


### PR DESCRIPTION
No change in tests expected.

 * restores previous behavior before removal of GIO
 * optionally allow any output file to fall back to stdout

Addresses #8186
