### PR TITLE
Add warning for Kiva deep-ground boundary condition and deep-ground depth for auto

### DIFF
--- a/doc/input-output-reference/src/overview/group-advanced-surface-concepts.tex
+++ b/doc/input-output-reference/src/overview/group-advanced-surface-concepts.tex
@@ -1060,10 +1060,10 @@ Williamson, 1989):
 
 \[d_{wt}=0.1022\cdot d_{elev}\]
 
-If \(d_{wt} \le\) 40 m., the GroundWater boundary is applied, otherwise
+If \(d_{wt} \le\) 40 m., the GroundWater boundary is applied at this depth, otherwise
 a ZeroFlux boundary is applied at 40 m. If the calculated ground water depth is
-shallower than any element of the foundation construction, then the GroundWater
-is applied at 1 m below the lowest element.
+shallower than any element of a foundation construction, then the GroundWater
+is applied at 1 m below the lowest element for that foundation.
 
 Default: Autoselect.
 
@@ -1073,8 +1073,13 @@ The distance from the exterior grade to the deep ground boundary, in m.
 This distance represents either the distance to the ground water level,
 or a distance adequately far from the foundation such that it is
 isolated from the effects of the boundary (typically \textgreater{}= 40
-m). Default 40 m, or the distance determined by the ``Auto'' Deep-Ground
-Boundary Condition.
+m). Default 40 m, or the distance determined by the ``Autoselect'' Deep-Ground
+Boundary Condition. If the Deep-Ground Boundary Condition is set to ``Autoselect'', this field
+should be set to ``Autocalculate''. If the Deep-Ground Boundary Condition is not set
+to ``Autoselect'', but this field is set to ``Autocalculate'' (or allowed to default), an error
+will be issued.
+
+Default: Autocalculate.
 
 \paragraph{Field: Minimum Cell Dimension}\label{foundation-kiva-settings-minimum-cell-dimension}
 

--- a/src/EnergyPlus/HeatBalanceKivaManager.cc
+++ b/src/EnergyPlus/HeatBalanceKivaManager.cc
@@ -1267,6 +1267,7 @@ void KivaManager::defineDefaultFoundation(EnergyPlusData &state)
     Real64 waterTableDepth = 0.1022 * state.dataEnvrn->Elevation;
 
     if (settings.deepGroundBoundary == Settings::AUTO) {
+        // TODO: if depth is set to a number, AUTO is setting defFnd.deepGroundDepth
         if (waterTableDepth <= 40.) {
             defFnd.deepGroundDepth = waterTableDepth;
             defFnd.deepGroundBoundary = Kiva::Foundation::DGB_FIXED_TEMPERATURE;

--- a/src/EnergyPlus/HeatBalanceKivaManager.hh
+++ b/src/EnergyPlus/HeatBalanceKivaManager.hh
@@ -185,6 +185,7 @@ namespace HeatBalanceKivaManager {
 
             DGType deepGroundBoundary;
             Real64 deepGroundDepth;
+            bool autocalculateDeepGroundDepth;
             Real64 minCellDim;
             Real64 maxGrowthCoeff;
 
@@ -206,7 +207,7 @@ namespace HeatBalanceKivaManager {
         };
 
         Settings settings;
-        bool defaultSet;
+        bool defaultAdded;
         int defaultIndex;
     };
 

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -10745,6 +10745,12 @@ namespace SurfaceGeometry {
 
             if (state.dataIPShortCut->lNumericFieldBlanks(numF) || state.dataIPShortCut->rNumericArgs(numF) == DataGlobalConstants::AutoCalculate) {
                 state.dataSurfaceGeometry->kivaManager.settings.deepGroundDepth = 40.0;
+                if (state.dataSurfaceGeometry->kivaManager.settings.deepGroundBoundary != HeatBalanceKivaManager::KivaManager::Settings::AUTO) {
+                    ShowWarningMessage(state,
+                                       "Foundation:Kiva:Settings, " + state.dataIPShortCut->cNumericFieldNames(numF) +
+                                           " should not be set to the default or Autocalculate unless " + state.dataIPShortCut->cAlphaArgs(alpF - 1) +
+                                           " is set to Autoselect");
+                }
             } else {
                 state.dataSurfaceGeometry->kivaManager.settings.deepGroundDepth = state.dataIPShortCut->rNumericArgs(numF);
             }

--- a/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
+++ b/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
@@ -8577,7 +8577,8 @@ TEST_F(EnergyPlusFixture, SurfaceGeometry_GetKivaFoundationTest)
 
     GetFoundationData(*state, ErrorsFound);
     std::string const error_string = delimited_string({
-    "   ** Warning ** Foundation:Kiva:Settings, Deep-Ground Depth should not be set to the default or Autocalculate unless ZEROFLUX is set to Autoselect",
-        });
+        "   ** Warning ** Foundation:Kiva:Settings, Deep-Ground Depth should not be set to the default or Autocalculate unless ZEROFLUX is set to "
+        "Autoselect",
+    });
     EXPECT_TRUE(compare_err_stream(error_string, true));
 }

