### PR TITLE
Fix annoying err file diff

### DIFF
--- a/datasets/CodeCompliantEquipment.idf
+++ b/datasets/CodeCompliantEquipment.idf
@@ -104,7 +104,7 @@ Curve:Cubic,
     -0.6246776637429885,      !- Coefficient4 x3
     0.0,                      !- Minimum Value of x
     1.0,                      !- Maximum Value of x
-    ,                         !- Minimum Curve Output
+    ;                         !- Minimum Curve Output
 
 !- Set of performance curves for ASHRAE901_2019_air_A_gte528kW_2.985COP_4.137IPLV.SI
 
@@ -146,7 +146,7 @@ Curve:Cubic,
     -0.7739499331181423,      !- Coefficient4 x3
     0.0,                      !- Minimum Value of x
     1.0,                      !- Maximum Value of x
-    ,                         !- Minimum Curve Output
+    ;                         !- Minimum Curve Output
 
 !- Set of performance curves for ASHRAE901_2019_air_A_lt150ton_10.1kWpton_13.7IPLV.IP
 
@@ -188,7 +188,7 @@ Curve:Cubic,
     -0.8439853035608315,      !- Coefficient4 x3
     0.0,                      !- Minimum Value of x
     1.0,                      !- Maximum Value of x
-    ,                         !- Minimum Curve Output
+    ;                         !- Minimum Curve Output
 
 !- Set of performance curves for ASHRAE901_2019_air_A_lt528kW_2.985COP_4.048IPLV.SI
 
@@ -230,7 +230,7 @@ Curve:Cubic,
     -0.9136557506047499,      !- Coefficient4 x3
     0.0,                      !- Minimum Value of x
     1.0,                      !- Maximum Value of x
-    ,                         !- Minimum Curve Output
+    ;                         !- Minimum Curve Output
 
 !- Set of performance curves for ASHRAE901_2019_air_B_gte150ton_9.7kWpton_16.1IPLV.IP
 
@@ -272,7 +272,7 @@ Curve:Cubic,
     -0.830217972918539,       !- Coefficient4 x3
     0.0,                      !- Minimum Value of x
     1.0,                      !- Maximum Value of x
-    ,                         !- Minimum Curve Output
+    ;                         !- Minimum Curve Output
 
 !- Set of performance curves for ASHRAE901_2019_air_B_gte528kW_2.866COP_4.758IPLV.SI
 
@@ -314,7 +314,7 @@ Curve:Cubic,
     -0.6903373176376427,      !- Coefficient4 x3
     0.0,                      !- Minimum Value of x
     1.0,                      !- Maximum Value of x
-    ,                         !- Minimum Curve Output
+    ;                         !- Minimum Curve Output
 
 !- Set of performance curves for ASHRAE901_2019_air_B_lt150ton_9.7kWpton_15.8IPLV.IP
 
@@ -356,7 +356,7 @@ Curve:Cubic,
     -0.7990510830858572,      !- Coefficient4 x3
     0.0,                      !- Minimum Value of x
     1.0,                      !- Maximum Value of x
-    ,                         !- Minimum Curve Output
+    ;                         !- Minimum Curve Output
 
 !- Set of performance curves for ASHRAE901_2019_air_B_lt528kW_2.866COP_4.669IPLV.SI
 
@@ -398,7 +398,7 @@ Curve:Cubic,
     -0.7992244286842732,      !- Coefficient4 x3
     0.0,                      !- Minimum Value of x
     1.0,                      !- Maximum Value of x
