### PR TITLE
Fix #9353 - Kiva build error on mac with clang >= 13

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -75,11 +75,15 @@ elseif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" O
   target_compile_options(project_warnings INTERFACE -Wno-delete-non-virtual-dtor)
   target_compile_options(project_warnings INTERFACE -Wno-missing-braces)
   if(CMAKE_COMPILER_IS_GNUCXX) # g++
-    target_compile_options(project_warnings INTERFACE -Wno-unused-but-set-parameter -Wno-unused-but-set-variable)
     # Suppress unused-but-set warnings until more serious ones are addressed
+    target_compile_options(project_warnings INTERFACE -Wno-unused-but-set-parameter -Wno-unused-but-set-variable)
     target_compile_options(project_warnings INTERFACE -Wno-maybe-uninitialized)
     target_compile_options(project_warnings INTERFACE -Wno-aggressive-loop-optimizations)
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+      # Suppress unused-but-set warnings until more serious ones are addressed
+      target_compile_options(project_warnings INTERFACE -Wno-unused-but-set-parameter -Wno-unused-but-set-variable)
+    endif()
     target_compile_options(project_warnings INTERFACE -Wno-vexing-parse)
     target_compile_options(project_warnings INTERFACE -Wno-invalid-source-encoding)
   endif()

--- a/third_party/kiva-ep/src/libkiva/Ground.cpp
+++ b/third_party/kiva-ep/src/libkiva/Ground.cpp
@@ -327,7 +327,8 @@ void Ground::calculateSurfaceAverages() {
     }
 
     double totalQ = 0.0;
-    double totalQc = 0.0, totalQr = 0.0;
+    double totalQc = 0.0;
+    // double totalQr = 0.0;
     double TA = 0;
     double hA = 0.0, hcA = 0.0, hrA = 0.0;
     double totalArea = 0.0;
@@ -368,7 +369,7 @@ void Ground::calculateSurfaceAverages() {
             hA += Ahc + Ahr;
 
             totalQc += Qc;
-            totalQr += Qr;
+            // totalQr += Qr;
             totalQ += Qc + Qr + q * A;
 
             TA += TNew[index] * A;

--- a/third_party/kiva-ep/src/libkiva/Ground.hpp
+++ b/third_party/kiva-ep/src/libkiva/Ground.hpp
@@ -26,6 +26,7 @@
 #pragma clang diagnostic push
 #if __clang_major__ >= 13
 #pragma clang diagnostic ignored "-Wdeprecated-copy"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 #elif defined(__GNUC__) && defined(__linux__)
 #pragma GCC diagnostic push


### PR DESCRIPTION
Pull request overview
---------------------
 - Fix #9353 
 - Kiva build error on mac with clang >= 13
      * This is a new diagnostic flag in clang 13: `-Wunused-but-set-variable`: https://clang.llvm.org/docs/DiagnosticsReference.html#wunused-but-set-parameter
      * There is no such flag in version 12 of clang:
https://releases.llvm.org/12.0.0/tools/clang/docs/DiagnosticsReference.html
 - Silence unused-but-set warnings on clang 13 (those are NEW in clang 13)


--- 

**Note: I have xcode 13.3 (bleeding edge)**. Xcode 13.3 requires a Mac running macOS Monterey 12 or later.
Xcode 13.0 does not have the same problem, hence why @nealkruis wasn't getting these, neither was CI, and why I wasn't either until I upgraded last night.

```
c++ --version
Apple clang version 13.1.6 (clang-1316.0.21.2)
Target: arm64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
