### PR TITLE
Fix #9123 - GetVertices is dropping vertices inconsistently, causing fatal error

### DIFF
--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -9038,7 +9038,6 @@ namespace SurfaceGeometry {
         Real64 SurfWorldAz;
         Real64 SurfTilt;
         Real64 Perimeter; // Perimeter length of the surface
-        int Vrt;          // Used for calculating perimeter
         Real64 Xb;        // Intermediate calculation
         Real64 Yb;        // Intermediate calculation
         int ZoneNum;
@@ -9160,121 +9159,58 @@ namespace SurfaceGeometry {
         }
 
         if (NSides > 2) {
-            DistanceCheck = distance(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides),
-                                     state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(1));
-            if (DistanceCheck < 0.01) {
-                if (state.dataGlobal->DisplayExtraWarnings) {
-                    ShowWarningError(state,
-                                     std::string{RoutineName} + "Distance between two vertices < .01, possibly coincident. for Surface=" +
-                                         state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Name +
-                                         ", in Zone=" + state.dataSurfaceGeometry->SurfaceTmp(SurfNum).ZoneName);
-                    ShowContinueError(
-                        state,
-                        format("Vertex [{}", state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides) +
-                            format("]=({:.2R},{:.2R},{:.2R})",
-                                   state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides).x,
-                                   state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides).y,
-                                   state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides).z));
-                    ShowContinueError(state,
-                                      format("Vertex [{}", 1) +
-                                          format("]=({:.2R},{:.2R},{:.2R}",
-                                                 state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(1).x,
-                                                 state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(1).y,
-                                                 state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(1).z) +
-                                          ')');
-                }
-                ++state.dataErrTracking->TotalCoincidentVertices;
-                if (state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides > 3) {
-                    if (state.dataGlobal->DisplayExtraWarnings) {
-                        ShowContinueError(state, format("Dropping Vertex [{}].", state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides));
+            auto &surface = state.dataSurfaceGeometry->SurfaceTmp(SurfNum);
+            auto &vertices = surface.Vertex;
+            auto &nSides = surface.Sides;
+
+            bool poppedVertex = true;
+            while (poppedVertex) {
+                poppedVertex = false;
+                Perimeter = 0.0;
+
+                for (auto it = vertices.begin(); it != vertices.end(); ++it) {
+                    auto itnext = std::next(it);
+                    if (itnext == std::end(vertices)) {
+                        itnext = std::begin(vertices);
                     }
-                    --state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides;
-                    state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex.redimension(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides);
-                } else {
-                    if (state.dataGlobal->DisplayExtraWarnings) {
-                        ShowContinueError(
-                            state,
-                            format("Cannot Drop Vertex [{}]; Number of Surface Sides at minimum. This surface is now a degenerate surface.",
-                                   state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides));
-                    }
-                    ++state.dataErrTracking->TotalDegenerateSurfaces;
-                    // mark degenerate surface?
-                }
-                DistanceCheck = 0.0;
-            }
-            Perimeter = DistanceCheck;
-            //      DO Vrt=2,SurfaceTmp(SurfNum)%Sides
-            Vrt = 2;
-            while (true) {
-                DistanceCheck = distance(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(Vrt),
-                                         state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(Vrt - 1));
-                if (DistanceCheck < 0.01) {
-                    if (state.dataGlobal->DisplayExtraWarnings) {
-                        ShowWarningError(state,
-                                         std::string{RoutineName} + "Distance between two vertices < .01, possibly coincident. for Surface=" +
-                                             state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Name +
-                                             ", in Zone=" + state.dataSurfaceGeometry->SurfaceTmp(SurfNum).ZoneName);
-                        ShowContinueError(state,
-                                          format("Vertex [{}", Vrt) + format("]=({:.2R},{:.2R},{:.2R})",
-                                                                             state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(Vrt).x,
-                                                                             state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(Vrt).y,
-                                                                             state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(Vrt).z));
-                        ShowContinueError(state,
-                                          format("Vertex [{}]=({:.2R},", Vrt - 1, state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(Vrt - 1).x) +
-                                              format("{:.2R},{:.2R})",
-                                                     state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(Vrt - 1).y,
-                                                     state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(Vrt - 1).z));
-                    }
-                    ++state.dataErrTracking->TotalCoincidentVertices;
-                    if (Vrt == state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides) {
-                        if (state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides > 3) {
+
+                    // TODO: use isAlmostEqual3Pt for consistency? (which uses 0.0127 m / 1/2inch instead of 0.01 m)
+                    DistanceCheck = distance(*it, *itnext);
+                    if (DistanceCheck < 0.01) {
+                        int curVertexIndex = std::distance(vertices.begin(), it) + 1;
+                        int nextVertexIndex = std::distance(vertices.begin(), itnext) + 1;
+                        if (state.dataGlobal->DisplayExtraWarnings) {
+                            ShowWarningError(state,
+                                             format("{}Distance between two vertices < .01, possibly coincident. for Surface={}, in Zone={}",
+                                                    RoutineName,
+                                                    state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Name,
+                                                    state.dataSurfaceGeometry->SurfaceTmp(SurfNum).ZoneName));
+                            ShowContinueError(state, format("Vertex [{}]=({:.2R},{:.2R},{:.2R})", curVertexIndex, it->x, it->y, it->z));
+                            ShowContinueError(state, format("Vertex [{}]=({:.2R},{:.2R},{:.2R})", nextVertexIndex, itnext->x, itnext->y, it->z));
+                        }
+                        ++state.dataErrTracking->TotalCoincidentVertices;
+                        if (nSides > 3) {
                             if (state.dataGlobal->DisplayExtraWarnings) {
-                                ShowContinueError(state, format("Dropping Vertex [{}].", state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides));
+                                ShowContinueError(state, format("Dropping Vertex [{}].", nextVertexIndex));
                             }
-                            --state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides;
-                            state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex.redimension(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides);
+                            --nSides;
+                            vertices.erase(itnext);
+                            poppedVertex = true;
+                            break;
                         } else {
                             if (state.dataGlobal->DisplayExtraWarnings) {
                                 ShowContinueError(
                                     state,
                                     format("Cannot Drop Vertex [{}]; Number of Surface Sides at minimum. This surface is now a degenerate surface.",
-                                           state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides));
+                                           curVertexIndex));
                             }
                             ++state.dataErrTracking->TotalDegenerateSurfaces;
                             // mark degenerate surface?
                         }
-                        DistanceCheck = 0.0;
                     } else {
-                        if (state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides > 3) {
-                            if (state.dataGlobal->DisplayExtraWarnings) {
-                                ShowContinueError(state, format("Dropping Vertex [{}].", Vrt));
-                            }
-                            for (n = Vrt; n <= state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides - 1; ++n) {
-                                state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(n).x =
-                                    state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(n + 1).x;
-                                state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(n).y =
-                                    state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(n + 1).y;
-                                state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(n).z =
-                                    state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex(n + 1).z;
-                            }
-                            --state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides;
-                            state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Vertex.redimension(state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides);
-                        } else {
-                            if (state.dataGlobal->DisplayExtraWarnings) {
-                                ShowContinueError(
-                                    state,
-                                    format("Cannot Drop Vertex [{}]; Number of Surface Sides at minimum. This surface is now a degenerate surface.",
-                                           state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides));
-                            }
-                            ++state.dataErrTracking->TotalDegenerateSurfaces;
-                            // mark degenerate surface?
-                        }
-                        DistanceCheck = 0.0;
+                        Perimeter += DistanceCheck;
                     }
                 }
-                Perimeter += DistanceCheck;
-                ++Vrt;
-                if (Vrt > state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Sides) break;
             }
 
             state.dataSurfaceGeometry->SurfaceTmp(SurfNum).Perimeter = Perimeter;

--- a/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
+++ b/tst/EnergyPlus/unit/SurfaceGeometry.unit.cc
@@ -9227,3 +9227,118 @@ TEST_F(EnergyPlusFixture, SurfaceGeometry_GetSurfaceGroundSurfsTest)
     EXPECT_DOUBLE_EQ(0.1, GndSurfsProperty.GndSurfs(3).ViewFactor);
     EXPECT_DOUBLE_EQ(0.4, GndSurfsProperty.SurfsViewFactorSum);
 }
+
+TEST_F(EnergyPlusFixture, SurfaceGeometry_GetVerticesDropDuplicates)
+{
+    // Test for #9123
+    std::string const idf_objects = delimited_string({
+        "BuildingSurface:Detailed,",
+        "  Zn001:Ceiling002,        !- Name",
+        "  Ceiling,                 !- Surface Type",
+        "  FLOOR,                   !- Construction Name",
+        "  ZONE 1,                  !- Zone Name",
+        "  ,                        !- Space Name",
+        "  Surface,                 !- Outside Boundary Condition",
+        "  Zn002:Flr002,            !- Outside Boundary Condition Object",
+        "  NoSun,                   !- Sun Exposure",
+        "  NoWind,                  !- Wind Exposure",
+        "  ,                        !- View Factor to Ground",
+        "  ,                        !- Number of Vertices",
+        "  54.379, -28.887, 3.7,    !- X,Y,Z Vertex 1 {m}",
+        "  54.379, -23.003, 3.7,    !- X,Y,Z Vertex 2 {m}",
+        "  54.36,  -23.003, 3.7,    !- X,Y,Z Vertex 3 {m}",
+        "  54.36,  -28.881, 3.7,    !- X,Y,Z Vertex 4 {m}",
+        "  54.373, -28.881, 3.7,    !- X,Y,Z Vertex 5 {m}",
+        "  54.373, -28.887, 3.7;    !- X,Y,Z Vertex 6 {m}",
+        "",
+        "BuildingSurface:Detailed,",
+        "  Zn002:Flr002,            !- Name",
+        "  Floor,                   !- Surface Type",
+        "  FLOOR,                   !- Construction Name",
+        "  ZONE 2,                  !- Zone Name",
+        "  ,                        !- Space Name",
+        "  Surface,                 !- Outside Boundary Condition",
+        "  Zn001:Ceiling002,        !- Outside Boundary Condition Object",
+        "  NoSun,                   !- Sun Exposure",
+        "  NoWind,                  !- Wind Exposure",
+        "  ,                        !- View Factor to Ground",
+        "  ,                        !- Number of Vertices",
+        "  54.373, -28.887, 3.7,    !- X,Y,Z Vertex 1 {m}",
+        "  54.373, -28.881, 3.7,    !- X,Y,Z Vertex 2 {m}",
+        "  54.36,  -28.881, 3.7,    !- X,Y,Z Vertex 3 {m}",
+        "  54.36,  -23.003, 3.7,    !- X,Y,Z Vertex 4 {m}",
+        "  54.379, -23.003, 3.7,    !- X,Y,Z Vertex 5 {m}",
+        "  54.379, -28.887, 3.7;    !- X,Y,Z Vertex 6 {m}",
+
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+
+    state->dataGlobal->NumOfZones = 2;
+    state->dataHeatBal->Zone.allocate(2);
+    state->dataHeatBal->Zone(1).Name = "ZONE 1";
+    state->dataHeatBal->Zone(2).Name = "ZONE 2";
+    state->dataSurfaceGeometry->SurfaceTmp.allocate(2);
+    int SurfNum = 0;
+    int TotHTSurfs = 2;
+    Array1D_string const BaseSurfCls(3, {"WALL", "FLOOR", "ROOF"});
+    Array1D<DataSurfaces::SurfaceClass> const BaseSurfIDs(
+        3, {DataSurfaces::SurfaceClass::Wall, DataSurfaces::SurfaceClass::Floor, DataSurfaces::SurfaceClass::Roof});
+    int NeedToAddSurfaces;
+
+    bool ErrorsFound(false);
+    GetGeometryParameters(*state, ErrorsFound);
+    EXPECT_FALSE(ErrorsFound);
+
+    state->dataSurfaceGeometry->CosZoneRelNorth.allocate(2);
+    state->dataSurfaceGeometry->SinZoneRelNorth.allocate(2);
+
+    state->dataSurfaceGeometry->CosZoneRelNorth = 1.0;
+    state->dataSurfaceGeometry->SinZoneRelNorth = 0.0;
+    state->dataSurfaceGeometry->SinBldgRelNorth = 0.0;
+    state->dataSurfaceGeometry->CosBldgRelNorth = 1.0;
+
+    state->dataHeatBal->TotConstructs = 1;
+    state->dataConstruction->Construct.allocate(1);
+    state->dataConstruction->Construct(1).Name = "FLOOR";
+
+    state->dataGlobal->DisplayExtraWarnings = true;
+
+    GetHTSurfaceData(*state, ErrorsFound, SurfNum, TotHTSurfs, 0, 0, 0, BaseSurfCls, BaseSurfIDs, NeedToAddSurfaces);
+    EXPECT_FALSE(ErrorsFound);
+
+    EXPECT_EQ(2, SurfNum);
+    auto const error_string = delimited_string({
+        "   ** Warning ** GetVertices: Distance between two vertices < .01, possibly coincident. for Surface=ZN001:CEILING002, in Zone=ZONE 1",
+        "   **   ~~~   ** Vertex [5]=(54.37,-28.88,3.70)",
+        "   **   ~~~   ** Vertex [6]=(54.37,-28.89,3.70)",
+        "   **   ~~~   ** Dropping Vertex [6].",
+        "   ** Warning ** GetVertices: Distance between two vertices < .01, possibly coincident. for Surface=ZN001:CEILING002, in Zone=ZONE 1",
+        "   **   ~~~   ** Vertex [5]=(54.37,-28.88,3.70)",
+        "   **   ~~~   ** Vertex [1]=(54.38,-28.89,3.70)",
+        "   **   ~~~   ** Dropping Vertex [1].",
+        "   ** Warning ** GetVertices: Distance between two vertices < .01, possibly coincident. for Surface=ZN002:FLR002, in Zone=ZONE 2",
+        "   **   ~~~   ** Vertex [1]=(54.37,-28.89,3.70)",
+        "   **   ~~~   ** Vertex [2]=(54.37,-28.88,3.70)",
+        "   **   ~~~   ** Dropping Vertex [2].",
+        "   ** Warning ** GetVertices: Distance between two vertices < .01, possibly coincident. for Surface=ZN002:FLR002, in Zone=ZONE 2",
+        "   **   ~~~   ** Vertex [5]=(54.38,-28.89,3.70)",
+        "   **   ~~~   ** Vertex [1]=(54.37,-28.89,3.70)",
+        "   **   ~~~   ** Dropping Vertex [1].",
+    });
+    EXPECT_TRUE(compare_err_stream(error_string, true));
+
+    const auto &sf_temps = state->dataSurfaceGeometry->SurfaceTmp;
+    EXPECT_EQ(2, sf_temps.size());
+    EXPECT_EQ("ZN001:CEILING002", sf_temps(1).Name);
+    EXPECT_EQ("ZN002:FLR002", sf_temps(2).Name);
+
+    EXPECT_EQ(4, sf_temps(1).Sides);
+    EXPECT_EQ(4, sf_temps(1).Vertex.size());
+
+    EXPECT_EQ(4, sf_temps(2).Sides);
+    EXPECT_EQ(4, sf_temps(2).Vertex.size());
+
+    EXPECT_NEAR(11.80, sf_temps(1).Perimeter, 0.02);
+    EXPECT_NEAR(11.80, sf_temps(2).Perimeter, 0.02);
+}


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #9123

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