-    ,                         !- Minimum Curve Output
+    ;                         !- Minimum Curve Output
 
 !- Set of performance curves for ASHRAE901_2019_wtr_A_cent_gte1055lt1407kW_6.286COP_6.77IPLV.SI
 

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -6667,8 +6667,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptTS) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (TimeStep), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (TimeStep), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptTS) {
@@ -6693,8 +6693,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccTS) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (TimeStep), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (TimeStep), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccTS) {
@@ -6721,8 +6721,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptHR) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptHR) {
@@ -6748,8 +6748,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccHR) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccHR) {
@@ -6777,8 +6777,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptDY) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Daily), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (Daily), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptDY) {
@@ -6804,8 +6804,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccDY) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccDY) {
@@ -6833,8 +6833,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptMN) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Monthly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (Monthly), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptMN) {
@@ -6860,8 +6860,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccMN) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Monthly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (Monthly), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccMN) {
@@ -6889,8 +6889,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptYR) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Annual), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (Annual), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptYR) {
@@ -6916,8 +6916,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccYR) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Annual), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (Annual), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccYR) {
@@ -6945,8 +6945,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptSM) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (RunPeriod), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (RunPeriod), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptSM) {
@@ -6972,8 +6972,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccSM) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (RunPeriod), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
-                                         " and " + state.files.mtr.filePath.filename().string());
+                                         R"(" (RunPeriod), already on "Output:Meter". Will report to both )" +
+                                         state.files.eso.filePath.filename().string() + " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccSM) {

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -6652,26 +6652,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
     // PURPOSE OF THIS SUBROUTINE:
     // Set values and output initial names to output files.
 
-    // METHODOLOGY EMPLOYED:
-    // na
-
-    // REFERENCES:
-    // na
-
     // Using/Aliasing
     using namespace OutputProcessor;
-
-    // Locals
-    // SUBROUTINE ARGUMENT DEFINITIONS:
-
-    // SUBROUTINE PARAMETER DEFINITIONS:
-    // na
-
-    // INTERFACE BLOCK SPECIFICATIONS:
-    // na
-
-    // DERIVED TYPE DEFINITIONS:
-    // na
 
     // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
     int indexGroupKey;
