### PR TITLE
Fix #8484 - Flush all files when Running via API before finish

### DIFF
--- a/src/EnergyPlus/CMakeLists.txt
+++ b/src/EnergyPlus/CMakeLists.txt
@@ -1026,6 +1026,12 @@ if(BUILD_TESTING)
       COMMAND "${PYTHON_EXECUTABLE}" -m unittest "${API_TEST_TARGET_DIR}/test_DataTransferTypes.py"
       WORKING_DIRECTORY "${API_TEST_TARGET_DIR}")
 
+    configure_file("${PROJECT_SOURCE_DIR}/tst/EnergyPlus/api/test_OutputFiles.py" "${API_TEST_TARGET_DIR}/test_OutputFiles.py" @ONLY)
+    add_test(
+      NAME "API.test_OutputFiles"
+      COMMAND "${PYTHON_EXECUTABLE}" -m unittest "${API_TEST_TARGET_DIR}/test_OutputFiles.py"
+      WORKING_DIRECTORY "${API_TEST_TARGET_DIR}")
+
   endif()
 endif()
 

--- a/src/EnergyPlus/IOFiles.cc
+++ b/src/EnergyPlus/IOFiles.cc
@@ -433,6 +433,111 @@ IOFiles *&IOFiles::getSingletonInternal()
     return singleton;
 }
 
+void IOFiles::flushAll() {
+
+    audit.flush();
+    eio.flush();
+    eso.flush();
+    zsz.flush();
+    ssz.flush();
+    map.flush();
+    mtr.flush();
+    bnd.flush();
+    rdd.flush();
+    mdd.flush();
+    debug.flush();
+    dfs.flush();
+    mtd.flush();
+    edd.flush();
+    shade.flush();
+    csv.flush();
+
+    if (err_stream) {
+        err_stream->flush();
+    }
+    if (json.json_stream) {
+        json.json_stream->flush();
+    }
+    if (json.json_TSstream_Zone) {
+        json.json_TSstream_Zone->flush();
+    }
+    if (json.json_TSstream_HVAC) {
+        json.json_TSstream_HVAC->flush();
+    }
+    if (json.json_TSstream) {
+        json.json_TSstream->flush();
+    }
+    if (json.json_HRstream) {
+        json.json_HRstream->flush();
+    }
+    if (json.json_MNstream) {
+        json.json_MNstream->flush();
+    }
+    if (json.json_DYstream) {
+        json.json_DYstream->flush();
+    }
+    if (json.json_SMstream) {
+        json.json_SMstream->flush();
+    }
+    if (json.json_YRstream) {
+        json.json_YRstream->flush();
+    }
+    if (json.cbor_stream) {
+        json.cbor_stream->flush();
+    }
+    if (json.cbor_TSstream_Zone) {
+        json.cbor_TSstream_Zone->flush();
+    }
+    if (json.cbor_TSstream_HVAC) {
+        json.cbor_TSstream_HVAC->flush();
+    }
+    if (json.cbor_TSstream) {
+        json.cbor_TSstream->flush();
+    }
+    if (json.cbor_HRstream) {
+        json.cbor_HRstream->flush();
+    }
+    if (json.cbor_MNstream) {
+        json.cbor_MNstream->flush();
+    }
+    if (json.cbor_DYstream) {
+        json.cbor_DYstream->flush();
+    }
+    if (json.cbor_SMstream) {
+        json.cbor_SMstream->flush();
+    }
+    if (json.cbor_YRstream) {
+        json.cbor_YRstream->flush();
+    }
+    if (json.msgpack_stream) {
+        json.msgpack_stream->flush();
+    }
+    if (json.msgpack_TSstream_Zone) {
+        json.msgpack_TSstream_Zone->flush();
+    }
+    if (json.msgpack_TSstream_HVAC) {
+        json.msgpack_TSstream_HVAC->flush();
+    }
+    if (json.msgpack_TSstream) {
+        json.msgpack_TSstream->flush();
+    }
+    if (json.msgpack_HRstream) {
+        json.msgpack_HRstream->flush();
+    }
+    if (json.msgpack_MNstream) {
+        json.msgpack_MNstream->flush();
+    }
+    if (json.msgpack_DYstream) {
+        json.msgpack_DYstream->flush();
+    }
+    if (json.msgpack_SMstream) {
+        json.msgpack_SMstream->flush();
+    }
+    if (json.msgpack_YRstream) {
+        json.msgpack_YRstream->flush();
+    }
+}
+
 using arg_formatter = fmt::arg_formatter<fmt::buffer_range<char>>;
 
 class custom_arg_formatter : public arg_formatter

