### PR TITLE
`static inline` nlohmann/json `unescape` function to cleanup warning

### DIFF
--- a/third_party/nlohmann/json.hpp
+++ b/third_party/nlohmann/json.hpp
@@ -2570,7 +2570,7 @@ inline std::string escape(std::string s)
  *
  * Note the order of escaping "~1" to "/" and "~0" to "~" is important.
  */
-static void unescape(std::string& s)
+static inline void unescape(std::string& s)
 {
     replace_substring(s, "~1", "/");
     replace_substring(s, "~0", "~");


### PR DESCRIPTION
Pull request overview
---------------------
 - Cleans up warning introduced in #9246
 
```
warning: 'static' function 'unescape' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration] static void unescape(std::string& s)
```
