### PR TITLE
Support External Linkage with Constexprs in Visual Studio

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -23,6 +23,8 @@ if(MSVC AND NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")) # Visual C++ (VS 
   target_compile_options(project_options INTERFACE /nologo)
   target_compile_options(project_options INTERFACE /EHsc)
   target_compile_options(project_options INTERFACE /MP) # Enables multi-processor compilation of source within a single project
+  target_compile_options(project_options INTERFACE /Zc:externConstexpr)  # allows constexpr to be extern'd in headers, which is part of the standard, and supported by default on non-vs compilers
+
   # string(REGEX REPLACE "/W3" "/W1" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}"
   # )# Increase to /W2 then /W3 as more serious warnings are addressed (using regex to avoid VC override warnings)
 

--- a/src/EnergyPlus/Boilers.cc
+++ b/src/EnergyPlus/Boilers.cc
@@ -93,8 +93,6 @@ namespace EnergyPlus::Boilers {
 // METHODOLOGY EMPLOYED:
 // The BLAST/DOE-2 empirical model based on mfg. data
 
-    constexpr std::array<int, 3> a = {1, 2, 3};
-
 PlantComponent *BoilerSpecs::factory(EnergyPlusData &state, std::string const &objectName)
 {
     // Process the input data for boilers if it hasn't been done already

--- a/src/EnergyPlus/Boilers.cc
+++ b/src/EnergyPlus/Boilers.cc
@@ -93,6 +93,8 @@ namespace EnergyPlus::Boilers {
 // METHODOLOGY EMPLOYED:
 // The BLAST/DOE-2 empirical model based on mfg. data
 
+    constexpr std::array<int, 3> a = {1, 2, 3};
+
 PlantComponent *BoilerSpecs::factory(EnergyPlusData &state, std::string const &objectName)
 {
     // Process the input data for boilers if it hasn't been done already

--- a/src/EnergyPlus/Boilers.hh
+++ b/src/EnergyPlus/Boilers.hh
@@ -48,6 +48,8 @@
 #ifndef Boilers_hh_INCLUDED
 #define Boilers_hh_INCLUDED
 
+#include <array>
+
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array1D.hh>
 
@@ -67,6 +69,8 @@ struct EnergyPlusData;
 
 namespace Boilers {
 
+    extern const std::array<int, 3> a;
+        
     // water temperature evaluation method
     enum class TempMode
     {

--- a/src/EnergyPlus/Boilers.hh
+++ b/src/EnergyPlus/Boilers.hh
@@ -69,8 +69,6 @@ struct EnergyPlusData;
 
 namespace Boilers {
 
-    extern const std::array<int, 3> a;
-        
     // water temperature evaluation method
     enum class TempMode
     {


### PR DESCRIPTION
Visual Studio won't allow external linkage for constexpr variables like the standard says and like the other compilers allow.  The [`/Zc:externConstexpr` compiler flag "tells the compiler to conform to the C++ standard"](https://docs.microsoft.com/en-us/cpp/build/reference/zc-externconstexpr?view=msvc-170).  

The actual change in this PR is the one compiler flag addition.  In order to demonstrate that it works, I declared an `extern const` array in the boiler header, and then defined it as `constexpr` in the cc file.  If you take out this compiler flag, and regenerate the project, and compile the boiler cc file, it will fail.  With this compiler flag in place, it will compile just like it does in the other compilers.  I will take out this demonstration but wanted to give it a little context.