### PR TITLE
Tweak IFW Directory name

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -85,7 +85,7 @@ jobs:
       run: |
         set -x
         out_dir="C:/Qt"
-        aqt tool windows tools_ifw 4.0 qt.tools.ifw.4.0 --outputdir="$out_dir"
+        aqt tool windows tools_ifw 4.0 qt.tools.ifw.40 --outputdir="$out_dir"
         echo "$out_dir/Tools/QtInstallerFramework/4.0/bin" >> $GITHUB_PATH
 
     - name: Create Build Directory


### PR DESCRIPTION
The IFW builds, which were previously working, [failed](https://github.com/NREL/EnergyPlus/pull/8417#issuecomment-751875559) abruptly with a recent [build](https://github.com/NREL/EnergyPlus/runs/1618821650?check_suite_focus=true#step:9:1895).  Looking at the build log, the IFW install script is complaining that the specified target is not valid:

```
Run set -x
+ out_dir=C:/Qt
+ aqt tool windows tools_ifw 4.0 qt.tools.ifw.4.0 --outputdir=C:/Qt
2020-12-28 19:59:40,689 - aqt - INFO - aqtinstall(aqt) v0.10.1 on Python 3.7.9 [CPython MSC v.1900 64 bit (AMD64)]
2020-12-28 19:59:40,689 - aqt - WARNING - Specified target combination is not valid: windows tools_ifw qt.tools.ifw.4.0
2020-12-28 19:59:41,433 - aqt - INFO - Finished installation
2020-12-28 19:59:41,433 - aqt - INFO - Time elasped: 0.74826570 second
+ echo C:/Qt/Tools/QtInstallerFramework/4.0/bin
```

On previous builds, this worked fine:

```
Run set -x
+ out_dir=C:/Qt
+ aqt tool windows tools_ifw 4.0 qt.tools.ifw.4.0 --outputdir=C:/Qt
2020-11-16 11:41:47,233 - aqt - INFO - aqtinstall(aqt) v0.9.8 on Python 3.7.9 [CPython MSC v.1900 64 bit (AMD64)]
2020-11-16 11:41:47,233 - aqt - WARNING - Specified target combination is not valid: windows tools_ifw qt.tools.ifw.4.0
2020-11-16 11:41:47,815 - aqt - INFO - Downloading qt.tools.ifw.40...
2020-11-16 11:41:47,816 - aqt - DEBUG - Download URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/tools_ifw/qt.tools.ifw.40/4.0ifw-win-x86.7z
2020-11-16 11:41:48,321 - aqt - INFO - Redirected URL: http://qt.mirrors.tds.net/qt/online/qtsdkrepository/windows_x86/desktop/tools_ifw/qt.tools.ifw.40/4.0ifw-win-x86.7z
2020-11-16 11:42:50,985 - aqt - INFO - Finish installation of ifw-win-x86.7z in 63.16628889999999
2020-11-16 11:42:50,989 - aqt - INFO - Finished installation
2020-11-16 11:42:50,990 - aqt - INFO - Time elasped: 63.75698000 second
+ echo C:/Qt/Tools/QtInstallerFramework/4.0/bin
```

I looked into this part of the aqt install and found that it is marked experimental -- which is maybe why it's not surprising that it failed unexpectedly.  But that's fine.  If you search for "Installing tool and utility" on the `aqtinstall` [Pypi page](https://pypi.org/project/aqtinstall/), you'll see it is expecting an arch name with values from the Qt [archive site](https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/tools_ifw/).  This archive site currently has a directory named 
`qt.tools.ifw.40` only.  I think they must've cleared out old folders and renamed the folder from `4.0` to `40`.  

I am hoping that just tweaking the arch token in the `aqt` install command will be sufficient for fixing the build.

Thanks for spotting the issue early in the development cycle with a test build @mitchute.

FYI @jmarrec 