### PR TITLE
Revision to Sizing:Zone Error Message

### DIFF
--- a/doc/input-output-reference/src/overview/group-design-objects.tex
+++ b/doc/input-output-reference/src/overview/group-design-objects.tex
@@ -1087,7 +1087,7 @@ The input must be either \emph{SupplyAirTemperature} or \emph{TemperatureDiffere
 
 \paragraph{Field: Zone Cooling Design Supply Air Temperature}\label{field-zone-cooling-design-supply-air-temperature}
 
-The supply air temperature in degrees Celsius for the zone cooling design air flow rate calculation. Air is supplied to the zone at this temperature during the cooling design day simulation, The zone load is met by varying the zone air flow rate. The maximum zone flow rate is saved as the~ zone cooling design air flow rate. This field is only used when Zone Cooling Design Supply Air Temperature Input Method = \textbf{SupplyAirTemperature}.
+The supply air temperature in degrees Celsius for the zone cooling design air flow rate calculation. Air is supplied to the zone at this temperature during the cooling design day simulation. The zone load is met by varying the zone air flow rate. The maximum zone flow rate is saved as the~ zone cooling design air flow rate. This field is only used when Zone Cooling Design Supply Air Temperature Input Method = \textbf{SupplyAirTemperature}. If the value entered for this parameter is less than zero, a warning message is produced so that the user will double check the input to make sure it is correct.
 
 \paragraph{Field: Zone Cooling Design Supply Air Temperature Difference}\label{field-zone-cooling-design-supply-air-temperature-difference}
 
@@ -1099,7 +1099,8 @@ The input must be either \emph{SupplyAirTemperature} or \emph{TemperatureDiffere
 
 \paragraph{Field: Zone Heating Design Supply Air Temperature}\label{field-zone-heating-design-supply-air-temperature}
 
-The supply air temperature in degrees Celsius for the zone heating design air flow rate calculation. Air is supplied to the zone at this temperature during the heating design day simulation, The zone load is met by varying the zone air flow rate. The maximum zone flow rate is saved as the zone heating design air flow rate. This field is only used when Zone Heating Design Supply Air Temperature Input Method = \textbf{SupplyAirTemperature}.
+The supply air temperature in degrees Celsius for the zone heating design air flow rate calculation. Air is supplied to the zone at this temperature during the heating design day simulation. The zone load is met by varying the zone air flow rate. The maximum zone flow rate is saved as the zone heating design air flow rate. This field is only used when Zone Heating Design Supply Air Temperature Input Method = \textbf{SupplyAirTemperature}. If the value entered for this parameter is less than zero, a warning message is produced so that the user will double check the input to make sure it is correct though other severe errors may happen before this happens.  In addition, this parameter must be greater than the Zone Cooling Design Supply Air Temperature field shown above.
+
 
 \paragraph{Field: Zone Heating Design Supply Air Temperature Difference}\label{field-zone-heating-design-supply-air-temperature-difference}
 

--- a/src/EnergyPlus/SizingManager.cc
+++ b/src/EnergyPlus/SizingManager.cc
@@ -2912,7 +2912,7 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 if (state.dataIPShortCut->lNumericFieldBlanks(1)) {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp = 0.0;
                 } else if (state.dataSize->ZoneSizingInput(ZoneSizIndex).ZnCoolDgnSAMethod == SupplyAirTemperature) {
-                    ReportTemperatureInputError(state,cCurrentModuleObject,1,lowTempLimit,false,ErrorsFound);
+                    ReportTemperatureInputError(state, cCurrentModuleObject, 1, lowTempLimit, false, ErrorsFound);
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp = state.dataIPShortCut->rNumericArgs(1);
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp = 0.0;
@@ -2959,8 +2959,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 if (state.dataIPShortCut->lNumericFieldBlanks(3)) {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).HeatDesTemp = 0.0;
                 } else if (state.dataSize->ZoneSizingInput(ZoneSizIndex).ZnHeatDgnSAMethod == SupplyAirTemperature) {
-                    ReportTemperatureInputError(state,cCurrentModuleObject,1,lowTempLimit,false,ErrorsFound);
-                    ReportTemperatureInputError(state,cCurrentModuleObject,1,state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp,true,ErrorsFound);
+                    ReportTemperatureInputError(state, cCurrentModuleObject, 1, lowTempLimit, false, ErrorsFound);
+                    ReportTemperatureInputError(
+                        state, cCurrentModuleObject, 1, state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp, true, ErrorsFound);
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).HeatDesTemp = state.dataIPShortCut->rNumericArgs(3);
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).HeatDesTemp = 0.0;
@@ -3359,12 +3360,8 @@ void GetZoneSizingInput(EnergyPlusData &state)
     }
 }
 
