### PR TITLE
Move initialization of IO singleton to correct place

### DIFF
--- a/src/EnergyPlus/SimulationManager.cc
+++ b/src/EnergyPlus/SimulationManager.cc
@@ -307,10 +307,6 @@ namespace SimulationManager {
         bool AnyUnderwaterBoundaries = false;
         int EnvCount;
 
-        // Windows: ensure that EnergyPlusAPI.dll's notion of the "static singleton IOFiles" matches
-        // the exe's notion.
-        // TODO: Remove this after we have eliminated all remaining calls to IOFiles::getSingleton
-        IOFiles::setSingleton(&state.files);
 
         // CreateSQLiteDatabase();
         sqlite = EnergyPlus::CreateSQLiteDatabase();

--- a/src/EnergyPlus/api/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/api/EnergyPlusPgm.cc
@@ -227,6 +227,12 @@ int EnergyPlusPgm(EnergyPlus::EnergyPlusData &state, std::string const &filepath
 
 void commonInitialize(EnergyPlus::EnergyPlusData &state) {
     using namespace EnergyPlus;
+
+    // Windows: ensure that EnergyPlusAPI.dll's notion of the "static singleton IOFiles" matches
+    // the exe's notion.
+    // TODO: Remove this after we have eliminated all remaining calls to IOFiles::getSingleton
+    EnergyPlus::IOFiles::setSingleton(&state.files);
+
     // Disable C++ i/o synching with C methods for speed
     std::ios_base::sync_with_stdio(false);
     std::cin.tie(nullptr); // Untie cin and cout: Could cause odd behavior for interactive prompts
@@ -265,6 +271,7 @@ void commonInitialize(EnergyPlus::EnergyPlusData &state) {
 
 int commonRun(EnergyPlus::EnergyPlusData &state) {
     using namespace EnergyPlus;
+
     int errStatus = initErrorFile(state.files);
     if (errStatus) {
         return errStatus;


### PR DESCRIPTION
Addresses #8180

Note that the existence of this singleton is not ideal. It is still here
to avoid updating every place that ShowError* is called from

