### PR TITLE
Change floats to real64 to clean out build warnings

### DIFF
--- a/tst/EnergyPlus/unit/AirflowNetworkBalanceManager.unit.cc
+++ b/tst/EnergyPlus/unit/AirflowNetworkBalanceManager.unit.cc
@@ -20225,8 +20225,8 @@ TEST_F(EnergyPlusFixture, AirflowNetworkBalanceManager_TestNoZoneEqpSupportZoneE
     AirflowNetwork::AirflowNetworkSimu.AllowSupportZoneEqp = false;
 
     // Create Fans
-    float supplyFlowRate = 0.005;
-    float exhaustFlowRate = 0.005;
+    Real64 supplyFlowRate = 0.005;
+    Real64  exhaustFlowRate = 0.005;
     Fan.allocate(2);
     Fan(1).InletNodeNum = 2;
     Fan(1).OutletNodeNum = 3;
@@ -20362,8 +20362,8 @@ TEST_F(EnergyPlusFixture, AirflowNetworkBalanceManager_TestZoneEqpSupportZoneERV
     AirflowNetwork::AirflowNetworkSimu.AllowSupportZoneEqp = true;
 
     // Create Fans
-    float supplyFlowRate = 0.005;
-    float exhaustFlowRate = 0.005;
+    Real64 supplyFlowRate = 0.005;
+    Real64 exhaustFlowRate = 0.005;
     Fan.allocate(2);
     Fan(1).InletNodeNum = 2;
     Fan(1).OutletNodeNum = 3;
@@ -20490,8 +20490,8 @@ TEST_F(EnergyPlusFixture, AirflowNetworkBalanceManager_TestZoneEqpSupportUnbalan
     AirflowNetwork::AirflowNetworkSimu.AllowSupportZoneEqp = true;
 
     // Create Fans
-    float supplyFlowRate = 0.005;
-    float exhaustFlowRate = 0.003;
+    Real64 supplyFlowRate = 0.005;
+    Real64 exhaustFlowRate = 0.003;
     Fan.allocate(2);
     Fan(1).InletNodeNum = 2;
     Fan(1).OutletNodeNum = 3;


### PR DESCRIPTION
Tiny fix to clean up windows build warnings.