-void ReportTemperatureInputError(EnergyPlusData &state,
-                                 std::string cObjectName,
-                                 int const paramNum,
-                                 Real64 comparisonTemperature,
-                                 bool const shouldFlagSevere,
-                                 bool &ErrorsFound)
+void ReportTemperatureInputError(
+    EnergyPlusData &state, std::string cObjectName, int const paramNum, Real64 comparisonTemperature, bool const shouldFlagSevere, bool &ErrorsFound)
 {
     if (state.dataIPShortCut->rNumericArgs(1) < comparisonTemperature) {
         if (shouldFlagSevere) { // heating supply air temperature is lower than cooling supply air temperature--not allowed
@@ -3373,20 +3370,18 @@ void ReportTemperatureInputError(EnergyPlusData &state,
                               format("... incorrect {}=[{:.2R}] is less than {}=[{:.2R}]",
                                      state.dataIPShortCut->cNumericFieldNames(paramNum),
                                      state.dataIPShortCut->rNumericArgs(paramNum),
-                                     state.dataIPShortCut->cNumericFieldNames(paramNum-2),
-                                     state.dataIPShortCut->rNumericArgs(paramNum-2)));
-            ShowContinueError(state,
-                              format("This is not allowed.  Please check and revise your input."));
+                                     state.dataIPShortCut->cNumericFieldNames(paramNum - 2),
+                                     state.dataIPShortCut->rNumericArgs(paramNum - 2)));
+            ShowContinueError(state, format("This is not allowed.  Please check and revise your input."));
             ErrorsFound = true;
-        } else {    // then input is lower than comparison tempeature--just produce a warning for user to check input
+        } else { // then input is lower than comparison tempeature--just produce a warning for user to check input
             ShowWarningError(state, cObjectName + "=\"" + state.dataIPShortCut->cAlphaArgs(1) + "\" has invalid data.");
             ShowContinueError(state,
                               format("... incorrect {}=[{:.2R}] is less than [{:.2R}]",
                                      state.dataIPShortCut->cNumericFieldNames(paramNum),
                                      state.dataIPShortCut->rNumericArgs(paramNum),
                                      comparisonTemperature));
-            ShowContinueError(state,
-                              format("Please check your input to make sure this is correct."));
+            ShowContinueError(state, format("Please check your input to make sure this is correct."));
         }
     }
 }

--- a/src/EnergyPlus/SizingManager.cc
+++ b/src/EnergyPlus/SizingManager.cc
@@ -2908,18 +2908,11 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 //      \units C
                 //      \note Zone Cooling Design Supply Air Temperature is only used when Zone Cooling Design
                 //      \note Supply Air Temperature Input Method = SupplyAirTemperature
