### PR TITLE
Make floating point exceptions consistent across platforms

### DIFF
--- a/src/EnergyPlus/api/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/api/EnergyPlusPgm.cc
@@ -239,8 +239,14 @@ void commonInitialize(EnergyPlus::EnergyPlusData &state) {
 // Enable floating point exceptions
 #ifndef NDEBUG
 #ifdef __unix__
-    feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+    feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW); // These exceptions are enabled (FE_INEXACT and FE_UNDERFLOW will not throw)
 #endif
+#endif
+
+#ifdef MSVC_DEBUG
+    // the following line enables NaN detection in Visual Studio debug builds. See
+    // https://github.com/NREL/EnergyPlus/wiki/Debugging-Tips
+    int fp_control_state = _controlfp(_EM_INEXACT | _EM_UNDERFLOW, _MCW_EM); // These exceptions are disabled (_EM_INEXACT and _EM_UNDERFLOW will not throw)
 #endif
 
 #ifdef _MSC_VER

--- a/src/EnergyPlus/main.cc
+++ b/src/EnergyPlus/main.cc
@@ -54,12 +54,6 @@ using EnergyPlus::CommandLineInterface::ProcessArgs;
 
 int main(int argc, const char *argv[])
 {
-#ifdef MSVC_DEBUG
-    // the following line enables NaN detection in Visual Studio debug builds. See
-    // https://github.com/NREL/EnergyPlus/wiki/Debugging-Tips
-    unsigned int fp_control_state = _controlfp(_EM_INEXACT, _MCW_EM);
-#endif
-
     EnergyPlus::EnergyPlusData state;
 
     ProcessArgs(state, argc, argv);


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8233 

This disables underflow exceptions on Windows debug builds to be consistent with Unix debug builds (and moves the code setting exceptions to the same location). Disabling underflow exceptions means the hardware will round any values in the underflow gap to zero and continue.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
