### PR TITLE
Quick fix to format args thanks to @mitchute script

### DIFF
--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -12060,8 +12060,7 @@ namespace SurfaceGeometry {
                             ShowContinueError(
                                 state,
                                 fmt::format("  The surface \"{}\" has an edge that was used only once: it is not an edge on another surface",
-                                            state.dataSurface->Surface(edge.surfNum).Name,
-                                            edge.count));
+                                            state.dataSurface->Surface(edge.surfNum).Name));
 
                         } else {
                             ShowContinueError(


### PR DESCRIPTION
A PR was merged with a custom_check error, so this cleans it up to avoid it spreading to other PRs that pull in develop.

It's pretty simple, the format expression only has one arg placeholder, but two args were passed in.  The edge.count arg was not needed, so I just removed that from the args.  Should merge immediately once custom_check is happy.

FYI @mitchute @jmarrec 