+                Real64 lowTempLimit = 0.0;
                 if (state.dataIPShortCut->lNumericFieldBlanks(1)) {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp = 0.0;
-                } else if (state.dataIPShortCut->rNumericArgs(1) < 0.0 &&
-                           state.dataSize->ZoneSizingInput(ZoneSizIndex).ZnCoolDgnSAMethod == SupplyAirTemperature) {
-                    ShowSevereError(state, cCurrentModuleObject + "=\"" + state.dataIPShortCut->cAlphaArgs(1) + "\", invalid data.");
-                    ShowContinueError(state,
-                                      format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                             state.dataIPShortCut->cNumericFieldNames(1),
-                                             state.dataIPShortCut->rNumericArgs(1)));
-                    ErrorsFound = true;
-                } else if (state.dataIPShortCut->rNumericArgs(1) >= 0.0 &&
-                           state.dataSize->ZoneSizingInput(ZoneSizIndex).ZnCoolDgnSAMethod == SupplyAirTemperature) {
+                } else if (state.dataSize->ZoneSizingInput(ZoneSizIndex).ZnCoolDgnSAMethod == SupplyAirTemperature) {
+                    ReportTemperatureInputError(state,cCurrentModuleObject,1,lowTempLimit,false,ErrorsFound);
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp = state.dataIPShortCut->rNumericArgs(1);
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp = 0.0;
@@ -2965,16 +2958,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 //      \note Supply Air Temperature Input Method = SupplyAirTemperature
                 if (state.dataIPShortCut->lNumericFieldBlanks(3)) {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).HeatDesTemp = 0.0;
-                } else if (state.dataIPShortCut->rNumericArgs(3) < 0.0 &&
-                           state.dataSize->ZoneSizingInput(ZoneSizIndex).ZnHeatDgnSAMethod == SupplyAirTemperature) {
-                    ShowSevereError(state, cCurrentModuleObject + "=\"" + state.dataIPShortCut->cAlphaArgs(1) + "\", invalid data.");
-                    ShowContinueError(state,
-                                      format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                             state.dataIPShortCut->cNumericFieldNames(3),
-                                             state.dataIPShortCut->rNumericArgs(3)));
-                    ErrorsFound = true;
-                } else if (state.dataIPShortCut->rNumericArgs(3) >= 0.0 &&
-                           state.dataSize->ZoneSizingInput(ZoneSizIndex).ZnHeatDgnSAMethod == SupplyAirTemperature) {
+                } else if (state.dataSize->ZoneSizingInput(ZoneSizIndex).ZnHeatDgnSAMethod == SupplyAirTemperature) {
+                    ReportTemperatureInputError(state,cCurrentModuleObject,1,lowTempLimit,false,ErrorsFound);
+                    ReportTemperatureInputError(state,cCurrentModuleObject,1,state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesTemp,true,ErrorsFound);
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).HeatDesTemp = state.dataIPShortCut->rNumericArgs(3);
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).HeatDesTemp = 0.0;
@@ -3370,6 +3356,38 @@ void GetZoneSizingInput(EnergyPlusData &state)
 
     if (ErrorsFound) {
         ShowFatalError(state, cCurrentModuleObject + ": Errors found in getting input. Program terminates.");
+    }
+}
+
+void ReportTemperatureInputError(EnergyPlusData &state,
+                                 std::string cObjectName,
+                                 int const paramNum,
+                                 Real64 comparisonTemperature,
+                                 bool const shouldFlagSevere,
+                                 bool &ErrorsFound)
+{
+    if (state.dataIPShortCut->rNumericArgs(1) < comparisonTemperature) {
+        if (shouldFlagSevere) { // heating supply air temperature is lower than cooling supply air temperature--not allowed
+            ShowSevereError(state, cObjectName + "=\"" + state.dataIPShortCut->cAlphaArgs(1) + "\" has invalid data.");
+            ShowContinueError(state,
+                              format("... incorrect {}=[{:.2R}] is less than {}=[{:.2R}]",
+                                     state.dataIPShortCut->cNumericFieldNames(paramNum),
+                                     state.dataIPShortCut->rNumericArgs(paramNum),
+                                     state.dataIPShortCut->cNumericFieldNames(paramNum-2),
+                                     state.dataIPShortCut->rNumericArgs(paramNum-2)));
+            ShowContinueError(state,
+                              format("This is not allowed.  Please check and revise your input."));
+            ErrorsFound = true;
+        } else {    // then input is lower than comparison tempeature--just produce a warning for user to check input
+            ShowWarningError(state, cObjectName + "=\"" + state.dataIPShortCut->cAlphaArgs(1) + "\" has invalid data.");
+            ShowContinueError(state,
+                              format("... incorrect {}=[{:.2R}] is less than [{:.2R}]",
+                                     state.dataIPShortCut->cNumericFieldNames(paramNum),
+                                     state.dataIPShortCut->rNumericArgs(paramNum),
+                                     comparisonTemperature));
+            ShowContinueError(state,
+                              format("Please check your input to make sure this is correct."));
+        }
     }
 }
 

