### PR TITLE
Fixes #8372 - Incorrect transition of RoomAir:Node:AirflowNetwork:HVACEquipment from v9.2 to v9.3

### DIFF
--- a/src/Transition/CreateNewIDFUsingRulesV9_3_0.f90
+++ b/src/Transition/CreateNewIDFUsingRulesV9_3_0.f90
@@ -684,17 +684,18 @@ SUBROUTINE CreateNewIDFUsingRules(EndOfFile,DiffOnly,InLfn,AskForInput,InputFile
               ! Wait - there's more for the transition for AirTerminal:SingleDuct:Uncontrolled
               CASE('ROOMAIR:NODE:AIRFLOWNETWORK:HVACEQUIPMENT')
               IF(TotATSDUObjs > 0) THEN
+                 NoDiff = .true.
                  CALL GetNewObjectDefInIDD(ObjectName,NwNumArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
-                 OutArgs(1) = InArgs(1)
-                 ! Loop through fields looking for  AirTerminal:SingleDuct:Uncontrolled node name
-                 DO nodeCount=2, CurArgs
-                   IF (SameString(TRIM(InArgs(nodeCount)), TRIM(ATSDUNodeNames(atCount)))) THEN
-                     OutArgs(nodeCount) = TRIM(InArgs(nodeCount)) // ' ATInlet'
-                   ELSE
-                     OutArgs(nodeCount) = InArgs(nodeCount)
+                 OutArgs(1:CurArgs) = InArgs(1:CurArgs)
+                 ! Loop through "ZoneHVAC or Air Terminal Equipment Object Type" fields looking for
+                 ! "AirTerminal:SingleDuct:Uncontrolled" and replace with "AirTerminal:SingleDuct:ConstantVolume:NoReheat"
+                 ! Four extensible fields
+                 DO CurField=2, CurArgs-1, 4
+                   IF (SameString(TRIM(InArgs(CurField)),'AirTerminal:SingleDuct:Uncontrolled')) THEN
+                     OutArgs(CurField) = 'AirTerminal:SingleDuct:ConstantVolume:NoReheat'
+                     NoDiff = .false.
                    END IF
-                 ENDDO
-                NoDiff = .false.
+                 END DO
               ELSE
                 CALL GetNewObjectDefInIDD(ObjectName,NwNumArgs,NwAorN,NwReqFld,NwObjMinFlds,NwFldNames,NwFldDefaults,NwFldUnits)
                 OutArgs(1:CurArgs)=InArgs(1:CurArgs)


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8372
 - Incorrect transition of RoomAir:Node:AirflowNetwork:HVACEquipment from v9.2 to v9.3

The problem is due to how the move from `AirTerminal:SingleDuct:Uncontrolled` to `AirTerminal:SingleDuct:ConstantVolume:NoReheat` for this object.

## Testing 
See testing with https://github.com/NREL/EnergyPlusDevSupport/blob/ec4052601eebe20b3f9bf1bb59bd85866a9f5d53/DefectFiles/8000s/8372/RoomAirflowNetwork_mod.idf


### Before

```
./Transition-V9-2-0-to-V9-3-0 /home/julien/Software/Others/EnergyPlusDevSupport/DefectFiles/8000s/8372/RoomAirflowNetwork_mod.idf
 Transition Starting
 Conversion 9.2 => 9.3
 Processing Old IDD -- V9-2-0-Energy+.idd
 Processing New IDD -- V9-3-0-Energy+.idd
 Will create new full IDFs
 Will create new IDF lines with units where applicable
 Will create new IDF lines leaving blank incoming fields as blank (no default fill)
 F
 Processing IDF -- /home/julien/Software/Others/EnergyPlusDevSupport/DefectFiles/8000s/8372/RoomAirflowNetwork_mod.idf
 ** Warning ** IP: IDF line~2883 Obsolete object=AirTerminal:SingleDuct:Uncontrolled, encountered.  Should be replaced with new object=AirTerminal:SingleDuct:ConstantVolume:NoReheat
 Processing IDF -- Processing idf objects . . .
At line 691 of file /home/julien/Software/Others/EnergyPlus/src/Transition/CreateNewIDFUsingRulesV9_3_0.f90
Fortran runtime error: Index '2' of dimension 1 of array 'atsdunodenames' above upper bound of 1

Error termination. Backtrace:
#0  0x489e7d in ???
#1  0x48a0b5 in ???
#2  0x48a487 in ???
#3  0x4184de in ???
#4  0x4029ac in ???
#5  0x40087e in ???
#6  0x4c0c48 in ???
#7  0x400e89 in ???
```

### After

```
 Transition Starting
 Conversion 9.2 => 9.3
 Processing Old IDD -- V9-2-0-Energy+.idd
 Processing New IDD -- V9-3-0-Energy+.idd
 Will create new full IDFs
 Will create new IDF lines with units where applicable
 Will create new IDF lines leaving blank incoming fields as blank (no default fill)
 F
 Processing IDF -- /home/julien/Software/Others/EnergyPlusDevSupport/DefectFiles/8000s/8372/RoomAirflowNetwork_mod.idf
 ** Warning ** IP: IDF line~2883 Obsolete object=AirTerminal:SingleDuct:Uncontrolled, encountered.  Should be replaced with new object=AirTerminal:SingleDuct:ConstantVolume:NoReheat
 Processing IDF -- Processing idf objects . . .
 Processing IDF -- Processing idf objects complete.
 ************* Conversion Completed Successfully-- 1 Warning; 0 Severe Errors
```

The resulting IDF has the correct transition of the RoomAir:Node:AirflowNetwork:HVACEquipment:

```diff
-RoomAir:Node:AirflowNetwork:HVACEquipment,
+  RoomAir:Node:AirflowNetwork:HVACEquipment,
     LeftUpper_HVAC,          !- Name
-    AirTerminal:SingleDuct:Uncontrolled,  !- ZoneHVAC or Air Terminal Equipment Object Type 1
+    AirTerminal:SingleDuct:ConstantVolume:NoReheat,  !- ZoneHVAC or Air Terminal Equipment Object Type 1
     NORTH_ZONE PTAC,         !- ZoneHVAC or Air Terminal Equipment Object Name 1
     0.04,                    !- Fraction of Output or Supply Air from HVAC Equipment 1
     0.04;                    !- Fraction of Input or Return Air to HVAC Equipment 1
 
-RoomAir:Node:AirflowNetwork:HVACEquipment,
+  RoomAir:Node:AirflowNetwork:HVACEquipment,
     CentralUpper_HVAC,       !- Name
-    AirTerminal:SingleDuct:Uncontrolled,  !- ZoneHVAC or Air Terminal Equipment Object Type 1
+    AirTerminal:SingleDuct:ConstantVolume:NoReheat,  !- ZoneHVAC or Air Terminal Equipment Object Type 1
     NORTH_ZONE PTAC,         !- ZoneHVAC or Air Terminal Equipment Object Name 1
     0.14,                    !- Fraction of Output or Supply Air from HVAC Equipment 1
     0.14;                    !- Fraction of Input or Return Air to HVAC Equipment 1
```






### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [x] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [x] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [x] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [x] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [x] If structural output changes, add to output rules file and add OutputChange label
 - [x] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [x] Perform a Code Review on GitHub
 - [x] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
