### PR TITLE
Use epin variable properly for EPLaunch

### DIFF
--- a/release/readme.html
+++ b/release/readme.html
@@ -200,8 +200,8 @@
         version (including .rvi and .mvi files) to the current version. The install also includes the necessary programs
         to convert from older versions back to v7.2.0. For versions older than v7.2.0, first we applaud your dedication
         to EnergyPlus that stretches for quite some time, and second you will need to visit the
-        helpdesk (<a href="https://energyplushelp.freshdesk.com/">energyplushelp.freshdesk.com</a>) to request multiple
-        conversion set of programs.
+        <a href="https://energyplushelp.freshdesk.com/support/solutions/folders/67000241428">Helpdesk</a> to request
+        multiple conversion set of programs.
     </p>
 
     <h2><a id="Documentation_55"></a>Documentation</h2>
@@ -230,7 +230,7 @@
         EnergyPlus uses these files directly for annual simulations. The Weather Converter program that is part of
         EnergyPlus can read these weather files and provide .csv (comma separated variable) as well as statistics
         reports
-        about the included (or other) files. Weather data for more than 2100 locations in more than 100 countries can be
+        about the included (or other) files. Weather data for more than 3000 locations in more than 100 countries can be
         downloaded on the <a href="https://energyplus.net/weather">EnergyPlus Weather Page</a>.</p>
 
     <h2>Highlights of this release (V22.1.0)</h2>
@@ -386,13 +386,13 @@
         Packages changed slightly as of the 9.4 release.
         We began building our packages on a new system which adds better support
         for newer platforms. During the change, we stepped away from some older OS versions. For example, we are
-        not testing on Windows 7 or 8, only 10. However, both our 32-bit and 64-bit packages now include the new
+        not testing on Windows 7 or 8, only 10 and 11. However, both our 32-bit and 64-bit packages now include the new
         Python plugin system, rather than just the 64-bit as previously. We have also added packaging and testing
         with Ubuntu 20.04 <i>in addition to</i> Ubuntu 18.04. On Mac, we are officially releasing an installer for
         OSX 10.15 and moving toward OSX 11 as well.
     </p>
     <ul class="list-group">
-        <li class="list-group-item">Windows 10</li>
+        <li class="list-group-item">Windows 10 and 11</li>
         <li class="list-group-item">Linux (Ubuntu 18.04 and 20.04) 64 bit versions</li>
         <li class="list-group-item">Mac OSX 10.15 64 bit versions</li>
         <li class="list-group-item">EnergyPlus V22.1 has been tested on all of these platforms</li>
@@ -413,7 +413,7 @@
         known (and even more unknown) probably remain. Specifics on the remaining known problems can be found on the
         GitHub repository <a href="https://github.com/NREL/EnergyPlus/issues">issues page</a>. If you are interested in
         what has been addressed, the issues resolved in this release are installed similarly in the
-        <a href="changelog.html">changelog</a>.
+        <a href="https://github.com/NREL/EnergyPlus/releases/latest">release details</a>.
     </p>
 
     <h2>Additional steps you may want to consider:</h2>


### PR DESCRIPTION
Pull request overview
---------------------
Essentially a follow-up to #8985 

When EPLaunch sets the `epin` environment variable, it sets it to the IDF dir plus the file name.  In the case of importing files, it needs to go back to the original dir, so I had to search the parent directory.  This tweak was already made for Schedule:File, but I could not directly leverage that same function, because it does a lot of extra searching that could conflict with the Python-specific searching.  

Also, if the user does not have a SearchPaths object in their IDF, it was not searching the default locations, so I modified that as well.

At this point, EPLaunch appears to be running Python files perfectly fine.

@mjwitte @JasonGlazer could you confirm?