### PR TITLE
Fix humidity control anomalies

### DIFF
--- a/src/EnergyPlus/DataZoneEnergyDemands.cc
+++ b/src/EnergyPlus/DataZoneEnergyDemands.cc
@@ -72,8 +72,6 @@ namespace DataZoneEnergyDemands {
 
     Array1D_bool DeadBandOrSetback; // true if zone temperature is in the thermostat deadband
     // before any heating / cooling done
-    Array1D_bool Setback; // true if zone temperature has increased
-    // from previous setting
     Array1D_bool CurDeadBandOrSetback; // same as above except updated after each piece of zone equipment
     // in a zone is simulated
 
@@ -84,7 +82,6 @@ namespace DataZoneEnergyDemands {
     void clear_state()
     {
         DeadBandOrSetback.deallocate();
-        Setback.deallocate();
         CurDeadBandOrSetback.deallocate();
         ZoneSysEnergyDemand.deallocate();
         ZoneSysMoistureDemand.deallocate();

--- a/src/EnergyPlus/DataZoneEnergyDemands.hh
+++ b/src/EnergyPlus/DataZoneEnergyDemands.hh
@@ -66,8 +66,6 @@ namespace DataZoneEnergyDemands {
 
     extern Array1D_bool DeadBandOrSetback; // true if zone temperature is in the thermostat deadband
     // before any heating / cooling done
-    extern Array1D_bool Setback; // true if zone temperature has increased
-    // from previous setting
     extern Array1D_bool CurDeadBandOrSetback; // same as above except updated after each piece of zone equipment
     // in a zone is simulated
 

--- a/src/EnergyPlus/Furnaces.cc
+++ b/src/EnergyPlus/Furnaces.cc
@@ -7285,8 +7285,8 @@ namespace Furnaces {
             // Setback flag is used to avoid continued RH control when Tstat is setback (RH should float down)
             if ((GetCurrentScheduleValue(Furnace(FurnaceNum).SchedPtr) > 0.0 && CoolingLoad) ||
                 (Furnace(FurnaceNum).Humidistat && Furnace(FurnaceNum).DehumidControlType_Num == DehumidControl_CoolReheat &&
-                 (SystemMoistureLoad < 0.0 ||
-                  (SystemMoistureLoad >= 0.0 && HeatingLatentOutput > SystemMoistureLoad && !Setback(Furnace(FurnaceNum).ControlZoneNum))))) {
+                 (SystemMoistureLoad < 0.0 || (SystemMoistureLoad >= 0.0 && HeatingLatentOutput > SystemMoistureLoad &&
+                                               !CurDeadBandOrSetback(Furnace(FurnaceNum).ControlZoneNum))))) {
 
                 //     For cooling operation, the first step is to set the HX operation flag in case a HX assisted coil is used.
                 //      (if a HX assisted coil is not used, this flag is not used. It's only used in the CALL to SimHXAssistedCoolingCoil)
@@ -7315,8 +7315,8 @@ namespace Furnaces {
                 //     Air flow rate is set according to max of cooling and heating PLR if heating and latent load exists.
                 if (OpMode == CycFanCycCoil && Furnace(FurnaceNum).HeatPartLoadRatio > 0.0 && Furnace(FurnaceNum).Humidistat &&
                     Furnace(FurnaceNum).DehumidControlType_Num == DehumidControl_CoolReheat &&
-                    (SystemMoistureLoad < 0.0 ||
-                     (SystemMoistureLoad >= 0.0 && HeatingLatentOutput > SystemMoistureLoad && !Setback(Furnace(FurnaceNum).ControlZoneNum)))) {
+                    (SystemMoistureLoad < 0.0 || (SystemMoistureLoad >= 0.0 && HeatingLatentOutput > SystemMoistureLoad &&
+                                                  !CurDeadBandOrSetback(Furnace(FurnaceNum).ControlZoneNum)))) {
                     CoolingHeatingPLRRatio = min(1.0, PartLoadRatio / Furnace(FurnaceNum).HeatPartLoadRatio);
                     SetAverageAirFlow(FurnaceNum, max(PartLoadRatio, Furnace(FurnaceNum).HeatPartLoadRatio), OnOffAirFlowRatio);
 
@@ -7496,7 +7496,7 @@ namespace Furnaces {
                         //       ELSE calculate a new PLR for valid dehumidification control types if a moisture load exists.
                     } else if (Furnace(FurnaceNum).DehumidControlType_Num != DehumidControl_None &&
                                (SystemMoistureLoad < 0.0 || (SystemMoistureLoad >= 0.0 && TempLatentOutput > SystemMoistureLoad &&
-                                                             !Setback(Furnace(FurnaceNum).ControlZoneNum)))) {
+                                                             !CurDeadBandOrSetback(Furnace(FurnaceNum).ControlZoneNum)))) {
 
                         //         IF the furnace uses dehumidification control MultiMode, turn on the HX and calculate the latent output with
                         //         the HX ON to compare to the moisture load predicted by the humidistat.

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -132,7 +132,6 @@ namespace ZoneTempPredictorCorrector {
     using DataEnvironment::OutHumRat;
     using DataZoneEnergyDemands::CurDeadBandOrSetback;
     using DataZoneEnergyDemands::DeadBandOrSetback;
-    using DataZoneEnergyDemands::Setback;
     using DataZoneEnergyDemands::ZoneSysEnergyDemand;
     using DataZoneEnergyDemands::ZoneSysMoistureDemand;
     using namespace Psychrometrics;
@@ -2584,7 +2583,6 @@ namespace ZoneTempPredictorCorrector {
                 ZoneComfortControlsFanger.allocate(NumOfZones);
             }
             dataZoneTempPredictorCorrector.ZoneSetPointLast.dimension(NumOfZones, 0.0);
-            Setback.dimension(NumOfZones, false);
             DeadBandOrSetback.dimension(NumOfZones, false);
             CurDeadBandOrSetback.dimension(NumOfZones, false);
             SNLoadHeatEnergy.dimension(NumOfZones, 0.0);
@@ -4232,12 +4230,6 @@ namespace ZoneTempPredictorCorrector {
         // If the ZoneNodeNum has been set for a Controlled Zone, then the zone setpoint is placed on the node.
         if (Zone(ZoneNum).SystemZoneNodeNumber > 0) {
             Node(Zone(ZoneNum).SystemZoneNodeNumber).TempSetPoint = ZoneSetPoint;
-        }
-
-        if (ZoneSetPoint > dataZoneTempPredictorCorrector.ZoneSetPointLast(ZoneNum)) {
-            Setback(ZoneNum) = true;
-        } else {
-            Setback(ZoneNum) = false;
         }
 
         dataZoneTempPredictorCorrector.ZoneSetPointLast(ZoneNum) = ZoneSetPoint;

--- a/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
@@ -491,7 +491,6 @@ TEST_F(EnergyPlusFixture, ZoneTempPredictorCorrector_ReportingTest)
     ZoneSysEnergyDemand.allocate(NumTempControlledZones);
     TempZoneThermostatSetPoint.allocate(NumTempControlledZones);
     state.dataZoneTempPredictorCorrector.ZoneSetPointLast.allocate(NumTempControlledZones);
-    Setback.allocate(NumTempControlledZones);
     ZoneThermostatSetPointLo.allocate(NumTempControlledZones);
     ZoneThermostatSetPointHi.allocate(NumTempControlledZones);
     state.dataZoneTempPredictorCorrector.TempDepZnLd.allocate(NumTempControlledZones);
@@ -1235,7 +1234,6 @@ TEST_F(EnergyPlusFixture, SetPointWithCutoutDeltaT_test)
     DeadBandOrSetback.allocate(1);
     DataHeatBalance::Zone.allocate(1);
     state.dataZoneTempPredictorCorrector.ZoneSetPointLast.allocate(1);
-    DataZoneEnergyDemands::Setback.allocate(1);
 
     SNLoadPredictedRate.allocate(1);
     SNLoadPredictedHSPRate.allocate(1);
@@ -1370,7 +1368,6 @@ TEST_F(EnergyPlusFixture, TempAtPrevTimeStepWithCutoutDeltaT_test)
     DeadBandOrSetback.allocate(1);
     DataHeatBalance::Zone.allocate(1);
     state.dataZoneTempPredictorCorrector.ZoneSetPointLast.allocate(1);
-    DataZoneEnergyDemands::Setback.allocate(1);
 
     SNLoadPredictedRate.allocate(1);
     SNLoadPredictedHSPRate.allocate(1);


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8290 

Part 1 - The problem is that sometimes when the zone is in the deadband between heating and cooling setpoints and the furnace is running with continuous fan, and there's a humidistat, sometimes the furnace decides to turn on the cooling coil (and then lots of reheat) just to avoid raising the humidity level slightly in the zone. This is with Furnace which should only operate the cooling coil for sensible load (not for latent load only). Not completely understood is why this only happened on certain days during evening setback, but not on others. Once the cooling coil decided to turn on, then the zone temp got pushed down to the setback heating setpoint of 18C which then drove up the RH in the zone and resulted in hours of this type of operation. Problem can be seen in both annual simulations of Supermarket and FurnaceWithDXSystemRHcontrol and likely others.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