@@ -6685,8 +6667,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptTS) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (TimeStep), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (TimeStep), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptTS) {
@@ -6711,8 +6693,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccTS) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (TimeStep), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (TimeStep), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccTS) {
@@ -6739,8 +6721,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptHR) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptHR) {
@@ -6766,8 +6748,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccHR) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccHR) {
@@ -6795,8 +6777,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptDY) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Daily), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (Daily), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptDY) {
@@ -6822,8 +6804,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccDY) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (Hourly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccDY) {
@@ -6851,8 +6833,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptMN) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Monthly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (Monthly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptMN) {
@@ -6878,8 +6860,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccMN) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Monthly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (Monthly), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccMN) {
@@ -6907,8 +6889,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptYR) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Annual), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (Annual), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptYR) {
@@ -6934,8 +6916,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccYR) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (Annual), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (Annual), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccYR) {
@@ -6963,8 +6945,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptSM) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"" + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (RunPeriod), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (RunPeriod), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptSM) {
@@ -6990,8 +6972,8 @@ void SetInitialMeterReportingAndOutputNames(EnergyPlusData &state,
                 if (op->EnergyMeters(WhichMeter).RptAccSM) {
                     ShowWarningError(state,
                                      "Output:Meter:MeterFileOnly requested for \"Cumulative " + op->EnergyMeters(WhichMeter).Name +
-                                         R"(" (RunPeriod), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.string() +
-                                         " and " + state.files.mtr.filePath.string());
+                                         R"(" (RunPeriod), already on "Output:Meter". Will report to both )" + state.files.eso.filePath.filename().string() +
+                                         " and " + state.files.mtr.filePath.filename().string());
                 }
             }
             if (!op->EnergyMeters(WhichMeter).RptAccSM) {

--- a/src/EnergyPlus/WindowManager.cc
+++ b/src/EnergyPlus/WindowManager.cc
@@ -3714,64 +3714,59 @@ namespace WindowManager {
         auto &hcvBG = state.dataWindowManager->hcvBG;
         auto &AbsRadShadeFace = state.dataWindowManager->AbsRadShadeFace;
 
-        int iter;       // Iteration number
-        Real64 errtemp; // Absolute value of sum of face temperature differences
-        //   between iterations, divided by number of faces
-        Real64 VGap;                // Air velocity in gap between glass and shade/blind (m/s)
-        Real64 VAirflowGap;         // Air velocity in airflow gap between glass panes (m/s)
-        Real64 VGapPrev;            // Value of VGap from previous iteration
-        Real64 TGapNew;             // Average air temp in gap between glass and shade/blind (K)
-        Real64 TAirflowGapNew;      // Average air temp in airflow gap between glass panes (K)
-        Real64 TGapOutlet;          // Temperature of air leaving gap between glass and shade/blind (K)
-        Real64 TAirflowGapOutlet;   // Temperature of air leaving airflow gap between glass panes (K)
-        Real64 TAirflowGapOutletC;  // Temperature of air leaving airflow gap between glass panes (C)
-        Real64 hcv;                 // Convection coefficient from gap glass or shade/blind to gap air (W/m2-K)
-        Real64 hcvAirflowGap;       // Convection coefficient from airflow gap glass to airflow gap air (W/m2-K)
-        Real64 hcvPrev;             // Value of hcv from previous iteration
-        Real64 ConvHeatFlowNatural; // Convective heat flow from gap between glass and interior shade or blind (W)
-        Real64 ConvHeatFlowForced;  // Convective heat flow from forced airflow gap (W)
-        Real64 ShGlReflFacIR;       // Factor for long-wave inter-reflection between shade/blind and adjacent glass
-        Real64 RhoGlIR1;            // Long-wave reflectance of glass surface facing shade/blind; 1=exterior shade/blind,
-        Real64 RhoGlIR2;
+        int iter = 0;                     // Iteration number
+        Real64 errtemp = 0.0;             // Absolute value of sum of face temperature differences between iterations, divided by number of faces
+        Real64 VGap = 0.0;                // Air velocity in gap between glass and shade/blind (m/s)
+        Real64 VAirflowGap = 0.0;         // Air velocity in airflow gap between glass panes (m/s)
+        Real64 VGapPrev = 0.0;            // Value of VGap from previous iteration
+        Real64 TGapNew = 0.0;             // Average air temp in gap between glass and shade/blind (K)
+        Real64 TAirflowGapNew = 0.0;      // Average air temp in airflow gap between glass panes (K)
+        Real64 TGapOutlet = 0.0;          // Temperature of air leaving gap between glass and shade/blind (K)
+        Real64 TAirflowGapOutlet = 0.0;   // Temperature of air leaving airflow gap between glass panes (K)
+        Real64 TAirflowGapOutletC = 0.0;  // Temperature of air leaving airflow gap between glass panes (C)
+        Real64 hcv = 0.0;                 // Convection coefficient from gap glass or shade/blind to gap air (W/m2-K)
+        Real64 hcvAirflowGap = 0.0;       // Convection coefficient from airflow gap glass to airflow gap air (W/m2-K)
+        Real64 hcvPrev = 0.0;             // Value of hcv from previous iteration
+        Real64 ConvHeatFlowNatural = 0.0; // Convective heat flow from gap between glass and interior shade or blind (W)
+        Real64 ConvHeatFlowForced = 0.0;  // Convective heat flow from forced airflow gap (W)
+        Real64 ShGlReflFacIR = 0.0;       // Factor for long-wave inter-reflection between shade/blind and adjacent glass
+        Real64 RhoGlIR1 = 0.0;            // Long-wave reflectance of glass surface facing shade/blind; 1=exterior shade/blind,
+        Real64 RhoGlIR2 = 0.0;
         //  2=exterior shade/blind
-        Real64 EpsShIR1; // Long-wave emissivity of shade/blind surface facing glass; 1=interior shade/blind,
-        Real64 EpsShIR2;
+        Real64 EpsShIR1 = 0.0; // Long-wave emissivity of shade/blind surface facing glass; 1=interior shade/blind,
+        Real64 EpsShIR2 = 0.0;
         //  2=interior shade/blind
-        Real64 RhoShIR1; // Long-wave reflectance of shade/blind surface facing glass; 1=interior shade/blind,
-        Real64 RhoShIR2;
+        Real64 RhoShIR1 = 0.0; // Long-wave reflectance of shade/blind surface facing glass; 1=interior shade/blind,
+        Real64 RhoShIR2 = 0.0;
         //  2=exterior shade/blind
-        Real64 TauShIR; // Long-wave transmittance of isolated shade/blind
-        Real64 sconsh;  // shade/blind conductance (W/m2-K)
+        Real64 TauShIR = 0.0; // Long-wave transmittance of isolated shade/blind
+        Real64 sconsh = 0.0;  // shade/blind conductance (W/m2-K)
 
-        WinShadingType ShadeFlag; // Shading flag
+        WinShadingType ShadeFlag = WinShadingType::NoShade; // Shading flag
         //  radiation from lights and zone equipment absorbed by faces of shade/blind (W/m2)
-        Real64 ShadeArea;          // shade/blind area (m2)
-        Real64 CondHeatGainGlass;  // Conduction through inner glass layer, outside to inside (W)
-        Real64 CondHeatGainShade;  // Conduction through shade/blind, outside to inside (W)
-        Real64 NetIRHeatGainGlass; // Net IR heat gain to zone from shade/blind side of glass when interior
+        Real64 ShadeArea = 0.0;          // shade/blind area (m2)
+        Real64 CondHeatGainGlass = 0.0;  // Conduction through inner glass layer, outside to inside (W)
+        Real64 CondHeatGainShade = 0.0;  // Conduction through shade/blind, outside to inside (W)
+        Real64 NetIRHeatGainGlass = 0.0; // Net IR heat gain to zone from shade/blind side of glass when interior
         //  shade/blind is present. Zero if shade/blind has zero IR transmittance (W)
-        Real64 NetIRHeatGainShade;            // Net IR heat gain to zone from interior shade/blind (W)
-        Real64 ConvHeatGainFrZoneSideOfShade; // Convective heat gain to zone from side of interior shade facing zone (W)
-        Real64 ConvHeatGainFrZoneSideOfGlass; // Convective heat gain to zone from side of glass facing zone when
+        Real64 NetIRHeatGainShade = 0.0;            // Net IR heat gain to zone from interior shade/blind (W)
+        Real64 ConvHeatGainFrZoneSideOfShade = 0.0; // Convective heat gain to zone from side of interior shade facing zone (W)
+        Real64 ConvHeatGainFrZoneSideOfGlass = 0.0; // Convective heat gain to zone from side of glass facing zone when
         //  no interior shade/blind is present (W)
-        Real64 IncidentSolar;         // Solar incident on outside of window (W)
-        Real64 TransDiff;             // Diffuse shortwave transmittance
-        Real64 ConvHeatGainToZoneAir; // Convective heat gain to zone air from window gap airflow (W)
-        Real64 TotAirflowGap;         // Total volumetric airflow through window gap (m3/s)
-        Real64 CpAirOutlet;           // Heat capacity of air from window gap (J/kg-K)
-        Real64 CpAirZone;             // Heat capacity of zone air (J/kg-K)
-        Real64 InletAirHumRat;        // Humidity ratio of air from window gap entering fan
-        Real64 ZoneTemp;              // Zone air temperature (C)
-        int InsideFaceIndex;          // intermediate variable for index of inside face in thetas
+        Real64 IncidentSolar = 0.0;         // Solar incident on outside of window (W)
+        Real64 TransDiff = 0.0;             // Diffuse shortwave transmittance
+        Real64 ConvHeatGainToZoneAir = 0.0; // Convective heat gain to zone air from window gap airflow (W)
+        Real64 TotAirflowGap = 0.0;         // Total volumetric airflow through window gap (m3/s)
+        Real64 CpAirOutlet = 0.0;           // Heat capacity of air from window gap (J/kg-K)
+        Real64 CpAirZone = 0.0;             // Heat capacity of zone air (J/kg-K)
+        Real64 InletAirHumRat = 0.0;        // Humidity ratio of air from window gap entering fan
+        Real64 ZoneTemp = 0.0;              // Zone air temperature (C)
+        int InsideFaceIndex = 0;            // intermediate variable for index of inside face in thetas
 
-        iter = 0;
-        ConvHeatFlowNatural = 0.0;
-        ConvHeatFlowForced = 0.0;
         state.dataWindowManager->nglfacep = state.dataWindowManager->nglface;
         ShadeFlag = state.dataSurface->SurfWinShadingFlag(SurfNum);
         ZoneNum = state.dataSurface->Surface(SurfNum).Zone;
         AbsRadShadeFace = 0.0;
-        TGapNew = 0.0;
 
         if (ANY_SHADE_SCREEN(ShadeFlag) || ANY_BLIND(ShadeFlag)) {
             state.dataWindowManager->nglfacep = state.dataWindowManager->nglface + 2;

--- a/tst/EnergyPlus/unit/OutputProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/OutputProcessor.unit.cc
@@ -5845,16 +5845,14 @@ namespace OutputProcessor {
 
         // first call it as a non-cumulative variable
         SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, false);
-        std::string errMsg = delimited_string({
-            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Foo\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr"
-        });
+        std::string errMsg = delimited_string({"   ** Warning ** Output:Meter:MeterFileOnly requested for \"Foo\" (TimeStep), already on "
+                                               "\"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr"});
         compare_err_stream(errMsg);
 
         // then with a cumulative variable
         SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, true);
-        errMsg = delimited_string({
-            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Cumulative Foo\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr"
-        });
+        errMsg = delimited_string({"   ** Warning ** Output:Meter:MeterFileOnly requested for \"Cumulative Foo\" (TimeStep), already on "
+                                   "\"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr"});
         compare_err_stream(errMsg);
 
         // but then if you run EnergyPlus with `-d` to set an output directory, the variable will become a fully qualified path to the file
@@ -5864,16 +5862,14 @@ namespace OutputProcessor {
 
         // first call it as a non-cumulative variable
         SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, false);
-        errMsg = delimited_string({
-            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Foo\" (TimeStep), already on \"Output:Meter\". Will report to both bar.eso and bar.mtr"
-        });
+        errMsg = delimited_string({"   ** Warning ** Output:Meter:MeterFileOnly requested for \"Foo\" (TimeStep), already on \"Output:Meter\". Will "
+                                   "report to both bar.eso and bar.mtr"});
         compare_err_stream(errMsg);
 
         // then with a cumulative variable
         SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, true);
-        errMsg = delimited_string({
-            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Cumulative Foo\" (TimeStep), already on \"Output:Meter\". Will report to both bar.eso and bar.mtr"
-        });
+        errMsg = delimited_string({"   ** Warning ** Output:Meter:MeterFileOnly requested for \"Cumulative Foo\" (TimeStep), already on "
+                                   "\"Output:Meter\". Will report to both bar.eso and bar.mtr"});
         compare_err_stream(errMsg);
     }
 } // namespace OutputProcessor

