### PR TITLE
Fix #8690 - Avoid a double free on Linux for FMU parser

### DIFF
--- a/third_party/FMUParser/CMakeLists.txt
+++ b/third_party/FMUParser/CMakeLists.txt
@@ -41,3 +41,9 @@ set_target_properties(
   INSTALL_NAME_DIR "@executable_path"
 )
 endif()
+
+if(BUILD_TESTING)
+  add_test(NAME "FMUParser"
+    COMMAND parser "--printidf" "${PROJECT_SOURCE_DIR}/datasets/FMUs/ShadingController.fmu"
+  )
+endif()

--- a/third_party/FMUParser/CMakeLists.txt
+++ b/third_party/FMUParser/CMakeLists.txt
@@ -43,7 +43,9 @@ set_target_properties(
 endif()
 
 if(BUILD_TESTING)
+  # Avoid creating some artifacts (ShadingController/modelDescription.xml and ShadingController/binaries inside "${PROJECT_SOURCE_DIR}/datasets/FMUs/"
+  configure_file("${PROJECT_SOURCE_DIR}/datasets/FMUs/ShadingController.fmu" "${CMAKE_CURRENT_BINARY_DIR}/ShadingController.fmu" COPYONLY)
   add_test(NAME "FMUParser"
-    COMMAND parser "--printidf" "${PROJECT_SOURCE_DIR}/datasets/FMUs/ShadingController.fmu"
+    COMMAND parser "--printidf" "${CMAKE_CURRENT_BINARY_DIR}/ShadingController.fmu"
   )
 endif()

--- a/third_party/FMUParser/parser.c
+++ b/third_party/FMUParser/parser.c
@@ -92,8 +92,12 @@ int callparser(const char *fmuFilNam, const char *tmpPat)
     // Clean up memory
     // free(xmlPat); // Done above
     free(tmp);
+#ifdef _MSC_VER
+    // https://man7.org/linux/man-pages/man3/basename.3.html
+    // Both dirname() and basename() return pointers to null-terminated strings.  (Do not pass these pointers to free(3).)
     free(filNam);
     free(ext);
+#endif
     return 0;
 }
 


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #8690 - FMU `parser` is broken in 9.5.0 on Ubuntu
-  Avoid a double free on Linux for FMU parser

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