--- a/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
+++ b/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
@@ -54,6 +54,7 @@
 #include "Fixtures/EnergyPlusFixture.hh"
 #include <EnergyPlus/Construction.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
+#include <EnergyPlus/DataEnvironment.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
 #include <EnergyPlus/DataSurfaces.hh>
 #include <EnergyPlus/DataViewFactorInformation.hh>
@@ -8577,8 +8578,38 @@ TEST_F(EnergyPlusFixture, SurfaceGeometry_GetKivaFoundationTest)
 
     GetFoundationData(*state, ErrorsFound);
     std::string const error_string = delimited_string({
-        "   ** Warning ** Foundation:Kiva:Settings, Deep-Ground Depth should not be set to the default or Autocalculate unless ZEROFLUX is set to "
-        "Autoselect",
+        "   ** Severe  ** Foundation:Kiva:Settings, Deep-Ground Depth should not be set to Autocalculate unless Deep-Ground Boundary Condition is "
+        "set to Autoselect",
     });
+    EXPECT_TRUE(compare_err_stream(error_string, true));
+}
+
+TEST_F(EnergyPlusFixture, SurfaceGeometry_GetKivaFoundationTest2)
+{
+    bool ErrorsFound(false);
+
+    std::string const idf_objects = delimited_string({
+        "Foundation:Kiva:Settings,",
+        "  1.8,                     !- Soil Conductivity {W / m - K}",
+        "  3200,                    !- Soil Density {kg / m3}",
+        "  836,                     !- Soil Specific Heat {J / kg - K}",
+        "  0.9,                     !- Ground Solar Absorptivity {dimensionless}",
+        "  0.9,                     !- Ground Thermal Absorptivity {dimensionless}",
+        "  0.03,                    !- Ground Surface Roughness {m}",
+        "  40,                      !- Far-Field Width {m}",
+        "  Autoselect,              !- Deep-Ground Boundary Condition",
+        "  20;                      !- Deep-Ground Depth",
+
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+
+    state->dataEnvrn->Elevation = 600.;
+
+    GetFoundationData(*state, ErrorsFound);
+    std::string const error_string =
+        delimited_string({"   ** Warning ** Foundation:Kiva:Settings, when Deep-Ground Boundary Condition is Autoselect,\n"
+                          "   **   ~~~   ** the user-specified Deep-Ground Depth (20.0 m)\n"
+                          "   **   ~~~   ** will be overridden with the Autoselected depth (40.0 m)"});
     EXPECT_TRUE(compare_err_stream(error_string, true));
 }

--- a/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
+++ b/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
@@ -8554,3 +8554,30 @@ TEST_F(EnergyPlusFixture, Use_Gross_Roof_Area_for_Averge_Height_with_Window)
     EXPECT_NEAR(state->dataHeatBal->Zone(1).CeilingHeight, ceilingHeight_expected, 1e-6);
     EXPECT_NE(state->dataHeatBal->Zone(1).CeilingHeight, ceilingHeight_old);
 }
+
+TEST_F(EnergyPlusFixture, SurfaceGeometry_GetKivaFoundationTest)
+{
+    bool ErrorsFound(false);
+
+    std::string const idf_objects = delimited_string({
+        "Foundation:Kiva:Settings,",
+        "  1.8,                     !- Soil Conductivity {W / m - K}",
+        "  3200,                    !- Soil Density {kg / m3}",
+        "  836,                     !- Soil Specific Heat {J / kg - K}",
+        "  0.9,                     !- Ground Solar Absorptivity {dimensionless}",
+        "  0.9,                     !- Ground Thermal Absorptivity {dimensionless}",
+        "  0.03,                    !- Ground Surface Roughness {m}",
+        "  40,                      !- Far - Field Width {m}",
+        "  ZeroFlux,                !- Deep - Ground Boundary Condition",
+        "  AutoCalculate;           !- Deep - Ground Depth",
+
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+
+    GetFoundationData(*state, ErrorsFound);
+    std::string const error_string = delimited_string({
+    "   ** Warning ** Foundation:Kiva:Settings, Deep-Ground Depth should not be set to the default or Autocalculate unless ZEROFLUX is set to Autoselect",
+        });
+    EXPECT_TRUE(compare_err_stream(error_string, true));
+}


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #7200 
 - This pull request adds an error if the user of Foundation:Kiva:Settings if the deep-ground depth is set to Autocalculate but the deep-ground boundary condition is not set to Autoselect. This condition can lead to inaccurate calculations for the Kiva foundation. 
 - Also adds a warning if the deep-ground boundary condition is set to Autoselect, the deep-ground depth input is overridden based on the boundary condition selected.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport

### Reviewer
This will not be exhaustively relevant to every PR.
 - [x] Perform a Code Review on GitHub
 - [x] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [x] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [x] Run Unit Test(s) locally
