### PR TITLE
Correct logic in AirflowNetwork Duct Autosizing

### DIFF
--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -2256,7 +2256,7 @@ namespace AirflowNetwork {
                        "single object."));
             ShowContinueError(m_state, format("..Duct sizing is not performed"));
             simulation_control.autosize_ducts = false;
-        } else if (NumDuctSizing == 1) {
+        } else if (simulation_control.autosize_ducts && NumDuctSizing == 0) {
             ShowWarningError(m_state, format(RoutineName) + CurrentModuleObject + " object, ");
             ShowContinueError(
                 m_state,
@@ -2295,7 +2295,7 @@ namespace AirflowNetwork {
                                          Alphas(1)));
                 ErrorsFound = true;
             }
-            if (simulation_control.type == ControlType::MultizoneWithDistribution) {
+            if (simulation_control.type != ControlType::MultizoneWithDistribution) {
                 ShowWarningError(m_state, format(RoutineName) + CurrentModuleObject + " object, ");
                 ShowContinueError(m_state,
                                   format("Although {} = \"{}\" is entered, but {} is not MultizoneWithoutDistribution.",


### PR DESCRIPTION
Pull request overview
---------------------
This is a new feature of AirflowNetwork Duct Autosizing follow up.

The example file (AirflowNetwork_MULTIZONE_House_DuctSizing) does not perform duct sizing due to incorrect logic. 

Differences in csv are expected due to duct autosizing. Please compare differences of err and eio.

The expected additional eio output should be as below:

! <AirflowNetwork Model:Duct Autosizing>, Linkage Name, Duct Type, Duct Name, Duct Hydraunic Diameter, Duct Cross Section Area
AirflowNetwork Model:Duct Autosizing, MAIN LINK, Supply Trunk, MAINTRUCK, 0.5032,0.1989
AirflowNetwork Model:Duct Autosizing, ZONESUPPLYLINK1, Supply Branch, ZONESUPPLY, 0.4807,0.1815
AirflowNetwork Model:Duct Autosizing, ZONESUPPLY1LINK2 ATINLET, Supply Branch, ZONESUPPLY1LINK2 ATINLET DUCT, 0.4807,0.1815
AirflowNetwork Model:Duct Autosizing, ZONESUPPLY1LINK2, Supply Branch, ZONESUPPLY, 0.4807,0.1815
AirflowNetwork Model:Duct Autosizing, ZONERETURN1LINK, Return Branch, ZONERETURN, 0.6128,0.2949
AirflowNetwork Model:Duct Autosizing, ZONERETURN2LINK, Return Branch, ZONERETURN, 0.6128,0.2949
AirflowNetwork Model:Duct Autosizing, RETURNMIXERLINK, Return Trunk, MAINRETURN, 0.6492,0.3311

The develop version does not generate the above outputs.
 
### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ X] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ X] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