--- a/src/EnergyPlus/IOFiles.hh
+++ b/src/EnergyPlus/IOFiles.hh
@@ -356,6 +356,8 @@ public:
 
     JsonOutputStreams json; // Internal streams used for json outputs
 
+    void flushAll(); // For RunningEnergyPlusViaAPI only
+
 private:
     static IOFiles *&getSingletonInternal();
 };

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -741,6 +741,11 @@ namespace UtilityRoutines {
         // Close the socket used by ExternalInterface. This call also sends the flag "-1" to the ExternalInterface,
         // indicating that E+ terminated with an error.
         if (NumExternalInterfaces > 0) CloseSocket(-1);
+
+        if (state.dataGlobal->eplusRunningViaAPI) {
+            state.files.flushAll();
+        }
+
         return EXIT_FAILURE;
     }
 
@@ -890,6 +895,11 @@ namespace UtilityRoutines {
         // Close the ExternalInterface socket. This call also sends the flag "1" to the ExternalInterface,
         // indicating that E+ finished its simulation
         if ((NumExternalInterfaces > 0) && haveExternalInterfaceBCVTB) CloseSocket(1);
+
+        if (state.dataGlobal->eplusRunningViaAPI) {
+            state.files.flushAll();
+        }
+
         return EXIT_SUCCESS;
     }
 

