### PR TITLE
Fix public linkage of energypluslib to energyplus.exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ add_subdirectory(third_party)
 
 target_include_directories(project_options INTERFACE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(project_options INTERFACE ${PROJECT_SOURCE_DIR}/third_party)
+target_include_directories(project_options INTERFACE ${PROJECT_SOURCE_DIR}/third_party/fmt-8.0.1/include)
 target_include_directories(project_options INTERFACE ${PROJECT_SOURCE_DIR}/third_party/btwxt/src)
 target_include_directories(project_options INTERFACE ${PROJECT_SOURCE_DIR}/third_party/re2)
 target_include_directories(project_options INTERFACE ${PROJECT_SOURCE_DIR}/third_party/doj)

--- a/src/EnergyPlus/CMakeLists.txt
+++ b/src/EnergyPlus/CMakeLists.txt
@@ -841,7 +841,7 @@ else() # windows
   add_library(energyplusapi ${API_LIBRARY_TYPE} CommandLineInterface.hh CommandLineInterface.cc ${API_CORE_SRC}
                             "${CMAKE_CURRENT_BINARY_DIR}/energyplusapi.rc")
 endif()
-target_link_libraries(energyplusapi PUBLIC energypluslib)
+target_link_libraries(energyplusapi PRIVATE energypluslib)
 target_link_libraries(energyplusapi PRIVATE project_options project_fp_options project_warnings)
 
 set_target_properties(energyplusapi PROPERTIES INSTALL_NAME_DIR "@executable_path")

--- a/src/EnergyPlus/Data/EnergyPlusData.cc
+++ b/src/EnergyPlus/Data/EnergyPlusData.cc
@@ -308,6 +308,8 @@ EnergyPlusData::EnergyPlusData()
     this->dataZoneTempPredictorCorrector = std::make_unique<ZoneTempPredictorCorrectorData>();
 }
 
