### PR TITLE
Use IFW 4.1.1

### DIFF
--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         set -x
         out_dir=${{ runner.workspace }}/Qt
-        aqt tool linux tools_ifw 4.1 qt.tools.ifw.41 --outputdir="$out_dir"
+        aqt tool linux tools_ifw 4.1.1 qt.tools.ifw.41 --outputdir="$out_dir"
         echo "$out_dir/Tools/QtInstallerFramework/4.1/bin" >> $GITHUB_PATH
 
     - name: Create Build Directory

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         set -x
         out_dir=${{ runner.workspace }}/Qt
-        aqt tool mac tools_ifw 4.1 qt.tools.ifw.41 --outputdir="$out_dir"
+        aqt tool mac tools_ifw 4.1.1 qt.tools.ifw.41 --outputdir="$out_dir"
         echo "$out_dir/Tools/QtInstallerFramework/4.1/bin" >> $GITHUB_PATH
 
     - name: Create Build Directory

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -91,7 +91,7 @@ jobs:
       run: |
         set -x
         out_dir="C:/Qt"
-        aqt tool windows tools_ifw 4.1 qt.tools.ifw.41 --outputdir="$out_dir"
+        aqt tool windows tools_ifw 4.1.1 qt.tools.ifw.41 --outputdir="$out_dir"
         echo "$out_dir/Tools/QtInstallerFramework/4.1/bin" >> $GITHUB_PATH
 
     - name: Create Build Directory


### PR DESCRIPTION
Pull request overview
---------------------
Does _not_ f i x #8837 but will hopefully be a temporary workaround.  Version numbering rules changes caused the use of 4.1 to no longer be a valid option and you have to give the patch version number.  So I went with 4.1.1.  It works on my machine now.

With this, we _should_ be able to build packages again, which is my whole goal with this.  I believe @jmarrec will have a more elegant solution that makes this process more robust moving forward as QtIFW goes through versions.

If this successfully builds package, it should be merged.