--- a/tst/EnergyPlus/api/test_OutputFiles.py
+++ b/tst/EnergyPlus/api/test_OutputFiles.py
@@ -1,0 +1,160 @@
+# EnergyPlus, Copyright (c) 1996-2021, The Board of Trustees of the University
+# of Illinois, The Regents of the University of California, through Lawrence
+# Berkeley National Laboratory (subject to receipt of any required approvals
+# from the U.S. Dept. of Energy), Oak Ridge National Laboratory, managed by UT-
+# Battelle, Alliance for Sustainable Energy, LLC, and other contributors. All
+# rights reserved.
+#
+# NOTICE: This Software was developed under funding from the U.S. Department of
+# Energy and the U.S. Government consequently retains certain rights. As such,
+# the U.S. Government has been granted for itself and others acting on its
+# behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+# Software to reproduce, distribute copies to the public, prepare derivative
+# works, and perform publicly and display publicly, and to permit others to do
+# so.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the University of California, Lawrence Berkeley
+#     National Laboratory, the University of Illinois, U.S. Dept. of Energy nor
+#     the names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# (4) Use of EnergyPlus(TM) Name. If Licensee (i) distributes the software in
+#     stand-alone form without changes from the version obtained under this
+#     License, or (ii) Licensee makes a reference solely to the software
+#     portion of its product, Licensee must refer to the software as
+#     "EnergyPlus version X" software, where "X" is the version number Licensee
+#     obtained under this License and may not use a different name for the
+#     software. Except as specifically required in this Section (4), Licensee
+#     shall not use in a company name, a product name, in advertising,
+#     publicity, or other promotional activities any name, trade name,
+#     trademark, logo, or other designation of "EnergyPlus", "E+", "e+" or
+#     confusingly similar designation, without the U.S. Department of Energy's
+#     prior written consent.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import glob as gb
+import os
+import shlex
+import tempfile
+import unittest
+
+from pyenergyplus.api import EnergyPlusAPI
+
+
+class TestAPIFlushOutput(unittest.TestCase):
+    """
+    unittest on EnergyPlusAPI for #8484 - [pyenergyplus] EnergyPlus output not
+    flushed to eplusout.err
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        A class method called before tests in an individual class are run
+        """
+        cls.api = EnergyPlusAPI()
+
+    def setUp(self):
+        """
+        Prepare each test fixture, with a new state
+        """
+        self.state = self.api.state_manager.new_state()
+
+    def test_proper_run(self):
+        """
+        Tests the case where the simulation ends properly and EndEnergyPlus is
+        called
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            print(tempdir)
+            cmd_args = shlex.split(f'-d {tempdir} -D @IDF_FILE@')
+            return_code = self.api.runtime.run_energyplus(self.state, cmd_args)
+            self.assertEqual(return_code, 0)
+            out_files = gb.glob(os.path.join(tempdir, "*"))
+            # We need to find out files, and we expect NONE of them to be empty
+            self.assertGreater(len(out_files), 10)
+            empty_files = list(filter(lambda f: os.stat(f).st_size == 0,
+                                      out_files))
+            msg = f"Did not expect empty files, but found {len(empty_files)}:"
+            for f in empty_files:
+                msg += f"\n * {os.path.relpath(f, tempdir)}"
+            self.assertFalse(empty_files, msg)
+
+            # Check that the eplusout.err is not truncated, that the last line
+            # is what we expect it to be
+            with open(os.path.join(tempdir, 'eplusout.err'), 'r') as f:
+                lines = f.read().splitlines()
+            self.assertTrue(lines, "eplusout.err is empty!")
+            self.assertIn("EnergyPlus Completed Successfully", lines[-1])
+
+    def test_wrong_version_api_output(self):
+        """
+        Test for #8484 - When the simulation starts, but fails, we should still
+        find proper content in the eplusout.err (AbortEnergyPlus is called)
+        """
+
+        idf_content = """
+  Version,9.0;
+
+  Timestep,4;
+
+  Building,
+    Simple One Zone (Wireframe DXF),  !- Name
+    0,                       !- North Axis {deg}
+    Suburbs,                 !- Terrain
+    0.04,                    !- Loads Convergence Tolerance Value {W}
+    0.004,                   !- Temperature Convergence Tolerance Value {dC}
+    MinimalShadowing,        !- Solar Distribution
+    30,                      !- Maximum Number of Warmup Days
+    6;                       !- Minimum Number of Warmup Days
+
+  HeatBalanceAlgorithm,ConductionTransferFunction;
+
+  SurfaceConvectionAlgorithm:Inside,TARP;
+
+  SurfaceConvectionAlgorithm:Outside,DOE-2;
+
+  GlobalGeometryRules,
+    UpperLeftCorner,         !- Starting Vertex Position
+    CounterClockWise,        !- Vertex Entry Direction
+    World;                   !- Coordinate System
+        """
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            idf_file = os.path.join(tempdir, 'wrong_version.idf')
+
+            with open(idf_file, 'w') as f:
+                f.write(idf_content)
+
+            cmd_args = shlex.split(f'-d {tempdir} -D {idf_file}')
+            return_code = self.api.runtime.run_energyplus(self.state, cmd_args)
+            self.assertEqual(return_code, 1)
+            with open(os.path.join(tempdir, 'eplusout.err'), 'r') as f:
+                lines = f.read().splitlines()
+            self.assertTrue(lines, "eplusout.err is empty!")
+            self.assertIn("EnergyPlus Terminated", lines[-1])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8484 - pyenergyplus: EnergyPlus output not flushed to eplusout.err


### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [x] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [x] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [x] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [x] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [x] If structural output changes, add to output rules file and add OutputChange label
 - [x] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