--- a/src/EnergyPlus/SizingManager.hh
+++ b/src/EnergyPlus/SizingManager.hh
@@ -113,6 +113,14 @@ namespace SizingManager {
 
     void GetZoneSizingInput(EnergyPlusData &state);
 
+    void ReportTemperatureInputError(EnergyPlusData &state,
+                                     std::string cObjectName,
+                                     int const paramNum,
+                                     Real64 comparisonTemperature,
+                                     bool const shouldFlagSevere,
+                                     bool &ErrorsFound
+    );
+
     void GetZoneAndZoneListNames(
         EnergyPlusData &state, bool &ErrorsFound, int &NumZones, Array1D_string &ZoneNames, int &NumZoneLists, Array1D<ZoneListData> &ZoneListNames);
 

--- a/src/EnergyPlus/SizingManager.hh
+++ b/src/EnergyPlus/SizingManager.hh
@@ -118,8 +118,7 @@ namespace SizingManager {
                                      int const paramNum,
                                      Real64 comparisonTemperature,
                                      bool const shouldFlagSevere,
-                                     bool &ErrorsFound
-    );
+                                     bool &ErrorsFound);
 
     void GetZoneAndZoneListNames(
         EnergyPlusData &state, bool &ErrorsFound, int &NumZones, Array1D_string &ZoneNames, int &NumZoneLists, Array1D<ZoneListData> &ZoneListNames);

--- a/tst/EnergyPlus/unit/SizingManager.unit.cc
+++ b/tst/EnergyPlus/unit/SizingManager.unit.cc
@@ -54,11 +54,11 @@
 
 // EnergyPlus Headers
 #include <EnergyPlus/Data/EnergyPlusData.hh>
+#include <EnergyPlus/DataIPShortCuts.hh>
 #include <EnergyPlus/DataSizing.hh>
 #include <EnergyPlus/DataZoneEquipment.hh>
 #include <EnergyPlus/HeatBalanceManager.hh>
 #include <EnergyPlus/IOFiles.hh>
-#include <EnergyPlus/DataIPShortCuts.hh>
 #include <EnergyPlus/SizingManager.hh>
 #include <EnergyPlus/UtilityRoutines.hh>
 #include <EnergyPlus/ZoneEquipmentManager.hh>
@@ -555,37 +555,40 @@ TEST_F(EnergyPlusFixture, SizingManager_ReportTemperatureInputError)
     state->dataIPShortCut->rNumericArgs(paramNum) = 14.0;
     Real64 lowTempLimit = 0.0;
     bool errorsFound = false;
-    
+
     // Test 1: No problems, no errors, both parameters
-    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,false,errorsFound);
+    ReportTemperatureInputError(*state, objectName, paramNum, lowTempLimit, false, errorsFound);
     ASSERT_FALSE(errorsFound);
     paramNum = 3;
     state->dataIPShortCut->cNumericFieldNames(paramNum) = "Zone Heating Design Supply Air Temperature";
     state->dataIPShortCut->rNumericArgs(paramNum) = 50.0;
-    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,false,errorsFound);
+    ReportTemperatureInputError(*state, objectName, paramNum, lowTempLimit, false, errorsFound);
     ASSERT_FALSE(errorsFound);
 
     // Test 2: Temperature is less than the lower limit allowed, but it's not a severe (check for both parameters)
     paramNum = 1;
     state->dataIPShortCut->rNumericArgs(paramNum) = -1.0;
-    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,false,errorsFound);
+    ReportTemperatureInputError(*state, objectName, paramNum, lowTempLimit, false, errorsFound);
     ASSERT_FALSE(errorsFound);
