### PR TITLE
Fix file name in path returned by getAbsolutePath when a directory is not provided

### DIFF
--- a/src/EnergyPlus/FileSystem.cc
+++ b/src/EnergyPlus/FileSystem.cc
@@ -126,9 +126,14 @@ namespace FileSystem {
         }
 
         std::string pathTail;
-        if (parentPath == ".")
+        std::string currentDir = ".";
+        std::string currentDirWithSep = currentDir + DataStringGlobals::pathChar;
+        if ((parentPath == currentDir || parentPath == currentDirWithSep) && path.find(currentDirWithSep) == std::string::npos)
+            // If parent path is the current directory and the original path does not already contain
+            // the current directory in the string, then leave the path tail as-is.
             pathTail = path;
         else
+            // otherwise strip off any preceding content from the path tail
             pathTail = path.substr(parentPath.size(), path.size() - parentPath.size());
 
         char *absolutePathTemp = realpath(parentPath.c_str(), NULL);

--- a/tst/EnergyPlus/unit/FileSystem.unit.cc
+++ b/tst/EnergyPlus/unit/FileSystem.unit.cc
@@ -53,6 +53,7 @@
 // EnergyPlus Headers
 #include <iostream>
 #include <fstream>
+#include <EnergyPlus/DataStringGlobals.hh>
 #include <EnergyPlus/FileSystem.hh>
 
 
@@ -94,4 +95,16 @@ TEST(FileSystem, movefile_test)
     // remove files
     EnergyPlus::FileSystem::removeFile(filename);
     EnergyPlus::FileSystem::removeFile(filename_temp);
+}
+
+TEST(FileSystem, getAbsolutePath)
+{
+    std::string pathName = "FileSystemTest.idf";
+    std::string absPathName = EnergyPlus::FileSystem::getAbsolutePath(pathName);
+    EXPECT_TRUE(absPathName.find(pathName) != std::string::npos); // Check that the path name appears in the absolute path
+
+    std::string currentDirWithSep = std::string(".") + EnergyPlus::DataStringGlobals::pathChar;
+    pathName =  currentDirWithSep + std::string("FileSystemTest.idf");  // e.g., "./FileSystemTest.idf"
+    absPathName = EnergyPlus::FileSystem::getAbsolutePath(pathName);
+    EXPECT_FALSE(absPathName.find(currentDirWithSep) != std::string::npos); // Make sure "./" doesn't appear in absolute path
 }


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8329

This fixes `getAbsolutePath` for two scenarios:

1. When a file was specified in the current working directory (e.g., with no directory prefixes), the file name returned in the path had the first two characters stripped off. E.g.:

    ````
    getAbsolutePath("FileSystemTest.idf") = "/Path/to/cwd/leSystemTest.idf"
    ````
2. After an initial fix for (1), I noticed:
    ````
    getAbsolutePath("./FileSystemTest.idf") = "/Path/to/cwd/./FileSystemTest.idf"
    ````
This pull requests includes unit tests for both of these situations and they now both come out correctly:

````
"/Path/to/cwd/FileSystemTest.idf"
````

The fix and unit tests use the platform independent value of `DataStringGlobals::pathChar`.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts