### PR TITLE
Fix compiler warning on MSVC

### DIFF
--- a/src/EnergyPlus/MatrixDataManager.cc
+++ b/src/EnergyPlus/MatrixDataManager.cc
@@ -179,11 +179,18 @@ namespace MatrixDataManager {
             auto &matrix(MatData(MatNum).Mat2D);
             matrix.allocate(NumCols, NumRows); // This is standard order for a NumRows X NumCols matrix
             Array2<Real64>::size_type l(0);
+// MSVC was complaining that it detected a divide by zero in the Row = (El - 1) / NumCols + 1 line, indicating it thought NumCols was zero
+// the compiler should never have been able to identify that, as NumCols is based directly on rNumericArgs, which is based on input values
+// apparently, interaction between the high level optimizer that does flow-graph transformations and backend that emits warnings can cause
+// false positives.  This doesn't need to change, but the warning needs to be muted.  The pragma disables the warning for this block only.
+#pragma warning( push )
+#pragma warning( disable : 4723 )
             for (int ElementNum = 1; ElementNum <= NumElements; ++ElementNum, l += matrix.size()) {
                 int const RowIndex = (ElementNum - 1) / NumCols + 1;
                 int const ColIndex = mod((ElementNum - 1), NumCols) + 1;
                 matrix(ColIndex, RowIndex) = rNumericArgs(ElementNum + 2); // Matrix is read in row-by-row
             }
+#pragma warning( pop )
         }
 
         if (ErrorsFound) {

--- a/src/EnergyPlus/MatrixDataManager.cc
+++ b/src/EnergyPlus/MatrixDataManager.cc
@@ -103,8 +103,13 @@ namespace MatrixDataManager {
     // Object Data
     Array1D<MatrixDataStruct> MatData;
 
-    // Functions
-
+// MSVC was complaining that it detected a divide by zero in the Row = (El - 1) / NumCols + 1 line, indicating it thought NumCols was zero
+// the compiler should never have been able to identify that, as NumCols is based directly on rNumericArgs, which is based on input values
+// Apparently, interaction between the high level optimizer that does flow-graph transformations and backend that emits warnings can cause
+// false positives.  The warning simply needs to be muted.  Placing the pragma at the statement itself was not sufficient for muting, so I
+// placed the pragma out here at this level and it worked.  Note that this warning was only showing up on release builds, not debug builds
+#pragma warning( push )
+#pragma warning( disable : 4723 )
     void GetMatrixInput(EnergyPlusData &state)
     {
 
@@ -179,24 +184,18 @@ namespace MatrixDataManager {
             auto &matrix(MatData(MatNum).Mat2D);
             matrix.allocate(NumCols, NumRows); // This is standard order for a NumRows X NumCols matrix
             Array2<Real64>::size_type l(0);
-// MSVC was complaining that it detected a divide by zero in the Row = (El - 1) / NumCols + 1 line, indicating it thought NumCols was zero
-// the compiler should never have been able to identify that, as NumCols is based directly on rNumericArgs, which is based on input values
-// apparently, interaction between the high level optimizer that does flow-graph transformations and backend that emits warnings can cause
-// false positives.  This doesn't need to change, but the warning needs to be muted.  The pragma disables the warning for this block only.
-#pragma warning( push )
-#pragma warning( disable : 4723 )
             for (int ElementNum = 1; ElementNum <= NumElements; ++ElementNum, l += matrix.size()) {
                 int const RowIndex = (ElementNum - 1) / NumCols + 1;
                 int const ColIndex = mod((ElementNum - 1), NumCols) + 1;
                 matrix(ColIndex, RowIndex) = rNumericArgs(ElementNum + 2); // Matrix is read in row-by-row
             }
-#pragma warning( pop )
         }
 
         if (ErrorsFound) {
             ShowFatalError(state, "GetMatrixInput: Errors found in Matrix objects. Preceding condition(s) cause termination.");
         }
     }
+#pragma warning( pop )
 
     int MatrixIndex(EnergyPlusData &state, std::string const &MatrixName)
     {


### PR DESCRIPTION
I updated CMake and MSVC on Windows to get the build running again.  Everything looks good but there is one warning being emitted that appears to be a complete false positive.  I wrapped this in a pragma which will hopefully hush up the compiler and get Windows all green again.