-    EXPECT_TRUE(compare_err_stream(delimited_string({"   ** Warning ** Sizing:Zone=\"SPACE1-1\" has invalid data.",
-                                                     "   **   ~~~   ** ... incorrect Zone Cooling Design Supply Air Temperature=[-1.00] is less than [0.00]",
-                                                     "   **   ~~~   ** Please check your input to make sure this is correct."})));
+    EXPECT_TRUE(
+        compare_err_stream(delimited_string({"   ** Warning ** Sizing:Zone=\"SPACE1-1\" has invalid data.",
+                                             "   **   ~~~   ** ... incorrect Zone Cooling Design Supply Air Temperature=[-1.00] is less than [0.00]",
+                                             "   **   ~~~   ** Please check your input to make sure this is correct."})));
     paramNum = 3;
     state->dataIPShortCut->rNumericArgs(paramNum) = -1.0;
-    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,false,errorsFound);
+    ReportTemperatureInputError(*state, objectName, paramNum, lowTempLimit, false, errorsFound);
     ASSERT_FALSE(errorsFound);
-    EXPECT_TRUE(compare_err_stream(delimited_string({"   ** Warning ** Sizing:Zone=\"SPACE1-1\" has invalid data.",
-                                                     "   **   ~~~   ** ... incorrect Zone Heating Design Supply Air Temperature=[-1.00] is less than [0.00]",
-                                                     "   **   ~~~   ** Please check your input to make sure this is correct."})));
+    EXPECT_TRUE(
+        compare_err_stream(delimited_string({"   ** Warning ** Sizing:Zone=\"SPACE1-1\" has invalid data.",
+                                             "   **   ~~~   ** ... incorrect Zone Heating Design Supply Air Temperature=[-1.00] is less than [0.00]",
+                                             "   **   ~~~   ** Please check your input to make sure this is correct."})));
 
     // Test 3: Heating Temperature is lower Cooling Temperature--this should become a severe error
     state->dataIPShortCut->rNumericArgs(paramNum) = -2.0;
-    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,true,errorsFound);
+    ReportTemperatureInputError(*state, objectName, paramNum, lowTempLimit, true, errorsFound);
     ASSERT_TRUE(errorsFound);
     EXPECT_TRUE(compare_err_stream(delimited_string({"   ** Severe  ** Sizing:Zone=\"SPACE1-1\" has invalid data.",
-                                                     "   **   ~~~   ** ... incorrect Zone Heating Design Supply Air Temperature=[-2.00] is less than Zone Cooling Design Supply Air Temperature=[-1.00]",
+                                                     "   **   ~~~   ** ... incorrect Zone Heating Design Supply Air Temperature=[-2.00] is less than "
+                                                     "Zone Cooling Design Supply Air Temperature=[-1.00]",
                                                      "   **   ~~~   ** This is not allowed.  Please check and revise your input."})));
 }

--- a/tst/EnergyPlus/unit/SizingManager.unit.cc
+++ b/tst/EnergyPlus/unit/SizingManager.unit.cc
@@ -58,6 +58,7 @@
 #include <EnergyPlus/DataZoneEquipment.hh>
 #include <EnergyPlus/HeatBalanceManager.hh>
 #include <EnergyPlus/IOFiles.hh>
+#include <EnergyPlus/DataIPShortCuts.hh>
 #include <EnergyPlus/SizingManager.hh>
 #include <EnergyPlus/UtilityRoutines.hh>
 #include <EnergyPlus/ZoneEquipmentManager.hh>
@@ -539,4 +540,52 @@ TEST_F(EnergyPlusFixture, SizingManager_CalcdoLoadComponentPulseNowTest)
     state->dataGlobal->DayOfSim = 2;
     Answer = CalcdoLoadComponentPulseNow(*state, PulseSizing, WarmupFlag, HourNum, TimeStepNum, state->dataGlobal->KindOfSim);
     ASSERT_FALSE(Answer);
