### PR TITLE
Fix #9022 - conversion should respect outDirPath

### DIFF
--- a/src/EnergyPlus/DataStringGlobals.hh
+++ b/src/EnergyPlus/DataStringGlobals.hh
@@ -121,7 +121,6 @@ struct DataStringGlobalsData : BaseGlobalStruct
     fs::path outDirPath;
     fs::path idfFilePathNameOnly;
     fs::path inputDirPath;
-    fs::path outputDirPath;
     fs::path inputFilePathNameOnly;
     fs::path exeDirectoryPath;
     fs::path ProgramPath;          // Path for Program from INI file
@@ -141,7 +140,6 @@ struct DataStringGlobalsData : BaseGlobalStruct
         outDirPath.clear();
         inputFilePathNameOnly.clear();
         inputDirPath.clear();
-        outputDirPath.clear();
         exeDirectoryPath.clear();
         inputFilePath.clear();
         inputIddFilePath.clear();

--- a/src/EnergyPlus/InputProcessing/InputProcessor.cc
+++ b/src/EnergyPlus/InputProcessing/InputProcessor.cc
@@ -299,7 +299,7 @@ void InputProcessor::processInput(EnergyPlusData &state)
                 input_file = epJSONClean.dump(4, ' ', false, json::error_handler_t::replace);
                 // input_file = epJSON.dump(4, ' ', false, json::error_handler_t::replace);
                 fs::path convertedIDF = FileSystem::makeNativePath(
-                    FileSystem::replaceFileExtension(state.dataStrGlobals->outputDirPath / state.dataStrGlobals->inputFilePathNameOnly, ".epJSON"));
+                    FileSystem::replaceFileExtension(state.dataStrGlobals->outDirPath / state.dataStrGlobals->inputFilePathNameOnly, ".epJSON"));
                 std::ofstream convertedFS(convertedIDF, std::ofstream::out);
                 convertedFS << input_file << std::endl;
             }
@@ -332,7 +332,7 @@ void InputProcessor::processInput(EnergyPlusData &state)
         if (versionMatch) {
             std::string const encoded = idf_parser->encode(epJSON, schema);
             fs::path convertedEpJSON = FileSystem::makeNativePath(
-                FileSystem::replaceFileExtension(state.dataStrGlobals->outputDirPath / state.dataStrGlobals->inputFilePathNameOnly, ".idf"));
+                FileSystem::replaceFileExtension(state.dataStrGlobals->outDirPath / state.dataStrGlobals->inputFilePathNameOnly, ".idf"));
             std::ofstream convertedFS(convertedEpJSON, std::ofstream::out);
             convertedFS << encoded << std::endl;
         } else {


### PR DESCRIPTION
Pull request overview
---------------------

Fix #9022 - conversion should respect outDirPath

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
