### PR TITLE
Expose EPVector resize method, change allocation handling

### DIFF
--- a/src/EnergyPlus/AirflowNetwork/include/AirflowNetwork/Solver.hpp
+++ b/src/EnergyPlus/AirflowNetwork/include/AirflowNetwork/Solver.hpp
@@ -433,7 +433,7 @@ namespace AirflowNetwork {
         Array1D<AirflowNetwork::AirflowNetworkCompProp> AirflowNetworkCompData;
         Array1D<AirflowNetwork::AirflowNetworkLinkageProp> AirflowNetworkLinkageData;
         Array1D<AirflowNetwork::MultizoneZoneProp> MultizoneZoneData;
-        Array1D<AirflowNetwork::MultizoneSurfaceProp> MultizoneSurfaceData;
+        EPVector<AirflowNetwork::MultizoneSurfaceProp> MultizoneSurfaceData;
         Array1D<AirflowNetwork::DetailedOpening> MultizoneCompDetOpeningData;
         Array1D<AirflowNetwork::SimpleOpening> MultizoneCompSimpleOpeningData;
         Array1D<AirflowNetwork::HorizontalOpening> MultizoneCompHorOpeningData;
@@ -441,7 +441,7 @@ namespace AirflowNetwork {
         Array1D<AirflowNetwork::EffectiveLeakageArea> MultizoneSurfaceELAData;
         Array1D<AirflowNetwork::SpecifiedMassFlow> SpecifiedMassFlowData;
         Array1D<AirflowNetwork::SpecifiedVolumeFlow> SpecifiedVolumeFlowData;
-        Array1D<AirflowNetwork::MultizoneExternalNodeProp> MultizoneExternalNodeData;
+        EPVector<AirflowNetwork::MultizoneExternalNodeProp> MultizoneExternalNodeData;
         Array1D<AirflowNetwork::DeltaCpProp> DeltaCp;
         Array1D<AirflowNetwork::DeltaCpProp> EPDeltaCP;
         Array1D<AirflowNetwork::ZoneExhaustFan> MultizoneCompExhaustFanData;

--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -2760,7 +2760,7 @@ namespace AirflowNetwork {
                     }
                     AirflowNetworkNumOfOutAirNode -= 1;
                     AirflowNetworkNumOfExtNode -= 1;
-                    MultizoneExternalNodeData.redimension(AirflowNetworkNumOfExtNode);
+                    MultizoneExternalNodeData.resize(AirflowNetworkNumOfExtNode);
                 }
             }
         }

--- a/src/EnergyPlus/CMakeLists.txt
+++ b/src/EnergyPlus/CMakeLists.txt
@@ -241,6 +241,7 @@ set(SRC
     DualDuct.hh
     EMSManager.cc
     EMSManager.hh
+    EPVector.hh
     EarthTube.cc
     EarthTube.hh
     EcoRoofManager.cc

--- a/src/EnergyPlus/EPVector.hh
+++ b/src/EnergyPlus/EPVector.hh
@@ -99,20 +99,18 @@ template <typename T> struct EPVector : private std::vector<T>
 
     void allocate(std::size_t size)
     {
-        m_allocated = true;
         this->resize(size);
         std::fill(begin(), end(), T{});
     }
 
     void deallocate() noexcept
     {
-        m_allocated = false;
         this->clear();
     }
 
     [[nodiscard]] bool allocated() const noexcept
     {
-        return m_allocated || !this->empty();
+        return !this->empty();
     }
 
     // operator= used for initialization of the vector
@@ -134,8 +132,6 @@ template <typename T> struct EPVector : private std::vector<T>
         return static_cast<int>(this->size());
     }
 
-private:
-    bool m_allocated{false};
 };
 
 template <> struct EPVector<bool> : private std::vector<std::uint8_t>
