### PR TITLE
Correct Kiva::setMessageCallback std:pair argument

### DIFF
--- a/src/EnergyPlus/HeatBalanceKivaManager.cc
+++ b/src/EnergyPlus/HeatBalanceKivaManager.cc
@@ -1243,8 +1243,8 @@ void KivaManager::calcKivaSurfaceResults(EnergyPlusData &state)
 {
     for (int surfNum = 1; surfNum <= (int)state.dataSurface->Surface.size(); ++surfNum) {
         if (state.dataSurface->Surface(surfNum).ExtBoundCond == DataSurfaces::KivaFoundation) {
-            std::string contextStr = "Surface=\"" + state.dataSurface->Surface(surfNum).Name + "\"";
-            Kiva::setMessageCallback(kivaErrorCallback, &contextStr);
+            std::pair<EnergyPlusData *, std::string> contextPair{&state, "Surface=\"" + state.dataSurface->Surface(surfNum).Name + "\""};
+            Kiva::setMessageCallback(kivaErrorCallback, &contextPair);
             surfaceMap[surfNum].calc_weighted_results();
             state.dataHeatBalSurf->SurfHConvInt(surfNum) = state.dataSurfaceGeometry->kivaManager.surfaceMap[surfNum].results.hconv;
         }

--- a/tst/EnergyPlus/unit/HeatBalanceKivaManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceKivaManager.unit.cc
@@ -804,4 +804,31 @@ TEST_F(EnergyPlusFixture, HeatBalanceKiva_GetAccDate)
     EXPECT_GT(accDate, 0);
 }
 
+TEST_F(EnergyPlusFixture, HeatBalanceKiva_setMessageCallback)
+{
+    // Unit test for Issue #9309
+
+    int SurfNum;
+
+    SurfNum = 1;
+    state->dataSurface->Surface.allocate(1);
+    state->dataSurface->Surface(SurfNum).ExtBoundCond = DataSurfaces::KivaFoundation;
+    state->dataSurface->Surface(SurfNum).Name = "Kiva Floor";
+
+    HeatBalanceKivaManager::KivaManager km;
+
+    EXPECT_THROW(km.calcKivaSurfaceResults(*state), std::runtime_error);
+
+    std::string const error_string = delimited_string({
+        "   ** Severe  ** Surface=\"Kiva Floor\": The weights of associated Kiva instances do not add to unity--check exposed perimeter values.",
+        "   **  Fatal  ** Kiva: Errors discovered, program terminates.",
+        "   ...Summary of Errors that led to program termination:",
+        "   ..... Reference severe error count=1",
+        "   ..... Last severe error=Surface=\"Kiva Floor\": The weights of associated Kiva instances do not add to "
+        "unity--check exposed perimeter values.",
+    });
+
+    EXPECT_TRUE(compare_err_stream(error_string, true));
+}
+
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #9309 
 - This pull request modifies the Kiva::setMessageCallback function argument which requires a std::pair consisting of the `state `pointer and std:string instead of just a std:string that is currently being passed in.  This is the only location a std::pair needs to be passed in.  A unit test was also created to confirm the Kiva messaging is working correctly.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 
### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
