### PR TITLE
Use specified program root for API usage

### DIFF
--- a/src/EnergyPlus/PluginManager.cc
+++ b/src/EnergyPlus/PluginManager.cc
@@ -406,8 +406,12 @@ PluginManager::PluginManager(EnergyPlusData &state)
 {
 #if LINK_WITH_PYTHON == 1
     // we'll need the program directory for a few things so get it once here at the top and sanitize it
-    fs::path programPath = FileSystem::getAbsolutePath(FileSystem::getProgramPath());
-    fs::path programDir = FileSystem::getParentDirectoryPath(programPath);
+    fs::path programDir;
+    if (state.dataGlobal->installRootOverride) {
+        programDir = state.dataStrGlobals->exeDirectoryPath;
+    } else {
+        programDir = FileSystem::getParentDirectoryPath(FileSystem::getAbsolutePath(FileSystem::getProgramPath()));
+    }
     fs::path sanitizedProgramDir = PluginManager::sanitizedPath(programDir);
 
     // I think we need to set the python path before initializing the library


### PR DESCRIPTION
While running EP Launch on 9.6 RC 2 which allows calling via API, an issue was found where EnergyPlus was giving a Python failure.  It looks like the Python library could not be found.  It looks like it is just trying to set Python's home directory to the wrong folder.  A recent fix #8918 allows the API client to set the install directory so that E+ can find things relative to EnergyPlus instead of just the "currently running binary".  As a bonus, with Python, it could use introspection to find the right directory automatically -- client didn't have to do anything.  This fix enabled EnergyPlus to find ExpandObjects, etc., but it seems the plugin manager snuck through still trying to find the "currently running binary".  This fixes that.  If CI comes back happy this can drop right in.  I'll add a relevant test to EPTravisTester as well.