--- a/tst/EnergyPlus/unit/OutputProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/OutputProcessor.unit.cc
@@ -5872,7 +5872,7 @@ namespace OutputProcessor {
         // then with a cumulative variable
         SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, true);
         errMsg = delimited_string({
-            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Cumulative Foo\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr"
+            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Cumulative Foo\" (TimeStep), already on \"Output:Meter\". Will report to both bar.eso and bar.mtr"
         });
         compare_err_stream(errMsg);
     }

--- a/tst/EnergyPlus/unit/OutputProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/OutputProcessor.unit.cc
@@ -5833,6 +5833,49 @@ namespace OutputProcessor {
 
         EXPECT_FALSE(errors_found);
     }
+
+    TEST_F(EnergyPlusFixture, OutputProcessor_FilePathInSetInitialMeterReportingAndOutputNames)
+    {
+        state->dataOutputProcessor->EnergyMeters.allocate(1);
+        state->dataOutputProcessor->EnergyMeters(1).Name = "Foo";
+        state->dataOutputProcessor->EnergyMeters(1).RptTS = true;
+        state->dataOutputProcessor->EnergyMeters(1).RptAccTS = true;
+
+        // by default, the eso fs::path instance will just be a filename, so this will definitely pass
+
+        // first call it as a non-cumulative variable
+        SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, false);
+        std::string errMsg = delimited_string({
+            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Foo\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr"
+        });
+        compare_err_stream(errMsg);
+
+        // then with a cumulative variable
+        SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, true);
+        errMsg = delimited_string({
+            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Cumulative Foo\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr"
+        });
+        compare_err_stream(errMsg);
+
+        // but then if you run EnergyPlus with `-d` to set an output directory, the variable will become a fully qualified path to the file
+        // to test this we need to set up a proper path for the current platform, luckily this seems to suffic
+        state->files.eso.filePath = fs::path("foo") / "bar.eso";
+        state->files.mtr.filePath = fs::path("foo") / "bar.mtr";
+
+        // first call it as a non-cumulative variable
+        SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, false);
+        errMsg = delimited_string({
+            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Foo\" (TimeStep), already on \"Output:Meter\". Will report to both bar.eso and bar.mtr"
+        });
+        compare_err_stream(errMsg);
+
+        // then with a cumulative variable
+        SetInitialMeterReportingAndOutputNames(*state, 1, true, ReportingFrequency::EachCall, true);
+        errMsg = delimited_string({
+            "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Cumulative Foo\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr"
+        });
+        compare_err_stream(errMsg);
+    }
 } // namespace OutputProcessor
 
 } // namespace EnergyPlus


