### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -2,6 +2,9 @@ name: CppCheck
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/custom_check.yml
+++ b/.github/workflows/custom_check.yml
@@ -2,6 +2,9 @@ name: Custom Check
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/documentation-windows.yml
+++ b/.github/workflows/documentation-windows.yml
@@ -9,6 +9,9 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-2019

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,6 +2,9 @@ name: Documentation
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
 #  base_build:
 #    runs-on: ${{ matrix.os }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
