### PR TITLE
Fix Python Prefix Warnings

### DIFF
--- a/src/EnergyPlus/PluginManager.cc
+++ b/src/EnergyPlus/PluginManager.cc
@@ -405,6 +405,9 @@ void PluginManager::setupOutputVariables([[maybe_unused]] EnergyPlusData &state)
 PluginManager::PluginManager(EnergyPlusData &state)
 {
 #if LINK_WITH_PYTHON == 1
+    // this frozen flag tells Python that the package and library have been frozen for embedding, so it shouldn't warn about missing prefixes
+    Py_FrozenFlag = 1;
+
     // we'll need the program directory for a few things so get it once here at the top and sanitize it
     fs::path programDir;
     if (state.dataGlobal->installRootOverride) {


### PR DESCRIPTION
Pull request overview
---------------------

Thought I had it solved a while ago, but [this problem] was still existing.  Basically, Python was doing a heckin concern that it couldn't find its own library files where it expected to find them, as seen in this example:

```
$ ./energyplus --version
EnergyPlus, Version 9.6.0-f420c06a69, YMD=2021.10.11 19:56

$ ./energyplus -D ExampleFiles/PythonPluginCustomOutputVariable.idf 
EnergyPlus Starting
EnergyPlus, Version 9.6.0-f420c06a69, YMD=2021.10.11 19:55
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Initializing Response Factors
Calculating CTFs for "INTERIORFURNISHINGS"
```

Confirmed this on Linux and Mac, not sure about Windows actually.  Anyway, no matter how much I tried to comfort Python to let it know everything was alright, the runtime would emit these warnings.  I was finally able to debug into the Python build itself and found that there is a flag available in CPython that lets you tell Python that it is being frozen, or embedded, so it knows it doesn't need to worry so much.  With this change:

```
$ ./energyplus --version
EnergyPlus, Version 9.6.0-d0838d4dbb, YMD=2021.10.11 19:55

$ ./energyplus -D ExampleFiles/PythonPluginCustomOutputVariable.idf 
EnergyPlus Starting
EnergyPlus, Version 9.6.0-d0838d4dbb, YMD=2021.10.11 19:54
Initializing Response Factors
Calculating CTFs for "INTERIORFURNISHINGS"
```

Ahh yes, that is the stuff.  I created a [release](https://github.com/NREL/EnergyPlus/releases/tag/PythonPrefixTest) of it (it will be deleted) if anyone wants to verify it, there won't be anything different except these messages are gone.