@@ -192,19 +188,17 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
 
     [[nodiscard]] bool allocated() const noexcept
     {
-        return m_allocated || !this->empty();
+        return !this->empty();
     }
 
     void allocate(std::size_t size)
     {
-        m_allocated = true;
         this->resize(size);
         std::fill(begin(), end(), false);
     }
 
     void deallocate() noexcept
     {
-        m_allocated = false;
         this->clear();
     }
 
@@ -227,8 +221,6 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
         return static_cast<int>(this->size());
     }
 
-private:
-    bool m_allocated{false};
 };
 
 template <typename T>[[nodiscard]] bool allocated(EPVector<T> const &v) noexcept
@@ -328,18 +320,6 @@ template <typename T>[[nodiscard]] T maxval(EPVector<T> const &a)
         return std::numeric_limits<T>::lowest();
     }
     return *max;
-}
-
-template <typename T> void clear_and_resize(EPVector<T> &a, size_t size)
-{
-    a.clear();
-    a.resize(size);
-}
-
-template <typename T> void clear_and_resize(EPVector<T> &a, size_t size, const T &v)
-{
-    a.clear();
-    a.resize(size, v);
 }
 
 } // namespace EnergyPlus

--- a/src/EnergyPlus/EPVector.hh
+++ b/src/EnergyPlus/EPVector.hh
@@ -221,12 +221,12 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
     }
 };
 
-template <typename T> [[nodiscard]] bool allocated(EPVector<T> const &v) noexcept
+template <typename T>[[nodiscard]] bool allocated(EPVector<T> const &v) noexcept
 {
     return v.allocated();
 }
 
-template <typename T> [[nodiscard]] auto isize(const EPVector<T> &v) noexcept
+template <typename T>[[nodiscard]] auto isize(const EPVector<T> &v) noexcept
 {
     return v.isize();
 }
@@ -258,7 +258,7 @@ template <typename T> [[nodiscard]] auto isize(const EPVector<T> &v) noexcept
     return c;
 }
 