+}
+
+TEST_F(EnergyPlusFixture, SizingManager_ReportTemperatureInputError)
+{
+
+    std::string objectName = "Sizing:Zone";
+    int paramNum = 1;
+    state->dataIPShortCut->cAlphaArgs.allocate(3);
+    state->dataIPShortCut->cNumericFieldNames.allocate(3);
+    state->dataIPShortCut->rNumericArgs.allocate(3);
+    state->dataIPShortCut->cAlphaArgs(paramNum) = "SPACE1-1";
+    state->dataIPShortCut->cNumericFieldNames(paramNum) = "Zone Cooling Design Supply Air Temperature";
+    state->dataIPShortCut->rNumericArgs(paramNum) = 14.0;
+    Real64 lowTempLimit = 0.0;
+    bool errorsFound = false;
+    
+    // Test 1: No problems, no errors, both parameters
+    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,false,errorsFound);
+    ASSERT_FALSE(errorsFound);
+    paramNum = 3;
+    state->dataIPShortCut->cNumericFieldNames(paramNum) = "Zone Heating Design Supply Air Temperature";
+    state->dataIPShortCut->rNumericArgs(paramNum) = 50.0;
+    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,false,errorsFound);
+    ASSERT_FALSE(errorsFound);
+
+    // Test 2: Temperature is less than the lower limit allowed, but it's not a severe (check for both parameters)
+    paramNum = 1;
+    state->dataIPShortCut->rNumericArgs(paramNum) = -1.0;
+    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,false,errorsFound);
+    ASSERT_FALSE(errorsFound);
+    EXPECT_TRUE(compare_err_stream(delimited_string({"   ** Warning ** Sizing:Zone=\"SPACE1-1\" has invalid data.",
+                                                     "   **   ~~~   ** ... incorrect Zone Cooling Design Supply Air Temperature=[-1.00] is less than [0.00]",
+                                                     "   **   ~~~   ** Please check your input to make sure this is correct."})));
+    paramNum = 3;
+    state->dataIPShortCut->rNumericArgs(paramNum) = -1.0;
+    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,false,errorsFound);
+    ASSERT_FALSE(errorsFound);
+    EXPECT_TRUE(compare_err_stream(delimited_string({"   ** Warning ** Sizing:Zone=\"SPACE1-1\" has invalid data.",
+                                                     "   **   ~~~   ** ... incorrect Zone Heating Design Supply Air Temperature=[-1.00] is less than [0.00]",
+                                                     "   **   ~~~   ** Please check your input to make sure this is correct."})));
+
+    // Test 3: Heating Temperature is lower Cooling Temperature--this should become a severe error
+    state->dataIPShortCut->rNumericArgs(paramNum) = -2.0;
+    ReportTemperatureInputError(*state,objectName,paramNum,lowTempLimit,true,errorsFound);
+    ASSERT_TRUE(errorsFound);
+    EXPECT_TRUE(compare_err_stream(delimited_string({"   ** Severe  ** Sizing:Zone=\"SPACE1-1\" has invalid data.",
+                                                     "   **   ~~~   ** ... incorrect Zone Heating Design Supply Air Temperature=[-2.00] is less than Zone Cooling Design Supply Air Temperature=[-1.00]",
+                                                     "   **   ~~~   ** This is not allowed.  Please check and revise your input."})));
 }


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8827 
 - This pull request provides code, unit tests, and modified documentation to fix a problem with the error messages for the supply air temperatures for the zone sizing object.  When the object was read in, there was a built in assumption that neither the heating or cooling supply air temperature was negative.  This was simply a test to avoid bad input.  While "reasonable", this was never documented and led to a severe error.  While very unlikely, it is possible that the values could be outside of the normal range.  It was suggested that the logic be modified so that the error message was only a warning with a note to double check the input values.  This was done and in addition it was verified that the heating supply air temperature is also greater than the cooling supply air temperature and that a severe error results if this is not the case.  A new unit test was created to test the new subroutine that produces the new error messages.  In addition, the documentation was enhanced so that the user knows that a warning will be produced if the supply air temperatures are negative and a severe error will be produced if the heating temperature is lower than the cooling temperature.

**NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE**

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
