### PR TITLE
Correct Window5 Data File window name if it contains spaces

### DIFF
--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -6902,7 +6902,7 @@ namespace HeatBalanceManager {
         }
 
         // Get window name and check for match
-        readItem(DataLine(4).substr(19), W5Name);
+        W5Name = std::string{DataLine(4).substr(19)};
         WindowNameInW5DataFile = UtilityRoutines::MakeUPPERCase(W5Name);
         if (DesiredConstructionName != WindowNameInW5DataFile) {
             // Doesn't match; read through file until next window entry is found

--- a/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
@@ -51,6 +51,7 @@
 #include <gtest/gtest.h>
 
 // EnergyPlus Headers
+#include <EnergyPlus/ConfiguredFunctions.hh>
 #include <EnergyPlus/Construction.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataAirLoop.hh>
@@ -2293,4 +2294,20 @@ TEST_F(EnergyPlusFixture, HeatBalanceManager_GetSpaceData)
     EXPECT_TRUE(state->dataHeatBal->space(spaceNum).tags.empty());
 }
 
+TEST_F(EnergyPlusFixture, Window5DataFileSpaceInName)
+{
+
+    fs::path window5DataFilePath;
+    window5DataFilePath = configured_source_directory() / "tst/EnergyPlus/unit/Resources/Window5DataFile_NameWithSpace.dat";
+    std::string ConstructName{"DOUBLE CLEAR"};
+    bool ConstructionFound{false};
+    bool EOFonW5File{false};
+    bool ErrorsFound{false};
+    state->dataHeatBal->MaxSolidWinLayers = 2;
+
+    SearchWindow5DataFile(*state, window5DataFilePath, ConstructName, ConstructionFound, EOFonW5File, ErrorsFound);
+
+    EXPECT_EQ(ConstructName, "DOUBLE CLEAR");
+    EXPECT_TRUE(ConstructionFound);
+}
 } // namespace EnergyPlus

--- a/tst/EnergyPlus/unit/Resources/Window5DataFile_NameWithSpace.dat
+++ b/tst/EnergyPlus/unit/Resources/Window5DataFile_NameWithSpace.dat
@@ -1,0 +1,39 @@
+Window5 Data File for EnergyPlus
+W5 Final PreRelease v0.64
+Date             : Tue Sep 25 14:54:50 2001
+Window name      : Double Clear
+Description      : Horizontal Slider, custom
+# Glazing Systems: 1
+GLAZING SYSTEM DATA: Height Width nPanes Uval-center SC-center SHGC-center Tvis-center
+ System1         :   1386   514      2      2.764      0.892      0.774       0.824
+FRAME/MULLION DATA: Width OutsideProj InsideProj Cond EdgeCondRatio SolAbs VisAbs Emiss  Orient'n (mull)
+    L Sill       :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+    R Sill       :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+    L Head       :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+    R Head       :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+    Top L Jamb   :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+    Bot L Jamb   :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+    Top R Jamb   :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+    Bot R Jamb   :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+    Mullion      :   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90 Vertical
+    Average frame:   57.2     25.4       25.4   56.424    1.458      0.900  0.900  0.90
+DIVIDER DATA     : Width OutsideProj InsideProj Cond EdgeCondRatio SolAbs VisAbs Emiss Type            #Hor #Vert
+ System1         :  16.0      0.0       0.0   24.000      1.916     0.300  0.300 0.900 Suspended         1    4
+GLASS DATA       : Layer#  Thickness  Cond Tsol Rfsol Rbsol Tvis Rfvis Rbvis  Tir  EmissF  EmissB  SpectralDataFile
+ System1         :   1      2.97     0.900 0.85  0.08  0.08 0.90  0.08  0.08 0.00   0.84    0.84   CLR-3.CIG
+                     2      2.97     0.900 0.85  0.08  0.08 0.90  0.08  0.08 0.00   0.84    0.84   CLR-3.CIG
+GAP DATA         : Gap# Thick nGasses
+ System1         :   1  12.70    1
+GAS DATA         : GasName       Fraction MolWeight    ACond    BCond    CCond    AVisc    BVisc    CVisc  ASpHeat  BSpHeat  CSpHeat
+ System1 Gap1    : Air             1.0000     28.97 0.002301 0.000080 0.000000 0.003516 0.000050 0.000000 1.001760 0.000015 0.000000
+GLAZING SYSTEM OPTICAL DATA:
+Angle     0    10    20    30    40    50    60    70    80    90 Hemis
+System1
+Tsol  0.727 0.726 0.723 0.717 0.703 0.671 0.601 0.458 0.220 0.000 0.624
+Abs1  0.081 0.081 0.083 0.085 0.089 0.094 0.100 0.108 0.111 0.000 0.092
+Abs2  0.062 0.062 0.063 0.064 0.066 0.067 0.066 0.060 0.044 0.000 0.063
+Rfsol 0.131 0.131 0.131 0.134 0.143 0.168 0.233 0.374 0.625 1.000 0.211
+Rbsol 0.131 0.131 0.131 0.134 0.143 0.168 0.233 0.374 0.625 1.000 0.211
+Tvis  0.824 0.823 0.822 0.818 0.807 0.776 0.703 0.545 0.278 0.000 0.721
+Rfvis 0.150 0.150 0.150 0.154 0.164 0.193 0.265 0.422 0.688 1.000 0.239
+Rbvis 0.150 0.150 0.150 0.154 0.164 0.193 0.265 0.422 0.688 1.000 0.239


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #9318 
 - This pull request modifies the line of code getting the window name in the Window5 data file so it reads the name correctly if there is a space in the name.  The `readItem `function is utilized for the GLAZING SYSTEM OPTICAL DATA table and looking up values separated by spaces.  This function doesn't apply to the Window Name as it is a single input.  It also adds a unit test for the `SearchWindow5DataFile `function to ensure it finds the correct window name that includes a space.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions

### Reviewer
This will not be exhaustively relevant to every PR.
 - [x] Perform a Code Review on GitHub
 - [x] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [x] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
 - [x] Check that performance is not impacted (CI Linux results include performance check)
 - [x] Run Unit Test(s) locally