-template <typename T> [[nodiscard]] EPVector<T> pack(EPVector<T> const &v, EPVector<bool> const &mask)
+template <typename T>[[nodiscard]] EPVector<T> pack(EPVector<T> const &v, EPVector<bool> const &mask)
 {
     EPVector<T> r;
     r.reserve(mask.size());
@@ -270,7 +270,7 @@ template <typename T> [[nodiscard]] EPVector<T> pack(EPVector<T> const &v, EPVec
     return r;
 }
 
-template <typename T> [[nodiscard]] Array1D<T> pack(Array1<T> const &a, EPVector<bool> const &mask)
+template <typename T>[[nodiscard]] Array1D<T> pack(Array1<T> const &a, EPVector<bool> const &mask)
 {
     Array1D<T> r;
     r.reserve(mask.size());
@@ -282,17 +282,17 @@ template <typename T> [[nodiscard]] Array1D<T> pack(Array1<T> const &a, EPVector
     return r;
 }
 
-template <typename T> [[nodiscard]] T magnitude_squared(const EPVector<T> &v)
+template <typename T>[[nodiscard]] T magnitude_squared(const EPVector<T> &v)
 {
     return std::inner_product(v.begin(), v.end(), v.begin(), T{});
 }
 
-template <typename T, typename V> [[nodiscard]] T dot(const EPVector<T> &u, const V &v)
+template <typename T, typename V>[[nodiscard]] T dot(const EPVector<T> &u, const V &v)
 {
     return std::inner_product(u.begin(), u.end(), v.begin(), T{});
 }
 
-template <typename Element, typename Member> [[nodiscard]] Member maxval(EPVector<Element> const &a, Member Element::*pmem)
+template <typename Element, typename Member>[[nodiscard]] Member maxval(EPVector<Element> const &a, Member Element::*pmem)
 {
     Member v(a.empty() ? std::numeric_limits<Member>::lowest() : a(1).*pmem);
     for (int i = 2, e = a.isize(); i <= e; ++i) {
@@ -311,7 +311,7 @@ template <typename Element, typename Member> inline Member sum(EPVector<Element>
     return s;
 }
 
-template <typename T> [[nodiscard]] T maxval(EPVector<T> const &a)
+template <typename T>[[nodiscard]] T maxval(EPVector<T> const &a)
 {
     auto max = std::max_element(a.begin(), a.end());
     if (max == a.end()) {

--- a/src/EnergyPlus/EPVector.hh
+++ b/src/EnergyPlus/EPVector.hh
@@ -69,6 +69,7 @@ template <typename T> struct EPVector : private std::vector<T>
     using std::vector<T>::clear;
     using std::vector<T>::emplace_back;
     using std::vector<T>::push_back;
+    using std::vector<T>::resize;
     using const_iterator = typename std::vector<T>::const_iterator;
 
     using value_type = T;
@@ -151,6 +152,7 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
     using std::vector<std::uint8_t>::clear;
     using std::vector<std::uint8_t>::emplace_back;
     using std::vector<std::uint8_t>::push_back;
+    using std::vector<std::uint8_t>::resize;
     using const_iterator = typename std::vector<std::uint8_t>::const_iterator;
 
     using value_type = std::uint8_t;
@@ -326,6 +328,18 @@ template <typename T>[[nodiscard]] T maxval(EPVector<T> const &a)
         return std::numeric_limits<T>::lowest();
     }
     return *max;
+}
+
+template <typename T> void clear_and_resize(EPVector<T> &a, size_t size)
+{
+    a.clear();
+    a.resize(size);
+}
+
+template <typename T> void clear_and_resize(EPVector<T> &a, size_t size, const T &v)
+{
+    a.clear();
+    a.resize(size, v);
 }
 
 } // namespace EnergyPlus

--- a/src/EnergyPlus/EPVector.hh
+++ b/src/EnergyPlus/EPVector.hh
@@ -66,51 +66,69 @@ template <typename T> struct EPVector : private std::vector<T>
     using std::vector<T>::end;
     using std::vector<T>::cbegin;
     using std::vector<T>::cend;
-    using std::vector<T>::clear;
     using std::vector<T>::emplace_back;
     using std::vector<T>::push_back;
-    using std::vector<T>::resize;
     using const_iterator = typename std::vector<T>::const_iterator;
 
     using value_type = T;
     using size_type = typename std::vector<T>::size_type;
 
 #ifndef NDEBUG
-    [[nodiscard]] T &operator[](std::size_t n)
+    [[nodiscard]] T &operator[](size_type n)
     {
         return std::vector<T>::at(n);
     }
 
-    [[nodiscard]] const T &operator[](std::size_t n) const
+    [[nodiscard]] const T &operator[](size_type n) const
     {
         return std::vector<T>::at(n);
     }
 #endif
 
-    [[nodiscard]] T &operator()(std::size_t n)
+    [[nodiscard]] T &operator()(size_type n)
     {
         return (*this)[n - 1];
     }
 
-    [[nodiscard]] const T &operator()(std::size_t n) const
+    [[nodiscard]] const T &operator()(size_type n) const
     {
         return (*this)[n - 1];
     }
 
-    void allocate(std::size_t size)
+    void allocate(size_type size)
     {
-        this->resize(size);
+        m_allocated = true;
+        std::vector<T>::resize(size);
         std::fill(begin(), end(), T{});
     }
 
     void deallocate() noexcept
     {
-        this->clear();
+        m_allocated = false;
+        std::vector<T>::clear();
+    }
+
+    void clear() noexcept
+    {
+        m_allocated = false;
+        std::vector<T>::clear();
+    }
+
+    void resize(size_type count)
+    {
+        m_allocated = true;
+        std::vector<T>::resize(count);
+    }
+
+    void resize(size_type count, const T &value)
+    {
+        m_allocated = true;
+        std::vector<T>::resize(count, value);
     }
 
     [[nodiscard]] bool allocated() const noexcept
     {
-        return !this->empty();
+        return m_allocated || !this->empty();
     }
 
     // operator= used for initialization of the vector
@@ -122,8 +140,8 @@ template <typename T> struct EPVector : private std::vector<T>
     // dimension is often used to initalize the vector instead of allocate + operator=
     void dimension(std::size_t size, const T &v)
     {
-        this->clear();
-        this->resize(size, v);
+        std::vector<T>::clear();
+        std::vector<T>::resize(size, v);
     }
 
     // isize needed for current FindItemInList
@@ -131,6 +149,9 @@ template <typename T> struct EPVector : private std::vector<T>
     {
         return static_cast<int>(this->size());
     }
+
+private:
+    bool m_allocated{false};
 };
 
 template <> struct EPVector<bool> : private std::vector<std::uint8_t>
@@ -144,10 +165,8 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
     using std::vector<std::uint8_t>::end;
     using std::vector<std::uint8_t>::cbegin;
     using std::vector<std::uint8_t>::cend;
-    using std::vector<std::uint8_t>::clear;
     using std::vector<std::uint8_t>::emplace_back;
     using std::vector<std::uint8_t>::push_back;
-    using std::vector<std::uint8_t>::resize;
     using const_iterator = typename std::vector<std::uint8_t>::const_iterator;
 
     using value_type = std::uint8_t;
@@ -159,27 +178,27 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
         return std::vector<std::uint8_t>::at(n);
     }
 
-    [[nodiscard]] const std::uint8_t &operator[](std::size_t n) const
+    [[nodiscard]] const std::uint8_t &operator[](size_type n) const
     {
         return std::vector<std::uint8_t>::at(n);
     }
 
-    [[nodiscard]] std::uint8_t &operator()(std::size_t n)
+    [[nodiscard]] std::uint8_t &operator()(size_type n)
     {
         return (*this)[n - 1];
     }
 
-    [[nodiscard]] const std::uint8_t &operator()(std::size_t n) const
+    [[nodiscard]] const std::uint8_t &operator()(size_type n) const
     {
         return (*this)[n - 1];
     }
 #else
-    [[nodiscard]] std::uint8_t &operator()(std::size_t n) noexcept
+    [[nodiscard]] std::uint8_t &operator()(size_type n) noexcept
     {
         return (*this)[n - 1];
     }
 
-    [[nodiscard]] const std::uint8_t &operator()(std::size_t n) const noexcept
+    [[nodiscard]] const std::uint8_t &operator()(size_type n) const noexcept
     {
         return (*this)[n - 1];
     }
@@ -187,18 +206,38 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
 
     [[nodiscard]] bool allocated() const noexcept
     {
-        return !this->empty();
+        return m_allocated || !this->empty();
     }
 
-    void allocate(std::size_t size)
+    void allocate(size_type size)
     {
-        this->resize(size);
+        m_allocated = true;
+        std::vector<std::uint8_t>::resize(size);
         std::fill(begin(), end(), false);
     }
 
     void deallocate() noexcept
     {
-        this->clear();
+        m_allocated = false;
+        std::vector<std::uint8_t>::clear();
+    }
+
+    void clear() noexcept
+    {
+        m_allocated = false;
+        std::vector<std::uint8_t>::clear();
+    }
+
+    void resize(size_type count)
+    {
+        m_allocated = true;
+        std::vector<std::uint8_t>::resize(count);
+    }
+
+    void resize(size_type count, const bool &value)
+    {
+        m_allocated = true;
+        std::vector<std::uint8_t>::resize(count, value);
     }
 
     // operator= used for initialization of the vector
@@ -210,8 +249,8 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
     // dimension is often used to initalize the vector instead of allocate + operator=
     void dimension(std::size_t size, const bool v)
     {
-        this->clear();
-        this->resize(size, v);
+        std::vector<std::uint8_t>::clear();
+        std::vector<std::uint8_t>::resize(size, v);
     }
 
     // isize needed for current FindItemInList
@@ -219,6 +258,9 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
     {
         return static_cast<int>(this->size());
     }
+
+private:
+    bool m_allocated{false};
 };
 
 template <typename T>[[nodiscard]] bool allocated(EPVector<T> const &v) noexcept

