### PR TITLE
Use Github autogenerated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - DoNotPublish
+  categories:
+    - title: New Features 🌟
+      labels:
+        - NewFeature
+    - title: Performance Enhancing Changes 🏁
+      labels:
+        - Performance
+    - title: Defects Repaired 🪲
+      labels:
+        - Defect
+    - title: Under the Hood Refactoring ⚙
+      labels:
+        - Refactoring
+


### PR DESCRIPTION
Pretty sweet recent enhancement from Github allows autogeneration of the release notes.  I made up a quick repo, added the same labels that we have on E+ repo, then whipped up a bunch of rapid PRs with each label.  A quick set of autogenerated release notes looked pretty sweet:

![image](https://user-images.githubusercontent.com/849824/137363891-5a37292b-03b6-46a2-b0c9-9a90f51abae5.png)

This will be yet another eliminated manual step when creating  a release.  I'll still have to put in some boilerplate stuff but I won't have to generate the merged PR list stuff anymore.