### PR TITLE
Fix clear_state missing vars in pollution module

### DIFF
--- a/src/EnergyPlus/PollutionModule.hh
+++ b/src/EnergyPlus/PollutionModule.hh
@@ -480,6 +480,10 @@ struct PollutionModuleData : BaseGlobalStruct {
 
     void clear_state() override
     {
+        this->PollutionReportSetup = false;
+        this->GetInputFlagPollution = true;
+        this->NumEnvImpactFactors = 0;
+        this->NumFuelFactors = 0;
         this->Pollution = {
             PollutionModule::ComponentProps(PollutionModule::ElecPollFactor, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
             PollutionModule::ComponentProps(PollutionModule::ElecPollFactor, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes an API test failure.  The API test in question would purposefully run E+ via API, clear the state, then run it again.  This failure revealed that a couple variables were not being reset in a clear_state method.

Quick fix, to be merged directly.