### PR TITLE
Fix Missing Argument in Runtime API

### DIFF
--- a/src/EnergyPlus/api/runtime.py
+++ b/src/EnergyPlus/api/runtime.py
@@ -133,15 +133,15 @@ class Runtime:
         self.api.callbackEndOfSystemTimeStepAfterHVACReporting.restype = c_void_p
         self.api.callbackEndOfZoneSizing.argtypes = [c_void_p, self.py_state_callback_type]
         self.api.callbackEndOfZoneSizing.restype = c_void_p
-        self.api.callbackEndOfSystemSizing.argtypes = [self.py_state_callback_type]
+        self.api.callbackEndOfSystemSizing.argtypes = [c_void_p, self.py_state_callback_type]
         self.api.callbackEndOfSystemSizing.restype = c_void_p
-        self.api.callbackEndOfAfterComponentGetInput.argtypes = [self.py_state_callback_type]
+        self.api.callbackEndOfAfterComponentGetInput.argtypes = [c_void_p, self.py_state_callback_type]
         self.api.callbackEndOfAfterComponentGetInput.restype = c_void_p
         # self.api.callbackUserDefinedComponentModel.argtypes = [self.py_empty_callback_type]
         # self.api.callbackUserDefinedComponentModel.restype = c_void_p
-        self.api.callbackUnitarySystemSizing.argtypes = [self.py_state_callback_type]
+        self.api.callbackUnitarySystemSizing.argtypes = [c_void_p, self.py_state_callback_type]
         self.api.callbackUnitarySystemSizing.restype = c_void_p
-        self.api.registerExternalHVACManager.argtypes = [self.py_state_callback_type]
+        self.api.registerExternalHVACManager.argtypes = [c_void_p, self.py_state_callback_type]
         self.api.registerExternalHVACManager.restype = c_void_p
 
     @staticmethod

--- a/tst/EnergyPlus/api/TestRuntime.py
+++ b/tst/EnergyPlus/api/TestRuntime.py
@@ -62,6 +62,11 @@ def environment_handler(_state) -> None:
     sys.stdout.flush()
 
 
+def common_callback_handler(_state) -> None:
+    print("OH HAI SOMETHING")
+    sys.stdout.flush()
+
+
 def progress_handler(progress: int) -> None:
     if 49 < progress < 51:
         print("HALFWAY THERE!!")
@@ -79,6 +84,9 @@ state = api.state_manager.new_state()
 api.runtime.callback_begin_new_environment(state, environment_handler)
 api.runtime.callback_progress(state, progress_handler)
 api.functional.callback_error(state, error_handler)
+api.runtime.callback_end_system_sizing(state, common_callback_handler)
+api.runtime.callback_after_component_get_input(state, common_callback_handler)
+api.runtime.callback_unitary_system_sizing(state, common_callback_handler)
 v = api.runtime.run_energyplus(state, sys.argv[1:])
 if v != 0:
     print("EnergyPlus Failed!")


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #9481
 - Note: This does **not** affect the user-facing API at all.
 - In the Python ctypes declarations, some of the last additions did not get the state first argument (a `c_void_p`).  The C API itself is fine.  And the Python API user-facing function calls are also properly formed.  It's just that these functions would fail when they tried to pass state along to the program.  

Workaround: As described in the issue, a workaround is to make a tiny manual edit of the runtime.py file in the user install.

Fix: Adds the `c_void_p` first argument to the `ctypes` declarations that were missing that argument.  Added a few callback registrations in the `TestRuntime.py` file which exercise this.  If you try the changes to `TestRuntime.py` in the develop branch, the script will fail.  With the changes to `runtime.py`, everything works great.

Reviewer: If you check Decent CI's mood ring and see happiness there, then that is a really good indicator that this works.  Feel free to test more locally, but it shouldn't be necessary.  