+EnergyPlusData::~EnergyPlusData() = default;
+
 void EnergyPlusData::clear_state()
 {
     this->ready = true;

--- a/src/EnergyPlus/Data/EnergyPlusData.hh
+++ b/src/EnergyPlus/Data/EnergyPlusData.hh
@@ -575,6 +575,7 @@ struct EnergyPlusData : BaseGlobalStruct
     std::unique_ptr<ZoneTempPredictorCorrectorData> dataZoneTempPredictorCorrector;
 
     EnergyPlusData();
+    ~EnergyPlusData();
 
     // Cannot safely copy or delete this until we eradicate all remaining
     // calls to IOFiles::getSingleton and IOFiles::setSingleton

--- a/src/EnergyPlus/api/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/api/EnergyPlusPgm.cc
@@ -219,8 +219,6 @@
 #include <unistd.h>
 #endif
 
-struct EnergyPlus::EnergyPlusData;
-
 int EnergyPlusPgm(int argc, const char *argv[], std::string const &filepath)
 {
     EnergyPlus::EnergyPlusData state;

--- a/src/EnergyPlus/api/EnergyPlusPgm.cc
+++ b/src/EnergyPlus/api/EnergyPlusPgm.cc
@@ -219,8 +219,23 @@
 #include <unistd.h>
 #endif
 
-int EnergyPlusPgm(EnergyPlus::EnergyPlusData &state, std::string const &filepath)
+struct EnergyPlus::EnergyPlusData;
+
+int EnergyPlusPgm(int argc, const char *argv[], std::string const &filepath)
 {
+    EnergyPlus::EnergyPlusData state;
+    //// these need to be set early to be used in help and version output messaging
+    Array1D_int value(8);
+    std::string datestring; // supposedly returns blank when no date available.
+    date_and_time(datestring, _, _, value);
+    if (!datestring.empty()) {
+        state.dataStrGlobals->CurrentDateTime = fmt::format(" YMD={:4}.{:02}.{:02} {:02}:{:02}", value(1), value(2), value(3), value(5), value(6));
+    } else {
+        state.dataStrGlobals->CurrentDateTime = " unknown date/time";
+    }
+    state.dataStrGlobals->VerStringVar = EnergyPlus::DataStringGlobals::VerString + "," + state.dataStrGlobals->CurrentDateTime;
+
+    EnergyPlus::CommandLineInterface::ProcessArgs(state, argc, argv);
     return RunEnergyPlus(state, filepath);
 }
 

--- a/src/EnergyPlus/api/EnergyPlusPgm.hh
+++ b/src/EnergyPlus/api/EnergyPlusPgm.hh
@@ -53,7 +53,9 @@
 // C++ Headers
 #include <string>
 
-namespace EnergyPlus { struct EnergyPlusData; }
+namespace EnergyPlus {
+struct EnergyPlusData;
+}
 
 // Functions
 

--- a/src/EnergyPlus/api/EnergyPlusPgm.hh
+++ b/src/EnergyPlus/api/EnergyPlusPgm.hh
@@ -48,11 +48,12 @@
 #ifndef EnergyPlusPgm_hh_INCLUDED
 #define EnergyPlusPgm_hh_INCLUDED
 
-#include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/api/EnergyPlusAPI.h>
 
 // C++ Headers
 #include <string>
+
+namespace EnergyPlus { struct EnergyPlusData; }
 
 // Functions
 
@@ -62,7 +63,7 @@ int initializeEnergyPlus(EnergyPlus::EnergyPlusData &state, std::string const &f
 
 int wrapUpEnergyPlus(EnergyPlus::EnergyPlusData &state);
 
-int ENERGYPLUSLIB_API EnergyPlusPgm(EnergyPlus::EnergyPlusData &state, std::string const &filepath = std::string());
+int ENERGYPLUSLIB_API EnergyPlusPgm(int argc, const char *argv[], std::string const &filepath = std::string());
 
 int ENERGYPLUSLIB_API RunEnergyPlus(EnergyPlus::EnergyPlusData &state, std::string const &filepath = std::string());
 

--- a/src/EnergyPlus/main.cc
+++ b/src/EnergyPlus/main.cc
@@ -45,29 +45,9 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <EnergyPlus/CommandLineInterface.hh>
-#include <EnergyPlus/Data/CommonIncludes.hh>
-#include <EnergyPlus/Data/EnergyPlusData.hh>
-#include <EnergyPlus/DataStringGlobals.hh>
 #include <EnergyPlus/api/EnergyPlusPgm.hh>
-#include <EnergyPlus/api/state.h>
 
 int main(int argc, const char *argv[])
 {
-    EnergyPlus::EnergyPlusData *state = reinterpret_cast<EnergyPlus::EnergyPlusData *>(stateNew());
-    // these need to be set early to be used in help and version output messaging
-    // this was pulled from EnergyPlusPgm.cc and needs to be removed once the release is done
-    Array1D_int value(8);
-    std::string datestring; // supposedly returns blank when no date available.
-    date_and_time(datestring, _, _, value);
-    if (!datestring.empty()) {
-        state->dataStrGlobals->CurrentDateTime = fmt::format(" YMD={:4}.{:02}.{:02} {:02}:{:02}", value(1), value(2), value(3), value(5), value(6));
-    } else {
-        state->dataStrGlobals->CurrentDateTime = " unknown date/time";
-    }
-    state->dataStrGlobals->VerStringVar = EnergyPlus::DataStringGlobals::VerString + "," + state->dataStrGlobals->CurrentDateTime;
-    EnergyPlus::CommandLineInterface::ProcessArgs(*state, argc, argv);
-    auto ep_ret = EnergyPlusPgm(*state);
-    stateDelete(reinterpret_cast<EnergyPlusState>(state));
-    return ep_ret;
+    return EnergyPlusPgm(argc, argv);
 }

--- a/src/EnergyPlus/test_ep_as_library.cc
+++ b/src/EnergyPlus/test_ep_as_library.cc
@@ -45,9 +45,8 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <EnergyPlus/Data/CommonIncludes.hh>
-#include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/api/EnergyPlusPgm.hh>
+#include <EnergyPlus/api/state.h>
 #include <iostream>
 
 void message_callback_handler(std::string const &message)
@@ -63,16 +62,17 @@ void progress_callback_handler(int const progress)
 int main(int argc, char *argv[])
 {
     std::cout << "Using EnergyPlus as a library." << std::endl;
-    EnergyPlus::EnergyPlusData state;
-    StoreMessageCallback(state, message_callback_handler);
-    StoreProgressCallback(state, progress_callback_handler);
+    EnergyPlus::EnergyPlusData *state {reinterpret_cast<EnergyPlus::EnergyPlusData *>(stateNew())};
+    StoreMessageCallback(*state, message_callback_handler);
+    StoreProgressCallback(*state, progress_callback_handler);
 
     int status(EXIT_FAILURE);
     if (argc < 2) {
         std::cout << "Call this with a path to run EnergyPlus as the only argument" << std::endl;
         return EXIT_FAILURE;
     } else {
-        status = RunEnergyPlus(state, argv[1]);
+        status = RunEnergyPlus(*state, argv[1]);
+        stateDelete(reinterpret_cast<EnergyPlusState>(state));
     }
     if (!std::cin.good()) std::cin.clear();
     if (!std::cerr.good()) std::cerr.clear();

--- a/src/EnergyPlus/test_ep_as_library.cc
+++ b/src/EnergyPlus/test_ep_as_library.cc
@@ -62,7 +62,7 @@ void progress_callback_handler(int const progress)
 int main(int argc, char *argv[])
 {
     std::cout << "Using EnergyPlus as a library." << std::endl;
-    EnergyPlus::EnergyPlusData *state {reinterpret_cast<EnergyPlus::EnergyPlusData *>(stateNew())};
+    EnergyPlus::EnergyPlusData *state{reinterpret_cast<EnergyPlus::EnergyPlusData *>(stateNew())};
     StoreMessageCallback(*state, message_callback_handler);
     StoreProgressCallback(*state, progress_callback_handler);
 

--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -255,13 +255,11 @@ set(test_src
 set(test_dependencies energypluslib)
 
 if(LINK_WITH_PYTHON)
-  # Python integration tests access API functions directly, so energyplusapi must be linked just for this single test.
-  list(APPEND test_dependencies energyplusapi)
   add_definitions("-DLINK_WITH_PYTHON")
   find_package(PythonLibs 3 REQUIRED)
   include_directories(${Python_INCLUDE_DIRS})
   if(CMAKE_HOST_UNIX)
-    list(APPEND test_src api/datatransfer.unit.cc)
+    #list(APPEND test_src api/datatransfer.unit.cc) # Requires API; will be moved
     list(APPEND test_src PluginManager.unit.cc)
     list(APPEND test_dependencies ${Python_LIBRARIES})
   endif()

--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -252,7 +252,7 @@ set(test_src
     ZoneTempPredictorCorrector.unit.cc
     main.cc)
 
-set(test_dependencies energyplusapi)
+set(test_dependencies energypluslib)
 
 if(LINK_WITH_PYTHON)
   add_definitions("-DLINK_WITH_PYTHON")

--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -255,6 +255,8 @@ set(test_src
 set(test_dependencies energypluslib)
 
 if(LINK_WITH_PYTHON)
+  # Python integration tests access API functions directly, so energyplusapi must be linked just for this single test.
+  list(APPEND test_dependencies energyplusapi)
   add_definitions("-DLINK_WITH_PYTHON")
   find_package(PythonLibs 3 REQUIRED)
   include_directories(${Python_INCLUDE_DIRS})


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #9287 
 - Decoupling the static energypluslib from the EP executable guarantees that the same objects may not be created from two different "modules," reducing the risk of internal global variable bifurcation (issue #9091). The application should only access energyplusapi(.dll/.so).

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