### PR DESCRIPTION
Recent PRs have encountered annoying diffs occurring in the err file regressions.  Something like:

``` diff
-   ** Warning ** blah. Will report to both /path/to/eplusout.eso and /path/to/eplusout.mtr
+   ** Warning ** blah. Will report to both /different/path/to/eplusout.eso and /different/path/to/eplusout.mtr
```

I tried to replicate locally, and initially my error file didn't have this issue, because it was only reporting the file name, not the full path:

```sh
./energyplus -D ASHRAE901_Warehouse_STD2019_Denver.idf
   ** Warning ** Output:Meter:MeterFileOnly ... Will report to both eplusout.eso and eplusout.mtr
   ** Warning ** Output:Meter:MeterFileOnly ... Will report to both eplusout.eso and eplusout.mtr
   ** Warning ** Output:Meter:MeterFileOnly ... Will report to both eplusout.eso and eplusout.mtr
```

This was surprising.  I tried running EnergyPlus with a `-d` output directory and then saw the full path show up:

```sh
./energyplus -d /tmp -D ASHRAE901_Warehouse_STD2019_Denver.idf
   ** Warning ** Output:Meter:MeterFileOnly ... Will report to both /tmp/eplusout.eso and /tmp/eplusout.mtr
   ** Warning ** Output:Meter:MeterFileOnly ... Will report to both /tmp/eplusout.eso and /tmp/eplusout.mtr
   ** Warning ** Output:Meter:MeterFileOnly ... Will report to both /tmp/eplusout.eso and /tmp/eplusout.mtr
```

This in and of itself indicated that the `fs::path` variables in the code used for holding the path to the eso and mtr files serve mixed duty - sometimes just the filename (relative to current working directory) and sometimes a full path.  This feels ... odd ... kinda seems like they should just always be full paths to avoid confusion, but I'm not going to think about that right now.

Anyway, I wrote a unit test to expect just the filename and it failed initially, then I made the fix in the code to just print the filename, and it passed.  For anyone reviewing it, this will show ERR diffs now because in develop the full path is shown in the ERR file and now in this branch we are only printing the filename.  After this branch however, there won't be any more of these annoying ERR diffs.