### PR TITLE
Fix Rounding of `minutes` Function

### DIFF
--- a/src/EnergyPlus/api/datatransfer.cc
+++ b/src/EnergyPlus/api/datatransfer.cc
@@ -53,7 +53,6 @@
 #include <EnergyPlus/Construction.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataEnvironment.hh>
-#include <EnergyPlus/DataGlobals.hh>
 #include <EnergyPlus/DataHVACGlobals.hh>
 #include <EnergyPlus/DataRuntimeLanguage.hh>
 #include <EnergyPlus/HeatBalFiniteDiffManager.hh>
@@ -742,7 +741,7 @@ int minutes(EnergyPlusState state)
     Real64 currentTimeVal = currentTime(state);
     auto *thisState = reinterpret_cast<EnergyPlus::EnergyPlusData *>(state);
     Real64 fractionalHoursIntoTheDay = currentTimeVal - double(thisState->dataGlobal->HourOfDay - 1);
-    Real64 fractionalMinutesIntoTheDay = fractionalHoursIntoTheDay * 60.0;
+    Real64 fractionalMinutesIntoTheDay = std::round(fractionalHoursIntoTheDay * 60.0);
     return (int)(fractionalMinutesIntoTheDay);
 }
 


### PR DESCRIPTION
Pull request overview
---------------------
- Fixes #9225
- Minutes computed need to be rounded to the nearest value to handle tiny values introduced by the float subtraction operation [here](https://github.com/NREL/EnergyPlus/blob/3d028d8976d1b7104662d53a55fb6d6c4ec9d6c4/src/EnergyPlus/api/datatransfer.cc#L744)
- See the issue for before and after eplusout csv files.