--- a/src/EnergyPlus/EPVector.hh
+++ b/src/EnergyPlus/EPVector.hh
@@ -131,7 +131,6 @@ template <typename T> struct EPVector : private std::vector<T>
     {
         return static_cast<int>(this->size());
     }
-
 };
 
 template <> struct EPVector<bool> : private std::vector<std::uint8_t>
@@ -220,15 +219,14 @@ template <> struct EPVector<bool> : private std::vector<std::uint8_t>
     {
         return static_cast<int>(this->size());
     }
-
 };
 
-template <typename T>[[nodiscard]] bool allocated(EPVector<T> const &v) noexcept
+template <typename T> [[nodiscard]] bool allocated(EPVector<T> const &v) noexcept
 {
     return v.allocated();
 }
 
-template <typename T>[[nodiscard]] auto isize(const EPVector<T> &v) noexcept
+template <typename T> [[nodiscard]] auto isize(const EPVector<T> &v) noexcept
 {
     return v.isize();
 }
@@ -260,7 +258,7 @@ template <typename T>[[nodiscard]] auto isize(const EPVector<T> &v) noexcept
     return c;
 }
 
-template <typename T>[[nodiscard]] EPVector<T> pack(EPVector<T> const &v, EPVector<bool> const &mask)
+template <typename T> [[nodiscard]] EPVector<T> pack(EPVector<T> const &v, EPVector<bool> const &mask)
 {
     EPVector<T> r;
     r.reserve(mask.size());
@@ -272,7 +270,7 @@ template <typename T>[[nodiscard]] EPVector<T> pack(EPVector<T> const &v, EPVect
     return r;
 }
 
-template <typename T>[[nodiscard]] Array1D<T> pack(Array1<T> const &a, EPVector<bool> const &mask)
+template <typename T> [[nodiscard]] Array1D<T> pack(Array1<T> const &a, EPVector<bool> const &mask)
 {
     Array1D<T> r;
     r.reserve(mask.size());
@@ -284,17 +282,17 @@ template <typename T>[[nodiscard]] Array1D<T> pack(Array1<T> const &a, EPVector<
     return r;
 }
 
-template <typename T>[[nodiscard]] T magnitude_squared(const EPVector<T> &v)
+template <typename T> [[nodiscard]] T magnitude_squared(const EPVector<T> &v)
 {
     return std::inner_product(v.begin(), v.end(), v.begin(), T{});
 }
 
-template <typename T, typename V>[[nodiscard]] T dot(const EPVector<T> &u, const V &v)
+template <typename T, typename V> [[nodiscard]] T dot(const EPVector<T> &u, const V &v)
 {
     return std::inner_product(u.begin(), u.end(), v.begin(), T{});
 }
 
-template <typename Element, typename Member>[[nodiscard]] Member maxval(EPVector<Element> const &a, Member Element::*pmem)
+template <typename Element, typename Member> [[nodiscard]] Member maxval(EPVector<Element> const &a, Member Element::*pmem)
 {
     Member v(a.empty() ? std::numeric_limits<Member>::lowest() : a(1).*pmem);
     for (int i = 2, e = a.isize(); i <= e; ++i) {
@@ -313,7 +311,7 @@ template <typename Element, typename Member> inline Member sum(EPVector<Element>
     return s;
 }
 
-template <typename T>[[nodiscard]] T maxval(EPVector<T> const &a)
+template <typename T> [[nodiscard]] T maxval(EPVector<T> const &a)
 {
     auto max = std::max_element(a.begin(), a.end());
     if (max == a.end()) {

--- a/tst/EnergyPlus/unit/AirflowNetworkSolver.unit.cc
+++ b/tst/EnergyPlus/unit/AirflowNetworkSolver.unit.cc
@@ -77,7 +77,8 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_SolverTest_HorizontalOpening)
 
     state->afn->AirflowNetworkCompData.allocate(j);
     state->afn->AirflowNetworkCompData(j).TypeNum = 1;
-    clear_and_resize(state->afn->MultizoneSurfaceData, i);
+    state->afn->MultizoneSurfaceData.clear();
+    state->afn->MultizoneSurfaceData.resize(i);
     state->afn->MultizoneSurfaceData(i).Width = 10.0;
     state->afn->MultizoneSurfaceData(i).Height = 5.0;
     state->afn->MultizoneSurfaceData(i).OpenFactor = 1.0;

--- a/tst/EnergyPlus/unit/AirflowNetworkSolver.unit.cc
+++ b/tst/EnergyPlus/unit/AirflowNetworkSolver.unit.cc
@@ -77,7 +77,7 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_SolverTest_HorizontalOpening)
 
     state->afn->AirflowNetworkCompData.allocate(j);
     state->afn->AirflowNetworkCompData(j).TypeNum = 1;
-    state->afn->MultizoneSurfaceData.allocate(i);
+    clear_and_resize(state->afn->MultizoneSurfaceData, i);
     state->afn->MultizoneSurfaceData(i).Width = 10.0;
     state->afn->MultizoneSurfaceData(i).Height = 5.0;
     state->afn->MultizoneSurfaceData(i).OpenFactor = 1.0;

--- a/tst/EnergyPlus/unit/EPVector.unit.cc
+++ b/tst/EnergyPlus/unit/EPVector.unit.cc
@@ -59,6 +59,7 @@ TEST_F(EnergyPlusFixture, EPVectorTest_Basic)
 {
     EPVector<int> v;
     v.allocate(4);
+    EXPECT_TRUE(v.allocated());
     v[0] = 1;
     v[1] = 2;
     v[2] = 3;
@@ -80,22 +81,35 @@ TEST_F(EnergyPlusFixture, EPVectorTest_Basic)
     EXPECT_EQ(2, v(2));
     EXPECT_EQ(0, v(3));
     EXPECT_EQ(0, v(4));
-    clear_and_resize(v, 4);
+    v.clear();
+    EXPECT_FALSE(v.allocated());
+    EXPECT_TRUE(v.empty());
+    v.resize(4);
     EXPECT_EQ(0, v(1));
     EXPECT_EQ(0, v(2));
     EXPECT_EQ(0, v(3));
     EXPECT_EQ(0, v(4));
-    clear_and_resize(v, 4, 1);
+    v.clear();
+    v.resize(4, true);
     EXPECT_EQ(1, v(1));
     EXPECT_EQ(1, v(2));
     EXPECT_EQ(1, v(3));
     EXPECT_EQ(1, v(4));
+    v.deallocate();
+    EXPECT_FALSE(v.allocated());
+    EXPECT_TRUE(v.empty());
+    v.resize(3, 2);
+    EXPECT_EQ(2, v(1));
+    EXPECT_EQ(2, v(2));
+    EXPECT_EQ(2, v(3));
+    EXPECT_TRUE(v.allocated());
 }
 
 TEST_F(EnergyPlusFixture, EPVectorTest_Bools)
 {
     EPVector<bool> v;
     v.allocate(4);
+    EXPECT_TRUE(v.allocated());
     v[0] = true;
     v[1] = false;
     v[2] = false;
@@ -117,14 +131,26 @@ TEST_F(EnergyPlusFixture, EPVectorTest_Bools)
     EXPECT_FALSE(v(2));
     EXPECT_FALSE(v(3));
     EXPECT_FALSE(v(4));
-    clear_and_resize(v, 4);
+    v.clear();
+    EXPECT_FALSE(v.allocated());
+    EXPECT_TRUE(v.empty());
+    v.resize(4);
     EXPECT_FALSE(v(1));
     EXPECT_FALSE(v(2));
     EXPECT_FALSE(v(3));
     EXPECT_FALSE(v(4));
-    clear_and_resize(v, 4, true);
+    v.clear();
+    v.resize(4, true);
     EXPECT_TRUE(v(1));
     EXPECT_TRUE(v(2));
     EXPECT_TRUE(v(3));
     EXPECT_TRUE(v(4));
+    v.deallocate();
+    EXPECT_FALSE(v.allocated());
+    EXPECT_TRUE(v.empty());
+    v.resize(3, true);
+    EXPECT_TRUE(v(1));
+    EXPECT_TRUE(v(2));
+    EXPECT_TRUE(v(3));
+    EXPECT_TRUE(v.allocated());
 }

--- a/tst/EnergyPlus/unit/EPVector.unit.cc
+++ b/tst/EnergyPlus/unit/EPVector.unit.cc
@@ -71,6 +71,25 @@ TEST_F(EnergyPlusFixture, EPVectorTest_Basic)
     ASSERT_THROW(v[4] = 5, std::out_of_range);
     ASSERT_THROW(v(5) = 5, std::out_of_range);
 #endif // !NDEBUG
+    v.resize(2);
+    EXPECT_EQ(2, v.size());
+    EXPECT_EQ(1, v(1));
+    EXPECT_EQ(2, v(2));
+    v.resize(4);
+    EXPECT_EQ(1, v(1));
+    EXPECT_EQ(2, v(2));
+    EXPECT_EQ(0, v(3));
+    EXPECT_EQ(0, v(4));
+    clear_and_resize(v, 4);
+    EXPECT_EQ(0, v(1));
+    EXPECT_EQ(0, v(2));
+    EXPECT_EQ(0, v(3));
+    EXPECT_EQ(0, v(4));
+    clear_and_resize(v, 4, 1);
+    EXPECT_EQ(1, v(1));
+    EXPECT_EQ(1, v(2));
+    EXPECT_EQ(1, v(3));
+    EXPECT_EQ(1, v(4));
 }
 
 TEST_F(EnergyPlusFixture, EPVectorTest_Bools)
@@ -89,4 +108,23 @@ TEST_F(EnergyPlusFixture, EPVectorTest_Bools)
     ASSERT_THROW(v[4] = true, std::out_of_range);
     ASSERT_THROW(v(5) = false, std::out_of_range);
 #endif // !NDEBUG
+    v.resize(2);
+    EXPECT_EQ(2, v.size());
+    EXPECT_TRUE(v(1));
+    EXPECT_FALSE(v(2));
+    v.resize(4);
+    EXPECT_TRUE(v(1));
+    EXPECT_FALSE(v(2));
+    EXPECT_FALSE(v(3));
+    EXPECT_FALSE(v(4));
+    clear_and_resize(v, 4);
+    EXPECT_FALSE(v(1));
+    EXPECT_FALSE(v(2));
+    EXPECT_FALSE(v(3));
+    EXPECT_FALSE(v(4));
+    clear_and_resize(v, 4, true);
+    EXPECT_TRUE(v(1));
+    EXPECT_TRUE(v(2));
+    EXPECT_TRUE(v(3));
+    EXPECT_TRUE(v(4));
 }


### PR DESCRIPTION
Pull request overview
---------------------
This PR exposes the inherited `resize` method from `std::vector`. In the course of moving some `Array1D`s over to `EPVector`s with the eventual goal of moving to `std::vector`, I ran into a use of `redimension` that I had not noticed before. There isn't an exact match for that in EPVector right now, so rather than work around it or add a similar method, I think we should expose the resize method. This way we don't introduce additional barriers to eventually getting to `std::vector`. I had originally thought about a convenience function with a similar role, but after some thought I decided it wasn't so convenient after all.

The original way we wrote this with an `m_allocated` Boolean means that the `allocated` function returns true after a call to `clear`. It isn't exactly a bug, but not great either, so I have removed the Boolean and rely upon the `empty` method to provide the result. Finally, the `EPVector.hh` header wasn't included in the CMake files, so I fixed that as well.

None of these things are super-important, possibly the code changes are a mistake, happy to get feedback.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
