### PR TITLE
Consolidate ControlledZoneNum and ActualZoneNum

### DIFF
--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -10465,7 +10465,7 @@ namespace AirflowNetwork {
             for (j = 1; j <= m_state.dataGlobal->NumOfZones; ++j) {
                 if (!m_state.dataZoneEquip->ZoneEquipConfig(j).IsControlled) continue;
                 if (m_state.dataZoneEquip->ZoneEquipConfig(j).ZoneNode == i) {
-                    if (m_state.dataZoneEquip->ZoneEquipConfig(j).ActualZoneNum > AirflowNetworkNumOfNodes) {
+                    if (j > AirflowNetworkNumOfNodes) {
                         ShowSevereError(m_state,
                                         format(RoutineName) + "'" + m_state.dataLoopNodes->NodeID(i) +
                                             "' is not defined as an AirflowNetwork:Distribution:Node object.");
@@ -10474,7 +10474,7 @@ namespace AirflowNetwork {
                         ErrorsFound = true;
                     } else {
                         NodeFound(i) = true;
-                        AirflowNetworkNodeData(m_state.dataZoneEquip->ZoneEquipConfig(j).ActualZoneNum).EPlusNodeNum = i;
+                        AirflowNetworkNodeData(j).EPlusNodeNum = i;
                     }
                     break;
                 }
@@ -11329,7 +11329,7 @@ namespace AirflowNetwork {
                     if (!m_state.dataZoneEquip->ZoneEquipConfig(j).IsControlled) continue;
                     for (k = 1; k <= m_state.dataZoneEquip->ZoneEquipConfig(j).NumExhaustNodes; ++k) {
                         if (m_state.dataZoneEquip->ZoneEquipConfig(j).ExhaustNode(k) == MultizoneCompExhaustFanData(i).InletNode) {
-                            MultizoneCompExhaustFanData(i).EPlusZoneNum = m_state.dataZoneEquip->ZoneEquipConfig(j).ActualZoneNum;
+                            MultizoneCompExhaustFanData(i).EPlusZoneNum = j;
                             break;
                         }
                     }
@@ -11387,7 +11387,7 @@ namespace AirflowNetwork {
                         for (k = 1; k <= m_state.dataZoneEquip->ZoneEquipConfig(j).NumExhaustNodes; ++k) {
                             for (i = 1; i <= AirflowNetworkNumOfExhFan; ++i) {
                                 if (m_state.dataZoneEquip->ZoneEquipConfig(j).ExhaustNode(k) == MultizoneCompExhaustFanData(i).InletNode) {
-                                    MultizoneCompExhaustFanData(i).EPlusZoneNum = m_state.dataZoneEquip->ZoneEquipConfig(j).ActualZoneNum;
+                                    MultizoneCompExhaustFanData(i).EPlusZoneNum = j;
                                     found = true;
                                 }
                             }
@@ -11468,11 +11468,11 @@ namespace AirflowNetwork {
                 for (int zoneInNode = 1; zoneInNode <= m_state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
                     if (AirLoopNum > 0) {
                         if (AirLoopNum == m_state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode)) {
-                            ActualZoneNum = m_state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum;
+                            ActualZoneNum = ControlledZoneNum;
                             break;
                         }
                     } else {
-                        if (HybridVentSysAvailActualZoneNum(SysAvailNum) == m_state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum) {
+                        if (HybridVentSysAvailActualZoneNum(SysAvailNum) == ControlledZoneNum) {
                             ActualZoneNum = HybridVentSysAvailActualZoneNum(SysAvailNum);
                         }
                     }

--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -10462,19 +10462,19 @@ namespace AirflowNetwork {
                 }
             }
 
-            for (j = 1; j <= m_state.dataGlobal->NumOfZones; ++j) {
-                if (!m_state.dataZoneEquip->ZoneEquipConfig(j).IsControlled) continue;
-                if (m_state.dataZoneEquip->ZoneEquipConfig(j).ZoneNode == i) {
-                    if (j > AirflowNetworkNumOfNodes) {
+            for (int zoneNum = 1; zoneNum <= m_state.dataGlobal->NumOfZones; ++zoneNum) {
+                if (!m_state.dataZoneEquip->ZoneEquipConfig(zoneNum).IsControlled) continue;
+                if (m_state.dataZoneEquip->ZoneEquipConfig(zoneNum).ZoneNode == i) {
+                    if (zoneNum > AirflowNetworkNumOfNodes) {
                         ShowSevereError(m_state,
                                         format(RoutineName) + "'" + m_state.dataLoopNodes->NodeID(i) +
                                             "' is not defined as an AirflowNetwork:Distribution:Node object.");
-                        ShowContinueError(m_state,
-                                          "This Node is the zone air node for Zone '" + m_state.dataZoneEquip->ZoneEquipConfig(j).ZoneName + "'.");
+                        ShowContinueError(
+                            m_state, "This Node is the zone air node for Zone '" + m_state.dataZoneEquip->ZoneEquipConfig(zoneNum).ZoneName + "'.");
                         ErrorsFound = true;
                     } else {
                         NodeFound(i) = true;
-                        AirflowNetworkNodeData(j).EPlusNodeNum = i;
+                        AirflowNetworkNodeData(zoneNum).EPlusNodeNum = i;
                     }
                     break;
                 }
@@ -11417,7 +11417,6 @@ namespace AirflowNetwork {
         //       AUTHOR         Lixing Gu
         //       DATE WRITTEN   Dec. 2006
         //       MODIFIED       July 2012, Chandan Sharma - FSEC: Added zone hybrid ventilation managers
-        //       RE-ENGINEERED  na
 
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine performs hybrid ventilation control
@@ -11440,7 +11439,6 @@ namespace AirflowNetwork {
         int SysAvailNum;       // Hybrid ventilation control number
         int AirLoopNum;        // Airloop number
         int ControlledZoneNum; // Controlled zone number
-        int ActualZoneNum;     // Actual zone number
         int ANSurfaceNum;      // AirflowNetwork Surface Number
         int SurfNum;           // Surface number
         int ControlType;       // Hybrid ventilation control type: 0 individual; 1 global
@@ -11461,7 +11459,7 @@ namespace AirflowNetwork {
                 ControlType = static_cast<int>(GetCurrentScheduleValue(m_state, HybridVentSysAvailANCtrlStatus(SysAvailNum)));
             }
             Found = false;
-            ActualZoneNum = 0;
+            int ActualZoneNum = 0;
             for (ControlledZoneNum = 1; ControlledZoneNum <= m_state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
                 if (!m_state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).IsControlled) continue;
                 // Ensure all the zones served by this AirLoopHVAC to be controlled by the hybrid ventilation

--- a/src/EnergyPlus/BaseboardElectric.cc
+++ b/src/EnergyPlus/BaseboardElectric.cc
@@ -83,8 +83,7 @@ namespace BaseboardElectric {
     const char *cCMO_BBRadiator_Electric = "ZoneHVAC:Baseboard:Convective:Electric";
     constexpr Real64 SimpConvAirFlowSpeed(0.5); // m/s
 
-    void SimElectricBaseboard(
-        EnergyPlusData &state, std::string const &EquipName, int const ActualZoneNum, int const ControlledZoneNum, Real64 &PowerMet, int &CompIndex)
+    void SimElectricBaseboard(EnergyPlusData &state, std::string const &EquipName, int const ControlledZoneNum, Real64 &PowerMet, int &CompIndex)
     {
 
         // SUBROUTINE INFORMATION:
@@ -137,7 +136,7 @@ namespace BaseboardElectric {
 
         InitBaseboard(state, BaseboardNum, ControlledZoneNum);
 
-        QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputReqToHeatSP;
+        QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputReqToHeatSP;
 
         // Simulate baseboard
         SimElectricConvective(state, BaseboardNum, QZnReq);

--- a/src/EnergyPlus/BaseboardElectric.hh
+++ b/src/EnergyPlus/BaseboardElectric.hh
@@ -89,7 +89,7 @@ namespace BaseboardElectric {
         bool ZoneEquipmentListChecked = false; // True after the Zone Equipment List has been checked for items
     };
 
-    void SimElectricBaseboard(EnergyPlusData &state, std::string const &EquipName, int ControlledZoneNum, Real64 &PowerMet, int &CompIndex);
+    void SimElectricBaseboard(EnergyPlusData &state, std::string const &EquipName, int const ControlledZoneNum, Real64 &PowerMet, int &CompIndex);
 
     void GetBaseboardInput(EnergyPlusData &state);
 

--- a/src/EnergyPlus/BaseboardElectric.hh
+++ b/src/EnergyPlus/BaseboardElectric.hh
@@ -89,8 +89,7 @@ namespace BaseboardElectric {
         bool ZoneEquipmentListChecked = false; // True after the Zone Equipment List has been checked for items
     };
 
-    void SimElectricBaseboard(
-        EnergyPlusData &state, std::string const &EquipName, int ActualZoneNum, int ControlledZoneNum, Real64 &PowerMet, int &CompIndex);
+    void SimElectricBaseboard(EnergyPlusData &state, std::string const &EquipName, int ControlledZoneNum, Real64 &PowerMet, int &CompIndex);
 
     void GetBaseboardInput(EnergyPlusData &state);
 

--- a/src/EnergyPlus/BaseboardRadiator.cc
+++ b/src/EnergyPlus/BaseboardRadiator.cc
@@ -540,14 +540,12 @@ namespace BaseboardRadiator {
         }
     }
 
-    void InitBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNumSub)
+    void InitBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum)
     {
 
         // SUBROUTINE INFORMATION:
         //       AUTHOR         Russ Taylor
         //       DATE WRITTEN   Nov 1997
-        //       MODIFIED       na
-        //       RE-ENGINEERED  na
 
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine initializes the Baseboard units during simulation.
@@ -569,8 +567,7 @@ namespace BaseboardRadiator {
 
         auto &baseboard = state.dataBaseboardRadiator;
 
-        if (baseboard->baseboards(BaseboardNum).ZonePtr <= 0)
-            baseboard->baseboards(BaseboardNum).ZonePtr = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ActualZoneNum;
+        baseboard->baseboards(BaseboardNum).ZonePtr = ZoneNum;
 
         if (baseboard->baseboards(BaseboardNum).SetLoopIndexFlag && allocated(state.dataPlnt->PlantLoop)) {
             errFlag = false;
@@ -645,7 +642,7 @@ namespace BaseboardRadiator {
 
         // Do the every time step initializations
         WaterInletNode = baseboard->baseboards(BaseboardNum).WaterInletNode;
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ZoneNode;
+        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
         baseboard->baseboards(BaseboardNum).WaterMassFlowRate = state.dataLoopNodes->Node(WaterInletNode).MassFlowRate;
         baseboard->baseboards(BaseboardNum).WaterInletTemp = state.dataLoopNodes->Node(WaterInletNode).Temp;
         baseboard->baseboards(BaseboardNum).WaterInletEnthalpy = state.dataLoopNodes->Node(WaterInletNode).Enthalpy;

--- a/src/EnergyPlus/BaseboardRadiator.cc
+++ b/src/EnergyPlus/BaseboardRadiator.cc
@@ -104,7 +104,6 @@ namespace BaseboardRadiator {
 
     void SimBaseboard(EnergyPlusData &state,
                       std::string const &EquipName,
-                      int const ActualZoneNum,
                       int const ControlledZoneNum,
                       bool const FirstHVACIteration,
                       Real64 &PowerMet,
@@ -167,7 +166,7 @@ namespace BaseboardRadiator {
 
         InitBaseboard(state, BaseboardNum, ControlledZoneNum);
 
-        QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputReqToHeatSP;
+        QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputReqToHeatSP;
 
         if ((QZnReq < SmallLoad) || (baseboard->baseboards(BaseboardNum).WaterInletTemp <= baseboard->baseboards(BaseboardNum).AirInletTemp)) {
             //  IF (Baseboard(BaseboardNum)%WaterInletTemp <= Baseboard(BaseboardNum)%AirInletTemp) THEN

--- a/src/EnergyPlus/BaseboardRadiator.cc
+++ b/src/EnergyPlus/BaseboardRadiator.cc
@@ -539,7 +539,7 @@ namespace BaseboardRadiator {
         }
     }
 
-    void InitBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum)
+    void InitBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNum)
     {
 
         // SUBROUTINE INFORMATION:
@@ -566,7 +566,7 @@ namespace BaseboardRadiator {
 
         auto &baseboard = state.dataBaseboardRadiator;
 
-        baseboard->baseboards(BaseboardNum).ZonePtr = ZoneNum;
+        baseboard->baseboards(BaseboardNum).ZonePtr = ControlledZoneNum;
 
         if (baseboard->baseboards(BaseboardNum).SetLoopIndexFlag && allocated(state.dataPlnt->PlantLoop)) {
             errFlag = false;
@@ -641,7 +641,7 @@ namespace BaseboardRadiator {
 
         // Do the every time step initializations
         WaterInletNode = baseboard->baseboards(BaseboardNum).WaterInletNode;
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
+        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
         baseboard->baseboards(BaseboardNum).WaterMassFlowRate = state.dataLoopNodes->Node(WaterInletNode).MassFlowRate;
         baseboard->baseboards(BaseboardNum).WaterInletTemp = state.dataLoopNodes->Node(WaterInletNode).Temp;
         baseboard->baseboards(BaseboardNum).WaterInletEnthalpy = state.dataLoopNodes->Node(WaterInletNode).Enthalpy;

--- a/src/EnergyPlus/BaseboardRadiator.hh
+++ b/src/EnergyPlus/BaseboardRadiator.hh
@@ -106,12 +106,8 @@ namespace BaseboardRadiator {
         bool ZoneEquipmentListChecked = false;
     };
 
-    void SimBaseboard(EnergyPlusData &state,
-                      std::string const &EquipName,
-                      int ControlledZoneNum,
-                      bool FirstHVACIteration,
-                      Real64 &PowerMet,
-                      int &CompIndex);
+    void SimBaseboard(
+        EnergyPlusData &state, std::string const &EquipName, int ControlledZoneNum, bool FirstHVACIteration, Real64 &PowerMet, int &CompIndex);
 
     void GetBaseboardInput(EnergyPlusData &state);
 

--- a/src/EnergyPlus/BaseboardRadiator.hh
+++ b/src/EnergyPlus/BaseboardRadiator.hh
@@ -108,7 +108,6 @@ namespace BaseboardRadiator {
 
     void SimBaseboard(EnergyPlusData &state,
                       std::string const &EquipName,
-                      int ActualZoneNum,
                       int ControlledZoneNum,
                       bool FirstHVACIteration,
                       Real64 &PowerMet,

--- a/src/EnergyPlus/BaseboardRadiator.hh
+++ b/src/EnergyPlus/BaseboardRadiator.hh
@@ -116,7 +116,7 @@ namespace BaseboardRadiator {
 
     void GetBaseboardInput(EnergyPlusData &state);
 
-    void InitBaseboard(EnergyPlusData &state, int BaseboardNum, int ControlledZoneNumSub);
+    void InitBaseboard(EnergyPlusData &state, int BaseboardNum, int ZoneNum);
 
     void SizeBaseboard(EnergyPlusData &state, int BaseboardNum);
 

--- a/src/EnergyPlus/ChilledCeilingPanelSimple.cc
+++ b/src/EnergyPlus/ChilledCeilingPanelSimple.cc
@@ -101,13 +101,8 @@ namespace EnergyPlus::CoolingPanelSimple {
 // MODULE PARAMETER DEFINITIONS
 std::string const cCMO_CoolingPanel_Simple("ZoneHVAC:CoolingPanel:RadiantConvective:Water");
 
-void SimCoolingPanel(EnergyPlusData &state,
-                     std::string const &EquipName,
-                     int const ActualZoneNum,
-                     int const ControlledZoneNum,
-                     bool const FirstHVACIteration,
-                     Real64 &PowerMet,
-                     int &CompIndex)
+void SimCoolingPanel(
+    EnergyPlusData &state, std::string const &EquipName, int const ControlledZoneNum, bool const FirstHVACIteration, Real64 &PowerMet, int &CompIndex)
 {
 
     // SUBROUTINE INFORMATION:
@@ -169,7 +164,7 @@ void SimCoolingPanel(EnergyPlusData &state,
 
         InitCoolingPanel(state, CoolingPanelNum, ControlledZoneNum, FirstHVACIteration);
 
-        QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputReqToCoolSP;
+        QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputReqToCoolSP;
 
         // On the first HVAC iteration the system values are given to the controller, but after that
         // the demand limits are in place and there needs to be feedback to the Zone Equipment

--- a/src/EnergyPlus/ChilledCeilingPanelSimple.cc
+++ b/src/EnergyPlus/ChilledCeilingPanelSimple.cc
@@ -856,7 +856,6 @@ void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int cons
     }
 
     // Do the every time step initializations
-    int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
     ThisCP.WaterMassFlowRate = ThisInNode.MassFlowRate;
     ThisCP.WaterInletTemp = ThisInNode.Temp;
     ThisCP.WaterInletEnthalpy = ThisInNode.Enthalpy;

--- a/src/EnergyPlus/ChilledCeilingPanelSimple.cc
+++ b/src/EnergyPlus/ChilledCeilingPanelSimple.cc
@@ -729,7 +729,7 @@ void GetCoolingPanelInput(EnergyPlusData &state)
     }
 }
 
-void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int const ZoneNum, bool const FirstHVACIteration)
+void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int const ControlledZoneNum, bool const FirstHVACIteration)
 {
 
     // SUBROUTINE INFORMATION:
@@ -763,7 +763,7 @@ void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int cons
     auto &ThisCP(state.dataChilledCeilingPanelSimple->CoolingPanel(CoolingPanelNum));
     auto &ThisInNode(state.dataLoopNodes->Node(ThisCP.WaterInletNode));
 
-    if (ThisCP.ZonePtr <= 0) ThisCP.ZonePtr = ZoneNum;
+    if (ThisCP.ZonePtr <= 0) ThisCP.ZonePtr = ControlledZoneNum;
 
     // Need to check all units to see if they are on ZoneHVAC:EquipmentList or issue warning
     if (!ThisCP.ZoneEquipmentListChecked && state.dataZoneEquip->ZoneEquipInputsFilled) {

--- a/src/EnergyPlus/ChilledCeilingPanelSimple.cc
+++ b/src/EnergyPlus/ChilledCeilingPanelSimple.cc
@@ -734,7 +734,7 @@ void GetCoolingPanelInput(EnergyPlusData &state)
     }
 }
 
-void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int const ControlledZoneNumSub, bool const FirstHVACIteration)
+void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int const ZoneNum, bool const FirstHVACIteration)
 {
 
     // SUBROUTINE INFORMATION:
@@ -761,8 +761,6 @@ void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int cons
     static constexpr std::string_view RoutineName("ChilledCeilingPanelSimple:InitCoolingPanel");
 
     // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-    int ZoneNode;
-    int ZoneNum;
     Real64 rho; // local fluid density
     Real64 Cp;  // local fluid specific heat
     bool errFlag;
@@ -770,7 +768,7 @@ void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int cons
     auto &ThisCP(state.dataChilledCeilingPanelSimple->CoolingPanel(CoolingPanelNum));
     auto &ThisInNode(state.dataLoopNodes->Node(ThisCP.WaterInletNode));
 
-    if (ThisCP.ZonePtr <= 0) ThisCP.ZonePtr = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ActualZoneNum;
+    if (ThisCP.ZonePtr <= 0) ThisCP.ZonePtr = ZoneNum;
 
     // Need to check all units to see if they are on ZoneHVAC:EquipmentList or issue warning
     if (!ThisCP.ZoneEquipmentListChecked && state.dataZoneEquip->ZoneEquipInputsFilled) {
@@ -854,7 +852,7 @@ void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int cons
     }
 
     if (state.dataGlobal->BeginTimeStepFlag && FirstHVACIteration) {
-        ZoneNum = ThisCP.ZonePtr;
+        int ZoneNum = ThisCP.ZonePtr;
         state.dataHeatBal->Zone(ZoneNum).ZeroSourceSumHATsurf = SumHATsurf(state, ZoneNum);
         ThisCP.CoolingPanelSrcAvg = 0.0;
         ThisCP.LastCoolingPanelSrc = 0.0;
@@ -863,7 +861,7 @@ void InitCoolingPanel(EnergyPlusData &state, int const CoolingPanelNum, int cons
     }
 
     // Do the every time step initializations
-    ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ZoneNode;
+    int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
     ThisCP.WaterMassFlowRate = ThisInNode.MassFlowRate;
     ThisCP.WaterInletTemp = ThisInNode.Temp;
     ThisCP.WaterInletEnthalpy = ThisInNode.Enthalpy;

--- a/src/EnergyPlus/ChilledCeilingPanelSimple.hh
+++ b/src/EnergyPlus/ChilledCeilingPanelSimple.hh
@@ -165,13 +165,8 @@ namespace CoolingPanelSimple {
         void ReportCoolingPanel(EnergyPlusData &state);
     };
 
-    void SimCoolingPanel(EnergyPlusData &state,
-                         std::string const &EquipName,
-                         int ActualZoneNum,
-                         int ControlledZoneNum,
-                         bool FirstHVACIteration,
-                         Real64 &PowerMet,
-                         int &CompIndex);
+    void SimCoolingPanel(
+        EnergyPlusData &state, std::string const &EquipName, int ControlledZoneNum, bool FirstHVACIteration, Real64 &PowerMet, int &CompIndex);
 
     void GetCoolingPanelInput(EnergyPlusData &state);
 

--- a/src/EnergyPlus/ChilledCeilingPanelSimple.hh
+++ b/src/EnergyPlus/ChilledCeilingPanelSimple.hh
@@ -175,7 +175,7 @@ namespace CoolingPanelSimple {
 
     void GetCoolingPanelInput(EnergyPlusData &state);
 
-    void InitCoolingPanel(EnergyPlusData &state, int CoolingPanelNum, int ControlledZoneNumSub, bool FirstHVACIteration);
+    void InitCoolingPanel(EnergyPlusData &state, int CoolingPanelNum, int ZoneNum, bool FirstHVACIteration);
 
     void SizeCoolingPanel(EnergyPlusData &state, int CoolingPanelNum);
 

--- a/src/EnergyPlus/ChilledCeilingPanelSimple.hh
+++ b/src/EnergyPlus/ChilledCeilingPanelSimple.hh
@@ -170,7 +170,7 @@ namespace CoolingPanelSimple {
 
     void GetCoolingPanelInput(EnergyPlusData &state);
 
-    void InitCoolingPanel(EnergyPlusData &state, int CoolingPanelNum, int ZoneNum, bool FirstHVACIteration);
+    void InitCoolingPanel(EnergyPlusData &state, int CoolingPanelNum, int ControlledZoneNum, bool FirstHVACIteration);
 
     void SizeCoolingPanel(EnergyPlusData &state, int CoolingPanelNum);
 

--- a/src/EnergyPlus/DataHeatBalance.hh
+++ b/src/EnergyPlus/DataHeatBalance.hh
@@ -570,7 +570,6 @@ namespace DataHeatBalance {
         bool IsControlled = false;                      // True when this is a controlled zone.
         bool IsSupplyPlenum = false;                    // True when this zone is a supply plenum
         bool IsReturnPlenum = false;                    // True when this zone is a return plenum
-        int ZoneEqNum = 0;                              // Controlled zone equip config number
         int PlenumCondNum = 0;                          // Supply or return plenum conditions number, 0 if this is not a plenum zone
         int TempControlledZoneIndex = 0;                // this is the index number for TempControlledZone structure for lookup
         // Pointers to Surface Data Structure

--- a/src/EnergyPlus/DataSizing.hh
+++ b/src/EnergyPlus/DataSizing.hh
@@ -295,7 +295,7 @@ namespace DataSizing {
         // 3=supply cold ventilation air
         Real64 DOASLowSetpoint;         // Dedicated Outside Air Low Setpoint for Design [C]
         Real64 DOASHighSetpoint;        // Dedicated Outside Air High Setpoint for Design [C]
-        int ActualZoneNum;              // index into the Zone data array (in DataHeatBalance)
+        int ZoneNum;                    // index into the Zone data array (in DataHeatBalance)
         Real64 DesHeatMassFlow;         // zone design heating air mass flow rate [kg/s]
         Real64 DesHeatMassFlowNoOA;     // zone design heating air mass flow rate without applying MinOA as a limit [kg/s]
         Real64 DesHeatOAFlowFrac;       // zone design heating OA air volume fraction [-]
@@ -437,7 +437,7 @@ namespace DataSizing {
               DesOAFlowPerArea(0.0), CoolAirDesMethod(0), InpDesCoolAirFlow(0.0), DesCoolMinAirFlowPerArea(0.0), DesCoolMinAirFlow(0.0),
               DesCoolMinAirFlowFrac(0.0), HeatAirDesMethod(0), InpDesHeatAirFlow(0.0), DesHeatMaxAirFlowPerArea(0.0), DesHeatMaxAirFlow(0.0),
               DesHeatMaxAirFlowFrac(0.0), HeatSizingFactor(0.0), CoolSizingFactor(0.0), AccountForDOAS(false), DOASControlStrategy(0),
-              DOASLowSetpoint(0.0), DOASHighSetpoint(0.0), ActualZoneNum(0), DesHeatMassFlow(0.0), DesHeatMassFlowNoOA(0.0), DesHeatOAFlowFrac(0.0),
+              DOASLowSetpoint(0.0), DOASHighSetpoint(0.0), ZoneNum(0), DesHeatMassFlow(0.0), DesHeatMassFlowNoOA(0.0), DesHeatOAFlowFrac(0.0),
               EMSOverrideDesHeatMassOn(false), EMSValueDesHeatMassFlow(0.0), DesCoolMassFlow(0.0), DesCoolMassFlowNoOA(0.0), DesCoolOAFlowFrac(0.0),
               EMSOverrideDesCoolMassOn(false), EMSValueDesCoolMassFlow(0.0), DesHeatLoad(0.0), NonAirSysDesHeatLoad(0.0),
               EMSOverrideDesHeatLoadOn(false), EMSValueDesHeatLoad(0.0), DesCoolLoad(0.0), NonAirSysDesCoolLoad(0.0), EMSOverrideDesCoolLoadOn(false),

--- a/src/EnergyPlus/DataZoneEquipment.cc
+++ b/src/EnergyPlus/DataZoneEquipment.cc
@@ -159,7 +159,6 @@ void GetZoneEquipmentData(EnergyPlusData &state)
     int NodeNum;
     int PathNum;
     int CompNum;
-    int ControlledZoneNum;
     int ControlledZoneLoop;
     int ZoneEquipTypeNum;
     int ZoneEquipListNum;
@@ -179,7 +178,6 @@ void GetZoneEquipmentData(EnergyPlusData &state)
     bool IsNotOK; // Flag to verify nam
     bool NodeListError;
     bool UniqueNodeError;
-    int NumOfControlledZones;        // The number of Controlled Zone Equip Configuration objects
     std::string CurrentModuleObject; // Object type for getting and error messages
     Array1D_string cAlphaFields;     // Alpha field names
     Array1D_string cNumericFields;   // Numeric field names
@@ -216,7 +214,7 @@ void GetZoneEquipmentData(EnergyPlusData &state)
 
     // Look in the input file for zones with air loop and zone equipment attached
 
-    NumOfControlledZones = state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, "ZoneHVAC:EquipmentConnections");
+    int NumOfControlledZones = state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, "ZoneHVAC:EquipmentConnections");
     state.dataZoneEquip->NumOfZoneEquipLists = state.dataInputProcessing->inputProcessor->getNumObjectsFound(
         state, "ZoneHVAC:EquipmentList"); // Look for lists of equipment data - there should
     // be as many of these as there are controlled zones
@@ -306,27 +304,25 @@ void GetZoneEquipmentData(EnergyPlusData &state)
                                                                  cAlphaFields,
                                                                  cNumericFields); // Get Equipment | data for one zone
 
-        ControlledZoneNum = UtilityRoutines::FindItemInList(AlphArray(1), Zone);
+        int zoneNum = UtilityRoutines::FindItemInList(AlphArray(1), Zone);
 
-        if (ControlledZoneNum == 0) {
+        if (zoneNum == 0) {
             ShowSevereError(state, std::string{RoutineName} + CurrentModuleObject + ": " + cAlphaFields(1) + "=\"" + AlphArray(1) + "\"");
             ShowContinueError(state, "..Requested Controlled Zone not among Zones, remaining items for this object not processed.");
             state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
             continue;
         } else {
-            //    Zone(ZoneEquipConfig(ControlledZoneNum)%ActualZoneNum)%ZoneEquipConfigNum = ControlledZoneNum
-            if (Zone(ControlledZoneNum).IsControlled) {
+            if (Zone(zoneNum).IsControlled) {
                 ShowSevereError(state, std::string{RoutineName} + CurrentModuleObject + ": " + cAlphaFields(1) + "=\"" + AlphArray(1) + "\"");
                 ShowContinueError(state, "..Duplicate Controlled Zone entered, only one " + CurrentModuleObject + " per zone is allowed.");
                 state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
                 continue;
             }
-            Zone(ControlledZoneNum).IsControlled = true;
-            Zone(ControlledZoneNum).ZoneEqNum = ControlledZoneNum;
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).IsControlled = true;
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum = ControlledZoneNum;
+            Zone(zoneNum).IsControlled = true;
+            state.dataZoneEquip->ZoneEquipConfig(zoneNum).IsControlled = true;
         }
-        state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName = AlphArray(1); // for x-referencing with the geometry data
+        auto &thisZoneEquipConfig = state.dataZoneEquip->ZoneEquipConfig(zoneNum);
+        thisZoneEquipConfig.ZoneName = AlphArray(1); // for x-referencing with the geometry data
 
         IsNotOK = false;
         GlobalNames::IntraObjUniquenessCheck(
@@ -335,20 +331,19 @@ void GetZoneEquipmentData(EnergyPlusData &state)
             ShowContinueError(state, "..another Controlled Zone has been assigned that " + cAlphaFields(2) + '.');
             state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
         }
-        state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).EquipListName = AlphArray(2); // the name of the list containing all the zone eq.
+        thisZoneEquipConfig.EquipListName = AlphArray(2); // the name of the list containing all the zone eq.
         InletNodeListName = AlphArray(3);
         ExhaustNodeListName = AlphArray(4);
-        state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode =
-            GetOnlySingleNode(state,
-                              AlphArray(5),
-                              state.dataZoneEquip->GetZoneEquipmentDataErrorsFound,
-                              DataLoopNode::ConnectionObjectType::ZoneHVACEquipmentConnections,
-                              AlphArray(1),
-                              DataLoopNode::NodeFluidType::Air,
-                              DataLoopNode::ConnectionType::ZoneNode,
-                              NodeInputManager::CompFluidStream::Primary,
-                              ObjectIsNotParent); // all zone air state variables are
-        if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode == 0) {
+        thisZoneEquipConfig.ZoneNode = GetOnlySingleNode(state,
+                                                         AlphArray(5),
+                                                         state.dataZoneEquip->GetZoneEquipmentDataErrorsFound,
+                                                         DataLoopNode::ConnectionObjectType::ZoneHVACEquipmentConnections,
+                                                         AlphArray(1),
+                                                         DataLoopNode::NodeFluidType::Air,
+                                                         DataLoopNode::ConnectionType::ZoneNode,
+                                                         NodeInputManager::CompFluidStream::Primary,
+                                                         ObjectIsNotParent); // all zone air state variables are
+        if (thisZoneEquipConfig.ZoneNode == 0) {
             ShowSevereError(state, std::string{RoutineName} + CurrentModuleObject + ": " + cAlphaFields(1) + "=\"" + AlphArray(1) + "\", invalid");
             ShowContinueError(state, cAlphaFields(5) + " must be present.");
             state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
@@ -361,17 +356,16 @@ void GetZoneEquipmentData(EnergyPlusData &state)
             }
         }
         // assigned to this node
-        if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum > 0) {
-            Zone(state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum).SystemZoneNodeNumber =
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
+        if (zoneNum > 0) {
+            Zone(zoneNum).SystemZoneNodeNumber = thisZoneEquipConfig.ZoneNode;
         } // This error already detected and program will be terminated.
 
         ReturnNodeListName = AlphArray(6);
         if (lAlphaBlanks(7)) {
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnFlowSchedPtrNum = DataGlobalConstants::ScheduleAlwaysOn;
+            thisZoneEquipConfig.ReturnFlowSchedPtrNum = DataGlobalConstants::ScheduleAlwaysOn;
         } else {
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnFlowSchedPtrNum = GetScheduleIndex(state, AlphArray(7));
-            if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnFlowSchedPtrNum == 0) {
+            thisZoneEquipConfig.ReturnFlowSchedPtrNum = GetScheduleIndex(state, AlphArray(7));
+            if (thisZoneEquipConfig.ReturnFlowSchedPtrNum == 0) {
                 ShowSevereError(state,
                                 std::string{RoutineName} + CurrentModuleObject + ": invalid " + cAlphaFields(7) + " entered =" + AlphArray(7) +
                                     " for " + cAlphaFields(1) + '=' + AlphArray(1));
@@ -385,11 +379,10 @@ void GetZoneEquipmentData(EnergyPlusData &state)
 
         CurrentModuleObject = "ZoneHVAC:EquipmentList";
 
-        ZoneEquipListNum = state.dataInputProcessing->inputProcessor->getObjectItemNum(
-            state, CurrentModuleObject, state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).EquipListName);
+        ZoneEquipListNum = state.dataInputProcessing->inputProcessor->getObjectItemNum(state, CurrentModuleObject, thisZoneEquipConfig.EquipListName);
         if (ZoneEquipListNum > 0) {
 
-            EquipList &thisZoneEquipList = state.dataZoneEquip->ZoneEquipList(ControlledZoneNum);
+            EquipList &thisZoneEquipList = state.dataZoneEquip->ZoneEquipList(zoneNum);
 
             state.dataInputProcessing->inputProcessor->getObjectItem(state,
                                                                      CurrentModuleObject,
@@ -600,11 +593,8 @@ void GetZoneEquipmentData(EnergyPlusData &state)
             }
 
         } else {
-            ShowSevereError(state,
-                            std::string{RoutineName} + CurrentModuleObject +
-                                " not found = " + state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).EquipListName);
-            ShowContinueError(
-                state, "In ZoneHVAC:EquipmentConnections object, for Zone = " + state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName);
+            ShowSevereError(state, std::string{RoutineName} + CurrentModuleObject + " not found = " + thisZoneEquipConfig.EquipListName);
+            ShowContinueError(state, "In ZoneHVAC:EquipmentConnections object, for Zone = " + thisZoneEquipConfig.ZoneName);
             state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
         }
 
@@ -618,45 +608,41 @@ void GetZoneEquipmentData(EnergyPlusData &state)
                     NodeListError,
                     DataLoopNode::NodeFluidType::Air,
                     DataLoopNode::ConnectionObjectType::ZoneHVACEquipmentConnections,
-                    state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName,
+                    thisZoneEquipConfig.ZoneName,
                     DataLoopNode::ConnectionType::ZoneInlet,
                     NodeInputManager::CompFluidStream::Primary,
                     ObjectIsNotParent);
 
         if (!NodeListError) {
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes = NumNodes;
+            thisZoneEquipConfig.NumInletNodes = NumNodes;
 
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNode.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeADUNum.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).AirDistUnitCool.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).AirDistUnitHeat.allocate(NumNodes);
+            thisZoneEquipConfig.InletNode.allocate(NumNodes);
+            thisZoneEquipConfig.InletNodeAirLoopNum.allocate(NumNodes);
+            thisZoneEquipConfig.InletNodeADUNum.allocate(NumNodes);
+            thisZoneEquipConfig.AirDistUnitCool.allocate(NumNodes);
+            thisZoneEquipConfig.AirDistUnitHeat.allocate(NumNodes);
 
             for (NodeNum = 1; NodeNum <= NumNodes; ++NodeNum) {
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNode(NodeNum) = NodeNums(NodeNum);
+                thisZoneEquipConfig.InletNode(NodeNum) = NodeNums(NodeNum);
                 UniqueNodeError = false;
-                CheckUniqueNodeNumbers(state,
-                                       "Zone Air Inlet Nodes",
-                                       UniqueNodeError,
-                                       NodeNums(NodeNum),
-                                       state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName);
+                CheckUniqueNodeNumbers(state, "Zone Air Inlet Nodes", UniqueNodeError, NodeNums(NodeNum), thisZoneEquipConfig.ZoneName);
                 if (UniqueNodeError) {
                     state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
                 }
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(NodeNum) = 0;
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeADUNum(NodeNum) = 0;
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).AirDistUnitCool(NodeNum).InNode = 0;
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).AirDistUnitHeat(NodeNum).InNode = 0;
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).AirDistUnitCool(NodeNum).OutNode = 0;
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).AirDistUnitHeat(NodeNum).OutNode = 0;
+                thisZoneEquipConfig.InletNodeAirLoopNum(NodeNum) = 0;
+                thisZoneEquipConfig.InletNodeADUNum(NodeNum) = 0;
+                thisZoneEquipConfig.AirDistUnitCool(NodeNum).InNode = 0;
+                thisZoneEquipConfig.AirDistUnitHeat(NodeNum).InNode = 0;
+                thisZoneEquipConfig.AirDistUnitCool(NodeNum).OutNode = 0;
+                thisZoneEquipConfig.AirDistUnitHeat(NodeNum).OutNode = 0;
                 ++locTermUnitSizingCounter;
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).AirDistUnitCool(NodeNum).TermUnitSizingIndex = locTermUnitSizingCounter;
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).AirDistUnitHeat(NodeNum).TermUnitSizingIndex = locTermUnitSizingCounter;
+                thisZoneEquipConfig.AirDistUnitCool(NodeNum).TermUnitSizingIndex = locTermUnitSizingCounter;
+                thisZoneEquipConfig.AirDistUnitHeat(NodeNum).TermUnitSizingIndex = locTermUnitSizingCounter;
             }
         } else {
             ShowContinueError(state,
                               "Invalid Zone Air Inlet Node or NodeList Name in ZoneHVAC:EquipmentConnections object, for Zone = " +
-                                  state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName);
+                                  thisZoneEquipConfig.ZoneName);
             state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
         }
 
@@ -668,24 +654,20 @@ void GetZoneEquipmentData(EnergyPlusData &state)
                     NodeListError,
                     DataLoopNode::NodeFluidType::Air,
                     DataLoopNode::ConnectionObjectType::ZoneHVACEquipmentConnections,
-                    state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName,
+                    thisZoneEquipConfig.ZoneName,
                     DataLoopNode::ConnectionType::ZoneExhaust,
                     NodeInputManager::CompFluidStream::Primary,
                     ObjectIsNotParent);
 
         if (!NodeListError) {
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumExhaustNodes = NumNodes;
+            thisZoneEquipConfig.NumExhaustNodes = NumNodes;
 
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ExhaustNode.allocate(NumNodes);
+            thisZoneEquipConfig.ExhaustNode.allocate(NumNodes);
 
             for (NodeNum = 1; NodeNum <= NumNodes; ++NodeNum) {
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ExhaustNode(NodeNum) = NodeNums(NodeNum);
+                thisZoneEquipConfig.ExhaustNode(NodeNum) = NodeNums(NodeNum);
                 UniqueNodeError = false;
-                CheckUniqueNodeNumbers(state,
-                                       "Zone Air Exhaust Nodes",
-                                       UniqueNodeError,
-                                       NodeNums(NodeNum),
-                                       state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName);
+                CheckUniqueNodeNumbers(state, "Zone Air Exhaust Nodes", UniqueNodeError, NodeNums(NodeNum), thisZoneEquipConfig.ZoneName);
                 if (UniqueNodeError) {
                     // ShowContinueError(state,  "Occurs for Zone = " + trim( AlphArray( 1 ) ) );
                     state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
@@ -694,7 +676,7 @@ void GetZoneEquipmentData(EnergyPlusData &state)
         } else {
             ShowContinueError(state,
                               "Invalid Zone Air Exhaust Node or NodeList Name in ZoneHVAC:EquipmentConnections object, for Zone=" +
-                                  state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName);
+                                  thisZoneEquipConfig.ZoneName);
             state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
         }
 
@@ -706,37 +688,33 @@ void GetZoneEquipmentData(EnergyPlusData &state)
                     NodeListError,
                     DataLoopNode::NodeFluidType::Air,
                     DataLoopNode::ConnectionObjectType::ZoneHVACEquipmentConnections,
-                    state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName,
+                    thisZoneEquipConfig.ZoneName,
                     DataLoopNode::ConnectionType::ZoneReturn,
                     NodeInputManager::CompFluidStream::Primary,
                     ObjectIsNotParent);
 
         if (!NodeListError) {
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumReturnNodes = NumNodes;
+            thisZoneEquipConfig.NumReturnNodes = NumNodes;
 
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNode.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNodeAirLoopNum.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNodeInletNum.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).FixedReturnFlow.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNodePlenumNum.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNodeExhaustNodeNum.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).SharedExhaustNode.allocate(NumNodes);
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNode = 0;               // initialize to zero here
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNodeAirLoopNum = 0;     // initialize to zero here
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNodeInletNum = 0;       // initialize to zero here
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).FixedReturnFlow = false;      // initialize to false here
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNodePlenumNum = 0;      // initialize to zero here
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNodeExhaustNodeNum = 0; // initialize to zero here
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).SharedExhaustNode = LightReturnExhaustConfig::NoExhast; // initialize to zero here
+            thisZoneEquipConfig.ReturnNode.allocate(NumNodes);
+            thisZoneEquipConfig.ReturnNodeAirLoopNum.allocate(NumNodes);
+            thisZoneEquipConfig.ReturnNodeInletNum.allocate(NumNodes);
+            thisZoneEquipConfig.FixedReturnFlow.allocate(NumNodes);
+            thisZoneEquipConfig.ReturnNodePlenumNum.allocate(NumNodes);
+            thisZoneEquipConfig.ReturnNodeExhaustNodeNum.allocate(NumNodes);
+            thisZoneEquipConfig.SharedExhaustNode.allocate(NumNodes);
+            thisZoneEquipConfig.ReturnNode = 0;                                         // initialize to zero here
+            thisZoneEquipConfig.ReturnNodeAirLoopNum = 0;                               // initialize to zero here
+            thisZoneEquipConfig.ReturnNodeInletNum = 0;                                 // initialize to zero here
+            thisZoneEquipConfig.FixedReturnFlow = false;                                // initialize to false here
+            thisZoneEquipConfig.ReturnNodePlenumNum = 0;                                // initialize to zero here
+            thisZoneEquipConfig.ReturnNodeExhaustNodeNum = 0;                           // initialize to zero here
+            thisZoneEquipConfig.SharedExhaustNode = LightReturnExhaustConfig::NoExhast; // initialize to zero here
 
             for (NodeNum = 1; NodeNum <= NumNodes; ++NodeNum) {
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNode(NodeNum) = NodeNums(NodeNum);
+                thisZoneEquipConfig.ReturnNode(NodeNum) = NodeNums(NodeNum);
                 UniqueNodeError = false;
-                CheckUniqueNodeNumbers(state,
-                                       "Zone Return Air Nodes",
-                                       UniqueNodeError,
-                                       NodeNums(NodeNum),
-                                       state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName);
+                CheckUniqueNodeNumbers(state, "Zone Return Air Nodes", UniqueNodeError, NodeNums(NodeNum), thisZoneEquipConfig.ZoneName);
                 if (UniqueNodeError) {
                     // ShowContinueError(state,  "Occurs for Zone = " + trim( AlphArray( 1 ) ) );
                     state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
@@ -745,7 +723,7 @@ void GetZoneEquipmentData(EnergyPlusData &state)
         } else {
             ShowContinueError(state,
                               "Invalid Zone Return Air Node or NodeList Name in ZoneHVAC:EquipmentConnections object, for Zone=" +
-                                  state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName);
+                                  thisZoneEquipConfig.ZoneName);
             state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
         }
 
@@ -757,24 +735,24 @@ void GetZoneEquipmentData(EnergyPlusData &state)
                     NodeListError,
                     DataLoopNode::NodeFluidType::Air,
                     DataLoopNode::ConnectionObjectType::ZoneHVACEquipmentConnections,
-                    state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName,
+                    thisZoneEquipConfig.ZoneName,
                     DataLoopNode::ConnectionType::Sensor,
                     NodeInputManager::CompFluidStream::Primary,
                     ObjectIsNotParent);
 
         if (!NodeListError) {
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumReturnFlowBasisNodes = NumNodes;
+            thisZoneEquipConfig.NumReturnFlowBasisNodes = NumNodes;
 
-            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnFlowBasisNode.allocate(NumNodes);
+            thisZoneEquipConfig.ReturnFlowBasisNode.allocate(NumNodes);
 
             for (NodeNum = 1; NodeNum <= NumNodes; ++NodeNum) {
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnFlowBasisNode(NodeNum) = NodeNums(NodeNum);
+                thisZoneEquipConfig.ReturnFlowBasisNode(NodeNum) = NodeNums(NodeNum);
             }
         } else {
             ShowContinueError(
                 state,
                 "Invalid Zone Return Air Node 1 Flow Rate Basis Node or NodeList Name in ZoneHVAC:EquipmentConnections object, for Zone=" +
-                    state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneName);
+                    thisZoneEquipConfig.ZoneName);
             state.dataZoneEquip->GetZoneEquipmentDataErrorsFound = true;
         }
 
@@ -1089,33 +1067,27 @@ int FindControlledZoneIndexFromSystemNodeNumberForZone(EnergyPlusData &state,
     // FUNCTION INFORMATION:
     //       AUTHOR         Brent Griffith
     //       DATE WRITTEN   August 2013
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS FUNCTION:
     // This function returns the zone number for the indicated
     // zone node num.  Returns 0 if did not find zone node in any Zone
 
     // Return value
-    int ControlledZoneIndex; // Index into Controlled Zone structure
+    int ControlledZoneIndex = 0; // Index into Controlled Zone structure
 
-    // FUNCTION LOCAL VARIABLE DECLARATIONS:
-    bool FoundIt;
-    int ZoneNum;
-
-    FoundIt = false;
+    bool FoundIt = false;
 
     if (!state.dataZoneEquip->ZoneEquipInputsFilled) {
         GetZoneEquipmentData(state);
         state.dataZoneEquip->ZoneEquipInputsFilled = true;
     }
-    ControlledZoneIndex = 0;
-    for (ZoneNum = 1; ZoneNum <= state.dataGlobal->NumOfZones; ++ZoneNum) {
-        if (state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ActualZoneNum > 0) {
+
+    for (int ZoneNum = 1; ZoneNum <= state.dataGlobal->NumOfZones; ++ZoneNum) {
+        if (state.dataZoneEquip->ZoneEquipConfig(ZoneNum).IsControlled) {
             if (TrialZoneNodeNum == state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode) {
                 // found it.
                 FoundIt = true;
-                ControlledZoneIndex = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ActualZoneNum;
+                ControlledZoneIndex = ZoneNum;
             }
         }
     }
@@ -1123,35 +1095,28 @@ int FindControlledZoneIndexFromSystemNodeNumberForZone(EnergyPlusData &state,
     return ControlledZoneIndex;
 }
 
-int GetSystemNodeNumberForZone(EnergyPlusData &state, std::string const &ZoneName) // Zone name to match into Controlled Zone structure
+int GetSystemNodeNumberForZone(EnergyPlusData &state, int const zoneNum)
 {
 
     // FUNCTION INFORMATION:
     //       AUTHOR         Linda Lawrie
     //       DATE WRITTEN   March 2008
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS FUNCTION:
     // This function returns the system node number for the indicated
     // zone.  Returns 0 if the Zone is not a controlled zone.
 
     // Return value
-    int SystemZoneNodeNumber; // System node number for controlled zone
-
-    // FUNCTION LOCAL VARIABLE DECLARATIONS:
-    int ControlledZoneIndex;
+    int SystemZoneNodeNumber = 0; // System node number for controlled zone
 
     if (!state.dataZoneEquip->ZoneEquipInputsFilled) {
         GetZoneEquipmentData(state);
         state.dataZoneEquip->ZoneEquipInputsFilled = true;
     }
 
-    ControlledZoneIndex = UtilityRoutines::FindItemInList(ZoneName, state.dataZoneEquip->ZoneEquipConfig, &EquipConfiguration::ZoneName);
-    SystemZoneNodeNumber = 0; // default is not found
-    if (ControlledZoneIndex > 0) {
-        if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneIndex).ActualZoneNum > 0) {
-            SystemZoneNodeNumber = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneIndex).ZoneNode;
+    if (zoneNum > 0) {
+        if (state.dataZoneEquip->ZoneEquipConfig(zoneNum).IsControlled) {
+            SystemZoneNodeNumber = state.dataZoneEquip->ZoneEquipConfig(zoneNum).ZoneNode;
         }
     }
 
@@ -1159,7 +1124,7 @@ int GetSystemNodeNumberForZone(EnergyPlusData &state, std::string const &ZoneNam
 }
 
 int GetReturnAirNodeForZone(EnergyPlusData &state,
-                            std::string const &ZoneName,             // Zone name to match into Controlled Zone structure
+                            int const zoneNum,
                             std::string const &NodeName,             // Return air node name to match (may be blank)
                             std::string const &calledFromDescription // String identifying the calling function and object
 )
@@ -1177,20 +1142,18 @@ int GetReturnAirNodeForZone(EnergyPlusData &state,
     // Returns 0 if the Zone is not a controlled zone or the node name does not match.
 
     // Return value
-    int ReturnAirNodeNumber; // Return Air node number for controlled zone
-    int ControlledZoneIndex;
+    int ReturnAirNodeNumber = 0; // Return Air node number for controlled zone
 
     if (!state.dataZoneEquip->ZoneEquipInputsFilled) {
         GetZoneEquipmentData(state);
         state.dataZoneEquip->ZoneEquipInputsFilled = true;
     }
 
-    ControlledZoneIndex = UtilityRoutines::FindItemInList(ZoneName, state.dataZoneEquip->ZoneEquipConfig, &EquipConfiguration::ZoneName);
     ReturnAirNodeNumber = 0; // default is not found
-    if (ControlledZoneIndex > 0) {
+    if (zoneNum > 0) {
         {
-            auto const &thisZoneEquip(state.dataZoneEquip->ZoneEquipConfig(ControlledZoneIndex));
-            if (thisZoneEquip.ActualZoneNum > 0) {
+            auto const &thisZoneEquip(state.dataZoneEquip->ZoneEquipConfig(zoneNum));
+            if (thisZoneEquip.IsControlled) {
                 if (NodeName.empty()) {
                     // If NodeName is blank, return first return node number, but warn if there are multiple return nodes for this zone
                     ReturnAirNodeNumber = thisZoneEquip.ReturnNode(1);
@@ -1217,8 +1180,8 @@ int GetReturnAirNodeForZone(EnergyPlusData &state,
 }
 
 int GetReturnNumForZone(EnergyPlusData &state,
-                        std::string const &ZoneName, // Zone name to match into Controlled Zone structure
-                        std::string const &NodeName  // Return air node name to match (may be blank)
+                        int const zoneNum,
+                        std::string const &NodeName // Return air node name to match (may be blank)
 )
 {
 
@@ -1229,25 +1192,21 @@ int GetReturnNumForZone(EnergyPlusData &state,
     // Returns 0 if the Zone is not a controlled zone or the node name does not match.
 
     // Return value
-    int ReturnIndex; // Return number for the given zone (not the node number)
-
-    int ControlledZoneIndex;
+    int ReturnIndex = 0; // Return number for the given zone (not the node number)
 
     if (!state.dataZoneEquip->ZoneEquipInputsFilled) {
         GetZoneEquipmentData(state);
         state.dataZoneEquip->ZoneEquipInputsFilled = true;
     }
 
-    ControlledZoneIndex = UtilityRoutines::FindItemInList(ZoneName, state.dataZoneEquip->ZoneEquipConfig, &EquipConfiguration::ZoneName);
-    ReturnIndex = 0; // default if not found
-    if (ControlledZoneIndex > 0) {
-        if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneIndex).ActualZoneNum > 0) {
+    if (zoneNum > 0) {
+        if (state.dataZoneEquip->ZoneEquipConfig(zoneNum).IsControlled) {
             if (NodeName.empty()) {
                 // If NodeName is blank, return first return node number
                 ReturnIndex = 1;
             } else {
-                for (int nodeCount = 1; nodeCount <= state.dataZoneEquip->ZoneEquipConfig(ControlledZoneIndex).NumReturnNodes; ++nodeCount) {
-                    int curNodeNum = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneIndex).ReturnNode(nodeCount);
+                for (int nodeCount = 1; nodeCount <= state.dataZoneEquip->ZoneEquipConfig(zoneNum).NumReturnNodes; ++nodeCount) {
+                    int curNodeNum = state.dataZoneEquip->ZoneEquipConfig(zoneNum).ReturnNode(nodeCount);
                     if (NodeName == state.dataLoopNodes->NodeID(curNodeNum)) {
                         ReturnIndex = nodeCount;
                     }
@@ -1261,19 +1220,15 @@ int GetReturnNumForZone(EnergyPlusData &state,
 
 bool VerifyLightsExhaustNodeForZone(EnergyPlusData &state, int const ZoneNum, int const ZoneExhaustNodeNum)
 {
-    bool exhaustNodeError;
-    int ExhaustNum;
-
-    exhaustNodeError = true;
+    bool exhaustNodeError = true;
 
     if (!state.dataZoneEquip->ZoneEquipInputsFilled) {
         GetZoneEquipmentData(state);
         state.dataZoneEquip->ZoneEquipInputsFilled = true;
     }
 
-    for (ExhaustNum = 1; ExhaustNum <= state.dataZoneEquip->ZoneEquipConfig(state.dataHeatBal->Zone(ZoneNum).ZoneEqNum).NumExhaustNodes;
-         ++ExhaustNum) {
-        if (ZoneExhaustNodeNum == state.dataZoneEquip->ZoneEquipConfig(state.dataHeatBal->Zone(ZoneNum).ZoneEqNum).ExhaustNode(ExhaustNum)) {
+    for (int ExhaustNum = 1; ExhaustNum <= state.dataZoneEquip->ZoneEquipConfig(ZoneNum).NumExhaustNodes; ++ExhaustNum) {
+        if (ZoneExhaustNodeNum == state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ExhaustNode(ExhaustNum)) {
             exhaustNodeError = false;
             break;
         }

--- a/src/EnergyPlus/DataZoneEquipment.hh
+++ b/src/EnergyPlus/DataZoneEquipment.hh
@@ -282,7 +282,6 @@ namespace DataZoneEquipment {
     {
         // Members
         std::string ZoneName;
-        int ActualZoneNum; // index into the Zone data
         std::string EquipListName;
         int EquipListIndex;
         std::string ControlListName;
@@ -339,9 +338,9 @@ namespace DataZoneEquipment {
 
         // Default Constructor
         EquipConfiguration()
-            : ZoneName("Uncontrolled Zone"), ActualZoneNum(0), EquipListIndex(0), ZoneNode(0), NumInletNodes(0), NumExhaustNodes(0),
-              NumReturnNodes(0), NumReturnFlowBasisNodes(0), ReturnFlowSchedPtrNum(0), FlowError(false), ZonalSystemOnly(false), IsControlled(false),
-              ZoneExh(0.0), ZoneExhBalanced(0.0), PlenumMassFlow(0.0), ExcessZoneExh(0.0), TotAvailAirLoopOA(0.0), TotInletAirMassFlowRate(0.0),
+            : ZoneName("Uncontrolled Zone"), EquipListIndex(0), ZoneNode(0), NumInletNodes(0), NumExhaustNodes(0), NumReturnNodes(0),
+              NumReturnFlowBasisNodes(0), ReturnFlowSchedPtrNum(0), FlowError(false), ZonalSystemOnly(false), IsControlled(false), ZoneExh(0.0),
+              ZoneExhBalanced(0.0), PlenumMassFlow(0.0), ExcessZoneExh(0.0), TotAvailAirLoopOA(0.0), TotInletAirMassFlowRate(0.0),
               TotExhaustAirMassFlowRate(0.0), InFloorActiveElement(false), InWallActiveElement(false), InCeilingActiveElement(false),
               ZoneHasAirFlowWindowReturn(false), ZoneHasAirLoopWithOASys(false), ZoneAirDistributionIndex(0), ZoneDesignSpecOAIndex(0),
               AirLoopDesSupply(0.0)
@@ -485,17 +484,17 @@ namespace DataZoneEquipment {
     int FindControlledZoneIndexFromSystemNodeNumberForZone(EnergyPlusData &state,
                                                            int TrialZoneNodeNum); // Node number to match into Controlled Zone structure
 
-    int GetSystemNodeNumberForZone(EnergyPlusData &state, std::string const &ZoneName); // Zone name to match into Controlled Zone structure
+    int GetSystemNodeNumberForZone(EnergyPlusData &state, int const zoneNum);
 
     int GetReturnAirNodeForZone(EnergyPlusData &state,
-                                std::string const &ZoneName,             // Zone name to match into Controlled Zone structure
+                                int const zoneNum,
                                 std::string const &NodeName,             // Return air node name to match (may be blank)
                                 std::string const &calledFromDescription // String identifying the calling function and object
     );
 
     int GetReturnNumForZone(EnergyPlusData &state,
-                            std::string const &ZoneName, // Zone name to match into Controlled Zone structure
-                            std::string const &NodeName  // Return air node name to match (may be blank)
+                            int const zoneNum,
+                            std::string const &NodeName // Return air node name to match (may be blank)
     );
 
     int GetZoneEquipControlledZoneNum(EnergyPlusData &state, DataZoneEquipment::ZoneEquip const ZoneEquipTypeNum, std::string const &EquipmentName);

--- a/src/EnergyPlus/DualDuct.cc
+++ b/src/EnergyPlus/DualDuct.cc
@@ -337,7 +337,6 @@ namespace DualDuct {
                                     state.dataDefineEquipment->AirDistUnit(thisDD.ADUNum).ZoneEqNum = CtrlZone;
                                 }
                                 thisDD.CtrlZoneNum = CtrlZone;
-                                thisDD.ActualZoneNum = thisZoneEquipConfig.ActualZoneNum;
                                 thisDD.CtrlZoneInNodeIndex = SupAirIn;
                             }
                         }
@@ -469,7 +468,6 @@ namespace DualDuct {
                                 state.dataDefineEquipment->AirDistUnit(thisDD.ADUNum).ZoneEqNum = CtrlZone;
 
                                 thisDD.CtrlZoneNum = CtrlZone;
-                                thisDD.ActualZoneNum = thisZoneEquipConfig.ActualZoneNum;
                                 thisDD.CtrlZoneInNodeIndex = SupAirIn;
                             }
                         }
@@ -649,7 +647,6 @@ namespace DualDuct {
                                 state.dataDefineEquipment->AirDistUnit(thisDD.ADUNum).ZoneEqNum = CtrlZone;
 
                                 thisDD.CtrlZoneNum = CtrlZone;
-                                thisDD.ActualZoneNum = thisZoneEquipConfig.ActualZoneNum;
                                 thisDD.CtrlZoneInNodeIndex = SupAirIn;
                             }
                         }
@@ -838,7 +835,7 @@ namespace DualDuct {
                 // figure per person by design level for the OA duct.
                 PeopleFlow = 0.0;
                 for (Loop = 1; Loop <= state.dataHeatBal->TotPeople; ++Loop) {
-                    if (state.dataHeatBal->People(Loop).ZonePtr != this->ActualZoneNum) continue;
+                    if (state.dataHeatBal->People(Loop).ZonePtr != this->CtrlZoneNum) continue;
                     int damperOAFlowMethod = state.dataSize->OARequirements(this->OARequirementsPtr).OAFlowMethod;
                     if (damperOAFlowMethod == DataSizing::OAFlowPPer || damperOAFlowMethod == DataSizing::OAFlowSum ||
                         damperOAFlowMethod == DataSizing::OAFlowMax) {
@@ -1663,7 +1660,7 @@ namespace DualDuct {
                 Real64 const OAVolumeFlowRate =
                     DataSizing::calcDesignSpecificationOutdoorAir(state,
                                                                   this->OARequirementsPtr,
-                                                                  this->ActualZoneNum,
+                                                                  this->CtrlZoneNum,
                                                                   state.dataAirLoop->AirLoopControlInfo(AirLoopNum).AirLoopDCVFlag,
                                                                   UseMinOASchFlag);
                 Real64 const OAMassFlow = OAVolumeFlowRate * state.dataEnvrn->StdRhoAir;
@@ -1711,7 +1708,7 @@ namespace DualDuct {
         bool constexpr UseMinOASchFlag(true); // Always use min OA schedule in calculations.
         Real64 OAVolumeFlowRate = DataSizing::calcDesignSpecificationOutdoorAir(state,
                                                                                 this->OARequirementsPtr,
-                                                                                this->ActualZoneNum,
+                                                                                this->CtrlZoneNum,
                                                                                 UseOccSchFlag,
                                                                                 UseMinOASchFlag,
                                                                                 PerPersonNotSet); // outside air volume flow rate (m3/s)
@@ -1720,7 +1717,7 @@ namespace DualDuct {
 
         if (present(MaxOAVolFlow)) {
             OAVolumeFlowRate = DataSizing::calcDesignSpecificationOutdoorAir(
-                state, this->OARequirementsPtr, this->ActualZoneNum, UseOccSchFlag, UseMinOASchFlag, false, true);
+                state, this->OARequirementsPtr, this->CtrlZoneNum, UseOccSchFlag, UseMinOASchFlag, false, true);
             MaxOAVolFlow = OAVolumeFlowRate;
         }
     }

--- a/src/EnergyPlus/DualDuct.hh
+++ b/src/EnergyPlus/DualDuct.hh
@@ -122,7 +122,6 @@ namespace DualDuct {
         int ADUNum = 0;                                            // index of corresponding air distribution unit ZoneHVAC:AirdistributionUnit
         int CtrlZoneNum = 0;                                       // Pointer to CtrlZone data structure
         int CtrlZoneInNodeIndex = 0;                               // which controlled zone inlet node number corresponds with this unit
-        int ActualZoneNum = 0;                                     // Pointer to Zone data Structure
         Real64 OutdoorAirFlowRate = 0.0;                           // report variable for TU outdoor air flow rate
         bool NoOAFlowInputFromUser = true;                         // avoids OA calculation if no input specified by user
         int OARequirementsPtr = 0;                                 // - Index to DesignSpecification:OutdoorAir object

--- a/src/EnergyPlus/ElectricBaseboardRadiator.cc
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.cc
@@ -561,7 +561,7 @@ namespace ElectricBaseboardRadiator {
         }
     }
 
-    void InitElectricBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration)
+    void InitElectricBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNum, bool const FirstHVACIteration)
     {
 
         // SUBROUTINE INFORMATION:
@@ -608,7 +608,7 @@ namespace ElectricBaseboardRadiator {
             MyOneTimeFlag = false;
         }
 
-        if (ElecBaseboard(BaseboardNum).ZonePtr <= 0) ElecBaseboard(BaseboardNum).ZonePtr = ZoneNum;
+        if (ElecBaseboard(BaseboardNum).ZonePtr <= 0) ElecBaseboard(BaseboardNum).ZonePtr = ControlledZoneNum;
 
         if (!state.dataGlobal->SysSizingCalc && MySizeFlag(BaseboardNum)) {
             // for each coil, do the sizing once.
@@ -645,7 +645,7 @@ namespace ElectricBaseboardRadiator {
         }
 
         if (state.dataGlobal->BeginTimeStepFlag && FirstHVACIteration) {
-            ZeroSourceSumHATsurf(ZoneNum) = SumHATsurf(state, ZoneNum);
+            ZeroSourceSumHATsurf(ControlledZoneNum) = SumHATsurf(state, ControlledZoneNum);
             QBBElecRadSrcAvg(BaseboardNum) = 0.0;
             LastQBBElecRadSrc(BaseboardNum) = 0.0;
             LastSysTimeElapsed(BaseboardNum) = 0.0;
@@ -653,7 +653,7 @@ namespace ElectricBaseboardRadiator {
         }
 
         // Do the every time step initializations
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
+        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
         ElecBaseboard(BaseboardNum).AirInletTemp = state.dataLoopNodes->Node(ZoneNode).Temp;
         ElecBaseboard(BaseboardNum).AirInletHumRat = state.dataLoopNodes->Node(ZoneNode).HumRat;
 

--- a/src/EnergyPlus/ElectricBaseboardRadiator.cc
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.cc
@@ -99,7 +99,6 @@ namespace ElectricBaseboardRadiator {
 
     void SimElecBaseboard(EnergyPlusData &state,
                           std::string const &EquipName,
-                          [[maybe_unused]] int const ActualZoneNum,
                           int const ControlledZoneNum,
                           bool const FirstHVACIteration,
                           Real64 &PowerMet,
@@ -609,8 +608,7 @@ namespace ElectricBaseboardRadiator {
             MyOneTimeFlag = false;
         }
 
-        if (ElecBaseboard(BaseboardNum).ZonePtr <= 0)
-            ElecBaseboard(BaseboardNum).ZonePtr = ZoneNum;
+        if (ElecBaseboard(BaseboardNum).ZonePtr <= 0) ElecBaseboard(BaseboardNum).ZonePtr = ZoneNum;
 
         if (!state.dataGlobal->SysSizingCalc && MySizeFlag(BaseboardNum)) {
             // for each coil, do the sizing once.

--- a/src/EnergyPlus/ElectricBaseboardRadiator.cc
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.cc
@@ -562,7 +562,7 @@ namespace ElectricBaseboardRadiator {
         }
     }
 
-    void InitElectricBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNumSub, bool const FirstHVACIteration)
+    void InitElectricBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration)
     {
 
         // SUBROUTINE INFORMATION:
@@ -578,7 +578,6 @@ namespace ElectricBaseboardRadiator {
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         int ZoneNode;
-        int ZoneNum;
         int Loop;
 
         auto &ElecBaseboard = state.dataElectBaseboardRad->ElecBaseboard;
@@ -611,7 +610,7 @@ namespace ElectricBaseboardRadiator {
         }
 
         if (ElecBaseboard(BaseboardNum).ZonePtr <= 0)
-            ElecBaseboard(BaseboardNum).ZonePtr = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ActualZoneNum;
+            ElecBaseboard(BaseboardNum).ZonePtr = ZoneNum;
 
         if (!state.dataGlobal->SysSizingCalc && MySizeFlag(BaseboardNum)) {
             // for each coil, do the sizing once.
@@ -648,7 +647,6 @@ namespace ElectricBaseboardRadiator {
         }
 
         if (state.dataGlobal->BeginTimeStepFlag && FirstHVACIteration) {
-            ZoneNum = ElecBaseboard(BaseboardNum).ZonePtr;
             ZeroSourceSumHATsurf(ZoneNum) = SumHATsurf(state, ZoneNum);
             QBBElecRadSrcAvg(BaseboardNum) = 0.0;
             LastQBBElecRadSrc(BaseboardNum) = 0.0;
@@ -657,7 +655,7 @@ namespace ElectricBaseboardRadiator {
         }
 
         // Do the every time step initializations
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ZoneNode;
+        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
         ElecBaseboard(BaseboardNum).AirInletTemp = state.dataLoopNodes->Node(ZoneNode).Temp;
         ElecBaseboard(BaseboardNum).AirInletHumRat = state.dataLoopNodes->Node(ZoneNode).HumRat;
 

--- a/src/EnergyPlus/ElectricBaseboardRadiator.hh
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.hh
@@ -122,7 +122,7 @@ namespace ElectricBaseboardRadiator {
 
     void GetElectricBaseboardInput(EnergyPlusData &state);
 
-    void InitElectricBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration);
+    void InitElectricBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNum, bool const FirstHVACIteration);
 
     void SizeElectricBaseboard(EnergyPlusData &state, int const BaseboardNum);
 

--- a/src/EnergyPlus/ElectricBaseboardRadiator.hh
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.hh
@@ -117,12 +117,8 @@ namespace ElectricBaseboardRadiator {
         }
     };
 
-    void SimElecBaseboard(EnergyPlusData &state,
-                          std::string const &EquipName,
-                          int const ZoneNum,
-                          bool const FirstHVACIteration,
-                          Real64 &PowerMet,
-                          int &CompIndex);
+    void SimElecBaseboard(
+        EnergyPlusData &state, std::string const &EquipName, int const ZoneNum, bool const FirstHVACIteration, Real64 &PowerMet, int &CompIndex);
 
     void GetElectricBaseboardInput(EnergyPlusData &state);
 

--- a/src/EnergyPlus/ElectricBaseboardRadiator.hh
+++ b/src/EnergyPlus/ElectricBaseboardRadiator.hh
@@ -119,15 +119,14 @@ namespace ElectricBaseboardRadiator {
 
     void SimElecBaseboard(EnergyPlusData &state,
                           std::string const &EquipName,
-                          int const ActualZoneNum,
-                          int const ControlledZoneNum,
+                          int const ZoneNum,
                           bool const FirstHVACIteration,
                           Real64 &PowerMet,
                           int &CompIndex);
 
     void GetElectricBaseboardInput(EnergyPlusData &state);
 
-    void InitElectricBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNumSub, bool const FirstHVACIteration);
+    void InitElectricBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration);
 
     void SizeElectricBaseboard(EnergyPlusData &state, int const BaseboardNum);
 

--- a/src/EnergyPlus/FanCoilUnits.cc
+++ b/src/EnergyPlus/FanCoilUnits.cc
@@ -143,7 +143,6 @@ namespace FanCoilUnits {
     void SimFanCoilUnit(EnergyPlusData &state,
                         std::string_view CompName,     // name of the fan coil unit
                         int const ZoneNum,             // number of zone being served
-                        int const ControlledZoneNum,   // index into ZoneEquipConfig array; may not be equal to ZoneNum
                         bool const FirstHVACIteration, // TRUE if 1st HVAC simulation of system timestep
                         Real64 &PowerMet,              // Sensible power supplied (W)
                         Real64 &LatOutputProvided,     // Latent add/removal supplied by window AC (kg/s), dehumid = negative
@@ -201,11 +200,11 @@ namespace FanCoilUnits {
         state.dataSize->ZoneEqFanCoil = true;
 
         // Initialize the fan coil unit
-        InitFanCoilUnits(state, FanCoilNum, ZoneNum, ControlledZoneNum);
+        InitFanCoilUnits(state, FanCoilNum, ZoneNum);
 
         // Select the correct unit type
         if (state.dataFanCoilUnits->FanCoil(FanCoilNum).UnitType_Num == FanCoilUnit_4Pipe) {
-            Sim4PipeFanCoil(state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, PowerMet, LatOutputProvided);
+            Sim4PipeFanCoil(state, FanCoilNum, ZoneNum, FirstHVACIteration, PowerMet, LatOutputProvided);
         }
 
         // Report the result of the simulation

--- a/src/EnergyPlus/FanCoilUnits.hh
+++ b/src/EnergyPlus/FanCoilUnits.hh
@@ -276,7 +276,7 @@ namespace FanCoilUnits {
 
     void SimFanCoilUnit(EnergyPlusData &state,
                         std::string_view CompName,     // name of the fan coil unit
-                        int const ZoneNum,             // number of zone being served
+                        int const ControlledZoneNum,   // number of zone being served
                         bool const FirstHVACIteration, // TRUE if 1st HVAC simulation of system timestep
                         Real64 &PowerMet,              // Sensible power supplied (W)
                         Real64 &LatOutputProvided,     // Latent add/removal supplied by window AC (kg/s), dehumid = negative
@@ -285,14 +285,15 @@ namespace FanCoilUnits {
     void GetFanCoilUnits(EnergyPlusData &state);
 
     void InitFanCoilUnits(EnergyPlusData &state,
-                          int const FanCoilNum, // number of the current fan coil unit being simulated
-                          int const ZoneNum);   // number of zone being served
+                          int const FanCoilNum,         // number of the current fan coil unit being simulated
+                          int const ControlledZoneNum); // number of zone being served
 
-    void SizeFanCoilUnit(EnergyPlusData &state, int const FanCoilNum, int const ZoneNum);
+    void SizeFanCoilUnit(EnergyPlusData &state, int const FanCoilNum,
+                         int const ControlledZoneNum); // index into ZoneEquipConfig array
 
     void Sim4PipeFanCoil(EnergyPlusData &state,
                          int &FanCoilNum,               // number of the current fan coil unit being simulated
-                         int const ZoneNum,             // number of zone being served
+                         int const ControlledZoneNum,   // index into ZoneEqupConfig
                          bool const FirstHVACIteration, // TRUE if 1st HVAC simulation of system timestep
                          Real64 &PowerMet,              // Sensible power supplied (W)
                          Real64 &LatOutputProvided      // Latent power supplied (kg/s), negative = dehumidification
@@ -324,7 +325,7 @@ namespace FanCoilUnits {
 
     void Calc4PipeFanCoil(EnergyPlusData &state,
                           int const FanCoilNum,          // Unit index in fan coil array
-                          int const ZoneNum,             // Zone index
+                          int const ControlledZoneNum,   // ZoneEquipConfig index
                           bool const FirstHVACIteration, // flag for 1st HVAV iteration in the time step
                           Real64 &LoadMet,               // load met by unit (watts)
                           Optional<Real64> PLR = _,      // Part Load Ratio, fraction of time step fancoil is on
@@ -333,7 +334,7 @@ namespace FanCoilUnits {
 
     void SimMultiStage4PipeFanCoil(EnergyPlusData &state,
                                    int &FanCoilNum,               // number of the current fan coil unit being simulated
-                                   int const ZoneNum,             // Zone index
+                                   int const ControlledZoneNum,   // index into ZoneEqupConfig
                                    bool const FirstHVACIteration, // TRUE if 1st HVAC simulation of system timestep
                                    Real64 &PowerMet               // Sensible power supplied (W)
     );

--- a/src/EnergyPlus/FanCoilUnits.hh
+++ b/src/EnergyPlus/FanCoilUnits.hh
@@ -277,7 +277,6 @@ namespace FanCoilUnits {
     void SimFanCoilUnit(EnergyPlusData &state,
                         std::string_view CompName,     // name of the fan coil unit
                         int const ZoneNum,             // number of zone being served
-                        int const ControlledZoneNum,   // index into ZoneEquipConfig array; may not be equal to ZoneNum
                         bool const FirstHVACIteration, // TRUE if 1st HVAC simulation of system timestep
                         Real64 &PowerMet,              // Sensible power supplied (W)
                         Real64 &LatOutputProvided,     // Latent add/removal supplied by window AC (kg/s), dehumid = negative
@@ -286,18 +285,14 @@ namespace FanCoilUnits {
     void GetFanCoilUnits(EnergyPlusData &state);
 
     void InitFanCoilUnits(EnergyPlusData &state,
-                          int const FanCoilNum,         // number of the current fan coil unit being simulated
-                          int const ZoneNum,            // number of zone being served
-                          int const ControlledZoneNum); // index into ZoneEquipConfig array; may not be equal to ZoneNum
+                          int const FanCoilNum, // number of the current fan coil unit being simulated
+                          int const ZoneNum);   // number of zone being served
 
-    void SizeFanCoilUnit(EnergyPlusData &state,
-                         int const FanCoilNum,
-                         int const ControlledZoneNum); // index into ZoneEquipConfig array; may not be equal to ZoneNum
+    void SizeFanCoilUnit(EnergyPlusData &state, int const FanCoilNum, int const ZoneNum);
 
     void Sim4PipeFanCoil(EnergyPlusData &state,
                          int &FanCoilNum,               // number of the current fan coil unit being simulated
                          int const ZoneNum,             // number of zone being served
-                         int const ControlledZoneNum,   // index into ZoneEqupConfig
                          bool const FirstHVACIteration, // TRUE if 1st HVAC simulation of system timestep
                          Real64 &PowerMet,              // Sensible power supplied (W)
                          Real64 &LatOutputProvided      // Latent power supplied (kg/s), negative = dehumidification
@@ -329,7 +324,7 @@ namespace FanCoilUnits {
 
     void Calc4PipeFanCoil(EnergyPlusData &state,
                           int const FanCoilNum,          // Unit index in fan coil array
-                          int const ControlledZoneNum,   // ZoneEquipConfig index
+                          int const ZoneNum,             // Zone index
                           bool const FirstHVACIteration, // flag for 1st HVAV iteration in the time step
                           Real64 &LoadMet,               // load met by unit (watts)
                           Optional<Real64> PLR = _,      // Part Load Ratio, fraction of time step fancoil is on
@@ -338,7 +333,7 @@ namespace FanCoilUnits {
 
     void SimMultiStage4PipeFanCoil(EnergyPlusData &state,
                                    int &FanCoilNum,               // number of the current fan coil unit being simulated
-                                   int const ControlledZoneNum,   // index into ZoneEqupConfig
+                                   int const ZoneNum,             // Zone index
                                    bool const FirstHVACIteration, // TRUE if 1st HVAC simulation of system timestep
                                    Real64 &PowerMet               // Sensible power supplied (W)
     );

--- a/src/EnergyPlus/Furnaces.cc
+++ b/src/EnergyPlus/Furnaces.cc
@@ -1123,7 +1123,6 @@ namespace Furnaces {
                     }
                     if (AirLoopFound) break;
                 }
-                if (AirLoopFound) break;
                 if (!AirNodeFound) {
                     ShowSevereError(state, CurrentModuleObject + " = " + Alphas(1));
                     ShowSevereError(state, "Did not find Air Node (Zone with Thermostat).");
@@ -1731,7 +1730,6 @@ namespace Furnaces {
                     }
                     if (AirLoopFound) break;
                 }
-                if (AirLoopFound) break;
                 if (!AirNodeFound) {
                     ShowSevereError(state, CurrentModuleObject + " = " + Alphas(1));
                     ShowContinueError(state, "Did not find air node (zone with thermostat).");
@@ -3071,7 +3069,6 @@ namespace Furnaces {
                     }
                     if (AirLoopFound) break;
                 }
-                if (AirLoopFound) break;
                 if (!AirNodeFound) {
                     ShowSevereError(state, CurrentModuleObject + " = " + Alphas(1));
                     ShowContinueError(state, "Did not find air node (zone with thermostat).");
@@ -4064,7 +4061,6 @@ namespace Furnaces {
                     }
                     if (AirLoopFound) break;
                 }
-                if (AirLoopFound) break;
                 if (!AirNodeFound) {
                     ShowSevereError(state, CurrentModuleObject + " = " + Alphas(1));
                     ShowContinueError(state, "Did not find air node (zone with thermostat).");

--- a/src/EnergyPlus/HVACManager.cc
+++ b/src/EnergyPlus/HVACManager.cc
@@ -2931,8 +2931,6 @@ void SetHeatToReturnAirFlag(EnergyPlusData &state)
     // SUBROUTINE INFORMATION:
     //       AUTHOR         Fred Buhl
     //       DATE WRITTEN   February 2008
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // This sets some flags at the air loop and zone level: these flags indicate
@@ -2952,13 +2950,7 @@ void SetHeatToReturnAirFlag(EnergyPlusData &state)
     using ScheduleManager::GetCurrentScheduleValue;
     using ScheduleManager::GetScheduleMaxValue;
 
-    // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-    int AirLoopNum(0);      // the air loop index
-    int ZoneNum(0);         // zone index
-    int ControlledZoneNum;  // controlled zone index
     bool CyclingFan(false); // TRUE means air loop operates in cycling fan mode at some point
-    int LightNum;           // Lights object index
-    int SurfNum;            // Surface index
 
     auto &Zone(state.dataHeatBal->Zone);
     auto &AirLoopControlInfo(state.dataAirLoop->AirLoopControlInfo);
@@ -2968,7 +2960,7 @@ void SetHeatToReturnAirFlag(EnergyPlusData &state)
 
     if (state.dataHVACMgr->MyOneTimeFlag) {
         // set the air loop Any Continuous Fan flag
-        for (AirLoopNum = 1; AirLoopNum <= NumPrimaryAirSys; ++AirLoopNum) {
+        for (int AirLoopNum = 1; AirLoopNum <= NumPrimaryAirSys; ++AirLoopNum) {
             if (AirLoopControlInfo(AirLoopNum).UnitarySys) { // for unitary systems check the cycling fan schedule
                 if (AirLoopControlInfo(AirLoopNum).CycFanSchedPtr > 0) {
                     Real64 CycFanMaxVal = GetScheduleMaxValue(state, AirLoopControlInfo(AirLoopNum).CycFanSchedPtr);
@@ -2985,8 +2977,7 @@ void SetHeatToReturnAirFlag(EnergyPlusData &state)
             }
         }
         // check to see if a controlled zone is served exclusively by a zonal system
-        for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-            ZoneNum = ZoneEquipConfig(ControlledZoneNum).ActualZoneNum;
+        for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
             bool airLoopFound = false;
             for (int zoneInNode = 1; zoneInNode <= ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
                 if (ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode) > 0) {
@@ -2999,12 +2990,11 @@ void SetHeatToReturnAirFlag(EnergyPlusData &state)
         }
         // issue warning messages if zone is served by a zonal system or a cycling system and the input calls for
         // heat gain to return air
-        for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+        for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
             if (!ZoneEquipConfig(ControlledZoneNum).IsControlled) continue;
-            ZoneNum = ZoneEquipConfig(ControlledZoneNum).ActualZoneNum;
             CyclingFan = false;
             for (int zoneInNode = 1; zoneInNode <= ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
-                AirLoopNum = ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode);
+                int AirLoopNum = ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode);
                 if (AirLoopNum > 0) {
                     if (AirLoopControlInfo(AirLoopNum).CycFanSchedPtr > 0) {
                         CyclingFan = CheckScheduleValue(state, AirLoopControlInfo(AirLoopNum).CycFanSchedPtr, 0.0);
@@ -3012,24 +3002,26 @@ void SetHeatToReturnAirFlag(EnergyPlusData &state)
                 }
             }
             if (ZoneEquipConfig(ControlledZoneNum).ZonalSystemOnly || CyclingFan) {
-                if (Zone(ZoneNum).RefrigCaseRA) {
+                if (Zone(ControlledZoneNum).RefrigCaseRA) {
                     ShowWarningError(state,
-                                     "For zone=" + Zone(ZoneNum).Name + " return air cooling by refrigerated cases will be applied to the zone air.");
+                                     "For zone=" + Zone(ControlledZoneNum).Name +
+                                         " return air cooling by refrigerated cases will be applied to the zone air.");
                     ShowContinueError(state, "  This zone has no return air or is served by an on/off HVAC system.");
                 }
-                for (LightNum = 1; LightNum <= state.dataHeatBal->TotLights; ++LightNum) {
-                    if (state.dataHeatBal->Lights(LightNum).ZonePtr != ZoneNum) continue;
+                for (int LightNum = 1; LightNum <= state.dataHeatBal->TotLights; ++LightNum) {
+                    if (state.dataHeatBal->Lights(LightNum).ZonePtr != ControlledZoneNum) continue;
                     if (state.dataHeatBal->Lights(LightNum).FractionReturnAir > 0.0) {
-                        ShowWarningError(state,
-                                         "For zone=" + Zone(ZoneNum).Name + " return air heat gain from lights will be applied to the zone air.");
+                        ShowWarningError(
+                            state, "For zone=" + Zone(ControlledZoneNum).Name + " return air heat gain from lights will be applied to the zone air.");
                         ShowContinueError(state, "  This zone has no return air or is served by an on/off HVAC system.");
                         break;
                     }
                 }
-                for (SurfNum = Zone(ZoneNum).HTSurfaceFirst; SurfNum <= Zone(ZoneNum).HTSurfaceLast; ++SurfNum) {
+                for (int SurfNum = Zone(ControlledZoneNum).HTSurfaceFirst; SurfNum <= Zone(ControlledZoneNum).HTSurfaceLast; ++SurfNum) {
                     if (state.dataSurface->SurfWinAirflowDestination(SurfNum) == AirFlowWindow_Destination_ReturnAir) {
-                        ShowWarningError(
-                            state, "For zone=" + Zone(ZoneNum).Name + " return air heat gain from air flow windows will be applied to the zone air.");
+                        ShowWarningError(state,
+                                         "For zone=" + Zone(ControlledZoneNum).Name +
+                                             " return air heat gain from air flow windows will be applied to the zone air.");
                         ShowContinueError(state, "  This zone has no return air or is served by an on/off HVAC system.");
                     }
                 }
@@ -3039,7 +3031,7 @@ void SetHeatToReturnAirFlag(EnergyPlusData &state)
     }
 
     // set the air loop fan operation mode
-    for (AirLoopNum = 1; AirLoopNum <= NumPrimaryAirSys; ++AirLoopNum) {
+    for (int AirLoopNum = 1; AirLoopNum <= NumPrimaryAirSys; ++AirLoopNum) {
         if (AirLoopControlInfo(AirLoopNum).CycFanSchedPtr > 0) {
             if (GetCurrentScheduleValue(state, AirLoopControlInfo(AirLoopNum).CycFanSchedPtr) == 0.0) {
                 AirLoopControlInfo(AirLoopNum).FanOpMode = CycFanCycCoil;
@@ -3050,16 +3042,15 @@ void SetHeatToReturnAirFlag(EnergyPlusData &state)
     }
     // set the zone level NoHeatToReturnAir flag
     // if any air loop in the zone is continuous fan, then set NoHeatToReturnAir = false and sort it out node-by-node
-    for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+    for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
         if (!ZoneEquipConfig(ControlledZoneNum).IsControlled) continue;
-        ZoneNum = ZoneEquipConfig(ControlledZoneNum).ActualZoneNum;
-        Zone(ZoneNum).NoHeatToReturnAir = true;
+        Zone(ControlledZoneNum).NoHeatToReturnAir = true;
         if (!ZoneEquipConfig(ControlledZoneNum).ZonalSystemOnly) {
             for (int zoneInNode = 1; zoneInNode <= ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
-                AirLoopNum = ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode);
+                int AirLoopNum = ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode);
                 if (AirLoopNum > 0) {
                     if (AirLoopControlInfo(AirLoopNum).FanOpMode == ContFanCycCoil) {
-                        Zone(ZoneNum).NoHeatToReturnAir = false;
+                        Zone(ControlledZoneNum).NoHeatToReturnAir = false;
                         break;
                     }
                 }

--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
@@ -543,11 +543,7 @@ namespace HVACMultiSpeedHeatPump {
         bool IsNotOK;                  // Flag to verify name
         bool AirNodeFound;             // True when an air node is found
         bool AirLoopFound;             // True when an air loop is found
-        int ControlledZoneNum;         // Controlled zone number
         int FanType;                   // Fan type
-        int BranchNum;                 // Index to branch
-        int CompNum;                   // Index to component
-        int TstatZoneNum;              // Used to determine if control zone has a thermostat object
         int i;                         // Index to speeds
         int j;                         // Index to speeds
         bool Found;                    // Flag to find autosize
@@ -679,49 +675,44 @@ namespace HVACMultiSpeedHeatPump {
             if (MSHeatPump(MSHPNum).ControlZoneNum > 0) {
                 AirNodeFound = false;
                 AirLoopFound = false;
-                for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                    if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum != MSHeatPump(MSHPNum).ControlZoneNum) continue;
-                    // Find the controlled zone number for the specified thermostat location
-                    MSHeatPump(MSHPNum).NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
-                    // Determine if furnace is on air loop served by the thermostat location specified
-                    for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
-                        int AirLoopNumber = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode);
-                        if (AirLoopNumber > 0) {
-                            for (BranchNum = 1; BranchNum <= state.dataAirSystemsData->PrimaryAirSystems(AirLoopNumber).NumBranches; ++BranchNum) {
-                                for (CompNum = 1;
-                                     CompNum <= state.dataAirSystemsData->PrimaryAirSystems(AirLoopNumber).Branch(BranchNum).TotalComponents;
-                                     ++CompNum) {
-                                    if (!UtilityRoutines::SameString(
-                                            state.dataAirSystemsData->PrimaryAirSystems(AirLoopNumber).Branch(BranchNum).Comp(CompNum).Name,
-                                            MSHeatPump(MSHPNum).Name) ||
-                                        !UtilityRoutines::SameString(
-                                            state.dataAirSystemsData->PrimaryAirSystems(AirLoopNumber).Branch(BranchNum).Comp(CompNum).TypeOf,
-                                            state.dataHVACMultiSpdHP->CurrentModuleObject))
-                                        continue;
-                                    AirLoopFound = true;
-                                    MSHeatPump(MSHPNum).AirLoopNumber = AirLoopNumber;
-                                    break;
-                                }
-                                MSHeatPump(MSHPNum).ZoneInletNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNode(zoneInNode);
-                                if (AirLoopFound) break;
-                            }
-                            for (TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
-                                if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum != MSHeatPump(MSHPNum).ControlZoneNum)
+                int ControlledZoneNum = MSHeatPump(MSHPNum).ControlZoneNum;
+                // Find the controlled zone number for the specified thermostat location
+                MSHeatPump(MSHPNum).NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
+                // Determine if furnace is on air loop served by the thermostat location specified
+                for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
+                    int AirLoopNumber = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode);
+                    if (AirLoopNumber > 0) {
+                        for (int BranchNum = 1; BranchNum <= state.dataAirSystemsData->PrimaryAirSystems(AirLoopNumber).NumBranches; ++BranchNum) {
+                            for (int CompNum = 1;
+                                 CompNum <= state.dataAirSystemsData->PrimaryAirSystems(AirLoopNumber).Branch(BranchNum).TotalComponents;
+                                 ++CompNum) {
+                                if (!UtilityRoutines::SameString(
+                                        state.dataAirSystemsData->PrimaryAirSystems(AirLoopNumber).Branch(BranchNum).Comp(CompNum).Name,
+                                        MSHeatPump(MSHPNum).Name) ||
+                                    !UtilityRoutines::SameString(
+                                        state.dataAirSystemsData->PrimaryAirSystems(AirLoopNumber).Branch(BranchNum).Comp(CompNum).TypeOf,
+                                        state.dataHVACMultiSpdHP->CurrentModuleObject))
                                     continue;
-                                AirNodeFound = true;
+                                AirLoopFound = true;
+                                MSHeatPump(MSHPNum).AirLoopNumber = AirLoopNumber;
+                                break;
                             }
-                            for (TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
-                                if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum != MSHeatPump(MSHPNum).ControlZoneNum)
-                                    continue;
-                                AirNodeFound = true;
-                            }
-                            for (TstatZoneNum = 1; TstatZoneNum <= state.dataZoneTempPredictorCorrector->NumStageCtrZone; ++TstatZoneNum) {
-                                if (state.dataZoneCtrls->StageControlledZone(TstatZoneNum).ActualZoneNum != MSHeatPump(MSHPNum).ControlZoneNum)
-                                    continue;
-                                AirNodeFound = true;
-                            }
+                            MSHeatPump(MSHPNum).ZoneInletNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNode(zoneInNode);
+                            if (AirLoopFound) break;
                         }
-                        if (AirLoopFound) break;
+                        for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
+                            if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum != MSHeatPump(MSHPNum).ControlZoneNum) continue;
+                            AirNodeFound = true;
+                        }
+                        for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
+                            if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum != MSHeatPump(MSHPNum).ControlZoneNum)
+                                continue;
+                            AirNodeFound = true;
+                        }
+                        for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneTempPredictorCorrector->NumStageCtrZone; ++TstatZoneNum) {
+                            if (state.dataZoneCtrls->StageControlledZone(TstatZoneNum).ActualZoneNum != MSHeatPump(MSHPNum).ControlZoneNum) continue;
+                            AirNodeFound = true;
+                        }
                     }
                     if (AirLoopFound) break;
                 }
@@ -2098,7 +2089,7 @@ namespace HVACMultiSpeedHeatPump {
         }
 
         if (allocated(state.dataZoneEquip->ZoneEquipConfig) && MSHeatPump(MSHeatPumpNum).MyCheckFlag) {
-            int zoneNum = state.dataHeatBal->Zone(MSHeatPump(MSHeatPumpNum).ControlZoneNum).ZoneEqNum;
+            int zoneNum = MSHeatPump(MSHeatPumpNum).ControlZoneNum;
             int zoneInlet = MSHeatPump(MSHeatPumpNum).ZoneInletNode;
             int coolingPriority = 0;
             int heatingPriority = 0;

--- a/src/EnergyPlus/HVACUnitaryBypassVAV.cc
+++ b/src/EnergyPlus/HVACUnitaryBypassVAV.cc
@@ -1204,7 +1204,7 @@ namespace HVACUnitaryBypassVAV {
             if (CBVAV(CBVAVNum).AirLoopNumber > 0) {
                 CBVAV(CBVAVNum).NumControlledZones = state.dataAirLoop->AirToZoneNodeInfo(CBVAV(CBVAVNum).AirLoopNumber).NumZonesCooled;
                 CBVAV(CBVAVNum).ControlledZoneNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
-                CBVAV(CBVAVNum).ZoneNodeNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
+                CBVAV(CBVAVNum).ControlledZoneNodeNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
                 CBVAV(CBVAVNum).CBVAVBoxOutletNode.allocate(CBVAV(CBVAVNum).NumControlledZones);
                 CBVAV(CBVAVNum).ZoneSequenceCoolingNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
                 CBVAV(CBVAVNum).ZoneSequenceHeatingNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
@@ -1215,7 +1215,7 @@ namespace HVACUnitaryBypassVAV {
                     CBVAV(CBVAVNum).ControlledZoneNum(AirLoopZoneNum) =
                         state.dataAirLoop->AirToZoneNodeInfo(CBVAV(CBVAVNum).AirLoopNumber).CoolCtrlZoneNums(AirLoopZoneNum);
                     if (CBVAV(CBVAVNum).ControlledZoneNum(AirLoopZoneNum) > 0) {
-                        CBVAV(CBVAVNum).ZoneNodeNum(AirLoopZoneNum) =
+                        CBVAV(CBVAVNum).ControlledZoneNodeNum(AirLoopZoneNum) =
                             state.dataZoneEquip->ZoneEquipConfig(CBVAV(CBVAVNum).ControlledZoneNum(AirLoopZoneNum)).ZoneNode;
                         CBVAV(CBVAVNum).CBVAVBoxOutletNode(AirLoopZoneNum) =
                             state.dataAirLoop->AirToZoneNodeInfo(CBVAV(CBVAVNum).AirLoopNumber).CoolZoneInletNodes(AirLoopZoneNum);
@@ -3762,7 +3762,7 @@ namespace HVACUnitaryBypassVAV {
         Real64 TSupplyToCoolSetPtMin = 99999.0;  // Minimum of the supply air temperatures required to reach the cooling setpoint [C]
 
         for (int ZoneNum = 1; ZoneNum <= CBVAV(CBVAVNumber).NumControlledZones; ++ZoneNum) {
-            int ZoneNodeNum = CBVAV(CBVAVNumber).ZoneNodeNum(ZoneNum);
+            int ZoneNodeNum = CBVAV(CBVAVNumber).ControlledZoneNodeNum(ZoneNum);
             int BoxOutletNodeNum = CBVAV(CBVAVNumber).CBVAVBoxOutletNode(ZoneNum);
             if ((CBVAV(CBVAVNumber).ZoneSequenceCoolingNum(ZoneNum) > 0) && (CBVAV(CBVAVNumber).ZoneSequenceHeatingNum(ZoneNum) > 0)) {
                 QToCoolSetPt = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CBVAV(CBVAVNumber).ControlledZoneNum(ZoneNum))
@@ -4020,7 +4020,7 @@ namespace HVACUnitaryBypassVAV {
         Real64 CpSupplyAir = Psychrometrics::PsyCpAirFnW(state.dataLoopNodes->Node(OutletNode).HumRat); // Specific heat of outlet air [J/kg-K]
         // Determine zone air flow
         for (int ZoneNum = 1; ZoneNum <= CBVAV(CBVAVNum).NumControlledZones; ++ZoneNum) {
-            int ZoneNodeNum = CBVAV(CBVAVNum).ZoneNodeNum(ZoneNum);
+            int ZoneNodeNum = CBVAV(CBVAVNum).ControlledZoneNodeNum(ZoneNum);
             int BoxOutletNodeNum = CBVAV(CBVAVNum).CBVAVBoxOutletNode(ZoneNum); // Zone supply air inlet node number
             if ((CBVAV(CBVAVNum).ZoneSequenceCoolingNum(ZoneNum) > 0) && (CBVAV(CBVAVNum).ZoneSequenceHeatingNum(ZoneNum) > 0)) {
                 Real64 QToCoolSetPt = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CBVAV(CBVAVNum).ControlledZoneNum(ZoneNum))

--- a/src/EnergyPlus/HVACUnitaryBypassVAV.cc
+++ b/src/EnergyPlus/HVACUnitaryBypassVAV.cc
@@ -1204,23 +1204,19 @@ namespace HVACUnitaryBypassVAV {
             if (CBVAV(CBVAVNum).AirLoopNumber > 0) {
                 CBVAV(CBVAVNum).NumControlledZones = state.dataAirLoop->AirToZoneNodeInfo(CBVAV(CBVAVNum).AirLoopNumber).NumZonesCooled;
                 CBVAV(CBVAVNum).ControlledZoneNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
-                CBVAV(CBVAVNum).ActualZoneNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
-                CBVAV(CBVAVNum).ActualZoneNodeNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
+                CBVAV(CBVAVNum).ZoneNodeNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
                 CBVAV(CBVAVNum).CBVAVBoxOutletNode.allocate(CBVAV(CBVAVNum).NumControlledZones);
                 CBVAV(CBVAVNum).ZoneSequenceCoolingNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
                 CBVAV(CBVAVNum).ZoneSequenceHeatingNum.allocate(CBVAV(CBVAVNum).NumControlledZones);
 
                 CBVAV(CBVAVNum).ControlledZoneNum = 0;
-                CBVAV(CBVAVNum).ActualZoneNum = 0;
                 for (int AirLoopZoneNum = 1; AirLoopZoneNum <= state.dataAirLoop->AirToZoneNodeInfo(CBVAV(CBVAVNum).AirLoopNumber).NumZonesCooled;
                      ++AirLoopZoneNum) {
                     CBVAV(CBVAVNum).ControlledZoneNum(AirLoopZoneNum) =
                         state.dataAirLoop->AirToZoneNodeInfo(CBVAV(CBVAVNum).AirLoopNumber).CoolCtrlZoneNums(AirLoopZoneNum);
                     if (CBVAV(CBVAVNum).ControlledZoneNum(AirLoopZoneNum) > 0) {
-                        CBVAV(CBVAVNum).ActualZoneNodeNum(AirLoopZoneNum) =
+                        CBVAV(CBVAVNum).ZoneNodeNum(AirLoopZoneNum) =
                             state.dataZoneEquip->ZoneEquipConfig(CBVAV(CBVAVNum).ControlledZoneNum(AirLoopZoneNum)).ZoneNode;
-                        CBVAV(CBVAVNum).ActualZoneNum(AirLoopZoneNum) =
-                            state.dataZoneEquip->ZoneEquipConfig(CBVAV(CBVAVNum).ControlledZoneNum(AirLoopZoneNum)).ActualZoneNum;
                         CBVAV(CBVAVNum).CBVAVBoxOutletNode(AirLoopZoneNum) =
                             state.dataAirLoop->AirToZoneNodeInfo(CBVAV(CBVAVNum).AirLoopNumber).CoolZoneInletNodes(AirLoopZoneNum);
                         // check for thermostat in controlled zone
@@ -3766,7 +3762,7 @@ namespace HVACUnitaryBypassVAV {
         Real64 TSupplyToCoolSetPtMin = 99999.0;  // Minimum of the supply air temperatures required to reach the cooling setpoint [C]
 
         for (int ZoneNum = 1; ZoneNum <= CBVAV(CBVAVNumber).NumControlledZones; ++ZoneNum) {
-            int ZoneNodeNum = CBVAV(CBVAVNumber).ActualZoneNodeNum(ZoneNum);
+            int ZoneNodeNum = CBVAV(CBVAVNumber).ZoneNodeNum(ZoneNum);
             int BoxOutletNodeNum = CBVAV(CBVAVNumber).CBVAVBoxOutletNode(ZoneNum);
             if ((CBVAV(CBVAVNumber).ZoneSequenceCoolingNum(ZoneNum) > 0) && (CBVAV(CBVAVNumber).ZoneSequenceHeatingNum(ZoneNum) > 0)) {
                 QToCoolSetPt = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CBVAV(CBVAVNumber).ControlledZoneNum(ZoneNum))
@@ -4024,7 +4020,7 @@ namespace HVACUnitaryBypassVAV {
         Real64 CpSupplyAir = Psychrometrics::PsyCpAirFnW(state.dataLoopNodes->Node(OutletNode).HumRat); // Specific heat of outlet air [J/kg-K]
         // Determine zone air flow
         for (int ZoneNum = 1; ZoneNum <= CBVAV(CBVAVNum).NumControlledZones; ++ZoneNum) {
-            int ZoneNodeNum = CBVAV(CBVAVNum).ActualZoneNodeNum(ZoneNum);
+            int ZoneNodeNum = CBVAV(CBVAVNum).ZoneNodeNum(ZoneNum);
             int BoxOutletNodeNum = CBVAV(CBVAVNum).CBVAVBoxOutletNode(ZoneNum); // Zone supply air inlet node number
             if ((CBVAV(CBVAVNum).ZoneSequenceCoolingNum(ZoneNum) > 0) && (CBVAV(CBVAVNum).ZoneSequenceHeatingNum(ZoneNum) > 0)) {
                 Real64 QToCoolSetPt = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CBVAV(CBVAVNum).ControlledZoneNum(ZoneNum))

--- a/src/EnergyPlus/HVACUnitaryBypassVAV.hh
+++ b/src/EnergyPlus/HVACUnitaryBypassVAV.hh
@@ -199,8 +199,7 @@ namespace HVACUnitaryBypassVAV {
         int AirLoopNumber;              // Air loop served by the CBVAV system
         int NumControlledZones;
         Array1D_int ControlledZoneNum;           // Index to controlled zones
-        Array1D_int ActualZoneNum;               // Actual zone number of controlled zone
-        Array1D_int ActualZoneNodeNum;           // Actual zone node num of controlled zone
+        Array1D_int ZoneNodeNum;                 // Zone node num of controlled zone
         Array1D_int CBVAVBoxOutletNode;          // Outlet node of CBVAV Box in controlled zone
         Array1D_int ZoneSequenceCoolingNum;      // Index to cooling sequence/priority for this zone
         Array1D_int ZoneSequenceHeatingNum;      // Index to heating sequence/priority for this zone

--- a/src/EnergyPlus/HVACUnitaryBypassVAV.hh
+++ b/src/EnergyPlus/HVACUnitaryBypassVAV.hh
@@ -199,7 +199,7 @@ namespace HVACUnitaryBypassVAV {
         int AirLoopNumber;              // Air loop served by the CBVAV system
         int NumControlledZones;
         Array1D_int ControlledZoneNum;           // Index to controlled zones
-        Array1D_int ZoneNodeNum;                 // Zone node num of controlled zone
+        Array1D_int ControlledZoneNodeNum;       // Zone node num of controlled zone
         Array1D_int CBVAVBoxOutletNode;          // Outlet node of CBVAV Box in controlled zone
         Array1D_int ZoneSequenceCoolingNum;      // Index to cooling sequence/priority for this zone
         Array1D_int ZoneSequenceHeatingNum;      // Index to heating sequence/priority for this zone

--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
@@ -6099,39 +6099,33 @@ void InitVRF(EnergyPlusData &state, int const VRFTUNum, int const ZoneNum, bool 
                                     if (state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum > 0) {
                                         state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneAirNode =
                                             state.dataZoneEquip->ZoneEquipConfig(state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum).ZoneNode;
-                                        for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                                            if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum !=
+                                        int ControlledZoneNum = state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum;
+                                        for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
+                                            if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum !=
                                                 state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum)
                                                 continue;
-                                            for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
-                                                if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum !=
-                                                    state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum)
-                                                    continue;
-                                                state.dataHVACVarRefFlow->VRF(state.dataHVACVarRefFlow->VRFTU(TUIndex).VRFSysNum).MasterZoneTUIndex =
-                                                    TUIndex;
-                                                AirNodeFound = true;
-                                                ctrlZoneNum = ControlledZoneNum;
-                                                goto EquipList_exit;
-                                            }
-                                            for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones;
-                                                 ++TstatZoneNum) {
-                                                if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum !=
-                                                    state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum)
-                                                    continue;
-                                                state.dataHVACVarRefFlow->VRF(state.dataHVACVarRefFlow->VRFTU(TUIndex).VRFSysNum).MasterZoneTUIndex =
-                                                    TUIndex;
-                                                AirNodeFound = true;
-                                                ctrlZoneNum = ControlledZoneNum;
-                                                goto EquipList_exit;
-                                            }
-                                            if (!AirNodeFound && state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum > 0) {
-                                                ShowSevereError(state, "Input errors for " + cCurrentModuleObject + ":" + thisObjectName);
-                                                ShowContinueError(state,
-                                                                  "Did not find Air node (Zone with Thermostat or Thermal Comfort Thermostat).");
-                                                // ShowContinueError(state, "specified Controlling Zone or Thermostat Location name = " +
-                                                // loc_controlZoneName);
-                                                errorsFound = true;
-                                            }
+                                            state.dataHVACVarRefFlow->VRF(state.dataHVACVarRefFlow->VRFTU(TUIndex).VRFSysNum).MasterZoneTUIndex =
+                                                TUIndex;
+                                            AirNodeFound = true;
+                                            ctrlZoneNum = ControlledZoneNum;
+                                            goto EquipList_exit;
+                                        }
+                                        for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
+                                            if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum !=
+                                                state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum)
+                                                continue;
+                                            state.dataHVACVarRefFlow->VRF(state.dataHVACVarRefFlow->VRFTU(TUIndex).VRFSysNum).MasterZoneTUIndex =
+                                                TUIndex;
+                                            AirNodeFound = true;
+                                            ctrlZoneNum = ControlledZoneNum;
+                                            goto EquipList_exit;
+                                        }
+                                        if (!AirNodeFound && state.dataHVACVarRefFlow->VRFTU(TUIndex).ZoneNum > 0) {
+                                            ShowSevereError(state, "Input errors for " + cCurrentModuleObject + ":" + thisObjectName);
+                                            ShowContinueError(state, "Did not find Air node (Zone with Thermostat or Thermal Comfort Thermostat).");
+                                            // ShowContinueError(state, "specified Controlling Zone or Thermostat Location name = " +
+                                            // loc_controlZoneName);
+                                            errorsFound = true;
                                         }
                                     } else if (AirLoopFound) { // control zone name not entered in TU object input
                                         state.dataHVACVarRefFlow->VRFTU(TUIndex).isSetPointControlled = true;

--- a/src/EnergyPlus/HWBaseboardRadiator.cc
+++ b/src/EnergyPlus/HWBaseboardRadiator.cc
@@ -128,7 +128,6 @@ namespace HWBaseboardRadiator {
 
     void SimHWBaseboard(EnergyPlusData &state,
                         std::string const &EquipName,
-                        int const ActualZoneNum,
                         int const ControlledZoneNum,
                         bool const FirstHVACIteration,
                         Real64 &PowerMet,
@@ -138,8 +137,6 @@ namespace HWBaseboardRadiator {
         // SUBROUTINE INFORMATION:
         //       AUTHOR         Russ Taylor
         //       DATE WRITTEN   Nov 1997
-        //       MODIFIED
-        //       RE-ENGINEERED  na
 
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine simulates the Baseboard Radiators.
@@ -198,7 +195,7 @@ namespace HWBaseboardRadiator {
 
             InitHWBaseboard(state, BaseboardNum, ControlledZoneNum, FirstHVACIteration);
 
-            QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputReqToHeatSP;
+            QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputReqToHeatSP;
 
             // On the first HVAC iteration the system values are given to the controller, but after that
             // the demand limits are in place and there needs to be feedback to the Zone Equipment

--- a/src/EnergyPlus/HWBaseboardRadiator.cc
+++ b/src/EnergyPlus/HWBaseboardRadiator.cc
@@ -827,7 +827,7 @@ namespace HWBaseboardRadiator {
         }
     }
 
-    void InitHWBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration)
+    void InitHWBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNum, bool const FirstHVACIteration)
     {
 
         // SUBROUTINE INFORMATION:
@@ -906,7 +906,7 @@ namespace HWBaseboardRadiator {
             }
         }
 
-        HWBaseboard(BaseboardNum).ZonePtr = ZoneNum;
+        HWBaseboard(BaseboardNum).ZonePtr = ControlledZoneNum;
 
         // Need to check all units to see if they are on ZoneHVAC:EquipmentList or issue warning
         if (!ZoneEquipmentListChecked && state.dataZoneEquip->ZoneEquipInputsFilled) {
@@ -1003,7 +1003,7 @@ namespace HWBaseboardRadiator {
 
         // Do the every time step initializations
         WaterInletNode = HWBaseboard(BaseboardNum).WaterInletNode;
-        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
+        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
         HWBaseboard(BaseboardNum).WaterMassFlowRate = state.dataLoopNodes->Node(WaterInletNode).MassFlowRate;
         HWBaseboard(BaseboardNum).WaterInletTemp = state.dataLoopNodes->Node(WaterInletNode).Temp;
         HWBaseboard(BaseboardNum).WaterInletEnthalpy = state.dataLoopNodes->Node(WaterInletNode).Enthalpy;

--- a/src/EnergyPlus/HWBaseboardRadiator.cc
+++ b/src/EnergyPlus/HWBaseboardRadiator.cc
@@ -830,7 +830,7 @@ namespace HWBaseboardRadiator {
         }
     }
 
-    void InitHWBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNumSub, bool const FirstHVACIteration)
+    void InitHWBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration)
     {
 
         // SUBROUTINE INFORMATION:
@@ -840,7 +840,6 @@ namespace HWBaseboardRadiator {
         //                      Feb 2001
         //       MODIFIED       Aug 2007 Daeho Kang (Add radiant component)
         //                      Sept 2010 Brent Griffith (plant interactions)
-        //       RE-ENGINEERED  na
 
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine initializes the baseboard units, and determines the UA values during simulation.
@@ -861,28 +860,15 @@ namespace HWBaseboardRadiator {
         using PlantUtilities::InitComponentNodes;
         using PlantUtilities::ScanPlantLoopsForObject;
 
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
         Real64 constexpr Constant(0.0062); // Constant of linear equation for air mass flow rate
         Real64 constexpr Coeff(0.0000275); // Correlation coefficient to capacity
         static constexpr std::string_view RoutineName("BaseboardRadiatorWater:InitHWBaseboard");
 
-        // INTERFACE BLOCK SPECIFICATIONS
-        // na
-
-        // DERIVED TYPE DEFINITIONS
-        // na
-
-        // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         auto &MyOneTimeFlag = state.dataHWBaseboardRad->MyOneTimeFlag;
         auto &ZoneEquipmentListChecked = state.dataHWBaseboardRad->ZoneEquipmentListChecked;
         auto &MyEnvrnFlag = state.dataHWBaseboardRad->MyEnvrnFlag;
         int Loop;
         int WaterInletNode;
-        int ZoneNode;
-        int ZoneNum;
         Real64 RhoAirStdInit;
         Real64 rho; // local fluid density
         Real64 Cp;  // local fluid specific heat
@@ -923,8 +909,7 @@ namespace HWBaseboardRadiator {
             }
         }
 
-        if (HWBaseboard(BaseboardNum).ZonePtr <= 0)
-            HWBaseboard(BaseboardNum).ZonePtr = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ActualZoneNum;
+        HWBaseboard(BaseboardNum).ZonePtr = ZoneNum;
 
         // Need to check all units to see if they are on ZoneHVAC:EquipmentList or issue warning
         if (!ZoneEquipmentListChecked && state.dataZoneEquip->ZoneEquipInputsFilled) {
@@ -1011,7 +996,7 @@ namespace HWBaseboardRadiator {
         }
 
         if (state.dataGlobal->BeginTimeStepFlag && FirstHVACIteration) {
-            ZoneNum = HWBaseboard(BaseboardNum).ZonePtr;
+            int ZoneNum = HWBaseboard(BaseboardNum).ZonePtr;
             ZeroSourceSumHATsurf(ZoneNum) = SumHATsurf(state, ZoneNum);
             QBBRadSrcAvg(BaseboardNum) = 0.0;
             LastQBBRadSrc(BaseboardNum) = 0.0;
@@ -1021,7 +1006,7 @@ namespace HWBaseboardRadiator {
 
         // Do the every time step initializations
         WaterInletNode = HWBaseboard(BaseboardNum).WaterInletNode;
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ZoneNode;
+        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
         HWBaseboard(BaseboardNum).WaterMassFlowRate = state.dataLoopNodes->Node(WaterInletNode).MassFlowRate;
         HWBaseboard(BaseboardNum).WaterInletTemp = state.dataLoopNodes->Node(WaterInletNode).Temp;
         HWBaseboard(BaseboardNum).WaterInletEnthalpy = state.dataLoopNodes->Node(WaterInletNode).Enthalpy;

--- a/src/EnergyPlus/HWBaseboardRadiator.hh
+++ b/src/EnergyPlus/HWBaseboardRadiator.hh
@@ -184,7 +184,7 @@ namespace HWBaseboardRadiator {
 
     void GetHWBaseboardInput(EnergyPlusData &state);
 
-    void InitHWBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration);
+    void InitHWBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNum, bool const FirstHVACIteration);
 
     void SizeHWBaseboard(EnergyPlusData &state, int const BaseboardNum);
 

--- a/src/EnergyPlus/HWBaseboardRadiator.hh
+++ b/src/EnergyPlus/HWBaseboardRadiator.hh
@@ -177,7 +177,6 @@ namespace HWBaseboardRadiator {
 
     void SimHWBaseboard(EnergyPlusData &state,
                         std::string const &EquipName,
-                        int const ActualZoneNum,
                         int const ControlledZoneNum,
                         bool const FirstHVACIteration,
                         Real64 &PowerMet,

--- a/src/EnergyPlus/HWBaseboardRadiator.hh
+++ b/src/EnergyPlus/HWBaseboardRadiator.hh
@@ -185,7 +185,7 @@ namespace HWBaseboardRadiator {
 
     void GetHWBaseboardInput(EnergyPlusData &state);
 
-    void InitHWBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNumSub, bool const FirstHVACIteration);
+    void InitHWBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration);
 
     void SizeHWBaseboard(EnergyPlusData &state, int const BaseboardNum);
 

--- a/src/EnergyPlus/InternalHeatGains.cc
+++ b/src/EnergyPlus/InternalHeatGains.cc
@@ -1292,8 +1292,7 @@ namespace InternalHeatGains {
                         }
                     }
                     if (thisLights.ZonePtr > 0) {
-                        thisLights.ZoneReturnNum =
-                            DataZoneEquipment::GetReturnNumForZone(state, state.dataHeatBal->Zone(zoneNum).Name, thisLights.RetNodeName);
+                        thisLights.ZoneReturnNum = DataZoneEquipment::GetReturnNumForZone(state, thisLights.ZonePtr, thisLights.RetNodeName);
                     }
 
                     if ((thisLights.ZoneReturnNum == 0) && (thisLights.FractionReturnAir > 0.0) && (!state.dataIPShortCut->lAlphaFieldBlanks(7))) {
@@ -1334,8 +1333,8 @@ namespace InternalHeatGains {
                                 ErrorsFound = true;
                             } else {
                                 if (thisLights.ZoneReturnNum > 0) {
-                                    state.dataZoneEquip->ZoneEquipConfig(state.dataHeatBal->Zone(thisLights.ZonePtr).ZoneEqNum)
-                                        .ReturnNodeExhaustNodeNum(thisLights.ZoneReturnNum) = thisLights.ZoneExhaustNodeNum;
+                                    state.dataZoneEquip->ZoneEquipConfig(thisLights.ZonePtr).ReturnNodeExhaustNodeNum(thisLights.ZoneReturnNum) =
+                                        thisLights.ZoneExhaustNodeNum;
                                     CheckSharedExhaustFlag = true;
                                 } else {
                                     ShowSevereError(state,

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -2464,9 +2464,7 @@ void ProcessOAControllerInputs(EnergyPlusData &state,
             AirLoopFound = false;
             OASysFound = false;
             for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum !=
-                    state.dataMixedAir->OAController(OutAirNum).HumidistatZoneNum)
-                    continue;
+                if (ControlledZoneNum != state.dataMixedAir->OAController(OutAirNum).HumidistatZoneNum) continue;
                 //           Find the controlled zone number for the specified humidistat location
                 state.dataMixedAir->OAController(OutAirNum).NodeNumofHumidistatZone =
                     state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
@@ -4245,7 +4243,7 @@ void VentilationMechanicalProps::CalcMechVentController(
                         // Get schedule value for the zone air distribution effectiveness
                         ZoneEz = GetCurrentScheduleValue(state, ADEffSchPtr);
                     } else {
-                        ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(curZoneEquipConfig.ActualZoneNum).TotalOutputRequired;
+                        ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ZoneNum).TotalOutputRequired;
 
                         // Zone in cooling mode
                         if (ZoneLoad < 0.0) ZoneEz = this->ZoneADEffCooling(ZoneIndex);

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -6326,10 +6326,9 @@ void FillRemainingPredefinedEntries(EnergyPlusData &state)
 
             // air loop name
             std::string airLoopName = "";
-            int ctrlZoneNum = Zone(iZone).ZoneEqNum;
-            if (ctrlZoneNum > 0) {
-                for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(ctrlZoneNum).NumInletNodes; ++zoneInNode) {
-                    int airLoopNumber = state.dataZoneEquip->ZoneEquipConfig(ctrlZoneNum).InletNodeAirLoopNum(zoneInNode);
+            if (Zone(iZone).IsControlled) {
+                for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(iZone).NumInletNodes; ++zoneInNode) {
+                    int airLoopNumber = state.dataZoneEquip->ZoneEquipConfig(iZone).InletNodeAirLoopNum(zoneInNode);
                     if (airLoopNumber > 0) {
                         if (airLoopName.empty()) {
                             airLoopName = state.dataAirSystemsData->PrimaryAirSystems(airLoopNumber).Name;

--- a/src/EnergyPlus/PurchasedAirManager.cc
+++ b/src/EnergyPlus/PurchasedAirManager.cc
@@ -180,7 +180,7 @@ void SimPurchasedAir(EnergyPlusData &state,
         }
     }
 
-    InitPurchasedAir(state, PurchAirNum, FirstHVACIteration, ControlledZoneNum);
+    InitPurchasedAir(state, PurchAirNum, ControlledZoneNum);
 
     CalcPurchAirLoads(state, PurchAirNum, SysOutputProvided, MoistOutputProvided, ControlledZoneNum);
 
@@ -1158,18 +1158,12 @@ void GetPurchasedAir(EnergyPlusData &state)
     }
 }
 
-void InitPurchasedAir(EnergyPlusData &state,
-                      int const PurchAirNum,
-                      [[maybe_unused]] bool const FirstHVACIteration, // unused1208
-                      int const ControlledZoneNum,
-                      int const ActualZoneNum)
+void InitPurchasedAir(EnergyPlusData &state, int const PurchAirNum, int const ControlledZoneNum)
 {
 
     // SUBROUTINE INFORMATION:
     //       AUTHOR         Russ Taylor
     //       DATE WRITTEN   Nov 1997
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // Initialize the PurchAir data structure.
@@ -1333,8 +1327,8 @@ void InitPurchasedAir(EnergyPlusData &state,
 
     // These initializations are done every iteration
     // check that supply air temps can meet the zone thermostat setpoints
-    if (PurchAir(PurchAirNum).MinCoolSuppAirTemp > state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ActualZoneNum) &&
-        state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ActualZoneNum) != 0 && PurchAir(PurchAirNum).CoolingLimit == LimitType::NoLimit) {
+    if (PurchAir(PurchAirNum).MinCoolSuppAirTemp > state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ControlledZoneNum) &&
+        state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ControlledZoneNum) != 0 && PurchAir(PurchAirNum).CoolingLimit == LimitType::NoLimit) {
         // Check if the unit is scheduled off
         UnitOn = true;
         //        IF (PurchAir(PurchAirNum)%AvailSchedPtr > 0) THEN
@@ -1353,12 +1347,12 @@ void InitPurchasedAir(EnergyPlusData &state,
             if (PurchAir(PurchAirNum).CoolErrIndex == 0) {
                 ShowSevereError(state,
                                 "InitPurchasedAir: For " + PurchAir(PurchAirNum).cObjectName + " = " + PurchAir(PurchAirNum).Name + " serving Zone " +
-                                    state.dataHeatBal->Zone(ActualZoneNum).Name);
+                                    state.dataHeatBal->Zone(ControlledZoneNum).Name);
                 ShowContinueError(state,
                                   format("..the minimum supply air temperature for cooling [{:.2R}] is greater than the zone cooling mean air "
                                          "temperature (MAT) setpoint [{:.2R}].",
                                          PurchAir(PurchAirNum).MinCoolSuppAirTemp,
-                                         state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ActualZoneNum)));
+                                         state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ControlledZoneNum)));
                 ShowContinueError(state, "..For operative and comfort thermostat controls, the MAT setpoint is computed.");
                 ShowContinueError(state, "..This error may indicate that the mean radiant temperature or another comfort factor is too warm.");
                 ShowContinueError(state, "Unit availability is nominally ON and Cooling availability is nominally ON.");
@@ -1368,7 +1362,7 @@ void InitPurchasedAir(EnergyPlusData &state,
             }
             ShowRecurringSevereErrorAtEnd(state,
                                           "InitPurchasedAir: For " + PurchAir(PurchAirNum).cObjectName + " = " + PurchAir(PurchAirNum).Name +
-                                              " serving Zone " + state.dataHeatBal->Zone(ActualZoneNum).Name +
+                                              " serving Zone " + state.dataHeatBal->Zone(ControlledZoneNum).Name +
                                               ", the minimum supply air temperature for cooling error continues",
                                           PurchAir(PurchAirNum).CoolErrIndex,
                                           PurchAir(PurchAirNum).MinCoolSuppAirTemp,
@@ -1378,8 +1372,8 @@ void InitPurchasedAir(EnergyPlusData &state,
                                           "C");
         }
     }
-    if (PurchAir(PurchAirNum).MaxHeatSuppAirTemp < state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ActualZoneNum) &&
-        state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ActualZoneNum) != 0 && PurchAir(PurchAirNum).HeatingLimit == LimitType::NoLimit) {
+    if (PurchAir(PurchAirNum).MaxHeatSuppAirTemp < state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ControlledZoneNum) &&
+        state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ControlledZoneNum) != 0 && PurchAir(PurchAirNum).HeatingLimit == LimitType::NoLimit) {
         // Check if the unit is scheduled off
         UnitOn = true;
         //        IF (PurchAir(PurchAirNum)%AvailSchedPtr > 0) THEN
@@ -1398,12 +1392,12 @@ void InitPurchasedAir(EnergyPlusData &state,
             if (PurchAir(PurchAirNum).HeatErrIndex == 0) {
                 ShowSevereMessage(state,
                                   "InitPurchasedAir: For " + PurchAir(PurchAirNum).cObjectName + " = " + PurchAir(PurchAirNum).Name +
-                                      " serving Zone " + state.dataHeatBal->Zone(ActualZoneNum).Name);
+                                      " serving Zone " + state.dataHeatBal->Zone(ControlledZoneNum).Name);
                 ShowContinueError(state,
                                   format("..the maximum supply air temperature for heating [{:.2R}] is less than the zone mean air temperature "
                                          "heating setpoint [{:.2R}].",
                                          PurchAir(PurchAirNum).MaxHeatSuppAirTemp,
-                                         state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ActualZoneNum)));
+                                         state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ControlledZoneNum)));
                 ShowContinueError(state, "..For operative and comfort thermostat controls, the MAT setpoint is computed.");
                 ShowContinueError(state, "..This error may indicate that the mean radiant temperature or another comfort factor is too cold.");
                 ShowContinueError(state, "Unit availability is nominally ON and Heating availability is nominally ON.");
@@ -1413,7 +1407,7 @@ void InitPurchasedAir(EnergyPlusData &state,
             }
             ShowRecurringSevereErrorAtEnd(state,
                                           "InitPurchasedAir: For " + PurchAir(PurchAirNum).cObjectName + " = " + PurchAir(PurchAirNum).Name +
-                                              " serving Zone " + state.dataHeatBal->Zone(ActualZoneNum).Name +
+                                              " serving Zone " + state.dataHeatBal->Zone(ControlledZoneNum).Name +
                                               ", maximum supply air temperature for heating error continues",
                                           PurchAir(PurchAirNum).HeatErrIndex,
                                           PurchAir(PurchAirNum).MaxHeatSuppAirTemp,
@@ -2942,9 +2936,9 @@ void CalcPurchAirLoads(EnergyPlusData &state,
 }
 
 void CalcPurchAirMinOAMassFlow(EnergyPlusData &state,
-                               int const PurchAirNum,   // index to ideal loads unit
-                               int const ZoneNum, // index to zone
-                               Real64 &OAMassFlowRate   // outside air mass flow rate [kg/s] from volume flow using std density
+                               int const PurchAirNum, // index to ideal loads unit
+                               int const ZoneNum,     // index to zone
+                               Real64 &OAMassFlowRate // outside air mass flow rate [kg/s] from volume flow using std density
 )
 {
 
@@ -2977,8 +2971,8 @@ void CalcPurchAirMinOAMassFlow(EnergyPlusData &state,
         } else {
             UseOccSchFlag = false;
         }
-        OAVolumeFlowRate = DataSizing::calcDesignSpecificationOutdoorAir(
-            state, PurchAir(PurchAirNum).OARequirementsPtr, ZoneNum, UseOccSchFlag, UseMinOASchFlag);
+        OAVolumeFlowRate =
+            DataSizing::calcDesignSpecificationOutdoorAir(state, PurchAir(PurchAirNum).OARequirementsPtr, ZoneNum, UseOccSchFlag, UseMinOASchFlag);
         OAMassFlowRate = OAVolumeFlowRate * state.dataEnvrn->StdRhoAir;
 
         // If DCV with CO2SetPoint then check required OA flow to meet CO2 setpoint

--- a/src/EnergyPlus/PurchasedAirManager.hh
+++ b/src/EnergyPlus/PurchasedAirManager.hh
@@ -343,10 +343,7 @@ namespace PurchasedAirManager {
 
     void GetPurchasedAir(EnergyPlusData &state);
 
-    void InitPurchasedAir(EnergyPlusData &state,
-                          int PurchAirNum,
-                          bool FirstHVACIteration, // unused1208
-                          int ControlledZoneNum);
+    void InitPurchasedAir(EnergyPlusData &state, int const PurchAirNum, int const ControlledZoneNum);
 
     void SizePurchasedAir(EnergyPlusData &state, int PurchAirNum);
 

--- a/src/EnergyPlus/PurchasedAirManager.hh
+++ b/src/EnergyPlus/PurchasedAirManager.hh
@@ -339,7 +339,6 @@ namespace PurchasedAirManager {
                          Real64 &MoistOutputProvided, // Moisture output provided (kg/s), dehumidification = negative
                          bool FirstHVACIteration,
                          int ControlledZoneNum,
-                         int ActualZoneNum,
                          int &CompIndex);
 
     void GetPurchasedAir(EnergyPlusData &state);
@@ -347,8 +346,7 @@ namespace PurchasedAirManager {
     void InitPurchasedAir(EnergyPlusData &state,
                           int PurchAirNum,
                           bool FirstHVACIteration, // unused1208
-                          int ControlledZoneNum,
-                          int ActualZoneNum);
+                          int ControlledZoneNum);
 
     void SizePurchasedAir(EnergyPlusData &state, int PurchAirNum);
 
@@ -356,12 +354,11 @@ namespace PurchasedAirManager {
                            int PurchAirNum,
                            Real64 &SysOutputProvided,   // Sensible output provided [W] cooling = negative
                            Real64 &MoistOutputProvided, // Moisture output provided [kg/s] dehumidification = negative
-                           int ControlledZoneNum,
-                           int ActualZoneNum);
+                           int ControlledZoneNum);
 
     void CalcPurchAirMinOAMassFlow(EnergyPlusData &state,
                                    int PurchAirNum,       // index to ideal loads unit
-                                   int ActualZoneNum,     // index to actual zone number
+                                   int ZoneNum,           // index to zone
                                    Real64 &OAMassFlowRate // outside air mass flow rate [kg/s] from volume flow using std density
     );
 

--- a/src/EnergyPlus/RefrigeratedCase.cc
+++ b/src/EnergyPlus/RefrigeratedCase.cc
@@ -632,7 +632,7 @@ void GetRefrigerationInput(EnergyPlusData &state)
                 state.dataRefrigCase->RefrigPresentInZone(RefrigCase(CaseNum).ActualZoneNum) = true;
             }
 
-            RefrigCase(CaseNum).ZoneNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, RefrigCase(CaseNum).ZoneName);
+            RefrigCase(CaseNum).ZoneNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, RefrigCase(CaseNum).ActualZoneNum);
 
             RefrigCase(CaseNum).RatedAmbientTemp = Numbers(1);
             if (Numbers(1) <= 0.0) {
@@ -1113,7 +1113,7 @@ void GetRefrigerationInput(EnergyPlusData &state)
             if (RefrigCase(CaseNum).RAFrac > 0.0) {
                 std::string callDescription = CurrentModuleObject + "=" + RefrigCase(CaseNum).Name;
                 RefrigCase(CaseNum).ZoneRANode =
-                    DataZoneEquipment::GetReturnAirNodeForZone(state, RefrigCase(CaseNum).ZoneName, retNodeName, callDescription);
+                    DataZoneEquipment::GetReturnAirNodeForZone(state, RefrigCase(CaseNum).ActualZoneNum, retNodeName, callDescription);
             }
 
             if (RefrigCase(CaseNum).ActualZoneNum >= 0) {
@@ -1594,7 +1594,7 @@ void GetRefrigerationInput(EnergyPlusData &state)
                 } else {
                     state.dataRefrigCase->RefrigPresentInZone(WalkIn(WalkInID).ZoneNum(ZoneID)) = true;
                 }
-                WalkIn(WalkInID).ZoneNodeNum(ZoneID) = DataZoneEquipment::GetSystemNodeNumberForZone(state, WalkIn(WalkInID).ZoneName(ZoneID));
+                WalkIn(WalkInID).ZoneNodeNum(ZoneID) = DataZoneEquipment::GetSystemNodeNumberForZone(state, WalkIn(WalkInID).ZoneNum(ZoneID));
                 if (WalkIn(WalkInID).ZoneNum(ZoneID) >= 0) {
                     if (WalkIn(WalkInID).ZoneNodeNum(ZoneID) == 0) {
                         ShowSevereError(state,
@@ -2413,7 +2413,7 @@ void GetRefrigerationInput(EnergyPlusData &state)
                                     cAlphaFieldNames(AlphaNum) + " not valid: " + Alphas(AlphaNum));
                 ErrorsFound = true;
             }
-            AirChillerSet(SetID).ZoneNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, AirChillerSet(SetID).ZoneName);
+            AirChillerSet(SetID).ZoneNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, AirChillerSet(SetID).ZoneNum);
             if (AirChillerSet(SetID).ZoneNodeNum == 0) {
                 ShowSevereError(state,
                                 std::string{RoutineName} + CurrentModuleObject + "=\"" + AirChillerSet(SetID).Name +
@@ -2973,7 +2973,8 @@ void GetRefrigerationInput(EnergyPlusData &state)
                         ErrorsFound = true;
                     } else { // alpha (15) not blank
                         RefrigRack(RackNum).HeatRejectionZoneNum = UtilityRoutines::FindItemInList(Alphas(15), state.dataHeatBal->Zone);
-                        RefrigRack(RackNum).HeatRejectionZoneNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, Alphas(15));
+                        RefrigRack(RackNum).HeatRejectionZoneNodeNum =
+                            DataZoneEquipment::GetSystemNodeNumberForZone(state, RefrigRack(RackNum).HeatRejectionZoneNum);
                         if (RefrigRack(RackNum).HeatRejectionZoneNum == 0) {
                             ShowSevereError(state,
                                             std::string{RoutineName} + CurrentModuleObject + "=\"" + RefrigRack(RackNum).Name + "\", invalid  " +
@@ -3122,7 +3123,7 @@ void GetRefrigerationInput(EnergyPlusData &state)
                     // need to clearly id node number for air inlet conditions and zone number for casecredit assignment
                     if (Condenser(CondNum).InletAirZoneNum != 0) {
                         // set condenser flag (later used to set system flag) and zone flag
-                        Condenser(CondNum).InletAirNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, Alphas(4));
+                        Condenser(CondNum).InletAirNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, Condenser(CondNum).InletAirZoneNum);
                         Condenser(CondNum).CondenserRejectHeatToZone = true;
                         state.dataRefrigCase->RefrigPresentInZone(Condenser(CondNum).InletAirZoneNum) = true;
                     } else { // not in a conditioned zone, so see if it's outside
@@ -3810,7 +3811,7 @@ void GetRefrigerationInput(EnergyPlusData &state)
                     // need to clearly id node number for air inlet conditions and zone number for casecredit assignment
                     if (GasCooler(GCNum).InletAirZoneNum != 0) {
                         // set condenser flag (later used to set system flag) and zone flag
-                        GasCooler(GCNum).InletAirNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, Alphas(4));
+                        GasCooler(GCNum).InletAirNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, GasCooler(GCNum).InletAirZoneNum);
                         GasCooler(GCNum).GasCoolerRejectHeatToZone = true;
                         state.dataRefrigCase->RefrigPresentInZone(GasCooler(GCNum).InletAirZoneNum) = true;
                     } else { // not in a conditioned zone, so see if it's outside
@@ -4313,7 +4314,8 @@ void GetRefrigerationInput(EnergyPlusData &state)
                 if (!lNumericBlanks(NumNum) && !lAlphaBlanks(AlphaNum)) {
                     Secondary(SecondaryNum).SumUADistPiping = Numbers(NumNum);
                     Secondary(SecondaryNum).DistPipeZoneNum = UtilityRoutines::FindItemInList(Alphas(AlphaNum), state.dataHeatBal->Zone);
-                    Secondary(SecondaryNum).DistPipeZoneNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, Alphas(AlphaNum));
+                    Secondary(SecondaryNum).DistPipeZoneNodeNum =
+                        DataZoneEquipment::GetSystemNodeNumberForZone(state, Secondary(SecondaryNum).DistPipeZoneNum);
 
                     if (Secondary(SecondaryNum).DistPipeZoneNum == 0) {
                         ShowSevereError(state,
@@ -4359,7 +4361,8 @@ void GetRefrigerationInput(EnergyPlusData &state)
                 if (!lNumericBlanks(NumNum) && !lAlphaBlanks(AlphaNum)) {
                     Secondary(SecondaryNum).SumUAReceiver = Numbers(NumNum);
                     Secondary(SecondaryNum).ReceiverZoneNum = UtilityRoutines::FindItemInList(Alphas(AlphaNum), state.dataHeatBal->Zone);
-                    Secondary(SecondaryNum).ReceiverZoneNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, Alphas(AlphaNum));
+                    Secondary(SecondaryNum).ReceiverZoneNodeNum =
+                        DataZoneEquipment::GetSystemNodeNumberForZone(state, Secondary(SecondaryNum).ReceiverZoneNum);
 
                     if (Secondary(SecondaryNum).ReceiverZoneNum == 0) {
                         ShowSevereError(state,
@@ -5319,7 +5322,8 @@ void GetRefrigerationInput(EnergyPlusData &state)
             if (!lNumericBlanks(2) && !lAlphaBlanks(AlphaNum)) {
                 System(RefrigSysNum).SumUASuctionPiping = Numbers(2);
                 System(RefrigSysNum).SuctionPipeActualZoneNum = UtilityRoutines::FindItemInList(Alphas(AlphaNum), state.dataHeatBal->Zone);
-                System(RefrigSysNum).SuctionPipeZoneNodeNum = DataZoneEquipment::GetSystemNodeNumberForZone(state, Alphas(AlphaNum));
+                System(RefrigSysNum).SuctionPipeZoneNodeNum =
+                    DataZoneEquipment::GetSystemNodeNumberForZone(state, System(RefrigSysNum).SuctionPipeActualZoneNum);
                 if (System(RefrigSysNum).SuctionPipeZoneNodeNum == 0) {
                     ShowSevereError(state,
                                     std::string{RoutineName} + CurrentModuleObject + "=\"" + System(RefrigSysNum).Name +
@@ -6193,7 +6197,8 @@ void GetRefrigerationInput(EnergyPlusData &state)
                 TransSystem(TransRefrigSysNum).SumUASuctionPipingMT = Numbers(3);
                 TransSystem(TransRefrigSysNum).SuctionPipeActualZoneNumMT =
                     UtilityRoutines::FindItemInList(Alphas(AlphaNum), state.dataHeatBal->Zone);
-                TransSystem(TransRefrigSysNum).SuctionPipeZoneNodeNumMT = DataZoneEquipment::GetSystemNodeNumberForZone(state, Alphas(AlphaNum));
+                TransSystem(TransRefrigSysNum).SuctionPipeZoneNodeNumMT =
+                    DataZoneEquipment::GetSystemNodeNumberForZone(state, TransSystem(TransRefrigSysNum).SuctionPipeActualZoneNumMT);
                 if (TransSystem(TransRefrigSysNum).SuctionPipeZoneNodeNumMT == 0) {
                     ShowSevereError(state,
                                     std::string{RoutineName} + CurrentModuleObject + "=\"" + TransSystem(TransRefrigSysNum).Name +
@@ -6226,7 +6231,8 @@ void GetRefrigerationInput(EnergyPlusData &state)
                 TransSystem(TransRefrigSysNum).SumUASuctionPipingLT = Numbers(4);
                 TransSystem(TransRefrigSysNum).SuctionPipeActualZoneNumLT =
                     UtilityRoutines::FindItemInList(Alphas(AlphaNum), state.dataHeatBal->Zone);
-                TransSystem(TransRefrigSysNum).SuctionPipeZoneNodeNumLT = DataZoneEquipment::GetSystemNodeNumberForZone(state, Alphas(AlphaNum));
+                TransSystem(TransRefrigSysNum).SuctionPipeZoneNodeNumLT =
+                    DataZoneEquipment::GetSystemNodeNumberForZone(state, TransSystem(TransRefrigSysNum).SuctionPipeActualZoneNumLT);
                 if (TransSystem(TransRefrigSysNum).SuctionPipeZoneNodeNumLT == 0) {
                     ShowSevereError(state,
                                     std::string{RoutineName} + CurrentModuleObject + "=\"" + TransSystem(TransRefrigSysNum).Name +

--- a/src/EnergyPlus/ReportCoilSelection.cc
+++ b/src/EnergyPlus/ReportCoilSelection.cc
@@ -1387,7 +1387,7 @@ void ReportCoilSelection::setCoilCoolingCapacity(
         c->zoneNum.resize(1);
         c->zoneName.resize(1);
         c->zoneNum[0] = curZoneEqNum;
-        c->zoneName[0] = state.dataHeatBal->Zone(curZoneEqNum).Name;
+        if (allocated(state.dataZoneEquip->ZoneEquipConfig)) c->zoneName[0] = state.dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ZoneName;
         c->desDayNameAtSensPeak = state.dataSize->FinalZoneSizing(curZoneEqNum).CoolDesDay;
         c->oaPeakTemp = state.dataSize->FinalZoneSizing(curZoneEqNum).OutTempAtCoolPeak;
         c->oaPeakHumRat = state.dataSize->FinalZoneSizing(curZoneEqNum).OutHumRatAtCoolPeak;
@@ -1617,7 +1617,7 @@ void ReportCoilSelection::setCoilHeatingCapacity(
         c->zoneNum.resize(1);
         c->zoneName.resize(1);
         c->zoneNum[0] = curZoneEqNum;
-        c->zoneName[0] = state.dataHeatBal->Zone(curZoneEqNum).Name;
+        if (allocated(state.dataZoneEquip->ZoneEquipConfig)) c->zoneName[0] = state.dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ZoneName;
         c->desDayNameAtSensPeak = state.dataSize->FinalZoneSizing(curZoneEqNum).HeatDesDay;
         c->oaPeakTemp = state.dataSize->FinalZoneSizing(curZoneEqNum).OutTempAtHeatPeak;
         c->oaPeakHumRat = state.dataSize->FinalZoneSizing(curZoneEqNum).OutHumRatAtHeatPeak;

--- a/src/EnergyPlus/ReportCoilSelection.cc
+++ b/src/EnergyPlus/ReportCoilSelection.cc
@@ -542,7 +542,7 @@ void ReportCoilSelection::doZoneEqSetup(EnergyPlusData &state, int const coilVec
     auto &c(coilSelectionDataObjs[coilVecIndex]);
     c->coilLocation = "Zone";
     c->zoneNum.resize(1);
-    c->zoneNum[0] = state.dataZoneEquip->ZoneEquipConfig(c->zoneEqNum).ActualZoneNum;
+    c->zoneNum[0] = c->zoneEqNum;
     c->zoneName.resize(1);
     c->zoneName[0] = state.dataHeatBal->Zone(c->zoneNum[0]).Name;
     c->typeHVACname = "Zone Equipment"; // init
@@ -1386,8 +1386,8 @@ void ReportCoilSelection::setCoilCoolingCapacity(
     } else if (curZoneEqNum > 0 && allocated(state.dataSize->FinalZoneSizing)) {
         c->zoneNum.resize(1);
         c->zoneName.resize(1);
-        if (allocated(state.dataZoneEquip->ZoneEquipConfig)) c->zoneNum[0] = state.dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ActualZoneNum;
-        if (allocated(state.dataZoneEquip->ZoneEquipConfig)) c->zoneName[0] = state.dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ZoneName;
+        c->zoneNum[0] = curZoneEqNum;
+        c->zoneName[0] = state.dataHeatBal->Zone(curZoneEqNum).Name;
         c->desDayNameAtSensPeak = state.dataSize->FinalZoneSizing(curZoneEqNum).CoolDesDay;
         c->oaPeakTemp = state.dataSize->FinalZoneSizing(curZoneEqNum).OutTempAtCoolPeak;
         c->oaPeakHumRat = state.dataSize->FinalZoneSizing(curZoneEqNum).OutHumRatAtCoolPeak;
@@ -1616,8 +1616,8 @@ void ReportCoilSelection::setCoilHeatingCapacity(
     } else if (curZoneEqNum > 0 && allocated(state.dataSize->FinalZoneSizing)) {
         c->zoneNum.resize(1);
         c->zoneName.resize(1);
-        if (allocated(state.dataZoneEquip->ZoneEquipConfig)) c->zoneNum[0] = state.dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ActualZoneNum;
-        if (allocated(state.dataZoneEquip->ZoneEquipConfig)) c->zoneName[0] = state.dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ZoneName;
+        c->zoneNum[0] = curZoneEqNum;
+        c->zoneName[0] = state.dataHeatBal->Zone(curZoneEqNum).Name;
         c->desDayNameAtSensPeak = state.dataSize->FinalZoneSizing(curZoneEqNum).HeatDesDay;
         c->oaPeakTemp = state.dataSize->FinalZoneSizing(curZoneEqNum).OutTempAtHeatPeak;
         c->oaPeakHumRat = state.dataSize->FinalZoneSizing(curZoneEqNum).OutHumRatAtHeatPeak;

--- a/src/EnergyPlus/RoomAirModelAirflowNetwork.cc
+++ b/src/EnergyPlus/RoomAirModelAirflowNetwork.cc
@@ -1267,7 +1267,6 @@ namespace RoomAirModelAirflowNetwork {
                 SimHWBaseboard(state,
                                ThisRAFNNode.HVAC(I).Name,
                                ZoneNum,
-                               state.dataRoomAirMod->RoomAirflowNetworkZoneInfo(ZoneNum).ActualZoneID,
                                false,
                                SysOutputProvided,
                                ThisRAFNNode.HVAC(I).CompIndex);
@@ -1280,7 +1279,6 @@ namespace RoomAirModelAirflowNetwork {
                 SimSteamBaseboard(state,
                                   ThisRAFNNode.HVAC(I).Name,
                                   ZoneNum,
-                                  state.dataRoomAirMod->RoomAirflowNetworkZoneInfo(ZoneNum).ActualZoneID,
                                   false,
                                   SysOutputProvided,
                                   ThisRAFNNode.HVAC(I).CompIndex);
@@ -1294,7 +1292,6 @@ namespace RoomAirModelAirflowNetwork {
                 SimBaseboard(state,
                              ThisRAFNNode.HVAC(I).Name,
                              ZoneNum,
-                             state.dataRoomAirMod->RoomAirflowNetworkZoneInfo(ZoneNum).ActualZoneID,
                              false,
                              SysOutputProvided,
                              ThisRAFNNode.HVAC(I).CompIndex);
@@ -1307,7 +1304,6 @@ namespace RoomAirModelAirflowNetwork {
                 SimElectricBaseboard(state,
                                      ThisRAFNNode.HVAC(I).Name,
                                      ZoneNum,
-                                     state.dataRoomAirMod->RoomAirflowNetworkZoneInfo(ZoneNum).ActualZoneID,
                                      SysOutputProvided,
                                      ThisRAFNNode.HVAC(I).CompIndex);
                 ThisRAFNNode.NonAirSystemResponse += ThisRAFNNode.HVAC(I).SupplyFraction * SysOutputProvided;

--- a/src/EnergyPlus/RoomAirModelAirflowNetwork.cc
+++ b/src/EnergyPlus/RoomAirModelAirflowNetwork.cc
@@ -253,7 +253,6 @@ namespace RoomAirModelAirflowNetwork {
         int NodeNum;
         int NodeIn;
         int Link;
-        int IdZone;
         int IdNode;
         int EquipLoop;
         int MaxNodeNum;

--- a/src/EnergyPlus/RoomAirModelAirflowNetwork.cc
+++ b/src/EnergyPlus/RoomAirModelAirflowNetwork.cc
@@ -1264,24 +1264,14 @@ namespace RoomAirModelAirflowNetwork {
 
             if (ThisRAFNNode.HVAC(I).TypeOfNum == ZoneEquipTypeOf_BaseboardRadiantConvectiveWater) {
                 //'ZoneHVAC:Baseboard:RadiantConvective:Water' 13
-                SimHWBaseboard(state,
-                               ThisRAFNNode.HVAC(I).Name,
-                               ZoneNum,
-                               false,
-                               SysOutputProvided,
-                               ThisRAFNNode.HVAC(I).CompIndex);
+                SimHWBaseboard(state, ThisRAFNNode.HVAC(I).Name, ZoneNum, false, SysOutputProvided, ThisRAFNNode.HVAC(I).CompIndex);
                 ThisRAFNNode.NonAirSystemResponse += ThisRAFNNode.HVAC(I).SupplyFraction * SysOutputProvided;
                 // LatOutputProvided = 0.0d0 !This baseboard does not add / remove any latent heat
             }
 
             if (ThisRAFNNode.HVAC(I).TypeOfNum == ZoneEquipTypeOf_BaseboardRadiantConvectiveSteam) {
                 // CASE(BBSteam_Num) !'ZoneHVAC:Baseboard:RadiantConvective:Steam' 14
-                SimSteamBaseboard(state,
-                                  ThisRAFNNode.HVAC(I).Name,
-                                  ZoneNum,
-                                  false,
-                                  SysOutputProvided,
-                                  ThisRAFNNode.HVAC(I).CompIndex);
+                SimSteamBaseboard(state, ThisRAFNNode.HVAC(I).Name, ZoneNum, false, SysOutputProvided, ThisRAFNNode.HVAC(I).CompIndex);
 
                 ThisRAFNNode.NonAirSystemResponse += ThisRAFNNode.HVAC(I).SupplyFraction * SysOutputProvided;
                 // LatOutputProvided = 0.0d0 !This baseboard does not add / remove any latent heat
@@ -1289,23 +1279,14 @@ namespace RoomAirModelAirflowNetwork {
 
             if (ThisRAFNNode.HVAC(I).TypeOfNum == ZoneEquipTypeOf_BaseboardConvectiveWater) {
                 // CASE(BBWaterConvective_Num)  !'ZoneHVAC:Baseboard:Convective:Water' 16
-                SimBaseboard(state,
-                             ThisRAFNNode.HVAC(I).Name,
-                             ZoneNum,
-                             false,
-                             SysOutputProvided,
-                             ThisRAFNNode.HVAC(I).CompIndex);
+                SimBaseboard(state, ThisRAFNNode.HVAC(I).Name, ZoneNum, false, SysOutputProvided, ThisRAFNNode.HVAC(I).CompIndex);
                 ThisRAFNNode.NonAirSystemResponse += ThisRAFNNode.HVAC(I).SupplyFraction * SysOutputProvided;
                 // LatOutputProvided = 0.0d0 !This baseboard does not add / remove any latent heat
             }
 
             if (ThisRAFNNode.HVAC(I).TypeOfNum == ZoneEquipTypeOf_BaseboardConvectiveElectric) {
                 // CASE(BBElectricConvective_Num)  !'ZoneHVAC:Baseboard:Convective:Electric' 15
-                SimElectricBaseboard(state,
-                                     ThisRAFNNode.HVAC(I).Name,
-                                     ZoneNum,
-                                     SysOutputProvided,
-                                     ThisRAFNNode.HVAC(I).CompIndex);
+                SimElectricBaseboard(state, ThisRAFNNode.HVAC(I).Name, ZoneNum, SysOutputProvided, ThisRAFNNode.HVAC(I).CompIndex);
                 ThisRAFNNode.NonAirSystemResponse += ThisRAFNNode.HVAC(I).SupplyFraction * SysOutputProvided;
                 // LatOutputProvided = 0.0d0 !This baseboard does not add / remove any latent heat
             }

--- a/src/EnergyPlus/RoomAirModelManager.cc
+++ b/src/EnergyPlus/RoomAirModelManager.cc
@@ -3140,8 +3140,8 @@ namespace RoomAirModelManager {
         } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalDualDuctVAV) { // AirTerminal : DualDuct : VAV
             SupplyNodeName = Alphas(1);
             ReturnNodeName = "";
-        } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctConstantVolumeReheat) { // AirTerminal : SingleDuct :
-                                                                                                            // ConstantVolume : Reheat
+        } else if (TypeNum ==
+                   DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctConstantVolumeReheat) { // AirTerminal : SingleDuct : ConstantVolume : Reheat
             SupplyNodeName = Alphas(1);
             ReturnNodeName = "";
         } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctConstantVolumeNoReheat) { // AirTerminal : SingleDuct :

--- a/src/EnergyPlus/RoomAirModelManager.cc
+++ b/src/EnergyPlus/RoomAirModelManager.cc
@@ -2585,13 +2585,8 @@ namespace RoomAirModelManager {
                                         state.dataHeatBal->Zone(state.dataRoomAirModelMgr->Loop).Name);
 
                     // set zone equip pointer in the UCSDUI data structure
-                    for (ZoneEquipConfigNum = 1; ZoneEquipConfigNum <= state.dataGlobal->NumOfZones; ++ZoneEquipConfigNum) {
-                        if (state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).ActualZoneNum == state.dataRoomAirModelMgr->Loop) {
-                            state.dataRoomAirMod->ZoneUCSDUI(state.dataRoomAirMod->ZoneUFPtr(state.dataRoomAirModelMgr->Loop)).ZoneEquipPtr =
-                                ZoneEquipConfigNum;
-                            break;
-                        }
-                    } // ZoneEquipConfigNum
+                    state.dataRoomAirMod->ZoneUCSDUI(state.dataRoomAirMod->ZoneUFPtr(state.dataRoomAirModelMgr->Loop)).ZoneEquipPtr =
+                        state.dataRoomAirModelMgr->Loop;
                 }
                 for (state.dataRoomAirModelMgr->Loop = 1; state.dataRoomAirModelMgr->Loop <= state.dataGlobal->NumOfZones;
                      ++state.dataRoomAirModelMgr->Loop) {
@@ -2676,13 +2671,8 @@ namespace RoomAirModelManager {
                                         OutputProcessor::SOVStoreType::State,
                                         state.dataHeatBal->Zone(state.dataRoomAirModelMgr->Loop).Name);
                     // set zone equip pointer in the UCSDUE data structure
-                    for (ZoneEquipConfigNum = 1; ZoneEquipConfigNum <= state.dataGlobal->NumOfZones; ++ZoneEquipConfigNum) {
-                        if (state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).ActualZoneNum == state.dataRoomAirModelMgr->Loop) {
-                            state.dataRoomAirMod->ZoneUCSDUE(state.dataRoomAirMod->ZoneUFPtr(state.dataRoomAirModelMgr->Loop)).ZoneEquipPtr =
-                                ZoneEquipConfigNum;
-                            break;
-                        }
-                    } // ZoneEquipConfigNum
+                    state.dataRoomAirMod->ZoneUCSDUE(state.dataRoomAirMod->ZoneUFPtr(state.dataRoomAirModelMgr->Loop)).ZoneEquipPtr =
+                        state.dataRoomAirModelMgr->Loop;
                 }
             }
 
@@ -3150,8 +3140,8 @@ namespace RoomAirModelManager {
         } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalDualDuctVAV) { // AirTerminal : DualDuct : VAV
             SupplyNodeName = Alphas(1);
             ReturnNodeName = "";
-        } else if (TypeNum ==
-                   DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctConstantVolumeReheat) { // AirTerminal : SingleDuct : ConstantVolume : Reheat
+        } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctConstantVolumeReheat) { // AirTerminal : SingleDuct :
+                                                                                                            // ConstantVolume : Reheat
             SupplyNodeName = Alphas(1);
             ReturnNodeName = "";
         } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctConstantVolumeNoReheat) { // AirTerminal : SingleDuct :
@@ -3176,8 +3166,8 @@ namespace RoomAirModelManager {
                                                                                                             // ConstantVolume : FourPipeInduction
             SupplyNodeName = Alphas(1);
             ReturnNodeName = "";
-        } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctVAVReheatVariableSpeedFan) { // AirTerminal : SingleDuct : VAV :
-                                                                                                                 // Reheat : VariableSpeedFan
+        } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctVAVReheatVariableSpeedFan) { // AirTerminal : SingleDuct : VAV
+                                                                                                                 // : Reheat : VariableSpeedFan
             SupplyNodeName = Alphas(1);
             ReturnNodeName = "";
         } else if (TypeNum == DataHVACGlobals::ZoneEquipTypeOf_AirTerminalSingleDuctVAVHeatAndCoolReheat) { // AirTerminal : SingleDuct : VAV :

--- a/src/EnergyPlus/RoomAirModelUserTempPattern.cc
+++ b/src/EnergyPlus/RoomAirModelUserTempPattern.cc
@@ -807,10 +807,9 @@ void SetSurfHBDataForTempDistModel(EnergyPlusData &state, int const ZoneNum) // 
             state.dataRoomAirMod->AirPatternZoneInfo(ZoneNum).Tleaving;
     }
 
-    int zoneEquipNum = state.dataHeatBal->Zone(ZoneNum).ZoneEqNum;
-    for (int nodeCount = 1; nodeCount <= state.dataZoneEquip->ZoneEquipConfig(zoneEquipNum).NumReturnNodes; ++nodeCount) {
+    for (int nodeCount = 1; nodeCount <= state.dataZoneEquip->ZoneEquipConfig(ZoneNum).NumReturnNodes; ++nodeCount) {
         // BEGIN BLOCK of code from CalcZoneLeavingConditions*********************************
-        int ReturnNode = state.dataZoneEquip->ZoneEquipConfig(zoneEquipNum).ReturnNode(nodeCount);
+        int ReturnNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ReturnNode(nodeCount);
         ZoneNode = state.dataRoomAirMod->AirPatternZoneInfo(ZoneNum).ZoneNodeID;
         ZoneMult = state.dataHeatBal->Zone(ZoneNum).Multiplier * state.dataHeatBal->Zone(ZoneNum).ListMultiplier;
         // RETURN AIR HEAT GAIN from the Lights statement; this heat gain is stored in
@@ -831,7 +830,7 @@ void SetSurfHBDataForTempDistModel(EnergyPlusData &state, int const ZoneNum) // 
         WinGapTtoRA = 0.0;
         WinGapFlowTtoRA = 0.0;
 
-        if (state.dataZoneEquip->ZoneEquipConfig(zoneEquipNum).ZoneHasAirFlowWindowReturn) {
+        if (state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneHasAirFlowWindowReturn) {
             for (SurfNum = state.dataHeatBal->Zone(ZoneNum).HTSurfaceFirst; SurfNum <= state.dataHeatBal->Zone(ZoneNum).HTSurfaceLast; ++SurfNum) {
                 if (state.dataSurface->SurfWinAirflowThisTS(SurfNum) > 0.0 &&
                     state.dataSurface->SurfWinAirflowDestination(SurfNum) == AirFlowWindow_Destination_ReturnAir) {

--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -6743,8 +6743,6 @@ void DefineWarmestSetPointManager::calculate(EnergyPlusData &state)
     // SUBROUTINE INFORMATION:
     //       AUTHOR         Fred Buhl
     //       DATE WRITTEN   May 2002
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // Calculate the "warmest" supply air setpoint temperature that will satisfy the cooling
@@ -6764,7 +6762,6 @@ void DefineWarmestSetPointManager::calculate(EnergyPlusData &state)
     int AirLoopNum;          // the index of the air loop served by this setpoint manager
     Real64 TotCoolLoad;      // sum of the zone cooling loads for this air loop [W]
     int ZonesCooledIndex;    // DO loop index for zones cooled by the air loop
-    int ZoneInletNode;       // the zone inlet node number
     Real64 ZoneTemp;         // zone temperature [C]
     Real64 ZoneSetPointTemp; // zone supply air temperature [C]
     Real64 SetPointTemp;     // the system setpoint temperature [C]
@@ -6825,7 +6822,6 @@ void DefineColdestSetPointManager::calculate(EnergyPlusData &state)
     Real64 CpAir;            // inlet air specific heat [J/kg-C]
     int AirLoopNum;          // the index of the air loop served by this setpoint manager
     Real64 TotHeatLoad;      // sum of the zone heating loads for this air loop [W]
-    int ZoneInletNode;       // the zone inlet node number
     Real64 ZoneTemp;         // zone temperature [C]
     Real64 ZoneSetPointTemp; // zone supply air temperature [C]
     Real64 SetPointTemp;     // the system setpoint temperature [C]

--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -1364,12 +1364,10 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
             ErrorsFound = true;
         }
         state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNodes.allocate(NumZones);
-        state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNum.allocate(NumZones);
         state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).CtrlZoneNum.allocate(NumZones);
 
         for (ZoneNum = 1; ZoneNum <= NumZones; ++ZoneNum) {
             state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNodes(ZoneNum) = NodeNums(ZoneNum);
-            state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNum(ZoneNum) = 0;
             state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(ZoneNum) = 0;
         }
 
@@ -1468,13 +1466,11 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
             ErrorsFound = true;
         }
         state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNodes.allocate(NumZones);
-        state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNum.allocate(NumZones);
         state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).CtrlZoneNum.allocate(NumZones);
 
         for (ZoneNum = 1; ZoneNum <= NumZones; ++ZoneNum) {
             state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNodes(ZoneNum) = NodeNums(ZoneNum);
             //   Actual zone node and controlled zone numbers set in Init subroutine
-            state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNum(ZoneNum) = 0;
             state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(ZoneNum) = 0;
         }
 
@@ -3395,7 +3391,6 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
         }
 
         state.dataSetPointManager->SZOneStageCoolingSetPtMgr(SetPtMgrNum).ControlZoneName = cAlphaArgs(2);
-        state.dataSetPointManager->SZOneStageCoolingSetPtMgr(SetPtMgrNum).ZoneNodeNum = GetSystemNodeNumberForZone(state, cAlphaArgs(2));
         // get the actual zone number of the control zone
         state.dataSetPointManager->SZOneStageCoolingSetPtMgr(SetPtMgrNum).ControlZoneNum =
             UtilityRoutines::FindItemInList(cAlphaArgs(2), state.dataHeatBal->Zone);
@@ -3404,6 +3399,8 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
             ShowContinueError(state, "..invalid " + cAlphaFieldNames(2) + "=\"" + cAlphaArgs(2) + "\".");
             ErrorsFound = true;
         } else {
+            state.dataSetPointManager->SZOneStageCoolingSetPtMgr(SetPtMgrNum).ZoneNodeNum =
+                GetSystemNodeNumberForZone(state, state.dataSetPointManager->SZOneStageCoolingSetPtMgr(SetPtMgrNum).ControlZoneNum);
             if (allocated(state.dataZoneCtrls->StageZoneLogic)) {
                 if (!state.dataZoneCtrls->StageZoneLogic(state.dataSetPointManager->SZOneStageCoolingSetPtMgr(SetPtMgrNum).ControlZoneNum)) {
                     ShowSevereError(state, format("{}: {}=\"{}\", invalid field.", RoutineName, cCurrentModuleObject, cAlphaArgs(1)));
@@ -3506,7 +3503,6 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
         }
 
         state.dataSetPointManager->SZOneStageHeatingSetPtMgr(SetPtMgrNum).ControlZoneName = cAlphaArgs(2);
-        state.dataSetPointManager->SZOneStageHeatingSetPtMgr(SetPtMgrNum).ZoneNodeNum = GetSystemNodeNumberForZone(state, cAlphaArgs(2));
         // get the actual zone number of the control zone
         state.dataSetPointManager->SZOneStageHeatingSetPtMgr(SetPtMgrNum).ControlZoneNum =
             UtilityRoutines::FindItemInList(cAlphaArgs(2), state.dataHeatBal->Zone);
@@ -3515,6 +3511,8 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
             ShowContinueError(state, "..invalid " + cAlphaFieldNames(2) + "=\"" + cAlphaArgs(2) + "\".");
             ErrorsFound = true;
         } else {
+            state.dataSetPointManager->SZOneStageHeatingSetPtMgr(SetPtMgrNum).ZoneNodeNum =
+                GetSystemNodeNumberForZone(state, state.dataSetPointManager->SZOneStageHeatingSetPtMgr(SetPtMgrNum).ControlZoneNum);
             if (allocated(state.dataZoneCtrls->StageZoneLogic)) {
                 if (!state.dataZoneCtrls->StageZoneLogic(state.dataSetPointManager->SZOneStageHeatingSetPtMgr(SetPtMgrNum).ControlZoneNum)) {
                     ShowSevereError(state, format("{}: {}=\"{}\", invalid field.", RoutineName, cCurrentModuleObject, cAlphaArgs(1)));
@@ -4391,8 +4389,6 @@ void InitSetPointManagers(EnergyPlusData &state)
                         if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode ==
                             state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNodes(SetZoneNum)) {
                             state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(SetZoneNum) = ControlledZoneNum;
-                            state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNum(SetZoneNum) =
-                                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum;
                             break;
                         }
                     }
@@ -4403,14 +4399,14 @@ void InitSetPointManagers(EnergyPlusData &state)
                         ShowContinueError(
                             state,
                             "could not find Controlled Zone=" +
-                                state.dataHeatBal->Zone(state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNum(SetZoneNum)).Name);
+                                state.dataHeatBal->Zone(state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(SetZoneNum)).Name);
                         ErrorsFound = true;
                     } else {
                         // make sure humidity controlled zone
                         HstatZoneFound = false;
                         for (HStatZoneNum = 1; HStatZoneNum <= state.dataZoneCtrls->NumHumidityControlZones; ++HStatZoneNum) {
                             if (state.dataZoneCtrls->HumidityControlZone(HStatZoneNum).ActualZoneNum !=
-                                state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNum(SetZoneNum))
+                                state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(SetZoneNum))
                                 continue;
                             HstatZoneFound = true;
                             break;
@@ -4422,7 +4418,7 @@ void InitSetPointManagers(EnergyPlusData &state)
                             ShowContinueError(
                                 state,
                                 "could not locate Humidistat in Zone=" +
-                                    state.dataHeatBal->Zone(state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).ZoneNum(SetZoneNum)).Name);
+                                    state.dataHeatBal->Zone(state.dataSetPointManager->SZMinHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(SetZoneNum)).Name);
                             ErrorsFound = true;
                         }
                     }
@@ -4438,8 +4434,6 @@ void InitSetPointManagers(EnergyPlusData &state)
                         if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode ==
                             state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNodes(SetZoneNum)) {
                             state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(SetZoneNum) = ControlledZoneNum;
-                            state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNum(SetZoneNum) =
-                                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum;
                             break;
                         }
                     }
@@ -4450,14 +4444,14 @@ void InitSetPointManagers(EnergyPlusData &state)
                         ShowContinueError(
                             state,
                             "could not find Controlled Zone=" +
-                                state.dataHeatBal->Zone(state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNum(SetZoneNum)).Name);
+                                state.dataHeatBal->Zone(state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(SetZoneNum)).Name);
                         ErrorsFound = true;
                     } else {
                         // make sure humidity controlled zone
                         HstatZoneFound = false;
                         for (HStatZoneNum = 1; HStatZoneNum <= state.dataZoneCtrls->NumHumidityControlZones; ++HStatZoneNum) {
                             if (state.dataZoneCtrls->HumidityControlZone(HStatZoneNum).ActualZoneNum !=
-                                state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNum(SetZoneNum))
+                                state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(SetZoneNum))
                                 continue;
                             HstatZoneFound = true;
                             break;
@@ -4469,7 +4463,7 @@ void InitSetPointManagers(EnergyPlusData &state)
                             ShowContinueError(
                                 state,
                                 "could not locate Humidistat in Zone=" +
-                                    state.dataHeatBal->Zone(state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).ZoneNum(SetZoneNum)).Name);
+                                    state.dataHeatBal->Zone(state.dataSetPointManager->SZMaxHumSetPtMgr(SetPtMgrNum).CtrlZoneNum(SetZoneNum)).Name);
                             ErrorsFound = true;
                         }
                     }
@@ -6424,7 +6418,6 @@ void DefineSZMinHumSetPointManager::calculate(EnergyPlusData &state)
     //       DATE WRITTEN   October 2000
     //       MODIFIED       Shirey/Raustad Jan 2002
     //                      Gu, Dec 2007
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // From humidity load of the control zone, calculate the supply air humidity
@@ -6439,22 +6432,18 @@ void DefineSZMinHumSetPointManager::calculate(EnergyPlusData &state)
     using DataHVACGlobals::SmallMassFlow;
     using Psychrometrics::PsyWFnTdbRhPb;
 
-    int ZoneNode;
-    Real64 ZoneMassFlow;
-    int ZoneNum;
     Real64 MoistureLoad; // Zone moisture load (kg moisture/second) required to meet the relative humidity setpoint
     // Value obtained from ZoneTempPredictorCorrector (via ZoneSysMoistureDemand in DataZoneEnergyDemands)
     Real64 SupplyAirHumRat; // Desired air humidity ratio
 
     this->SetPt = 0.0;
     // Only use one zone for now
-    ZoneNode = this->ZoneNodes(1);
-    ZoneMassFlow = state.dataLoopNodes->Node(ZoneNode).MassFlowRate;
-    ZoneNum = this->ZoneNum(1);
+    int ZoneNode = this->ZoneNodes(1);
+    Real64 ZoneMassFlow = state.dataLoopNodes->Node(ZoneNode).MassFlowRate;
 
     if (ZoneMassFlow > SmallMassFlow) {
 
-        MoistureLoad = state.dataZoneEnergyDemand->ZoneSysMoistureDemand(this->ZoneNum(1)).OutputRequiredToHumidifyingSP;
+        MoistureLoad = state.dataZoneEnergyDemand->ZoneSysMoistureDemand(this->CtrlZoneNum(1)).OutputRequiredToHumidifyingSP;
 
         SupplyAirHumRat = max(0.0, state.dataLoopNodes->Node(ZoneNode).HumRat + MoistureLoad / ZoneMassFlow);
 
@@ -6471,7 +6460,6 @@ void DefineSZMaxHumSetPointManager::calculate(EnergyPlusData &state)
     //       AUTHOR         Raustad/Shirey, FSEC
     //       DATE WRITTEN   January 2004
     //       MODIFIED       Gu, Dec. 2007
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // From humidity load of the control zone, calculate the supply air humidity
@@ -6500,7 +6488,7 @@ void DefineSZMaxHumSetPointManager::calculate(EnergyPlusData &state)
 
     if (ZoneMassFlow > SmallMassFlow) {
 
-        MoistureLoad = state.dataZoneEnergyDemand->ZoneSysMoistureDemand(this->ZoneNum(1)).OutputRequiredToDehumidifyingSP;
+        MoistureLoad = state.dataZoneEnergyDemand->ZoneSysMoistureDemand(this->CtrlZoneNum(1)).OutputRequiredToDehumidifyingSP;
 
         SystemMassFlow = state.dataLoopNodes->Node(this->CtrlNodes(1)).MassFlowRate;
 
@@ -6776,25 +6764,21 @@ void DefineWarmestSetPointManager::calculate(EnergyPlusData &state)
     int AirLoopNum;          // the index of the air loop served by this setpoint manager
     Real64 TotCoolLoad;      // sum of the zone cooling loads for this air loop [W]
     int ZonesCooledIndex;    // DO loop index for zones cooled by the air loop
-    int CtrlZoneNum;         // the controlled zone index
     int ZoneInletNode;       // the zone inlet node number
     Real64 ZoneTemp;         // zone temperature [C]
     Real64 ZoneSetPointTemp; // zone supply air temperature [C]
     Real64 SetPointTemp;     // the system setpoint temperature [C]
-    int ZoneNode;            // the zone node number of the current zone
-    int ZoneNum;             // the actual zone number
 
     AirLoopNum = this->AirLoopNum;
     TotCoolLoad = 0.0;
     SetPointTemp = this->MaxSetTemp;
 
     for (ZonesCooledIndex = 1; ZonesCooledIndex <= state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).NumZonesCooled; ++ZonesCooledIndex) {
-        CtrlZoneNum = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolCtrlZoneNums(ZonesCooledIndex);
-        ZoneInletNode = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolZoneInletNodes(ZonesCooledIndex);
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneNode;
-        ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ActualZoneNum;
+        int CtrlZoneNum = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolCtrlZoneNums(ZonesCooledIndex);
+        int ZoneInletNode = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolZoneInletNodes(ZonesCooledIndex);
+        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneNode;
         ZoneMassFlowMax = state.dataLoopNodes->Node(ZoneInletNode).MassFlowRateMax;
-        ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ZoneNum).TotalOutputRequired;
+        ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CtrlZoneNum).TotalOutputRequired;
         ZoneTemp = state.dataLoopNodes->Node(ZoneNode).Temp;
         ZoneSetPointTemp = this->MaxSetTemp;
         if (ZoneLoad < 0.0) {
@@ -6841,14 +6825,10 @@ void DefineColdestSetPointManager::calculate(EnergyPlusData &state)
     Real64 CpAir;            // inlet air specific heat [J/kg-C]
     int AirLoopNum;          // the index of the air loop served by this setpoint manager
     Real64 TotHeatLoad;      // sum of the zone heating loads for this air loop [W]
-    int ZonesHeatedIndex;    // DO loop index for zones heated by the air loop
-    int CtrlZoneNum;         // the controlled zone index
     int ZoneInletNode;       // the zone inlet node number
     Real64 ZoneTemp;         // zone temperature [C]
     Real64 ZoneSetPointTemp; // zone supply air temperature [C]
     Real64 SetPointTemp;     // the system setpoint temperature [C]
-    int ZoneNode;            // the zone node number of the current zone
-    int ZoneNum;             // the actual zone number
 
     AirLoopNum = this->AirLoopNum;
     TotHeatLoad = 0.0;
@@ -6856,13 +6836,12 @@ void DefineColdestSetPointManager::calculate(EnergyPlusData &state)
 
     if (state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).NumZonesHeated > 0) {
         // dual-duct heated only zones
-        for (ZonesHeatedIndex = 1; ZonesHeatedIndex <= state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).NumZonesHeated; ++ZonesHeatedIndex) {
-            CtrlZoneNum = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).HeatCtrlZoneNums(ZonesHeatedIndex);
-            ZoneInletNode = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).HeatZoneInletNodes(ZonesHeatedIndex);
-            ZoneNode = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneNode;
-            ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ActualZoneNum;
+        for (int ZonesHeatedIndex = 1; ZonesHeatedIndex <= state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).NumZonesHeated; ++ZonesHeatedIndex) {
+            int CtrlZoneNum = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).HeatCtrlZoneNums(ZonesHeatedIndex);
+            int ZoneInletNode = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).HeatZoneInletNodes(ZonesHeatedIndex);
+            int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneNode;
             ZoneMassFlowMax = state.dataLoopNodes->Node(ZoneInletNode).MassFlowRateMax;
-            ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ZoneNum).TotalOutputRequired;
+            ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CtrlZoneNum).TotalOutputRequired;
             ZoneTemp = state.dataLoopNodes->Node(ZoneNode).Temp;
             ZoneSetPointTemp = this->MinSetTemp;
             if (ZoneLoad > 0.0) {
@@ -6876,13 +6855,12 @@ void DefineColdestSetPointManager::calculate(EnergyPlusData &state)
         }
     } else {
         // single-duct or central heated and cooled zones
-        for (ZonesHeatedIndex = 1; ZonesHeatedIndex <= state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).NumZonesCooled; ++ZonesHeatedIndex) {
-            CtrlZoneNum = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolCtrlZoneNums(ZonesHeatedIndex);
-            ZoneInletNode = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolZoneInletNodes(ZonesHeatedIndex);
-            ZoneNode = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneNode;
-            ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ActualZoneNum;
+        for (int ZonesHeatedIndex = 1; ZonesHeatedIndex <= state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).NumZonesCooled; ++ZonesHeatedIndex) {
+            int CtrlZoneNum = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolCtrlZoneNums(ZonesHeatedIndex);
+            int ZoneInletNode = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolZoneInletNodes(ZonesHeatedIndex);
+            int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneNode;
             ZoneMassFlowMax = state.dataLoopNodes->Node(ZoneInletNode).MassFlowRateMax;
-            ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ZoneNum).TotalOutputRequired;
+            ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CtrlZoneNum).TotalOutputRequired;
             ZoneTemp = state.dataLoopNodes->Node(ZoneNode).Temp;
             ZoneSetPointTemp = this->MinSetTemp;
             if (ZoneLoad > 0.0) {
@@ -6930,14 +6908,9 @@ void DefWarmestSetPtManagerTempFlow::calculate(EnergyPlusData &state)
     Real64 CpAir;            // inlet air specific heat [J/kg-C]
     int AirLoopNum;          // the index of the air loop served by this setpoint manager
     Real64 TotCoolLoad;      // sum of the zone cooling loads for this air loop [W]
-    int ZonesCooledIndex;    // DO loop index for zones cooled by the air loop
-    int CtrlZoneNum;         // the controlled zone index
-    int ZoneInletNode;       // the zone inlet node number
     Real64 ZoneTemp;         // zone temperature [C]
     Real64 ZoneSetPointTemp; // zone supply air temperature [C]
     Real64 SetPointTemp;     // the system setpoint temperature [C]
-    int ZoneNode;            // the zone node number of the current zone
-    int ZoneNum;             // the actual zone number
     Real64 MinFracFlow;
     Real64 ZoneFracFlow;
     Real64 FracFlow;
@@ -6957,13 +6930,12 @@ void DefWarmestSetPtManagerTempFlow::calculate(EnergyPlusData &state)
     CritZoneNumTemp = 0;
     CritZoneNumFlow = 0;
 
-    for (ZonesCooledIndex = 1; ZonesCooledIndex <= state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).NumZonesCooled; ++ZonesCooledIndex) {
-        CtrlZoneNum = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolCtrlZoneNums(ZonesCooledIndex);
-        ZoneInletNode = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolZoneInletNodes(ZonesCooledIndex);
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneNode;
-        ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ActualZoneNum;
+    for (int ZonesCooledIndex = 1; ZonesCooledIndex <= state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).NumZonesCooled; ++ZonesCooledIndex) {
+        int CtrlZoneNum = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolCtrlZoneNums(ZonesCooledIndex);
+        int ZoneInletNode = state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum).CoolZoneInletNodes(ZonesCooledIndex);
+        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneNode;
         ZoneMassFlowMax = state.dataLoopNodes->Node(ZoneInletNode).MassFlowRateMax;
-        ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ZoneNum).TotalOutputRequired;
+        ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CtrlZoneNum).TotalOutputRequired;
         ZoneTemp = state.dataLoopNodes->Node(ZoneNode).Temp;
         ZoneSetPointTemp = MaxSetPointTemp;
         ZoneFracFlow = MinFracFlow;
@@ -6996,11 +6968,11 @@ void DefWarmestSetPtManagerTempFlow::calculate(EnergyPlusData &state)
         }
         if (ZoneSetPointTemp < SetPointTemp) {
             SetPointTemp = ZoneSetPointTemp;
-            CritZoneNumTemp = ZoneNum;
+            CritZoneNumTemp = CtrlZoneNum;
         }
         if (ZoneFracFlow > FracFlow) {
             FracFlow = ZoneFracFlow;
-            CritZoneNumFlow = ZoneNum;
+            CritZoneNumFlow = CtrlZoneNum;
         }
     }
 

--- a/src/EnergyPlus/SetPointManager.hh
+++ b/src/EnergyPlus/SetPointManager.hh
@@ -336,7 +336,6 @@ namespace SetPointManager {
         int NumZones;            // number of zones whose humidity is being controlled
         int NumCtrlNodes;        // number of nodes whose humidity ratio is being set
         Array1D_int ZoneNodes;   // zone node numbers of zones being controlled
-        Array1D_int ZoneNum;     // actual zone number ( index into Zone array)
         Array1D_int CtrlZoneNum; // index into ZoneEquipConfig
         Array1D_int CtrlNodes;   // nodes where humidity ratio is being set
         Real64 SetPt;            // the setpoint
@@ -355,7 +354,6 @@ namespace SetPointManager {
         int NumZones;            // number of zones whose humidity is being controlled
         int NumCtrlNodes;        // number of nodes whose humidity ratio is being set
         Array1D_int ZoneNodes;   // zone node numbers of zones being controlled
-        Array1D_int ZoneNum;     // actual zone number (index into Zone array)
         Array1D_int CtrlZoneNum; // index into ZoneEquipConfig
         Array1D_int CtrlNodes;   // nodes where humidity ratio is being set
         Real64 SetPt;            // the setpoint

--- a/src/EnergyPlus/SimAirServingZones.cc
+++ b/src/EnergyPlus/SimAirServingZones.cc
@@ -1885,8 +1885,7 @@ void InitAirLoops(EnergyPlusData &state, bool const FirstHVACIteration) // TRUE 
             // Store cooling zone numbers in AirLoopZoneInfo data structure
             for (int NumAirLoopCooledZonesTemp = 1; NumAirLoopCooledZonesTemp <= NumAirLoopCooledZones; ++NumAirLoopCooledZonesTemp) {
                 thisAirLoopZoneInfo.Zone(NumAirLoopCooledZonesTemp) = thisAirToZoneNodeInfo.CoolCtrlZoneNums(NumAirLoopCooledZonesTemp);
-                thisAirLoopZoneInfo.ActualZoneNumber(NumAirLoopCooledZonesTemp) =
-                    state.dataZoneEquip->ZoneEquipConfig(thisAirToZoneNodeInfo.CoolCtrlZoneNums(NumAirLoopCooledZonesTemp)).ActualZoneNum;
+                thisAirLoopZoneInfo.ActualZoneNumber(NumAirLoopCooledZonesTemp) = thisAirToZoneNodeInfo.CoolCtrlZoneNums(NumAirLoopCooledZonesTemp);
             }
             // Store heating zone numbers in AirLoopZoneInfo data structure
             // Only store zone numbers that aren't already defined as cooling zones above
@@ -1900,7 +1899,7 @@ void InitAirLoops(EnergyPlusData &state, bool const FirstHVACIteration) // TRUE 
                 if (!CommonZone) {
                     ++AirLoopZones;
                     thisAirLoopZoneInfo.Zone(AirLoopZones) = ZoneNum;
-                    thisAirLoopZoneInfo.ActualZoneNumber(AirLoopZones) = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ActualZoneNum;
+                    thisAirLoopZoneInfo.ActualZoneNumber(AirLoopZones) = ZoneNum;
                 }
             }
             thisAirLoopZoneInfo.NumZones = AirLoopZones;

--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -2380,7 +2380,7 @@ void GetSysInput(EnergyPlusData &state)
              ++state.dataSingleDuct->SysIndexGSI) {
             for (ZoneSizIndex = 1; ZoneSizIndex <= NumZoneSiz; ++ZoneSizIndex) {
                 if (state.dataGlobal->DoZoneSizing) {
-                    if (state.dataSize->FinalZoneSizing(ZoneSizIndex).ActualZoneNum ==
+                    if (state.dataSize->FinalZoneSizing(ZoneSizIndex).ZoneNum ==
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysIndexGSI).CtrlZoneNum) {
                         if (state.dataSize->FinalZoneSizing(ZoneSizIndex).ZoneSecondaryRecirculation > 0.0) {
                             ShowWarningError(state,

--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -651,13 +651,9 @@ void GetSysInput(EnergyPlusData &state)
 
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneNum = CtrlZone;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneInNodeIndex = SupAirIn;
-                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum =
-                            state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ZoneFloorArea =
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).FloorArea *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).Multiplier *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum)
-                                .ListMultiplier;
+                            state.dataHeatBal->Zone(CtrlZone).FloorArea * state.dataHeatBal->Zone(CtrlZone).Multiplier *
+                            state.dataHeatBal->Zone(CtrlZone).ListMultiplier;
                     }
                 }
             }
@@ -995,13 +991,9 @@ void GetSysInput(EnergyPlusData &state)
                         }
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneNum = CtrlZone;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneInNodeIndex = SupAirIn;
-                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum =
-                            state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ZoneFloorArea =
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).FloorArea *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).Multiplier *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum)
-                                .ListMultiplier;
+                            state.dataHeatBal->Zone(CtrlZone).FloorArea * state.dataHeatBal->Zone(CtrlZone).Multiplier *
+                            state.dataHeatBal->Zone(CtrlZone).ListMultiplier;
                     }
                 }
             }
@@ -1276,13 +1268,9 @@ void GetSysInput(EnergyPlusData &state)
                         }
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneNum = CtrlZone;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneInNodeIndex = SupAirIn;
-                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum =
-                            state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ZoneFloorArea =
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).FloorArea *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).Multiplier *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum)
-                                .ListMultiplier;
+                            state.dataHeatBal->Zone(CtrlZone).FloorArea * state.dataHeatBal->Zone(CtrlZone).Multiplier *
+                            state.dataHeatBal->Zone(CtrlZone).ListMultiplier;
                     }
                 }
             }
@@ -1448,13 +1436,9 @@ void GetSysInput(EnergyPlusData &state)
                         }
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneNum = CtrlZone;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneInNodeIndex = SupAirIn;
-                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum =
-                            state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ZoneFloorArea =
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).FloorArea *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).Multiplier *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum)
-                                .ListMultiplier;
+                            state.dataHeatBal->Zone(CtrlZone).FloorArea * state.dataHeatBal->Zone(CtrlZone).Multiplier *
+                            state.dataHeatBal->Zone(CtrlZone).ListMultiplier;
                     }
                 }
             }
@@ -1716,13 +1700,9 @@ void GetSysInput(EnergyPlusData &state)
 
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneNum = CtrlZone;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneInNodeIndex = SupAirIn;
-                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum =
-                            state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ZoneFloorArea =
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).FloorArea *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).Multiplier *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum)
-                                .ListMultiplier;
+                            state.dataHeatBal->Zone(CtrlZone).FloorArea * state.dataHeatBal->Zone(CtrlZone).Multiplier *
+                            state.dataHeatBal->Zone(CtrlZone).ListMultiplier;
                     }
                 }
             }
@@ -1925,13 +1905,9 @@ void GetSysInput(EnergyPlusData &state)
                         }
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneNum = CtrlZone;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneInNodeIndex = SupAirIn;
-                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum =
-                            state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ZoneFloorArea =
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).FloorArea *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).Multiplier *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum)
-                                .ListMultiplier;
+                            state.dataHeatBal->Zone(CtrlZone).FloorArea * state.dataHeatBal->Zone(CtrlZone).Multiplier *
+                            state.dataHeatBal->Zone(CtrlZone).ListMultiplier;
                     }
                 }
             }
@@ -2328,13 +2304,9 @@ void GetSysInput(EnergyPlusData &state)
                         }
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneNum = CtrlZone;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).CtrlZoneInNodeIndex = SupAirIn;
-                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum =
-                            state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
                         state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ZoneFloorArea =
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).FloorArea *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum).Multiplier *
-                            state.dataHeatBal->Zone(state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysNumGSI).ActualZoneNum)
-                                .ListMultiplier;
+                            state.dataHeatBal->Zone(CtrlZone).FloorArea * state.dataHeatBal->Zone(CtrlZone).Multiplier *
+                            state.dataHeatBal->Zone(CtrlZone).ListMultiplier;
                     }
                 }
             }
@@ -2409,7 +2381,7 @@ void GetSysInput(EnergyPlusData &state)
             for (ZoneSizIndex = 1; ZoneSizIndex <= NumZoneSiz; ++ZoneSizIndex) {
                 if (state.dataGlobal->DoZoneSizing) {
                     if (state.dataSize->FinalZoneSizing(ZoneSizIndex).ActualZoneNum ==
-                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysIndexGSI).ActualZoneNum) {
+                        state.dataSingleDuct->sd_airterminal(state.dataSingleDuct->SysIndexGSI).CtrlZoneNum) {
                         if (state.dataSize->FinalZoneSizing(ZoneSizIndex).ZoneSecondaryRecirculation > 0.0) {
                             ShowWarningError(state,
                                              std::string{RoutineName} + "A zone secondary recirculation fraction is specified for zone served by ");
@@ -2794,7 +2766,6 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
     //       AUTHOR         Fred Buhl
     //       DATE WRITTEN   September 2001
     //       MODIFIED       August 2013 Daeho Kang, add component sizing table entries
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // This subroutine is for sizing Sys Components for which flow rates have not been
@@ -2832,8 +2803,7 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
     Real64 rho; // local fluid density
     Real64 Cp;  // local fluid specific heat
     bool IsAutoSize;
-    bool IsMaxFlowAutoSize; // Indicate if the maximum terminal flow is autosize
-    int ZoneNum(0);
+    bool IsMaxFlowAutoSize;                   // Indicate if the maximum terminal flow is autosize
     int AirLoopNum;                           // Air loop number
     int SysSizNum;                            // System sizing number
     Real64 MinMinFlowRatio(0.0);              // the minimum minimum flow ratio
@@ -2879,7 +2849,7 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
     AirLoopNum = 0;
     SysSizNum = 0;
 
-    ZoneNum = this->ActualZoneNum;
+    int ZoneNum = this->CtrlZoneNum;
 
     auto &TermUnitSizing(state.dataSize->TermUnitSizing);
 
@@ -4306,11 +4276,8 @@ void SingleDuctAirTerminal::CalcOAMassFlow(EnergyPlusData &state,
         if (this->NoOAFlowInputFromUser) return;
         // Calculate outdoor air flow rate, zone multipliers are applied in GetInput
         if (AirLoopOAFrac > 0.0) {
-            OAVolumeFlowRate = DataSizing::calcDesignSpecificationOutdoorAir(state,
-                                                                             this->OARequirementsPtr,
-                                                                             this->ActualZoneNum,
-                                                                             state.dataAirLoop->AirLoopControlInfo(AirLoopNum).AirLoopDCVFlag,
-                                                                             UseMinOASchFlag);
+            OAVolumeFlowRate = DataSizing::calcDesignSpecificationOutdoorAir(
+                state, this->OARequirementsPtr, this->CtrlZoneNum, state.dataAirLoop->AirLoopControlInfo(AirLoopNum).AirLoopDCVFlag, UseMinOASchFlag);
             OAMassFlow = OAVolumeFlowRate * state.dataEnvrn->StdRhoAir;
 
             // convert OA mass flow rate to supply air flow rate based on air loop OA fraction
@@ -6178,8 +6145,7 @@ void GetATMixers(EnergyPlusData &state)
                             state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ExhaustNode(NodeNum)) {
                             ZoneNodeNotFound = false;
                             state.dataDefineEquipment->AirDistUnit(state.dataSingleDuct->SysATMixer(ATMixerNum).ADUNum).ZoneEqNum = CtrlZone;
-                            state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneEqNum = CtrlZone;
-                            state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
+                            state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneNum = CtrlZone;
                             // Must wait until InitATMixer to fill other zone equip config data because ultimate zone inlet node is not known yet
                             // for inlet side mixers
                             if (!state.dataSingleDuct->SysATMixer(ATMixerNum).NoOAFlowInputFromUser) {
@@ -6206,8 +6172,7 @@ void GetATMixers(EnergyPlusData &state)
                                 UtilityRoutines::SameString(state.dataIPShortCut->cAlphaArgs(2),
                                                             state.dataZoneEquip->ZoneEquipList(CtrlZone).EquipType(Num))) {
                                 state.dataDefineEquipment->AirDistUnit(state.dataSingleDuct->SysATMixer(ATMixerNum).ADUNum).ZoneEqNum = CtrlZone;
-                                state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneEqNum = CtrlZone;
-                                state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
+                                state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneNum = CtrlZone;
                                 // Must wait until InitATMixer to fill other zone equip config data because ultimate zone inlet node is not known yet
                                 // for inlet side mixers
                                 if (!state.dataSingleDuct->SysATMixer(ATMixerNum).NoOAFlowInputFromUser) {
@@ -6251,8 +6216,7 @@ void GetATMixers(EnergyPlusData &state)
                             state.dataZoneEquip->ZoneEquipConfig(CtrlZone).InletNode(NodeNum)) {
                             ZoneNodeNotFound = false;
                             state.dataDefineEquipment->AirDistUnit(state.dataSingleDuct->SysATMixer(ATMixerNum).ADUNum).ZoneEqNum = CtrlZone;
-                            state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneEqNum = CtrlZone;
-                            state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZone).ActualZoneNum;
+                            state.dataSingleDuct->SysATMixer(ATMixerNum).ZoneNum = CtrlZone;
                             // Wait until InitATMixer to fill other zone equip config data
 
                             if (!state.dataSingleDuct->SysATMixer(ATMixerNum).NoOAFlowInputFromUser) {

--- a/src/EnergyPlus/SingleDuct.hh
+++ b/src/EnergyPlus/SingleDuct.hh
@@ -189,7 +189,6 @@ namespace SingleDuct {
         Real64 ZoneFloorArea;                 // Zone floor area
         int CtrlZoneNum;                      // Pointer to CtrlZone data structure
         int CtrlZoneInNodeIndex;              // which controlled zone inlet node number corresponds with this unit
-        int ActualZoneNum;                    // Pointer to Zone data Structure
         Real64 MaxAirVolFlowRateDuringReheat; // Maximum vol flow during reheat
         Real64 MaxAirVolFractionDuringReheat; // Maximum vol flow fraction during reheat
         Real64 AirMassFlowDuringReheatMax;    // Maximum mass flow during reheat
@@ -233,7 +232,7 @@ namespace SingleDuct {
               ReheatAirOutletNode(0), MaxReheatWaterVolFlow(0.0), MaxReheatSteamVolFlow(0.0), MaxReheatWaterFlow(0.0), MaxReheatSteamFlow(0.0),
               MinReheatWaterVolFlow(0.0), MinReheatSteamVolFlow(0.0), MinReheatWaterFlow(0.0), MinReheatSteamFlow(0.0), ControllerOffset(0.0),
               MaxReheatTemp(0.0), MaxReheatTempSetByUser(false), DamperHeatingAction(Action::HeatingNotUsed), DamperPosition(0.0), ADUNum(0),
-              FluidIndex(0), ErrCount1(0), ErrCount1c(0), ErrCount2(0), ZoneFloorArea(0.0), CtrlZoneNum(0), CtrlZoneInNodeIndex(0), ActualZoneNum(0),
+              FluidIndex(0), ErrCount1(0), ErrCount1c(0), ErrCount2(0), ZoneFloorArea(0.0), CtrlZoneNum(0), CtrlZoneInNodeIndex(0),
               MaxAirVolFlowRateDuringReheat(0.0), MaxAirVolFractionDuringReheat(0.0), AirMassFlowDuringReheatMax(0.0), ZoneOutdoorAirMethod(0),
               OutdoorAirFlowRate(0.0), NoOAFlowInputFromUser(true), OARequirementsPtr(0), AirLoopNum(0), HWplantLoc{}, SecInNode(0),
               IterationLimit(0), IterationFailed(0), OAPerPersonMode(DataZoneEquipment::PerPersonVentRateMode::Invalid), EMSOverrideAirFlow(false),
@@ -316,8 +315,7 @@ namespace SingleDuct {
         int TermUnitSizingIndex;      // Pointer to TermUnitSizing and TermUnitFinalZoneSizing data for this terminal unit
         bool OneTimeInitFlag;         // true if one-time inits should be done
         bool OneTimeInitFlag2;        // true if more one-time inits should be done
-        int ZoneEqNum;
-        int CtrlZoneInNodeIndex; // which controlled zone inlet node number corresponds with this unit
+        int CtrlZoneInNodeIndex;      // which controlled zone inlet node number corresponds with this unit
         int ZoneNum;
         bool NoOAFlowInputFromUser;                               // avoids OA calculation if no input specified by user
         int OARequirementsPtr;                                    // - Index to DesignSpecification:OutdoorAir object
@@ -331,8 +329,8 @@ namespace SingleDuct {
               ZoneAirHumRat(0.0), ZoneAirEnthalpy(0.0), ZoneAirPressure(0.0), ZoneAirMassFlowRate(0.0), DOASTemp(0.0), DOASHumRat(0.0),
               DOASEnthalpy(0.0), DOASPressure(0.0), DOASMassFlowRate(0.0), MixedAirTemp(0.0), MixedAirHumRat(0.0), MixedAirEnthalpy(0.0),
               MixedAirPressure(0.0), MixedAirMassFlowRate(0.0), MassFlowRateMaxAvail(0.0), ADUNum(0), TermUnitSizingIndex(0), OneTimeInitFlag(true),
-              OneTimeInitFlag2(true), ZoneEqNum(0), CtrlZoneInNodeIndex(0), ZoneNum(0), NoOAFlowInputFromUser(true), OARequirementsPtr(0),
-              AirLoopNum(0), DesignPrimaryAirVolRate(0.0), OAPerPersonMode(DataZoneEquipment::PerPersonVentRateMode::Invalid), printWarning(true)
+              OneTimeInitFlag2(true), CtrlZoneInNodeIndex(0), ZoneNum(0), NoOAFlowInputFromUser(true), OARequirementsPtr(0), AirLoopNum(0),
+              DesignPrimaryAirVolRate(0.0), OAPerPersonMode(DataZoneEquipment::PerPersonVentRateMode::Invalid), printWarning(true)
         {
         }
 

--- a/src/EnergyPlus/SizingManager.cc
+++ b/src/EnergyPlus/SizingManager.cc
@@ -1024,7 +1024,7 @@ void ManageSystemSizingAdjustments(EnergyPlusData &state)
                             designOAductFlow =
                                 DataSizing::calcDesignSpecificationOutdoorAir(state,
                                                                               state.dataDualDuct->dd_airterminal(dualDuctATUNum).OARequirementsPtr,
-                                                                              state.dataDualDuct->dd_airterminal(dualDuctATUNum).ActualZoneNum,
+                                                                              state.dataDualDuct->dd_airterminal(dualDuctATUNum).CtrlZoneNum,
                                                                               UseOccSchFlag,
                                                                               UseMinOASchFlag);
                             airLoopHeatingMinimumFlowRateSum += designOAductFlow;

--- a/src/EnergyPlus/SizingManager.cc
+++ b/src/EnergyPlus/SizingManager.cc
@@ -107,8 +107,6 @@ void ManageSizing(EnergyPlusData &state)
     // SUBROUTINE INFORMATION:
     //       AUTHOR         Fred Buhl
     //       DATE WRITTEN   December 2000
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // This subroutine manages the sizing simulations (using design day condiions)
@@ -148,8 +146,6 @@ void ManageSizing(EnergyPlusData &state)
     int TimeStepInDay(0); // time step number
     int LastMonth(0);
     int LastDayOfMonth(0);
-    int CtrlZoneNum(0);       // controlled zone index
-    int ZoneNum(0);           // index into the Zone data array for the controlled zone
     Real64 TempAtPeak(0.0);   // Outside temperature at peak cooling/heating for reporting
     Real64 HumRatAtPeak(0.0); // Outside humidity ratio at peak cooling/heating for reporting
     int TimeStepAtPeak(0);    // time step number at heat or cool peak
@@ -574,9 +570,8 @@ void ManageSizing(EnergyPlusData &state)
 
     // report sizing results to eio file
     if (state.dataSize->ZoneSizingRunDone) {
-        for (CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
+        for (int CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
             if (!state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).IsControlled) continue;
-            ZoneNum = state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum;
             if (state.dataSize->FinalZoneSizing(CtrlZoneNum).DesCoolVolFlow > 0.0) {
                 TimeStepAtPeak = state.dataSize->FinalZoneSizing(CtrlZoneNum).TimeStepNumAtCoolMax;
                 DDNum = state.dataSize->FinalZoneSizing(CtrlZoneNum).CoolDDNum;
@@ -602,8 +597,8 @@ void ManageSizing(EnergyPlusData &state)
                                  state.dataSize->CoolPeakDateHrMin(CtrlZoneNum),
                                  TempAtPeak,
                                  HumRatAtPeak,
-                                 state.dataHeatBal->Zone(ZoneNum).FloorArea,
-                                 state.dataHeatBal->Zone(ZoneNum).TotOccupants,
+                                 state.dataHeatBal->Zone(CtrlZoneNum).FloorArea,
+                                 state.dataHeatBal->Zone(CtrlZoneNum).TotOccupants,
                                  state.dataSize->FinalZoneSizing(CtrlZoneNum).MinOA,
                                  DOASHeatGainRateAtClPk);
                 curName = state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneName;
@@ -611,11 +606,11 @@ void ManageSizing(EnergyPlusData &state)
                     state, state.dataOutRptPredefined->pdchZnClCalcDesLd, curName, state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesCoolLoad);
                 PreDefTableEntry(
                     state, state.dataOutRptPredefined->pdchZnClUserDesLd, curName, state.dataSize->FinalZoneSizing(CtrlZoneNum).DesCoolLoad);
-                if (state.dataHeatBal->Zone(ZoneNum).FloorArea != 0.0) {
+                if (state.dataHeatBal->Zone(CtrlZoneNum).FloorArea != 0.0) {
                     PreDefTableEntry(state,
                                      state.dataOutRptPredefined->pdchZnClUserDesLdPerArea,
                                      curName,
-                                     state.dataSize->FinalZoneSizing(CtrlZoneNum).DesCoolLoad / state.dataHeatBal->Zone(ZoneNum).FloorArea);
+                                     state.dataSize->FinalZoneSizing(CtrlZoneNum).DesCoolLoad / state.dataHeatBal->Zone(CtrlZoneNum).FloorArea);
                 }
                 PreDefTableEntry(state,
                                  state.dataOutRptPredefined->pdchZnClCalcDesAirFlow,
@@ -686,8 +681,8 @@ void ManageSizing(EnergyPlusData &state)
                                  state.dataSize->HeatPeakDateHrMin(CtrlZoneNum),
                                  TempAtPeak,
                                  HumRatAtPeak,
-                                 state.dataHeatBal->Zone(ZoneNum).FloorArea,
-                                 state.dataHeatBal->Zone(ZoneNum).TotOccupants,
+                                 state.dataHeatBal->Zone(CtrlZoneNum).FloorArea,
+                                 state.dataHeatBal->Zone(CtrlZoneNum).TotOccupants,
                                  state.dataSize->FinalZoneSizing(CtrlZoneNum).MinOA,
                                  DOASHeatGainRateAtHtPk);
                 curName = state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneName;
@@ -695,11 +690,11 @@ void ManageSizing(EnergyPlusData &state)
                     state, state.dataOutRptPredefined->pdchZnHtCalcDesLd, curName, state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesHeatLoad);
                 PreDefTableEntry(
                     state, state.dataOutRptPredefined->pdchZnHtUserDesLd, curName, state.dataSize->FinalZoneSizing(CtrlZoneNum).DesHeatLoad);
-                if (state.dataHeatBal->Zone(ZoneNum).FloorArea != 0.0) {
+                if (state.dataHeatBal->Zone(CtrlZoneNum).FloorArea != 0.0) {
                     PreDefTableEntry(state,
                                      state.dataOutRptPredefined->pdchZnHtUserDesLdPerArea,
                                      curName,
-                                     state.dataSize->FinalZoneSizing(CtrlZoneNum).DesHeatLoad / state.dataHeatBal->Zone(ZoneNum).FloorArea);
+                                     state.dataSize->FinalZoneSizing(CtrlZoneNum).DesHeatLoad / state.dataHeatBal->Zone(CtrlZoneNum).FloorArea);
                 }
                 PreDefTableEntry(state,
                                  state.dataOutRptPredefined->pdchZnHtCalcDesAirFlow,
@@ -1981,9 +1976,8 @@ void ManageSystemVentilationAdjustments(EnergyPlusData &state)
                     Real64 VozMax = std::max(VozHtg, VozClg); // take larger of the heating and cooling Voz values
                     OutputReportPredefined::PreDefTableEntry(
                         state, state.dataOutRptPredefined->pdchOaMvDesZnOa, thisTermUnitFinalZoneSizing.ZoneName, VozMax, 4);
-                    state.dataOutRptPredefined->TotalVozMax += VozMax *
-                                                               state.dataHeatBal->Zone(thisTermUnitFinalZoneSizing.ActualZoneNum).Multiplier *
-                                                               state.dataHeatBal->Zone(thisTermUnitFinalZoneSizing.ActualZoneNum).ListMultiplier;
+                    state.dataOutRptPredefined->TotalVozMax += VozMax * state.dataHeatBal->Zone(thisTermUnitFinalZoneSizing.ZoneNum).Multiplier *
+                                                               state.dataHeatBal->Zone(thisTermUnitFinalZoneSizing.ZoneNum).ListMultiplier;
                     OutputReportPredefined::PreDefTableEntry(state,
                                                              state.dataOutRptPredefined->pdchS62zhdZpz,
                                                              thisTermUnitFinalZoneSizing.ZoneName,
@@ -2147,11 +2141,11 @@ void DetermineSystemPopulationDiversity(EnergyPlusData &state)
             for (int zoneNumOnLoop = 1; zoneNumOnLoop <= state.dataAirLoop->AirLoopZoneInfo(AirLoopNum).NumZones; ++zoneNumOnLoop) {
                 int CtrlZoneNum = state.dataAirLoop->AirLoopZoneInfo(AirLoopNum).ActualZoneNumber(zoneNumOnLoop);
                 for (int PeopleNum = 1; PeopleNum <= state.dataHeatBal->TotPeople; ++PeopleNum) {
-                    if (state.dataHeatBal->People(PeopleNum).ZonePtr == state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum) {
+                    if (state.dataHeatBal->People(PeopleNum).ZonePtr == state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneNum) {
                         state.dataSize->PzSumBySys(AirLoopNum) +=
                             (state.dataHeatBal->People(PeopleNum).NumberOfPeople *
-                             state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum).Multiplier *
-                             state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum).ListMultiplier);
+                             state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneNum).Multiplier *
+                             state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneNum).ListMultiplier);
                     }
                 }
             }
@@ -2194,11 +2188,11 @@ void DetermineSystemPopulationDiversity(EnergyPlusData &state)
                             int CtrlZoneNum = state.dataAirLoop->AirLoopZoneInfo(AirLoopNum).ActualZoneNumber(zoneNumOnLoop);
 
                             for (int PeopleNum = 1; PeopleNum <= state.dataHeatBal->TotPeople; ++PeopleNum) {
-                                if (state.dataHeatBal->People(PeopleNum).ZonePtr == state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum) {
+                                if (state.dataHeatBal->People(PeopleNum).ZonePtr == state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneNum) {
                                     Real64 PeopleInZone =
                                         (state.dataHeatBal->People(PeopleNum).NumberOfPeople *
-                                         state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum).Multiplier *
-                                         state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum).ListMultiplier);
+                                         state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneNum).Multiplier *
+                                         state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneNum).ListMultiplier);
                                     Real64 schMultiplier = ScheduleManager::LookUpScheduleValue(
                                         state, state.dataHeatBal->People(PeopleNum).NumberOfPeoplePtr, hrOfDay, TS);
                                     PeopleInZone = PeopleInZone * schMultiplier;

--- a/src/EnergyPlus/SteamBaseboardRadiator.cc
+++ b/src/EnergyPlus/SteamBaseboardRadiator.cc
@@ -848,7 +848,7 @@ namespace SteamBaseboardRadiator {
         }
     }
 
-    void InitSteamBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNumSub, bool const FirstHVACIteration)
+    void InitSteamBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration)
     {
 
         // SUBROUTINE INFORMATION:
@@ -858,7 +858,6 @@ namespace SteamBaseboardRadiator {
         //                      Feb 2001
         //       MODIFIED       Sep 2009 Daeho Kang (Add Radiant Component)
         //                      Sept 2010 Chandan Sharma, FSEC (plant interactions)
-        //       RE-ENGINEERED  na
 
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine initializes the baseboard units.
@@ -876,24 +875,11 @@ namespace SteamBaseboardRadiator {
         using PlantUtilities::InitComponentNodes;
         using PlantUtilities::ScanPlantLoopsForObject;
 
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
         static constexpr std::string_view RoutineName("InitSteamCoil");
 
-        // INTERFACE BLOCK SPECIFICATIONS
-        // na
-
-        // DERIVED TYPE DEFINITIONS
-        // na
-
-        // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         auto &MyEnvrnFlag = state.dataSteamBaseboardRadiator->MyEnvrnFlag;
         int Loop;
         int SteamInletNode;
-        int ZoneNode;
-        int ZoneNum;
         Real64 StartEnthSteam;
         Real64 SteamDensity;
         bool errFlag;
@@ -917,9 +903,7 @@ namespace SteamBaseboardRadiator {
             state.dataSteamBaseboardRadiator->SetLoopIndexFlag = true;
         }
 
-        if (state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).ZonePtr <= 0)
-            state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).ZonePtr =
-                state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ActualZoneNum;
+        state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).ZonePtr = ZoneNum;
 
         // Need to check all units to see if they are on ZoneHVAC:EquipmentList or issue warning
         if (!state.dataSteamBaseboardRadiator->ZoneEquipmentListChecked && state.dataZoneEquip->ZoneEquipInputsFilled) {
@@ -1008,7 +992,7 @@ namespace SteamBaseboardRadiator {
         }
 
         if (state.dataGlobal->BeginTimeStepFlag && FirstHVACIteration) {
-            ZoneNum = state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).ZonePtr;
+            int ZoneNum = state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).ZonePtr;
             state.dataSteamBaseboardRadiator->ZeroSourceSumHATsurf(ZoneNum) = SumHATsurf(state, ZoneNum);
             state.dataSteamBaseboardRadiator->QBBSteamRadSrcAvg(BaseboardNum) = 0.0;
             state.dataSteamBaseboardRadiator->LastQBBSteamRadSrc(BaseboardNum) = 0.0;
@@ -1018,7 +1002,7 @@ namespace SteamBaseboardRadiator {
 
         // Do the every time step initializations
         SteamInletNode = state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamInletNode;
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNumSub).ZoneNode;
+        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
         state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamMassFlowRate = state.dataLoopNodes->Node(SteamInletNode).MassFlowRate;
         state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamInletTemp = state.dataLoopNodes->Node(SteamInletNode).Temp;
         state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamInletEnthalpy = state.dataLoopNodes->Node(SteamInletNode).Enthalpy;

--- a/src/EnergyPlus/SteamBaseboardRadiator.cc
+++ b/src/EnergyPlus/SteamBaseboardRadiator.cc
@@ -1001,7 +1001,6 @@ namespace SteamBaseboardRadiator {
 
         // Do the every time step initializations
         SteamInletNode = state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamInletNode;
-        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
         state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamMassFlowRate = state.dataLoopNodes->Node(SteamInletNode).MassFlowRate;
         state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamInletTemp = state.dataLoopNodes->Node(SteamInletNode).Temp;
         state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamInletEnthalpy = state.dataLoopNodes->Node(SteamInletNode).Enthalpy;

--- a/src/EnergyPlus/SteamBaseboardRadiator.cc
+++ b/src/EnergyPlus/SteamBaseboardRadiator.cc
@@ -847,7 +847,7 @@ namespace SteamBaseboardRadiator {
         }
     }
 
-    void InitSteamBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration)
+    void InitSteamBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNum, bool const FirstHVACIteration)
     {
 
         // SUBROUTINE INFORMATION:
@@ -902,7 +902,7 @@ namespace SteamBaseboardRadiator {
             state.dataSteamBaseboardRadiator->SetLoopIndexFlag = true;
         }
 
-        state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).ZonePtr = ZoneNum;
+        state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).ZonePtr = ControlledZoneNum;
 
         // Need to check all units to see if they are on ZoneHVAC:EquipmentList or issue warning
         if (!state.dataSteamBaseboardRadiator->ZoneEquipmentListChecked && state.dataZoneEquip->ZoneEquipInputsFilled) {

--- a/src/EnergyPlus/SteamBaseboardRadiator.cc
+++ b/src/EnergyPlus/SteamBaseboardRadiator.cc
@@ -112,7 +112,6 @@ namespace SteamBaseboardRadiator {
 
     void SimSteamBaseboard(EnergyPlusData &state,
                            std::string const &EquipName,
-                           int const ActualZoneNum,
                            int const ControlledZoneNum,
                            bool const FirstHVACIteration,
                            Real64 &PowerMet,
@@ -175,13 +174,13 @@ namespace SteamBaseboardRadiator {
 
             InitSteamBaseboard(state, BaseboardNum, ControlledZoneNum, FirstHVACIteration);
 
-            QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputReqToHeatSP;
+            QZnReq = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputReqToHeatSP;
 
             SteamBaseboardDesignData SteamBaseboardDesignDataObject{state.dataSteamBaseboardRadiator->SteamBaseboardDesign(
                 state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum)
                     .DesignObjectPtr)}; // Array that contains the design data for steam baseboard objects
 
-            if (QZnReq > SmallLoad && !state.dataZoneEnergyDemand->CurDeadBandOrSetback(ActualZoneNum) &&
+            if (QZnReq > SmallLoad && !state.dataZoneEnergyDemand->CurDeadBandOrSetback(ControlledZoneNum) &&
                 (GetCurrentScheduleValue(state, state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SchedPtr) > 0.0)) {
 
                 // On the first HVAC iteration the system values are given to the controller, but after that

--- a/src/EnergyPlus/SteamBaseboardRadiator.hh
+++ b/src/EnergyPlus/SteamBaseboardRadiator.hh
@@ -173,7 +173,7 @@ namespace SteamBaseboardRadiator {
 
     void GetSteamBaseboardInput(EnergyPlusData &state);
 
-    void InitSteamBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration);
+    void InitSteamBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNum, bool const FirstHVACIteration);
 
     void SizeSteamBaseboard(EnergyPlusData &state, int const BaseboardNum);
 

--- a/src/EnergyPlus/SteamBaseboardRadiator.hh
+++ b/src/EnergyPlus/SteamBaseboardRadiator.hh
@@ -174,7 +174,7 @@ namespace SteamBaseboardRadiator {
 
     void GetSteamBaseboardInput(EnergyPlusData &state);
 
-    void InitSteamBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ControlledZoneNumSub, bool const FirstHVACIteration);
+    void InitSteamBaseboard(EnergyPlusData &state, int const BaseboardNum, int const ZoneNum, bool const FirstHVACIteration);
 
     void SizeSteamBaseboard(EnergyPlusData &state, int const BaseboardNum);
 

--- a/src/EnergyPlus/SteamBaseboardRadiator.hh
+++ b/src/EnergyPlus/SteamBaseboardRadiator.hh
@@ -166,7 +166,6 @@ namespace SteamBaseboardRadiator {
 
     void SimSteamBaseboard(EnergyPlusData &state,
                            std::string const &EquipName,
-                           int const ActualZoneNum,
                            int const ControlledZoneNum,
                            bool const FirstHVACIteration,
                            Real64 &PowerMet,

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -10696,7 +10696,7 @@ namespace SurfaceGeometry {
                     }
                     std::string callDescription = cCurrentModuleObject + "=" + state.dataSurface->Surface(SurfNum).Name;
                     state.dataSurface->SurfWinAirflowReturnNodePtr(SurfNum) =
-                        DataZoneEquipment::GetReturnAirNodeForZone(state, state.dataSurface->Surface(SurfNum).ZoneName, retNodeName, callDescription);
+                        DataZoneEquipment::GetReturnAirNodeForZone(state, state.dataSurface->Surface(SurfNum).Zone, retNodeName, callDescription);
                     if (state.dataSurface->SurfWinAirflowReturnNodePtr(SurfNum) == 0) {
                         ShowSevereError(state,
                                         std::string{RoutineName} + cCurrentModuleObject + "=\"" + state.dataSurface->Surface(SurfNum).Name +

--- a/src/EnergyPlus/SystemAvailabilityManager.cc
+++ b/src/EnergyPlus/SystemAvailabilityManager.cc
@@ -1626,7 +1626,6 @@ namespace SystemAvailabilityManager {
         //       AUTHOR         Fred Buhl
         //       DATE WRITTEN   August 2001
         //       MODIFIED       Brent Griffith, CR8376 initialize to NoAction every timestep
-        //       RE-ENGINEERED  na
 
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine is for initializations of the System Availability Manager objects.
@@ -1645,39 +1644,9 @@ namespace SystemAvailabilityManager {
 
         if (state.dataSystemAvailabilityManager->InitSysAvailManagers_MyOneTimeFlag) {
 
-            // for (SysAvailNum = 1; SysAvailNum <= state.dataSystemAvailabilityManager->NumNCycSysAvailMgrs; ++SysAvailNum) {
-            //     if (state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).nightCycleControlType == NightCycleControlType::OnControlZone)
-            //     {
-            //         // set the controlled zone numbers
-            //         for (int index = 1; index <= state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).NumOfCtrlZones; ++index) {
-            //             for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-            //                 if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
-            //                     if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum ==
-            //                         state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).CtrlZonePtrs(index)) {
-            //                         state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).CtrlZonePtrs(index) = ControlledZoneNum;
-            //                         break;
-            //                     }
-            //                 }
-            //             }
-            //         }
-            //     }
-            // }
-
             for (SysAvailNum = 1; SysAvailNum <= state.dataSystemAvailabilityManager->NumOptStartSysAvailMgrs; ++SysAvailNum) {
                 auto &optimumStartMgr = state.dataSystemAvailabilityManager->OptimumStartData(SysAvailNum);
-                switch (optimumStartMgr.optimumStartControlType) {
-                case OptimumStartControlType::ControlZone: {
-                    //// set the controlled zone numbers
-                    // for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                    //     if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
-                    //         if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum == optimumStartMgr.ZoneNum) {
-                    //             optimumStartMgr.ControlledZoneNum = ControlledZoneNum;
-                    //             break;
-                    //         }
-                    //     }
-                    // }
-                } break;
-                case OptimumStartControlType::MaximumOfZoneList: {
+                if (optimumStartMgr.optimumStartControlType == OptimumStartControlType::MaximumOfZoneList) {
                     // a zone list
                     ZoneListNum = UtilityRoutines::FindItemInList(optimumStartMgr.ZoneListName, state.dataHeatBal->ZoneList);
                     if (ZoneListNum > 0) {
@@ -1690,24 +1659,8 @@ namespace SystemAvailabilityManager {
                             optimumStartMgr.ZonePtrs(ScanZoneListNum) = ZoneNum;
                         }
                     }
-                } break;
-                default:
-                    break;
                 }
             }
-
-            // for (SysAvailNum = 1; SysAvailNum <= state.dataSystemAvailabilityManager->NumNVentSysAvailMgrs; ++SysAvailNum) {
-            //     // set the controlled zone numbers
-            //     for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-            //         if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
-            //             if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum ==
-            //                 state.dataSystemAvailabilityManager->NightVentData(SysAvailNum).ZoneNum) {
-            //                 state.dataSystemAvailabilityManager->NightVentData(SysAvailNum).ControlledZoneNum = ControlledZoneNum;
-            //                 break;
-            //             }
-            //         }
-            //     }
-            // }
 
             state.dataSystemAvailabilityManager->InitSysAvailManagers_MyOneTimeFlag = false;
 

--- a/src/EnergyPlus/SystemAvailabilityManager.cc
+++ b/src/EnergyPlus/SystemAvailabilityManager.cc
@@ -306,7 +306,7 @@ namespace SystemAvailabilityManager {
                             if (state.dataHVACGlobal->NumHybridVentSysAvailMgrs > 0) {
                                 for (HybridVentNum = 1; HybridVentNum <= state.dataHVACGlobal->NumHybridVentSysAvailMgrs; ++HybridVentNum) {
                                     if (!state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).HybridVentMgrConnectedToAirLoop) {
-                                        if (state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).ActualZoneNum ==
+                                        if (state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).ControlledZoneNum ==
                                             ZoneComp(ZoneEquipType).ZoneCompAvailMgrs(CompNum).ZoneNum) {
                                             if (state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).VentilationCtrl ==
                                                 HybridVentCtrl_Open) {
@@ -1645,36 +1645,37 @@ namespace SystemAvailabilityManager {
 
         if (state.dataSystemAvailabilityManager->InitSysAvailManagers_MyOneTimeFlag) {
 
-            for (SysAvailNum = 1; SysAvailNum <= state.dataSystemAvailabilityManager->NumNCycSysAvailMgrs; ++SysAvailNum) {
-                if (state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).nightCycleControlType == NightCycleControlType::OnControlZone) {
-                    // set the controlled zone numbers
-                    for (int index = 1; index <= state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).NumOfCtrlZones; ++index) {
-                        for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                            if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
-                                if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum ==
-                                    state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).CtrlZonePtrs(index)) {
-                                    state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).CtrlZonePtrs(index) = ControlledZoneNum;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            // for (SysAvailNum = 1; SysAvailNum <= state.dataSystemAvailabilityManager->NumNCycSysAvailMgrs; ++SysAvailNum) {
+            //     if (state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).nightCycleControlType == NightCycleControlType::OnControlZone)
+            //     {
+            //         // set the controlled zone numbers
+            //         for (int index = 1; index <= state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).NumOfCtrlZones; ++index) {
+            //             for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+            //                 if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
+            //                     if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum ==
+            //                         state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).CtrlZonePtrs(index)) {
+            //                         state.dataSystemAvailabilityManager->NightCycleData(SysAvailNum).CtrlZonePtrs(index) = ControlledZoneNum;
+            //                         break;
+            //                     }
+            //                 }
+            //             }
+            //         }
+            //     }
+            // }
 
             for (SysAvailNum = 1; SysAvailNum <= state.dataSystemAvailabilityManager->NumOptStartSysAvailMgrs; ++SysAvailNum) {
                 auto &optimumStartMgr = state.dataSystemAvailabilityManager->OptimumStartData(SysAvailNum);
                 switch (optimumStartMgr.optimumStartControlType) {
                 case OptimumStartControlType::ControlZone: {
-                    // set the controlled zone numbers
-                    for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                        if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
-                            if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum == optimumStartMgr.ZoneNum) {
-                                optimumStartMgr.ControlledZoneNum = ControlledZoneNum;
-                                break;
-                            }
-                        }
-                    }
+                    //// set the controlled zone numbers
+                    // for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+                    //     if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
+                    //         if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum == optimumStartMgr.ZoneNum) {
+                    //             optimumStartMgr.ControlledZoneNum = ControlledZoneNum;
+                    //             break;
+                    //         }
+                    //     }
+                    // }
                 } break;
                 case OptimumStartControlType::MaximumOfZoneList: {
                     // a zone list
@@ -1695,18 +1696,18 @@ namespace SystemAvailabilityManager {
                 }
             }
 
-            for (SysAvailNum = 1; SysAvailNum <= state.dataSystemAvailabilityManager->NumNVentSysAvailMgrs; ++SysAvailNum) {
-                // set the controlled zone numbers
-                for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                    if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
-                        if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum ==
-                            state.dataSystemAvailabilityManager->NightVentData(SysAvailNum).ZoneNum) {
-                            state.dataSystemAvailabilityManager->NightVentData(SysAvailNum).ControlledZoneNum = ControlledZoneNum;
-                            break;
-                        }
-                    }
-                }
-            }
+            // for (SysAvailNum = 1; SysAvailNum <= state.dataSystemAvailabilityManager->NumNVentSysAvailMgrs; ++SysAvailNum) {
+            //     // set the controlled zone numbers
+            //     for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+            //         if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
+            //             if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum ==
+            //                 state.dataSystemAvailabilityManager->NightVentData(SysAvailNum).ZoneNum) {
+            //                 state.dataSystemAvailabilityManager->NightVentData(SysAvailNum).ControlledZoneNum = ControlledZoneNum;
+            //                 break;
+            //             }
+            //         }
+            //     }
+            // }
 
             state.dataSystemAvailabilityManager->InitSysAvailManagers_MyOneTimeFlag = false;
 
@@ -2029,8 +2030,6 @@ namespace SystemAvailabilityManager {
         int StartTime;
         int StopTime;
         int ZoneInSysNum;
-        int CtrldZoneNum;
-        int ZoneNum;
         Real64 TempTol;
         auto &ZoneCompNCControlType = state.dataSystemAvailabilityManager->ZoneCompNCControlType;
 
@@ -2089,7 +2088,7 @@ namespace SystemAvailabilityManager {
                 } break;
                 case NightCycleControlType::OnControlZone: {
 
-                    ZoneNum = nightCycleMgr.CtrlZonePtrs(1);
+                    int ZoneNum = nightCycleMgr.CtrlZonePtrs(1);
 
                     switch (state.dataHeatBalFanSys->TempControlType(ZoneNum)) { // select on thermostat control
 
@@ -2186,8 +2185,7 @@ namespace SystemAvailabilityManager {
                     for (ZoneInSysNum = 1; ZoneInSysNum <= state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).NumZonesCooled;
                          ++ZoneInSysNum) { // loop over zones in system
 
-                        CtrldZoneNum = state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).CoolCtrlZoneNums(ZoneInSysNum);
-                        ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrldZoneNum).ActualZoneNum;
+                        int ZoneNum = state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).CoolCtrlZoneNums(ZoneInSysNum);
 
                         switch (state.dataHeatBalFanSys->TempControlType(ZoneNum)) {
                         case DataHVACGlobals::ThermostatType::SingleHeating: {
@@ -2518,14 +2516,12 @@ namespace SystemAvailabilityManager {
 
             // Pass the start time to ZoneTempPredictorCorrector
             for (int counter = 1; counter <= state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).NumZonesCooled; ++counter) {
-                int actZoneNum =
-                    state.dataZoneEquip->ZoneEquipConfig(state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).CoolCtrlZoneNums(counter)).ActualZoneNum;
+                int actZoneNum = state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).CoolCtrlZoneNums(counter);
                 OptStartData.OccStartTime(actZoneNum) = FanStartTime;
                 OptStartData.ActualZoneNum(actZoneNum) = actZoneNum;
             }
             for (int counter = 1; counter <= state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).NumZonesHeated; ++counter) {
-                int actZoneNum =
-                    state.dataZoneEquip->ZoneEquipConfig(state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).HeatCtrlZoneNums(counter)).ActualZoneNum;
+                int actZoneNum = state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).HeatCtrlZoneNums(counter);
                 OptStartData.OccStartTime(actZoneNum) = FanStartTime;
                 OptStartData.ActualZoneNum(actZoneNum) = actZoneNum;
             }
@@ -3505,12 +3501,10 @@ namespace SystemAvailabilityManager {
         // Set the OptStartFlag true for all zones on the air loop
         auto const &thisAirToZoneNodeInfo(state.dataAirLoop->AirToZoneNodeInfo(AirLoopNum));
         for (int counter = 1; counter <= thisAirToZoneNodeInfo.NumZonesCooled; ++counter) {
-            int actZoneNum = state.dataZoneEquip->ZoneEquipConfig(thisAirToZoneNodeInfo.CoolCtrlZoneNums(counter)).ActualZoneNum;
-            state.dataHVACGlobal->OptStartData.OptStartFlag(actZoneNum) = true;
+            state.dataHVACGlobal->OptStartData.OptStartFlag(thisAirToZoneNodeInfo.CoolCtrlZoneNums(counter)) = true;
         }
         for (int counter = 1; counter <= thisAirToZoneNodeInfo.NumZonesHeated; ++counter) {
-            int actZoneNum = state.dataZoneEquip->ZoneEquipConfig(thisAirToZoneNodeInfo.HeatCtrlZoneNums(counter)).ActualZoneNum;
-            state.dataHVACGlobal->OptStartData.OptStartFlag(actZoneNum) = true;
+            state.dataHVACGlobal->OptStartData.OptStartFlag(thisAirToZoneNodeInfo.HeatCtrlZoneNums(counter)) = true;
         }
     }
     void CalcNVentSysAvailMgr(EnergyPlusData &state,
@@ -3541,13 +3535,10 @@ namespace SystemAvailabilityManager {
         using namespace DataAirLoop;
 
         int ZoneInSysNum;
-        int CtrldZoneNum;
-        int ZoneNum;
-        bool TempCheck;     // TRUE if one zone's temperature is above the value of the vent temp sched
-        bool DelTCheck;     // TRUE if the control zone temperature - outside temperature > VentDelT
-        bool LowLimCheck;   // TRUE if one zones's air temperature is below this value
-        Real64 VentTemp;    // value of the ventilation temperature schedule
-        int ControlZoneNum; // actual zone number of the control zone
+        bool TempCheck;   // TRUE if one zone's temperature is above the value of the vent temp sched
+        bool DelTCheck;   // TRUE if the control zone temperature - outside temperature > VentDelT
+        bool LowLimCheck; // TRUE if one zones's air temperature is below this value
+        Real64 VentTemp;  // value of the ventilation temperature schedule
 
         TempCheck = false;
         DelTCheck = false;
@@ -3560,7 +3551,7 @@ namespace SystemAvailabilityManager {
         } else {
 
             VentTemp = GetCurrentScheduleValue(state, nightVentMgr.VentTempSchedPtr);
-            ControlZoneNum = nightVentMgr.ZoneNum;
+            int ControlZoneNum = nightVentMgr.ZoneNum;
 
             if (present(ZoneEquipType)) {
                 // if the room temperature is greater than the vent temp sched value, set the vent temp check to TRUE
@@ -3575,8 +3566,7 @@ namespace SystemAvailabilityManager {
                 for (ZoneInSysNum = 1; ZoneInSysNum <= state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).NumZonesCooled;
                      ++ZoneInSysNum) { // loop over zones in system
 
-                    CtrldZoneNum = state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).CoolCtrlZoneNums(ZoneInSysNum);
-                    ZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrldZoneNum).ActualZoneNum;
+                    int ZoneNum = state.dataAirLoop->AirToZoneNodeInfo(PriAirSysNum).CoolCtrlZoneNums(ZoneInSysNum);
                     // if the room temperature is greater than the vent temp sched value, set the vent temp check to TRUE
                     if (state.dataHeatBalFanSys->TempTstatAir(ZoneNum) > VentTemp) {
                         TempCheck = true;
@@ -3892,8 +3882,8 @@ namespace SystemAvailabilityManager {
             }
             hybridVentMgr.ControlZoneName = state.dataIPShortCut->cAlphaArgs(3);
             // Check zone number
-            hybridVentMgr.ActualZoneNum = UtilityRoutines::FindItemInList(state.dataIPShortCut->cAlphaArgs(3), state.dataHeatBal->Zone);
-            if (hybridVentMgr.ActualZoneNum == 0) {
+            hybridVentMgr.ControlledZoneNum = UtilityRoutines::FindItemInList(state.dataIPShortCut->cAlphaArgs(3), state.dataHeatBal->Zone);
+            if (hybridVentMgr.ControlledZoneNum == 0) {
                 ShowSevereError(state, format("{}{}=\"{}\", invalid", RoutineName, cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state,
                                   "not found: " + state.dataIPShortCut->cAlphaFieldNames(3) + "=\"" + state.dataIPShortCut->cAlphaArgs(3) + "\".");
@@ -4163,7 +4153,7 @@ namespace SystemAvailabilityManager {
 
             hybridVentMgr.ANControlTypeSchedPtr = GetScheduleIndex(state, state.dataIPShortCut->cAlphaArgs(8));
             if (hybridVentMgr.ANControlTypeSchedPtr > 0) {
-                HybridVentSysAvailMaster(SysAvailNum) = hybridVentMgr.ActualZoneNum;
+                HybridVentSysAvailMaster(SysAvailNum) = hybridVentMgr.ControlledZoneNum;
                 // Check schedule values
                 SchedMin = GetScheduleMinValue(state, hybridVentMgr.ANControlTypeSchedPtr);
                 SchedMax = GetScheduleMaxValue(state, hybridVentMgr.ANControlTypeSchedPtr);
@@ -4235,7 +4225,7 @@ namespace SystemAvailabilityManager {
 
             // Check simple airflow object
             if (hybridVentMgr.SimpleControlTypeSchedPtr > 0 && hybridVentMgr.VentilationPtr > 0) {
-                if (hybridVentMgr.ActualZoneNum != state.dataHeatBal->Ventilation(hybridVentMgr.VentilationPtr).ZonePtr) {
+                if (hybridVentMgr.ControlledZoneNum != state.dataHeatBal->Ventilation(hybridVentMgr.VentilationPtr).ZonePtr) {
                     ShowSevereError(state, format("{}{}=\"{}\"", RoutineName, cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
                                       "The Zone name specified in the Ventilation object " +
@@ -4438,7 +4428,6 @@ namespace SystemAvailabilityManager {
         auto &MyOneTimeFlag = state.dataSystemAvailabilityManager->MyOneTimeFlag;
         auto &MyEnvrnFlag = state.dataSystemAvailabilityManager->MyEnvrnFlag;
         int SysAvailNum;         // DO loop index for Sys Avail Manager objects
-        int ControlledZoneNum;   // Index into the ZoneEquipConfig array
         bool ErrorsFound(false); // Set to true if errors in input, fatal at end of routine
         int AirLoopNum;          // Air loop number
         int AirLoopCount;        // Air loop name count
@@ -4478,72 +4467,62 @@ namespace SystemAvailabilityManager {
                     }
                 }
                 HybridVentSysAvailAirLoopNum(SysAvailNum) = hybridVentMgr.AirLoopNum;
-                HybridVentSysAvailActualZoneNum(SysAvailNum) = hybridVentMgr.ActualZoneNum;
+                HybridVentSysAvailActualZoneNum(SysAvailNum) = hybridVentMgr.ControlledZoneNum;
 
-                // set the controlled zone numbers
-                for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                    if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum == hybridVentMgr.ActualZoneNum) {
-                        hybridVentMgr.ControlledZoneNum = ControlledZoneNum;
-                        bool zoneFound = false;
-                        if (hybridVentMgr.HybridVentMgrConnectedToAirLoop) {
-                            if (hybridVentMgr.ControlledZoneNum > 0) {
-                                for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes;
-                                     ++zoneInNode) {
-                                    if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode) ==
-                                        hybridVentMgr.AirLoopNum) {
-                                        zoneFound = true;
-                                        break;
-                                    }
-                                }
-                                if (!zoneFound) {
-                                    ShowSevereError(state,
-                                                    format("{}, The controlled zone ={} is not served by this Air Loop={}",
-                                                           SystemAvailabilityTypeNamesUC[static_cast<int>(hybridVentMgr.MgrType)],
-                                                           hybridVentMgr.ControlZoneName,
-                                                           hybridVentMgr.AirLoopName));
-                                    ErrorsFound = true;
-                                }
-                            }
-                            break;
-                        }
-                    }
-                    if (std::any_of(
-                            state.dataSystemAvailabilityManager->HybridVentData.begin(),
-                            state.dataSystemAvailabilityManager->HybridVentData.end(),
-                            [](SystemAvailabilityManager::SysAvailManagerHybridVent const &e) { return e.HybridVentMgrConnectedToAirLoop; })) {
+                bool zoneFound = false;
+                int ControlledZoneNum = hybridVentMgr.ControlledZoneNum;
+                if (hybridVentMgr.HybridVentMgrConnectedToAirLoop) {
+                    if (hybridVentMgr.ControlledZoneNum > 0) {
                         for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
-                            if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode) == hybridVentMgr.AirLoopNum &&
-                                hybridVentMgr.AirLoopNum > 0) {
-                                for (HybridVentNum = 1; HybridVentNum <= NumHybridVentSysAvailMgrs; ++HybridVentNum) {
-                                    if (!state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).HybridVentMgrConnectedToAirLoop &&
-                                        (HybridVentNum != SysAvailNum)) {
-                                        if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum ==
-                                                state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).ActualZoneNum &&
-                                            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum > 0) {
-                                            ShowWarningError(state,
-                                                             "AvailabilityManager:HybridVentilation = \"" +
-                                                                 state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).Name +
-                                                                 "\" has the controlled zone name = \"" +
-                                                                 state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).ControlZoneName +
-                                                                 "\".");
-                                            ShowContinueError(
-                                                state,
-                                                "This controlled zone already has hybrid ventilation control through this air loop = \"" +
-                                                    hybridVentMgr.AirLoopName + "\".");
-                                            ShowContinueError(state,
-                                                              "Only AvailabilityManager:HybridVentilation = \"" + hybridVentMgr.Name +
-                                                                  "\" will be simulated. Simulation continues...");
-                                        } else {
-                                            state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).SimHybridVentSysAvailMgr = true;
-                                        }
+                            if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode) == hybridVentMgr.AirLoopNum) {
+                                zoneFound = true;
+                                break;
+                            }
+                        }
+                        if (!zoneFound) {
+                            ShowSevereError(state,
+                                            format("{}, The controlled zone ={} is not served by this Air Loop={}",
+                                                   SystemAvailabilityTypeNamesUC[static_cast<int>(hybridVentMgr.MgrType)],
+                                                   hybridVentMgr.ControlZoneName,
+                                                   hybridVentMgr.AirLoopName));
+                            ErrorsFound = true;
+                        }
+                    }
+                    break;
+                }
+                if (std::any_of(state.dataSystemAvailabilityManager->HybridVentData.begin(),
+                                state.dataSystemAvailabilityManager->HybridVentData.end(),
+                                [](SystemAvailabilityManager::SysAvailManagerHybridVent const &e) { return e.HybridVentMgrConnectedToAirLoop; })) {
+                    for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
+                        if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode) == hybridVentMgr.AirLoopNum &&
+                            hybridVentMgr.AirLoopNum > 0) {
+                            for (HybridVentNum = 1; HybridVentNum <= NumHybridVentSysAvailMgrs; ++HybridVentNum) {
+                                if (!state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).HybridVentMgrConnectedToAirLoop &&
+                                    (HybridVentNum != SysAvailNum)) {
+                                    if (ControlledZoneNum == state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).ControlledZoneNum &&
+                                        ControlledZoneNum > 0) {
+                                        ShowWarningError(state,
+                                                         "AvailabilityManager:HybridVentilation = \"" +
+                                                             state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).Name +
+                                                             "\" has the controlled zone name = \"" +
+                                                             state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).ControlZoneName +
+                                                             "\".");
+                                        ShowContinueError(state,
+                                                          "This controlled zone already has hybrid ventilation control through this air loop = \"" +
+                                                              hybridVentMgr.AirLoopName + "\".");
+                                        ShowContinueError(state,
+                                                          "Only AvailabilityManager:HybridVentilation = \"" + hybridVentMgr.Name +
+                                                              "\" will be simulated. Simulation continues...");
+                                    } else {
+                                        state.dataSystemAvailabilityManager->HybridVentData(HybridVentNum).SimHybridVentSysAvailMgr = true;
                                     }
                                 }
                             }
                         }
-                    } else {
-                        for (auto &e : state.dataSystemAvailabilityManager->HybridVentData)
-                            e.SimHybridVentSysAvailMgr = true;
                     }
+                } else {
+                    for (auto &e : state.dataSystemAvailabilityManager->HybridVentData)
+                        e.SimHybridVentSysAvailMgr = true;
                 }
 
                 if (hybridVentMgr.ControlledZoneNum == 0) {
@@ -4688,7 +4667,6 @@ namespace SystemAvailabilityManager {
         using Psychrometrics::PsyTdpFnWPb;
         using Psychrometrics::PsyWFnTdbRhPb;
 
-        int ZoneNum;                        // actual zone number of the control zone
         int HStatZoneNum;                   // Humidity control zone number
         Real64 ZoneAirEnthalpy;             // Zone air enthalpy
         Real64 ZoneAirDewPoint;             // Zone air dew point temperature
@@ -4702,7 +4680,6 @@ namespace SystemAvailabilityManager {
         bool HybridVentModeOA;              // USed to check whether HybridVentModeOA is allowed
         Real64 ZoneRHHumidifyingSetPoint;   // Zone humidifying setpoint (%)
         Real64 ZoneRHDehumidifyingSetPoint; // Zone dehumidifying setpoint (%)
-        int ControlledZoneNum;              // Index into the ZoneEquipConfig array
         int SimpleControlType;              // Simple control type from a schedule: 0 individual, 1 global
         int i;                              // Array index
         Real64 minAdaTem;                   // minimum adaptive temperature for adaptive temperature control
@@ -4723,7 +4700,7 @@ namespace SystemAvailabilityManager {
             KeepStatus = true;
         }
 
-        ZoneNum = hybridVentMgr.ActualZoneNum;
+        int ZoneNum = hybridVentMgr.ControlledZoneNum;
         if (!KeepStatus) hybridVentMgr.VentilationCtrl = HybridVentCtrl_NoAction;
         TempExt = state.dataHeatBal->Zone(ZoneNum).OutDryBulbTemp;
         WindExt = state.dataHeatBal->Zone(ZoneNum).WindSpeed;
@@ -5024,12 +5001,12 @@ namespace SystemAvailabilityManager {
         // Set up flags to control simple airflow objects
         if (hybridVentMgr.AirLoopNum > 0 && hybridVentMgr.SimpleControlTypeSchedPtr > 0) {
             SimpleControlType = GetCurrentScheduleValue(state, hybridVentMgr.SimpleControlTypeSchedPtr);
-            for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+            for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
                 for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
                     if (hybridVentMgr.AirLoopNum == state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode)) {
                         // Setup flag for ventilation objects
                         for (i = 1; i <= state.dataHeatBal->TotVentilation; ++i) {
-                            if (state.dataHeatBal->Ventilation(i).ZonePtr == state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum) {
+                            if (state.dataHeatBal->Ventilation(i).ZonePtr == ControlledZoneNum) {
                                 state.dataHeatBal->Ventilation(i).HybridControlType = DataHeatBalance::HybridCtrlType::Indiv;
                                 if (hybridVentMgr.VentilationCtrl == HybridVentCtrl_Close) {
                                     state.dataHeatBal->Ventilation(i).HybridControlType = DataHeatBalance::HybridCtrlType::Close;
@@ -5043,7 +5020,7 @@ namespace SystemAvailabilityManager {
                         }
                         // Setup flag for Mixing objects
                         for (i = 1; i <= state.dataHeatBal->TotMixing; ++i) {
-                            if (state.dataHeatBal->Mixing(i).ZonePtr == state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum) {
+                            if (state.dataHeatBal->Mixing(i).ZonePtr == ControlledZoneNum) {
                                 state.dataHeatBal->Mixing(i).HybridControlType = DataHeatBalance::HybridCtrlType::Indiv;
                                 if (hybridVentMgr.VentilationCtrl == HybridVentCtrl_Close) {
                                     state.dataHeatBal->Mixing(i).HybridControlType = DataHeatBalance::HybridCtrlType::Close;
@@ -5063,7 +5040,7 @@ namespace SystemAvailabilityManager {
             // Hybrid ventilation manager is applied to zone component
             // setup flag for ventilation objects
             for (i = 1; i <= state.dataHeatBal->TotVentilation; ++i) {
-                if (state.dataHeatBal->Ventilation(i).ZonePtr == hybridVentMgr.ActualZoneNum) {
+                if (state.dataHeatBal->Ventilation(i).ZonePtr == hybridVentMgr.ControlledZoneNum) {
                     state.dataHeatBal->Ventilation(i).HybridControlType = DataHeatBalance::HybridCtrlType::Indiv;
                     if (hybridVentMgr.VentilationCtrl == HybridVentCtrl_Close) {
                         state.dataHeatBal->Ventilation(i).HybridControlType = DataHeatBalance::HybridCtrlType::Close;
@@ -5077,7 +5054,7 @@ namespace SystemAvailabilityManager {
             }
             // Setup flag for Mixing objects
             for (i = 1; i <= state.dataHeatBal->TotMixing; ++i) {
-                if (state.dataHeatBal->Mixing(i).ZonePtr == hybridVentMgr.ActualZoneNum) {
+                if (state.dataHeatBal->Mixing(i).ZonePtr == hybridVentMgr.ControlledZoneNum) {
                     state.dataHeatBal->Mixing(i).HybridControlType = DataHeatBalance::HybridCtrlType::Indiv;
                     if (hybridVentMgr.VentilationCtrl == HybridVentCtrl_Close) {
                         state.dataHeatBal->Mixing(i).HybridControlType = DataHeatBalance::HybridCtrlType::Close;
@@ -5118,7 +5095,7 @@ namespace SystemAvailabilityManager {
         VentControl = false;
 
         for (SysAvailNum = 1; SysAvailNum <= state.dataHVACGlobal->NumHybridVentSysAvailMgrs; ++SysAvailNum) {
-            if (state.dataSystemAvailabilityManager->HybridVentData(SysAvailNum).ActualZoneNum == ZoneNum) {
+            if (state.dataSystemAvailabilityManager->HybridVentData(SysAvailNum).ControlledZoneNum == ZoneNum) {
                 if (state.dataSystemAvailabilityManager->HybridVentData(SysAvailNum).SimpleControlTypeSchedPtr > 0) {
                     VentControl = true;
                 }

--- a/src/EnergyPlus/SystemAvailabilityManager.cc
+++ b/src/EnergyPlus/SystemAvailabilityManager.cc
@@ -4476,7 +4476,6 @@ namespace SystemAvailabilityManager {
                         for (int zoneInNode = 1; zoneInNode <= state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumInletNodes; ++zoneInNode) {
                             if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNodeAirLoopNum(zoneInNode) == hybridVentMgr.AirLoopNum) {
                                 zoneFound = true;
-                                break;
                             }
                         }
                         if (!zoneFound) {
@@ -4488,7 +4487,6 @@ namespace SystemAvailabilityManager {
                             ErrorsFound = true;
                         }
                     }
-                    break;
                 }
                 if (std::any_of(state.dataSystemAvailabilityManager->HybridVentData.begin(),
                                 state.dataSystemAvailabilityManager->HybridVentData.end(),

--- a/src/EnergyPlus/SystemAvailabilityManager.hh
+++ b/src/EnergyPlus/SystemAvailabilityManager.hh
@@ -175,7 +175,6 @@ namespace SystemAvailabilityManager {
         int FanSchedPtr;                   // Fan schedule pointer
         std::string CtrlZoneName;          // Name of the control zone
         int ZoneNum;                       // zone number of control zone
-        int ControlledZoneNum;             // controlled zone number of control zone
         std::string ZoneListName;          // Zone List name
         int NumOfZones;                    // Number of zones in the list
         Array1D_int ZonePtrs;              // Pointers to zones in the list
@@ -214,12 +213,12 @@ namespace SystemAvailabilityManager {
 
         // Default Constructor
         SysAvailManagerOptimumStart()
-            : isSimulated(false), FanSchedPtr(0), ZoneNum(0), ControlledZoneNum(0), NumOfZones(0), MaxOptStartTime(6.0),
-              controlAlgorithm(ControlAlgorithm::Invalid), ConstTGradCool(1.0), ConstTGradHeat(1.0), InitTGradCool(1.0), InitTGradHeat(1.0),
-              AdaptiveTGradCool(1.0), AdaptiveTGradHeat(1.0), ConstStartTime(2.0), NumPreDays(1), NumHoursBeforeOccupancy(0.0), TempDiffHi(0.0),
-              TempDiffLo(0.0), ATGWCZoneNumLo(0), ATGWCZoneNumHi(0), CycleOnFlag(false), ATGUpdateFlag1(false), ATGUpdateFlag2(false),
-              FirstTimeATGFlag(true), OverNightStartFlag(false), OSReportVarFlag(false), AdaTempGradHeat(0.0), AdaTempGradCool(0.0),
-              ATGUpdateTime1(0.0), ATGUpdateTime2(0.0), ATGUpdateTemp1(0.0), ATGUpdateTemp2(0.0)
+            : isSimulated(false), FanSchedPtr(0), ZoneNum(0), NumOfZones(0), MaxOptStartTime(6.0), controlAlgorithm(ControlAlgorithm::Invalid),
+              ConstTGradCool(1.0), ConstTGradHeat(1.0), InitTGradCool(1.0), InitTGradHeat(1.0), AdaptiveTGradCool(1.0), AdaptiveTGradHeat(1.0),
+              ConstStartTime(2.0), NumPreDays(1), NumHoursBeforeOccupancy(0.0), TempDiffHi(0.0), TempDiffLo(0.0), ATGWCZoneNumLo(0),
+              ATGWCZoneNumHi(0), CycleOnFlag(false), ATGUpdateFlag1(false), ATGUpdateFlag2(false), FirstTimeATGFlag(true), OverNightStartFlag(false),
+              OSReportVarFlag(false), AdaTempGradHeat(0.0), AdaTempGradCool(0.0), ATGUpdateTime1(0.0), ATGUpdateTime2(0.0), ATGUpdateTemp1(0.0),
+              ATGUpdateTemp2(0.0)
         {
         }
 
@@ -278,12 +277,10 @@ namespace SystemAvailabilityManager {
         Real64 VentTempLowLim;     // ventilation temperature low limit
         std::string CtrlZoneName;  // Name of the control zone
         int ZoneNum;               // zome number of control zone
-        int ControlledZoneNum;     // controlled zone number of control zone
         Real64 VentFlowFrac;       // the night venting flow fraction
 
         // Default Constructor
-        SysAvailManagerNightVent()
-            : FanSchedPtr(0), VentTempSchedPtr(0), VentDelT(0.0), VentTempLowLim(0.0), ZoneNum(0), ControlledZoneNum(0), VentFlowFrac(0.0)
+        SysAvailManagerNightVent() : FanSchedPtr(0), VentTempSchedPtr(0), VentDelT(0.0), VentTempLowLim(0.0), ZoneNum(0), VentFlowFrac(0.0)
         {
         }
     };
@@ -295,7 +292,6 @@ namespace SystemAvailabilityManager {
         int AirLoopNum;              // HVAC Air Loop number
         std::string ControlZoneName; // Controlled zone name
         int NodeNumOfControlledZone; // Controlled zone node number
-        int ActualZoneNum;           // Actual zone number
         int ControlledZoneNum;       // Controlled zone number
         int ControlModeSchedPtr;     // Ventilation control mode schedule pointer
         int ControlMode;             // hybrid ventilation control mode
@@ -338,11 +334,11 @@ namespace SystemAvailabilityManager {
 
         // Default Constructor
         SysAvailManagerHybridVent()
-            : AirLoopNum(0), NodeNumOfControlledZone(0), ActualZoneNum(0), ControlledZoneNum(0), ControlModeSchedPtr(0), ControlMode(0),
-              VentilationCtrl(0), MinOutdoorTemp(-100.0), MaxOutdoorTemp(100.0), MinOutdoorEnth(0.1), MaxOutdoorEnth(300000.0),
-              MinOutdoorDewPoint(-100.0), MaxOutdoorDewPoint(100.0), MaxWindSpeed(0.0), UseRainIndicator(true), MinOASchedPtr(0),
-              DewPointNoRHErrCount(0), DewPointNoRHErrIndex(0), DewPointErrCount(0), DewPointErrIndex(0), SingleHCErrCount(0), SingleHCErrIndex(0),
-              OpeningFactorFWS(0), ANControlTypeSchedPtr(0), SimpleControlTypeSchedPtr(0), VentilationPtr(0), HybridVentMgrConnectedToAirLoop(true),
+            : AirLoopNum(0), NodeNumOfControlledZone(0), ControlledZoneNum(0), ControlModeSchedPtr(0), ControlMode(0), VentilationCtrl(0),
+              MinOutdoorTemp(-100.0), MaxOutdoorTemp(100.0), MinOutdoorEnth(0.1), MaxOutdoorEnth(300000.0), MinOutdoorDewPoint(-100.0),
+              MaxOutdoorDewPoint(100.0), MaxWindSpeed(0.0), UseRainIndicator(true), MinOASchedPtr(0), DewPointNoRHErrCount(0),
+              DewPointNoRHErrIndex(0), DewPointErrCount(0), DewPointErrIndex(0), SingleHCErrCount(0), SingleHCErrIndex(0), OpeningFactorFWS(0),
+              ANControlTypeSchedPtr(0), SimpleControlTypeSchedPtr(0), VentilationPtr(0), HybridVentMgrConnectedToAirLoop(true),
               SimHybridVentSysAvailMgr(false), OperativeTemp(0.0), CO2(0.0), MinOperTime(0.0), MinVentTime(0.0), TimeOperDuration(0.0),
               TimeVentDuration(0.0), minAdaTem(0.0), maxAdaTem(0.0)
         {

--- a/src/EnergyPlus/SystemReports.cc
+++ b/src/EnergyPlus/SystemReports.cc
@@ -3268,11 +3268,11 @@ void ReportSystemEnergyUse(EnergyPlusData &state)
 
     for (int airLoopNum = 1; airLoopNum <= state.dataHVACGlobal->NumPrimaryAirSys; ++airLoopNum) {
         auto &thisSysLoadRepVars = state.dataSysRpts->SysLoadRepVars(airLoopNum);
-    // SYSTEM LOADS REPORT
+        // SYSTEM LOADS REPORT
         thisSysLoadRepVars.TotHTNG = 0.0;
         thisSysLoadRepVars.TotCLNG = 0.0;
 
-    // SYSTEM ENERGY USE REPORT
+        // SYSTEM ENERGY USE REPORT
         thisSysLoadRepVars.TotElec = 0.0;
         thisSysLoadRepVars.TotNaturalGas = 0.0;
         thisSysLoadRepVars.TotPropane = 0.0;
@@ -3280,7 +3280,7 @@ void ReportSystemEnergyUse(EnergyPlusData &state)
         thisSysLoadRepVars.TotH2OCOLD = 0.0;
         thisSysLoadRepVars.TotH2OHOT = 0.0;
 
-    // SYSTEM COMPONENT LOADS REPORT
+        // SYSTEM COMPONENT LOADS REPORT
         thisSysLoadRepVars.FANCompHTNG = 0.0;
         thisSysLoadRepVars.CCCompCLNG = 0.0;
         thisSysLoadRepVars.HCCompHTNG = 0.0;
@@ -3295,7 +3295,7 @@ void ReportSystemEnergyUse(EnergyPlusData &state)
         thisSysLoadRepVars.DesDehumidCLNG = 0.0;
         thisSysLoadRepVars.DomesticH2O = 0.0;
 
-    // SYSTEM COMPONENT ENERGY REPORT
+        // SYSTEM COMPONENT ENERGY REPORT
         thisSysLoadRepVars.FANCompElec = 0.0;
         thisSysLoadRepVars.HCCompH2OHOT = 0.0;
         thisSysLoadRepVars.CCCompH2OCOLD = 0.0;
@@ -4132,7 +4132,7 @@ void ReportVentilationLoads(EnergyPlusData &state)
         // retrieve the zone load for each zone
         Real64 ZoneLoad = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(CtrlZoneNum).TotalOutputRequired;
         Real64 ZoneVolume = state.dataHeatBal->Zone(CtrlZoneNum).Volume * state.dataHeatBal->Zone(CtrlZoneNum).Multiplier *
-                     state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier; // CR 7170
+                            state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier; // CR 7170
 
         bool constexpr UseOccSchFlag = true;
         bool constexpr UseMinOASchFlag = true;
@@ -4436,7 +4436,7 @@ void ReportVentilationLoads(EnergyPlusData &state)
                 }
                 state.dataSysRpts->SysVentRepVars(AirLoopNum).TargetVentilationFlowVoz +=
                     termUnitOAFrac * thisZoneVentRepVars.TargetVentilationFlowVoz;
-                Real64 naturalVentFlow = (state.dataHeatBal->ZnAirRpt(ActualZoneNum).VentilVolumeStdDensity + thisZonePredefRep.AFNVentVolStdDen) /
+                Real64 naturalVentFlow = (state.dataHeatBal->ZnAirRpt(CtrlZoneNum).VentilVolumeStdDensity + thisZonePredefRep.AFNVentVolStdDen) /
                                          (TimeStepSys * DataGlobalConstants::SecInHour);
                 state.dataSysRpts->SysVentRepVars(AirLoopNum).NatVentFlow += termUnitOAFrac * naturalVentFlow;
 
@@ -4489,7 +4489,7 @@ void ReportVentilationLoads(EnergyPlusData &state)
 
         // set time mechanical+natural ventilation is below, at, or above target Voz-dyn
         Real64 totMechNatVentVolStdRho =
-            thisZoneVentRepVars.OAVolStdRho + state.dataHeatBal->ZnAirRpt(ActualZoneNum).VentilVolumeStdDensity + thisZonePredefRep.AFNVentVolStdDen;
+            thisZoneVentRepVars.OAVolStdRho + state.dataHeatBal->ZnAirRpt(CtrlZoneNum).VentilVolumeStdDensity + thisZonePredefRep.AFNVentVolStdDen;
         Real64 targetVoz = thisZoneVentRepVars.TargetVentilationFlowVoz * TimeStepSys * DataGlobalConstants::SecInHour;
         // Allow 1% tolerance
         if (totMechNatVentVolStdRho < (0.99 * targetVoz)) {
@@ -4504,10 +4504,8 @@ void ReportVentilationLoads(EnergyPlusData &state)
         }
 
         // determine volumetric values from mass flow using current air density for zone (adjusted for elevation)
-        Real64 currentZoneAirDensity = Psychrometrics::PsyRhoAirFnPbTdbW(state,
-                                                                         state.dataEnvrn->OutBaroPress,
-                                                                         state.dataHeatBalFanSys->MAT(CtrlZoneNum),
-                                                                         state.dataHeatBalFanSys->ZoneAirHumRatAvg(CtrlZoneNum));
+        Real64 currentZoneAirDensity = Psychrometrics::PsyRhoAirFnPbTdbW(
+            state, state.dataEnvrn->OutBaroPress, state.dataHeatBalFanSys->MAT(CtrlZoneNum), state.dataHeatBalFanSys->ZoneAirHumRatAvg(CtrlZoneNum));
         if (currentZoneAirDensity > 0.0) thisZoneVentRepVars.OAVolFlowCrntRho = thisZoneVentRepVars.OAMassFlow / currentZoneAirDensity;
         thisZoneVentRepVars.OAVolCrntRho = thisZoneVentRepVars.OAVolFlowCrntRho * TimeStepSys * DataGlobalConstants::SecInHour;
         if (ZoneVolume > 0.0) thisZoneVentRepVars.MechACH = (thisZoneVentRepVars.OAVolCrntRho / TimeStepSys) / ZoneVolume;
@@ -4523,15 +4521,15 @@ void ReportVentilationLoads(EnergyPlusData &state)
             }
             thisZonePredefRep.MechVentVolTotalOccStdDen += thisZoneVentRepVars.OAVolStdRho;
             // infiltration
-            thisZonePredefRep.InfilVolTotalOcc += state.dataHeatBal->ZnAirRpt(ActualZoneNum).InfilVolumeCurDensity;
-            if (state.dataHeatBal->ZnAirRpt(ActualZoneNum).InfilVolumeCurDensity < thisZonePredefRep.InfilVolMin) {
-                thisZonePredefRep.InfilVolMin = state.dataHeatBal->ZnAirRpt(ActualZoneNum).InfilVolumeCurDensity;
+            thisZonePredefRep.InfilVolTotalOcc += state.dataHeatBal->ZnAirRpt(CtrlZoneNum).InfilVolumeCurDensity;
+            if (state.dataHeatBal->ZnAirRpt(CtrlZoneNum).InfilVolumeCurDensity < thisZonePredefRep.InfilVolMin) {
+                thisZonePredefRep.InfilVolMin = state.dataHeatBal->ZnAirRpt(CtrlZoneNum).InfilVolumeCurDensity;
             }
-            thisZonePredefRep.InfilVolTotalOccStdDen += state.dataHeatBal->ZnAirRpt(ActualZoneNum).InfilVolumeStdDensity;
+            thisZonePredefRep.InfilVolTotalOccStdDen += state.dataHeatBal->ZnAirRpt(CtrlZoneNum).InfilVolumeStdDensity;
             // 'simple' natural ventilation
-            thisZonePredefRep.SimpVentVolTotalOcc += state.dataHeatBal->ZnAirRpt(ActualZoneNum).VentilVolumeCurDensity;
-            if (state.dataHeatBal->ZnAirRpt(ActualZoneNum).VentilVolumeCurDensity < thisZonePredefRep.SimpVentVolMin) {
-                thisZonePredefRep.SimpVentVolMin = state.dataHeatBal->ZnAirRpt(ActualZoneNum).VentilVolumeCurDensity;
+            thisZonePredefRep.SimpVentVolTotalOcc += state.dataHeatBal->ZnAirRpt(CtrlZoneNum).VentilVolumeCurDensity;
+            if (state.dataHeatBal->ZnAirRpt(CtrlZoneNum).VentilVolumeCurDensity < thisZonePredefRep.SimpVentVolMin) {
+                thisZonePredefRep.SimpVentVolMin = state.dataHeatBal->ZnAirRpt(CtrlZoneNum).VentilVolumeCurDensity;
             }
             thisZonePredefRep.SimpVentVolTotalOccStdDen += state.dataHeatBal->ZnAirRpt(CtrlZoneNum).VentilVolumeStdDensity;
             // target ventilation Voz-dyn
@@ -4551,8 +4549,8 @@ void ReportVentilationLoads(EnergyPlusData &state)
         }
         // accumulate during occupancy or not
         thisZonePredefRep.MechVentVolTotalStdDen += thisZoneVentRepVars.OAVolStdRho;
-        thisZonePredefRep.InfilVolTotalStdDen += state.dataHeatBal->ZnAirRpt(ActualZoneNum).InfilVolumeStdDensity;
-        thisZonePredefRep.SimpVentVolTotalStdDen += state.dataHeatBal->ZnAirRpt(ActualZoneNum).VentilVolumeStdDensity;
+        thisZonePredefRep.InfilVolTotalStdDen += state.dataHeatBal->ZnAirRpt(CtrlZoneNum).InfilVolumeStdDensity;
+        thisZonePredefRep.SimpVentVolTotalStdDen += state.dataHeatBal->ZnAirRpt(CtrlZoneNum).VentilVolumeStdDensity;
         thisZonePredefRep.VozTargetTotal += targetVoz;
         thisZonePredefRep.VozTargetTimeBelow += thisZoneVentRepVars.TimeBelowVozDyn;
         thisZonePredefRep.VozTargetTimeAt += thisZoneVentRepVars.TimeAtVozDyn;

--- a/src/EnergyPlus/UnitarySystem.cc
+++ b/src/EnergyPlus/UnitarySystem.cc
@@ -3442,36 +3442,32 @@ namespace UnitarySystems {
             int branchIndex;
             AirLoopFound = searchTotalComponents(state, thisObjectName, compIndex, branchIndex, AirLoopNumber);
             if (AirLoopFound) {
-                for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                    if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
-                    //             Find the controlled zone number for the specified thermostat location
-                    this->NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
+                //             Find the controlled zone number for the specified thermostat location
+                this->NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).ZoneNode;
 
-                    //             Determine if system is on air loop served by the thermostat location specified
-                    ZoneInletNodeFound = false;
-                    int ZoneInletNum = 0;
-                    ZoneInletNodeFound = searchZoneInletNodeAirLoopNum(state, AirLoopNumber, ControlledZoneNum, ZoneInletNum);
-                    if (ZoneInletNodeFound) {
-                        this->m_ZoneInletNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNode(ZoneInletNum);
-                        TotalFloorAreaOnAirLoop +=
-                            state.dataHeatBal->Zone(state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum).FloorArea;
-                    }
+                //             Determine if system is on air loop served by the thermostat location specified
+                ZoneInletNodeFound = false;
+                int ZoneInletNum = 0;
+                ZoneInletNodeFound = searchZoneInletNodeAirLoopNum(state, AirLoopNumber, this->ControlZoneNum, ZoneInletNum);
+                if (ZoneInletNodeFound) {
+                    this->m_ZoneInletNode = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).InletNode(ZoneInletNum);
+                    TotalFloorAreaOnAirLoop += state.dataHeatBal->Zone(this->ControlZoneNum).FloorArea;
+                }
 
-                    // if (this->m_ZoneInletNode == 0) AirLoopFound = false;
-                    for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
-                        if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
-                        AirNodeFound = true;
-                    }
-                    for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
-                        if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
-                        AirNodeFound = true;
-                    }
-                    if (!AirNodeFound && this->ControlZoneNum > 0) {
-                        ShowSevereError(state, "Input errors for " + cCurrentModuleObject + ":" + thisObjectName);
-                        ShowContinueError(state, "Did not find Air Node (Zone with Thermostat or Thermal Comfort Thermostat).");
-                        ShowContinueError(state, "specified Controlling Zone or Thermostat Location name = " + loc_controlZoneName);
-                        errorsFound = true;
-                    }
+                // if (this->m_ZoneInletNode == 0) AirLoopFound = false;
+                for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
+                    if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
+                    AirNodeFound = true;
+                }
+                for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
+                    if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
+                    AirNodeFound = true;
+                }
+                if (!AirNodeFound && this->ControlZoneNum > 0) {
+                    ShowSevereError(state, "Input errors for " + cCurrentModuleObject + ":" + thisObjectName);
+                    ShowContinueError(state, "Did not find Air Node (Zone with Thermostat or Thermal Comfort Thermostat).");
+                    ShowContinueError(state, "specified Controlling Zone or Thermostat Location name = " + loc_controlZoneName);
+                    errorsFound = true;
                 }
             }
 
@@ -3486,37 +3482,32 @@ namespace UnitarySystems {
                                 cCurrentModuleObject)) {
                             AirLoopNumber = AirLoopNum;
                             AirLoopFound = true;
-                            for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
-                                if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
-                                //             Find the controlled zone number for the specified thermostat location
-                                this->NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
+                            //             Find the controlled zone number for the specified thermostat location
+                            this->NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).ZoneNode;
 
-                                //             Determine if system is on air loop served by the thermostat location specified
-                                ZoneInletNodeFound = false;
-                                int ZoneInletNum = 0;
-                                ZoneInletNodeFound = searchZoneInletNodeAirLoopNum(state, AirLoopNumber, ControlledZoneNum, ZoneInletNum);
-                                if (ZoneInletNodeFound) {
-                                    this->m_ZoneInletNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).InletNode(ZoneInletNum);
-                                    TotalFloorAreaOnAirLoop +=
-                                        state.dataHeatBal->Zone(state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum).FloorArea;
-                                }
+                            //             Determine if system is on air loop served by the thermostat location specified
+                            ZoneInletNodeFound = false;
+                            int ZoneInletNum = 0;
+                            ZoneInletNodeFound = searchZoneInletNodeAirLoopNum(state, AirLoopNumber, this->ControlZoneNum, ZoneInletNum);
+                            if (ZoneInletNodeFound) {
+                                this->m_ZoneInletNode = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).InletNode(ZoneInletNum);
+                                TotalFloorAreaOnAirLoop += state.dataHeatBal->Zone(this->ControlZoneNum).FloorArea;
+                            }
 
-                                // if (this->m_ZoneInletNode == 0) AirLoopFound = false;
-                                for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
-                                    if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
-                                    AirNodeFound = true;
-                                }
-                                for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
-                                    if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
-                                    AirNodeFound = true;
-                                }
-                                if (!AirNodeFound && this->ControlZoneNum > 0) {
-                                    ShowSevereError(state, "Input errors for " + cCurrentModuleObject + ":" + thisObjectName);
-                                    ShowContinueError(state, "Did not find Air Node (Zone with Thermostat or Thermal Comfort Thermostat).");
-                                    ShowContinueError(state, "specified Controlling Zone or Thermostat Location name = " + loc_controlZoneName);
-                                    errorsFound = true;
-                                }
-                                break;
+                            // if (this->m_ZoneInletNode == 0) AirLoopFound = false;
+                            for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
+                                if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
+                                AirNodeFound = true;
+                            }
+                            for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
+                                if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
+                                AirNodeFound = true;
+                            }
+                            if (!AirNodeFound && this->ControlZoneNum > 0) {
+                                ShowSevereError(state, "Input errors for " + cCurrentModuleObject + ":" + thisObjectName);
+                                ShowContinueError(state, "Did not find Air Node (Zone with Thermostat or Thermal Comfort Thermostat).");
+                                ShowContinueError(state, "specified Controlling Zone or Thermostat Location name = " + loc_controlZoneName);
+                                errorsFound = true;
                             }
                         }
                     }
@@ -9918,7 +9909,6 @@ namespace UnitarySystems {
 
         if (allocated(state.dataZoneEquip->ZoneEquipConfig) && this->m_MyCheckFlag) {
             if (this->m_AirLoopEquipment) {
-                int zoneNum = state.dataHeatBal->Zone(this->ControlZoneNum).ZoneEqNum;
                 int zoneInlet = this->m_ZoneInletNode;
                 if (zoneInlet == 0) {
                     this->m_ThisSysInputShouldBeGotten = true; // need to find zone inlet node once data is available
@@ -9930,8 +9920,8 @@ namespace UnitarySystems {
                 int coolingPriority = 0;
                 int heatingPriority = 0;
                 // setup zone equipment sequence information based on finding matching air terminal
-                if (state.dataZoneEquip->ZoneEquipConfig(zoneNum).EquipListIndex > 0) {
-                    state.dataZoneEquip->ZoneEquipList(state.dataZoneEquip->ZoneEquipConfig(zoneNum).EquipListIndex)
+                if (state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).EquipListIndex > 0) {
+                    state.dataZoneEquip->ZoneEquipList(state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).EquipListIndex)
                         .getPrioritiesForInletNode(state, zoneInlet, coolingPriority, heatingPriority);
                     this->m_ZoneSequenceCoolingNum = coolingPriority;
                     this->m_ZoneSequenceHeatingNum = heatingPriority;
@@ -17455,7 +17445,7 @@ namespace UnitarySystems {
     void UnitarySys::setSystemParams(EnergyPlusData &state, Real64 &TotalFloorAreaOnAirLoop, const std::string thisObjectName)
     {
         this->NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).ZoneNode;
-        TotalFloorAreaOnAirLoop = state.dataHeatBal->Zone(state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).ActualZoneNum).FloorArea;
+        TotalFloorAreaOnAirLoop = state.dataHeatBal->Zone(this->ControlZoneNum).FloorArea;
         this->m_AirLoopEquipment = false;
         if (state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).EquipListIndex > 0) {
             for (int EquipNum = 1;

--- a/src/EnergyPlus/UnitarySystem.cc
+++ b/src/EnergyPlus/UnitarySystem.cc
@@ -3441,7 +3441,7 @@ namespace UnitarySystems {
             int compIndex;
             int branchIndex;
             AirLoopFound = searchTotalComponents(state, thisObjectName, compIndex, branchIndex, AirLoopNumber);
-            if (AirLoopFound) {
+            if (AirLoopFound && (this->ControlZoneNum > 0)) {
                 //             Find the controlled zone number for the specified thermostat location
                 this->NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).ZoneNode;
 
@@ -3482,36 +3482,41 @@ namespace UnitarySystems {
                                 cCurrentModuleObject)) {
                             AirLoopNumber = AirLoopNum;
                             AirLoopFound = true;
-                            //             Find the controlled zone number for the specified thermostat location
-                            this->NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).ZoneNode;
+                            if (this->ControlZoneNum > 0) {
+                                //             Find the controlled zone number for the specified thermostat location
+                                this->NodeNumOfControlledZone = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).ZoneNode;
 
-                            //             Determine if system is on air loop served by the thermostat location specified
-                            ZoneInletNodeFound = false;
-                            int ZoneInletNum = 0;
-                            ZoneInletNodeFound = searchZoneInletNodeAirLoopNum(state, AirLoopNumber, this->ControlZoneNum, ZoneInletNum);
-                            if (ZoneInletNodeFound) {
-                                this->m_ZoneInletNode = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).InletNode(ZoneInletNum);
-                                TotalFloorAreaOnAirLoop += state.dataHeatBal->Zone(this->ControlZoneNum).FloorArea;
-                            }
+                                //             Determine if system is on air loop served by the thermostat location specified
+                                ZoneInletNodeFound = false;
+                                int ZoneInletNum = 0;
+                                ZoneInletNodeFound = searchZoneInletNodeAirLoopNum(state, AirLoopNumber, this->ControlZoneNum, ZoneInletNum);
+                                if (ZoneInletNodeFound) {
+                                    this->m_ZoneInletNode = state.dataZoneEquip->ZoneEquipConfig(this->ControlZoneNum).InletNode(ZoneInletNum);
+                                    TotalFloorAreaOnAirLoop += state.dataHeatBal->Zone(this->ControlZoneNum).FloorArea;
+                                }
 
-                            // if (this->m_ZoneInletNode == 0) AirLoopFound = false;
-                            for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
-                                if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
-                                AirNodeFound = true;
-                            }
-                            for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
-                                if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
-                                AirNodeFound = true;
-                            }
-                            if (!AirNodeFound && this->ControlZoneNum > 0) {
-                                ShowSevereError(state, "Input errors for " + cCurrentModuleObject + ":" + thisObjectName);
-                                ShowContinueError(state, "Did not find Air Node (Zone with Thermostat or Thermal Comfort Thermostat).");
-                                ShowContinueError(state, "specified Controlling Zone or Thermostat Location name = " + loc_controlZoneName);
-                                errorsFound = true;
+                                // if (this->m_ZoneInletNode == 0) AirLoopFound = false;
+                                for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TstatZoneNum) {
+                                    if (state.dataZoneCtrls->TempControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
+                                    AirNodeFound = true;
+                                }
+                                for (int TstatZoneNum = 1; TstatZoneNum <= state.dataZoneCtrls->NumComfortControlledZones; ++TstatZoneNum) {
+                                    if (state.dataZoneCtrls->ComfortControlledZone(TstatZoneNum).ActualZoneNum != this->ControlZoneNum) continue;
+                                    AirNodeFound = true;
+                                }
+                                if (!AirNodeFound && this->ControlZoneNum > 0) {
+                                    ShowSevereError(state, "Input errors for " + cCurrentModuleObject + ":" + thisObjectName);
+                                    ShowContinueError(state, "Did not find Air Node (Zone with Thermostat or Thermal Comfort Thermostat).");
+                                    ShowContinueError(state, "specified Controlling Zone or Thermostat Location name = " + loc_controlZoneName);
+                                    errorsFound = true;
+                                }
                             }
                         }
+                        if (AirLoopFound) break;
                     }
+                    if (AirLoopFound) break;
                 }
+                if (AirLoopFound) break;
             }
 
             if (ZoneEquipmentFound && !ZoneExhaustNodeFound && !InducedNodeFound) {

--- a/src/EnergyPlus/WaterThermalTanks.cc
+++ b/src/EnergyPlus/WaterThermalTanks.cc
@@ -2016,10 +2016,7 @@ bool getHPWaterHeaterInput(EnergyPlusData &state)
             if (allocated(state.dataZoneEquip->ZoneEquipConfig)) {
                 bool FoundInletNode = false;
                 bool FoundOutletNode = false;
-                int ZoneNum;
-                for (ZoneNum = 1; ZoneNum <= state.dataGlobal->NumOfZones; ++ZoneNum) {
-                    if (HPWH.AmbientTempZone == state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ActualZoneNum) break;
-                }
+                int ZoneNum = HPWH.AmbientTempZone;
                 if (ZoneNum <= state.dataGlobal->NumOfZones) {
                     for (int SupAirIn = 1; SupAirIn <= state.dataZoneEquip->ZoneEquipConfig(ZoneNum).NumInletNodes; ++SupAirIn) {
                         if (HPWH.HeatPumpAirOutletNode != state.dataZoneEquip->ZoneEquipConfig(ZoneNum).InletNode(SupAirIn)) continue;
@@ -4388,67 +4385,47 @@ bool GetWaterThermalTankInput(EnergyPlusData &state)
                         if (allocated(state.dataZoneEquip->ZoneEquipConfig) && allocated(state.dataZoneEquip->ZoneEquipList)) {
                             bool FoundTankInList = false;
                             bool TankNotLowestPriority = false;
-                            for (int ZoneEquipConfigNum = 1; ZoneEquipConfigNum <= state.dataGlobal->NumOfZones; ++ZoneEquipConfigNum) {
-                                if (state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).ActualZoneNum != HPWH.AmbientTempZone) continue;
-                                if (ZoneEquipConfigNum <= state.dataGlobal->NumOfZones) {
-                                    for (int ZoneEquipListNum = 1; ZoneEquipListNum <= state.dataGlobal->NumOfZones; ++ZoneEquipListNum) {
-                                        if (state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).EquipListName !=
-                                            state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).Name)
-                                            continue;
-                                        int TankCoolingPriority = 0;
-                                        int TankHeatingPriority = 0;
-                                        if (ZoneEquipConfigNum <= state.dataGlobal->NumOfZones) {
-                                            for (int EquipmentTypeNum = 1;
-                                                 EquipmentTypeNum <= state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).NumOfEquipTypes;
-                                                 ++EquipmentTypeNum) {
-                                                if (state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).EquipName(EquipmentTypeNum) != HPWH.Name)
-                                                    continue;
-                                                FoundTankInList = true;
-                                                TankCoolingPriority =
-                                                    state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).CoolingPriority(EquipmentTypeNum);
-                                                TankHeatingPriority =
-                                                    state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).HeatingPriority(EquipmentTypeNum);
-                                                break;
-                                            } // EquipmentTypeNum
-                                            if (!FoundTankInList) {
-                                                ShowSevereError(state, state.dataIPShortCut->cCurrentModuleObject + " = " + HPWH.Name + ':');
-                                                ShowContinueError(state,
-                                                                  "Heat pump water heater type and name must be listed in the correct "
-                                                                  "ZoneHVAC:EquipmentList object when Inlet Air Configuration is equal to "
-                                                                  "ZoneAirOnly or ZoneAndOutdoorAir.");
-                                                ErrorsFound = true;
-                                            }
-                                            //                     check that tank has lower priority than all other non-HPWH objects in Zone
-                                            //                     Equipment List
-                                            for (int EquipmentTypeNum = 1;
-                                                 EquipmentTypeNum <= state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).NumOfEquipTypes;
-                                                 ++EquipmentTypeNum) {
-                                                if (UtilityRoutines::SameString(
-                                                        state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).EquipType(EquipmentTypeNum),
-                                                        state.dataIPShortCut->cCurrentModuleObject))
-                                                    continue;
-                                                if (TankCoolingPriority >
-                                                        state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).CoolingPriority(EquipmentTypeNum) ||
-                                                    TankHeatingPriority >
-                                                        state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).HeatingPriority(EquipmentTypeNum)) {
-                                                    TankNotLowestPriority = true;
-                                                }
-                                            } // EquipmentTypeNum
-                                            if (TankNotLowestPriority && FoundTankInList) {
-                                                ShowWarningError(state, state.dataIPShortCut->cCurrentModuleObject + " = " + HPWH.Name + ':');
-                                                ShowContinueError(state,
-                                                                  "Heat pump water heaters should be simulated first, before other space "
-                                                                  "conditioning equipment.");
-                                                ShowContinueError(state,
-                                                                  "Poor temperature control may result if the Heating/Cooling sequence number is "
-                                                                  "not 1 in the ZoneHVAC:EquipmentList.");
-                                            }
-                                            break;
-                                        } // ZoneEquipConfigNum .LE. NumOfZoneEquipLists
-                                    }     // ZoneEquipListNum
-                                    break;
-                                } // ZoneEquipConfigNum .LE. NumOfZones
-                            }     // ZoneEquipConfigNum
+                            int ZoneEquipConfigNum = HPWH.AmbientTempZone;
+                            int ZoneEquipListNum = state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).EquipListIndex;
+                            int TankCoolingPriority = 0;
+                            int TankHeatingPriority = 0;
+                            for (int EquipmentTypeNum = 1; EquipmentTypeNum <= state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).NumOfEquipTypes;
+                                 ++EquipmentTypeNum) {
+                                if (state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).EquipName(EquipmentTypeNum) != HPWH.Name) continue;
+                                FoundTankInList = true;
+                                TankCoolingPriority = state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).CoolingPriority(EquipmentTypeNum);
+                                TankHeatingPriority = state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).HeatingPriority(EquipmentTypeNum);
+                                break;
+                            } // EquipmentTypeNum
+                            if (!FoundTankInList) {
+                                ShowSevereError(state, state.dataIPShortCut->cCurrentModuleObject + " = " + HPWH.Name + ':');
+                                ShowContinueError(state,
+                                                  "Heat pump water heater type and name must be listed in the correct "
+                                                  "ZoneHVAC:EquipmentList object when Inlet Air Configuration is equal to "
+                                                  "ZoneAirOnly or ZoneAndOutdoorAir.");
+                                ErrorsFound = true;
+                            }
+                            //                     check that tank has lower priority than all other non-HPWH objects in Zone
+                            //                     Equipment List
+                            for (int EquipmentTypeNum = 1; EquipmentTypeNum <= state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).NumOfEquipTypes;
+                                 ++EquipmentTypeNum) {
+                                if (UtilityRoutines::SameString(state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).EquipType(EquipmentTypeNum),
+                                                                state.dataIPShortCut->cCurrentModuleObject))
+                                    continue;
+                                if (TankCoolingPriority > state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).CoolingPriority(EquipmentTypeNum) ||
+                                    TankHeatingPriority > state.dataZoneEquip->ZoneEquipList(ZoneEquipListNum).HeatingPriority(EquipmentTypeNum)) {
+                                    TankNotLowestPriority = true;
+                                }
+                            } // EquipmentTypeNum
+                            if (TankNotLowestPriority && FoundTankInList) {
+                                ShowWarningError(state, state.dataIPShortCut->cCurrentModuleObject + " = " + HPWH.Name + ':');
+                                ShowContinueError(state,
+                                                  "Heat pump water heaters should be simulated first, before other space "
+                                                  "conditioning equipment.");
+                                ShowContinueError(state,
+                                                  "Poor temperature control may result if the Heating/Cooling sequence number is "
+                                                  "not 1 in the ZoneHVAC:EquipmentList.");
+                            }
                         } else {
                             ShowSevereError(state, state.dataIPShortCut->cCurrentModuleObject + " = " + HPWH.Name + ':');
                             ShowContinueError(state,

--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
@@ -91,7 +91,7 @@ namespace ZoneAirLoopEquipmentManager {
                                     Real64 &SysOutputProvided,
                                     Real64 &NonAirSysOutput,
                                     Real64 &LatOutputProvided, // Latent add/removal supplied by air dist unit (kg/s), dehumid = negative
-                                    int const ZoneNum,
+                                    int const ControlledZoneNum,
                                     int &CompIndex)
     {
         // SUBROUTINE INFORMATION:
@@ -139,14 +139,14 @@ namespace ZoneAirLoopEquipmentManager {
             }
         }
         state.dataSize->CurTermUnitSizingNum = state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).TermUnitSizingNum;
-        InitZoneAirLoopEquipment(state, AirDistUnitNum, ZoneNum);
+        InitZoneAirLoopEquipment(state, AirDistUnitNum, ControlledZoneNum);
         InitZoneAirLoopEquipmentTimeStep(state, AirDistUnitNum);
 
-        SimZoneAirLoopEquipment(state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZoneNum);
+        SimZoneAirLoopEquipment(state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ControlledZoneNum);
 
         // Call one-time init to fill termunit sizing and other data for the ADU - can't do this until the actual terminal unit nodes have been
         // matched to zone euqip config nodes
-        InitZoneAirLoopEquipment(state, AirDistUnitNum, ZoneNum);
+        InitZoneAirLoopEquipment(state, AirDistUnitNum, ControlledZoneNum);
     }
 
     void GetZoneAirLoopEquipment(EnergyPlusData &state)
@@ -536,7 +536,7 @@ namespace ZoneAirLoopEquipmentManager {
         }
     }
 
-    void InitZoneAirLoopEquipment(EnergyPlusData &state, int const AirDistUnitNum, int const ZoneNum)
+    void InitZoneAirLoopEquipment(EnergyPlusData &state, int const AirDistUnitNum, int const ControlledZoneNum)
     {
         // SUBROUTINE INFORMATION:
         //       AUTHOR         Russ Taylor
@@ -555,8 +555,8 @@ namespace ZoneAirLoopEquipmentManager {
             {
                 auto &thisADU(state.dataDefineEquipment->AirDistUnit(AirDistUnitNum));
                 {
-                    auto &thisZoneEqConfig(state.dataZoneEquip->ZoneEquipConfig(ZoneNum));
-                    thisADU.ZoneNum = ZoneNum;
+                    auto &thisZoneEqConfig(state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum));
+                    thisADU.ZoneNum = ControlledZoneNum;
                     for (int inletNum = 1; inletNum <= thisZoneEqConfig.NumInletNodes; ++inletNum) {
                         if (thisZoneEqConfig.InletNode(inletNum) == thisADU.OutletNodeNum)
                             thisZoneEqConfig.InletNodeADUNum(inletNum) = AirDistUnitNum;
@@ -624,7 +624,7 @@ namespace ZoneAirLoopEquipmentManager {
                                  Real64 &NonAirSysOutput,
                                  Real64 &LatOutputProvided, // Latent add/removal provided by this unit (kg/s), dehumidify = negative
                                  bool const FirstHVACIteration,
-                                 int const ZoneNum)
+                                 int const ControlledZoneNum)
     {
         // SUBROUTINE INFORMATION:
         //       AUTHOR         Russ Taylor
@@ -695,112 +695,112 @@ namespace ZoneAirLoopEquipmentManager {
                 SimulateDualDuct(state,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                  FirstHVACIteration,
-                                 ZoneNum,
-                                 state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                 ControlledZoneNum,
+                                 state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::DualDuctVAV: {
                 SimulateDualDuct(state,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                  FirstHVACIteration,
-                                 ZoneNum,
-                                 state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                 ControlledZoneNum,
+                                 state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::DualDuctVAVOutdoorAir: {
                 SimulateDualDuct(state,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                  FirstHVACIteration,
-                                 ZoneNum,
-                                 state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                 ControlledZoneNum,
+                                 state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctVAVReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                   ControlledZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctCBVAVReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                   ControlledZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctVAVNoReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                   ControlledZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctCBVAVNoReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                   ControlledZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctConstVolReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                   ControlledZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctConstVolNoReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                   ControlledZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuct_SeriesPIU_Reheat: {
                 SimPIU(state,
                        state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                        FirstHVACIteration,
-                       ZoneNum,
-                       state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                       ControlledZoneNum,
+                       state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                        state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuct_ParallelPIU_Reheat: {
                 SimPIU(state,
                        state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                        FirstHVACIteration,
-                       ZoneNum,
-                       state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                       ControlledZoneNum,
+                       state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                        state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuct_ConstVol_4PipeInduc: {
                 SimIndUnit(state,
                            state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                            FirstHVACIteration,
-                           ZoneNum,
-                           state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                           ControlledZoneNum,
+                           state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                            state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctVAVReheatVSFan: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                   ControlledZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctConstVolCooledBeam: {
                 SimCoolBeam(state,
                             state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                             FirstHVACIteration,
-                            ZoneNum,
-                            state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                            ControlledZoneNum,
+                            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                             state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum),
                             NonAirSysOutput);
             } break;
@@ -811,8 +811,8 @@ namespace ZoneAirLoopEquipmentManager {
                 SimAirTerminalUserDefined(state,
                                           state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                           FirstHVACIteration,
-                                          ZoneNum,
-                                          state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
+                                          ControlledZoneNum,
+                                          state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
                                           state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctATMixer: {
@@ -881,7 +881,7 @@ namespace ZoneAirLoopEquipmentManager {
         }
         if (ProvideSysOutput) {
             int OutletNodeNum = state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).OutletNodeNum;
-            int ZoneAirNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
+            int ZoneAirNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
             SpecHumOut = state.dataLoopNodes->Node(OutletNodeNum).HumRat;
             SpecHumIn = state.dataLoopNodes->Node(ZoneAirNode).HumRat;
             // Sign convention: SysOutputProvided <0 Zone is cooled

--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
@@ -91,8 +91,7 @@ namespace ZoneAirLoopEquipmentManager {
                                     Real64 &SysOutputProvided,
                                     Real64 &NonAirSysOutput,
                                     Real64 &LatOutputProvided, // Latent add/removal supplied by air dist unit (kg/s), dehumid = negative
-                                    int const ActualZoneNum,
-                                    int &ControlledZoneNum,
+                                    int const ZoneNum,
                                     int &CompIndex)
     {
         // SUBROUTINE INFORMATION:
@@ -140,15 +139,14 @@ namespace ZoneAirLoopEquipmentManager {
             }
         }
         state.dataSize->CurTermUnitSizingNum = state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).TermUnitSizingNum;
-        InitZoneAirLoopEquipment(state, AirDistUnitNum, ControlledZoneNum, ActualZoneNum);
+        InitZoneAirLoopEquipment(state, AirDistUnitNum, ZoneNum);
         InitZoneAirLoopEquipmentTimeStep(state, AirDistUnitNum);
 
-        SimZoneAirLoopEquipment(
-            state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ControlledZoneNum, ActualZoneNum);
+        SimZoneAirLoopEquipment(state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZoneNum);
 
         // Call one-time init to fill termunit sizing and other data for the ADU - can't do this until the actual terminal unit nodes have been
         // matched to zone euqip config nodes
-        InitZoneAirLoopEquipment(state, AirDistUnitNum, ControlledZoneNum, ActualZoneNum);
+        InitZoneAirLoopEquipment(state, AirDistUnitNum, ZoneNum);
     }
 
     void GetZoneAirLoopEquipment(EnergyPlusData &state)
@@ -626,8 +624,7 @@ namespace ZoneAirLoopEquipmentManager {
                                  Real64 &NonAirSysOutput,
                                  Real64 &LatOutputProvided, // Latent add/removal provided by this unit (kg/s), dehumidify = negative
                                  bool const FirstHVACIteration,
-                                 int const ControlledZoneNum,
-                                 int const ActualZoneNum)
+                                 int const ZoneNum)
     {
         // SUBROUTINE INFORMATION:
         //       AUTHOR         Russ Taylor
@@ -698,112 +695,112 @@ namespace ZoneAirLoopEquipmentManager {
                 SimulateDualDuct(state,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                  FirstHVACIteration,
-                                 ActualZoneNum,
-                                 state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                 ZoneNum,
+                                 state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::DualDuctVAV: {
                 SimulateDualDuct(state,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                  FirstHVACIteration,
-                                 ActualZoneNum,
-                                 state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                 ZoneNum,
+                                 state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::DualDuctVAVOutdoorAir: {
                 SimulateDualDuct(state,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                  FirstHVACIteration,
-                                 ActualZoneNum,
-                                 state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                 ZoneNum,
+                                 state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                  state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctVAVReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ActualZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                   ZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctCBVAVReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ActualZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                   ZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctVAVNoReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ActualZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                   ZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctCBVAVNoReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ActualZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                   ZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctConstVolReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ActualZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                   ZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctConstVolNoReheat: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ActualZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                   ZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuct_SeriesPIU_Reheat: {
                 SimPIU(state,
                        state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                        FirstHVACIteration,
-                       ActualZoneNum,
-                       state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                       ZoneNum,
+                       state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                        state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuct_ParallelPIU_Reheat: {
                 SimPIU(state,
                        state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                        FirstHVACIteration,
-                       ActualZoneNum,
-                       state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                       ZoneNum,
+                       state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                        state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuct_ConstVol_4PipeInduc: {
                 SimIndUnit(state,
                            state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                            FirstHVACIteration,
-                           ActualZoneNum,
-                           state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                           ZoneNum,
+                           state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                            state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctVAVReheatVSFan: {
                 SimulateSingleDuct(state,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                    FirstHVACIteration,
-                                   ActualZoneNum,
-                                   state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                   ZoneNum,
+                                   state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                    state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctConstVolCooledBeam: {
                 SimCoolBeam(state,
                             state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                             FirstHVACIteration,
-                            ActualZoneNum,
-                            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                            ZoneNum,
+                            state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                             state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum),
                             NonAirSysOutput);
             } break;
@@ -814,8 +811,8 @@ namespace ZoneAirLoopEquipmentManager {
                 SimAirTerminalUserDefined(state,
                                           state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipName(AirDistCompNum),
                                           FirstHVACIteration,
-                                          ActualZoneNum,
-                                          state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode,
+                                          ZoneNum,
+                                          state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode,
                                           state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).EquipIndex(AirDistCompNum));
             } break;
             case DataDefineEquip::ZnAirLoopEquipType::SingleDuctATMixer: {
@@ -884,7 +881,7 @@ namespace ZoneAirLoopEquipmentManager {
         }
         if (ProvideSysOutput) {
             int OutletNodeNum = state.dataDefineEquipment->AirDistUnit(AirDistUnitNum).OutletNodeNum;
-            int ZoneAirNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
+            int ZoneAirNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
             SpecHumOut = state.dataLoopNodes->Node(OutletNodeNum).HumRat;
             SpecHumIn = state.dataLoopNodes->Node(ZoneAirNode).HumRat;
             // Sign convention: SysOutputProvided <0 Zone is cooled

--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.cc
@@ -536,7 +536,7 @@ namespace ZoneAirLoopEquipmentManager {
         }
     }
 
-    void InitZoneAirLoopEquipment(EnergyPlusData &state, int const AirDistUnitNum, int const ControlledZoneNum, int const ActualZoneNum)
+    void InitZoneAirLoopEquipment(EnergyPlusData &state, int const AirDistUnitNum, int const ZoneNum)
     {
         // SUBROUTINE INFORMATION:
         //       AUTHOR         Russ Taylor
@@ -555,8 +555,8 @@ namespace ZoneAirLoopEquipmentManager {
             {
                 auto &thisADU(state.dataDefineEquipment->AirDistUnit(AirDistUnitNum));
                 {
-                    auto &thisZoneEqConfig(state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum));
-                    thisADU.ZoneNum = ActualZoneNum;
+                    auto &thisZoneEqConfig(state.dataZoneEquip->ZoneEquipConfig(ZoneNum));
+                    thisADU.ZoneNum = ZoneNum;
                     for (int inletNum = 1; inletNum <= thisZoneEqConfig.NumInletNodes; ++inletNum) {
                         if (thisZoneEqConfig.InletNode(inletNum) == thisADU.OutletNodeNum)
                             thisZoneEqConfig.InletNodeADUNum(inletNum) = AirDistUnitNum;

--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.hh
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.hh
@@ -68,12 +68,12 @@ namespace ZoneAirLoopEquipmentManager {
                                     Real64 &SysOutputProvided,
                                     Real64 &NonAirSysOutput,
                                     Real64 &LatOutputProvided, // Latent add/removal supplied by window AC (kg/s), dehumid = negative
-                                    int ZoneNum,
+                                    int ControlledZoneNum,
                                     int &CompIndex);
 
     void GetZoneAirLoopEquipment(EnergyPlusData &state);
 
-    void InitZoneAirLoopEquipment(EnergyPlusData &state, int AirDistUnitNum, int ZoneNum);
+    void InitZoneAirLoopEquipment(EnergyPlusData &state, int AirDistUnitNum, int ControlledZoneNum);
 
     void InitZoneAirLoopEquipmentTimeStep(EnergyPlusData &state, int AirDistUnitNum);
 
@@ -83,7 +83,7 @@ namespace ZoneAirLoopEquipmentManager {
                                  Real64 &NonAirSysOutput,
                                  Real64 &LatOutputProvided, // Latent add/removal provided by this unit (kg/s), dehumidify = negative
                                  bool FirstHVACIteration,
-                                 int ZoneNum);
+                                 int ControlledZoneNum);
 
 } // namespace ZoneAirLoopEquipmentManager
 

--- a/src/EnergyPlus/ZoneAirLoopEquipmentManager.hh
+++ b/src/EnergyPlus/ZoneAirLoopEquipmentManager.hh
@@ -68,13 +68,12 @@ namespace ZoneAirLoopEquipmentManager {
                                     Real64 &SysOutputProvided,
                                     Real64 &NonAirSysOutput,
                                     Real64 &LatOutputProvided, // Latent add/removal supplied by window AC (kg/s), dehumid = negative
-                                    int ActualZoneNum,
-                                    int &ControlledZoneNum,
+                                    int ZoneNum,
                                     int &CompIndex);
 
     void GetZoneAirLoopEquipment(EnergyPlusData &state);
 
-    void InitZoneAirLoopEquipment(EnergyPlusData &state, int AirDistUnitNum, int ControlledZoneNum, int ActualZoneNum);
+    void InitZoneAirLoopEquipment(EnergyPlusData &state, int AirDistUnitNum, int ZoneNum);
 
     void InitZoneAirLoopEquipmentTimeStep(EnergyPlusData &state, int AirDistUnitNum);
 
@@ -84,8 +83,7 @@ namespace ZoneAirLoopEquipmentManager {
                                  Real64 &NonAirSysOutput,
                                  Real64 &LatOutputProvided, // Latent add/removal provided by this unit (kg/s), dehumidify = negative
                                  bool FirstHVACIteration,
-                                 int ControlledZoneNum,
-                                 int ActualZoneNum);
+                                 int ZoneNum);
 
 } // namespace ZoneAirLoopEquipmentManager
 

--- a/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
@@ -2454,14 +2454,8 @@ void CorrectZoneContaminants(EnergyPlusData &state,
 
     static constexpr std::string_view RoutineName("CorrectZoneContaminants");
 
-    int NodeNum;
-    int ZoneNodeNum;
-    int ZoneEquipConfigNum;
-    bool ControlledZoneAirFlag;
-    int ZoneRetPlenumNum;
-    int ZoneSupPlenumNum;
-    bool ZoneRetPlenumAirFlag;
-    bool ZoneSupPlenumAirFlag;
+    bool ZoneRetPlenumAirFlag = false;
+    bool ZoneSupPlenumAirFlag = false;
     Real64 CO2Gain;             // Zone CO2 internal gain
     Real64 CO2GainExceptPeople; // Added for hybrid model, Zone CO2 internal gain
     Real64 GCGain;              // Zone generic contaminant internal gain
@@ -2478,12 +2472,11 @@ void CorrectZoneContaminants(EnergyPlusData &state,
     int ADUNum;
     int ADUInNode;
     int ADUOutNode;
-    int ZoneNum;
 
     auto &Node(state.dataLoopNodes->Node);
 
     // Update zone CO2
-    for (ZoneNum = 1; ZoneNum <= state.dataGlobal->NumOfZones; ++ZoneNum) {
+    for (int ZoneNum = 1; ZoneNum <= state.dataGlobal->NumOfZones; ++ZoneNum) {
 
         if (state.dataContaminantBalance->Contaminant.CO2Simulation) {
             state.dataContaminantBalance->AZ(ZoneNum) = 0.0;
@@ -2566,16 +2559,18 @@ void CorrectZoneContaminants(EnergyPlusData &state,
         ZoneMult = state.dataHeatBal->Zone(ZoneNum).Multiplier * state.dataHeatBal->Zone(ZoneNum).ListMultiplier;
 
         // Check to see if this is a controlled zone
-        ControlledZoneAirFlag = state.dataHeatBal->Zone(ZoneNum).IsControlled;
+        const bool ControlledZoneAirFlag = state.dataHeatBal->Zone(ZoneNum).IsControlled;
 
         // Check to see if this is a plenum zone
         ZoneRetPlenumAirFlag = false;
+        int ZoneRetPlenumNum = 0;
         for (ZoneRetPlenumNum = 1; ZoneRetPlenumNum <= state.dataZonePlenum->NumZoneReturnPlenums; ++ZoneRetPlenumNum) {
             if (state.dataZonePlenum->ZoneRetPlenCond(ZoneRetPlenumNum).ActualZoneNum != ZoneNum) continue;
             ZoneRetPlenumAirFlag = true;
             break;
         } // ZoneRetPlenumNum
         ZoneSupPlenumAirFlag = false;
+        int ZoneSupPlenumNum = 0;
         for (ZoneSupPlenumNum = 1; ZoneSupPlenumNum <= state.dataZonePlenum->NumZoneSupplyPlenums; ++ZoneSupPlenumNum) {
             if (state.dataZonePlenum->ZoneSupPlenCond(ZoneSupPlenumNum).ActualZoneNum != ZoneNum) continue;
             ZoneSupPlenumAirFlag = true;
@@ -2585,24 +2580,24 @@ void CorrectZoneContaminants(EnergyPlusData &state,
         if (ControlledZoneAirFlag) { // If there is system flow then calculate the flow rates
 
             // Calculate moisture flow rate into each zone
-            for (NodeNum = 1; NodeNum <= state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).NumInletNodes; ++NodeNum) {
+            for (int NodeNum = 1; NodeNum <= state.dataZoneEquip->ZoneEquipConfig(ZoneNum).NumInletNodes; ++NodeNum) {
 
                 if (state.dataContaminantBalance->Contaminant.CO2Simulation) {
-                    CO2MassFlowRate += (Node(state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).InletNode(NodeNum)).MassFlowRate *
-                                        Node(state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).InletNode(NodeNum)).CO2) /
+                    CO2MassFlowRate += (Node(state.dataZoneEquip->ZoneEquipConfig(ZoneNum).InletNode(NodeNum)).MassFlowRate *
+                                        Node(state.dataZoneEquip->ZoneEquipConfig(ZoneNum).InletNode(NodeNum)).CO2) /
                                        ZoneMult;
                 }
                 if (state.dataContaminantBalance->Contaminant.GenericContamSimulation) {
-                    GCMassFlowRate += (Node(state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).InletNode(NodeNum)).MassFlowRate *
-                                       Node(state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).InletNode(NodeNum)).GenContam) /
+                    GCMassFlowRate += (Node(state.dataZoneEquip->ZoneEquipConfig(ZoneNum).InletNode(NodeNum)).MassFlowRate *
+                                       Node(state.dataZoneEquip->ZoneEquipConfig(ZoneNum).InletNode(NodeNum)).GenContam) /
                                       ZoneMult;
                 }
-                ZoneMassFlowRate += Node(state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).InletNode(NodeNum)).MassFlowRate / ZoneMult;
+                ZoneMassFlowRate += Node(state.dataZoneEquip->ZoneEquipConfig(ZoneNum).InletNode(NodeNum)).MassFlowRate / ZoneMult;
             } // NodeNum
 
             // Do the calculations for the plenum zone
         } else if (ZoneRetPlenumAirFlag) {
-            for (NodeNum = 1; NodeNum <= state.dataZonePlenum->ZoneRetPlenCond(ZoneRetPlenumNum).NumInletNodes; ++NodeNum) {
+            for (int NodeNum = 1; NodeNum <= state.dataZonePlenum->ZoneRetPlenCond(ZoneRetPlenumNum).NumInletNodes; ++NodeNum) {
 
                 if (state.dataContaminantBalance->Contaminant.CO2Simulation) {
                     CO2MassFlowRate += (Node(state.dataZonePlenum->ZoneRetPlenCond(ZoneRetPlenumNum).InletNode(NodeNum)).MassFlowRate *
@@ -2742,7 +2737,7 @@ void CorrectZoneContaminants(EnergyPlusData &state,
                 InverseModelCO2(state, ZoneNum, CO2Gain, CO2GainExceptPeople, ZoneMassFlowRate, CO2MassFlowRate, RhoAir);
             }
             // Now put the calculated info into the actual zone nodes; ONLY if there is zone air flow, i.e. controlled zone or plenum zone
-            ZoneNodeNum = state.dataHeatBal->Zone(ZoneNum).SystemZoneNodeNumber;
+            const int ZoneNodeNum = state.dataHeatBal->Zone(ZoneNum).SystemZoneNodeNumber;
             if (ZoneNodeNum > 0) {
                 Node(ZoneNodeNum).CO2 = state.dataContaminantBalance->ZoneAirCO2Temp(ZoneNum);
             }
@@ -2809,7 +2804,7 @@ void CorrectZoneContaminants(EnergyPlusData &state,
             state.dataContaminantBalance->ZoneAirGC(ZoneNum) = state.dataContaminantBalance->ZoneAirGCTemp(ZoneNum);
 
             // Now put the calculated info into the actual zone nodes; ONLY if there is zone air flow, i.e. controlled zone or plenum zone
-            ZoneNodeNum = state.dataHeatBal->Zone(ZoneNum).SystemZoneNodeNumber;
+            const int ZoneNodeNum = state.dataHeatBal->Zone(ZoneNum).SystemZoneNodeNumber;
             if (ZoneNodeNum > 0) {
                 Node(ZoneNodeNum).GenContam = state.dataContaminantBalance->ZoneAirGCTemp(ZoneNum);
             }

--- a/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
@@ -2566,13 +2566,7 @@ void CorrectZoneContaminants(EnergyPlusData &state,
         ZoneMult = state.dataHeatBal->Zone(ZoneNum).Multiplier * state.dataHeatBal->Zone(ZoneNum).ListMultiplier;
 
         // Check to see if this is a controlled zone
-        ControlledZoneAirFlag = false;
-        for (ZoneEquipConfigNum = 1; ZoneEquipConfigNum <= state.dataGlobal->NumOfZones; ++ZoneEquipConfigNum) {
-            if (!state.dataHeatBal->Zone(ZoneEquipConfigNum).IsControlled) continue;
-            if (state.dataZoneEquip->ZoneEquipConfig(ZoneEquipConfigNum).ActualZoneNum != ZoneNum) continue;
-            ControlledZoneAirFlag = true;
-            break;
-        } // ZoneEquipConfigNum
+        ControlledZoneAirFlag = state.dataHeatBal->Zone(ZoneNum).IsControlled;
 
         // Check to see if this is a plenum zone
         ZoneRetPlenumAirFlag = false;

--- a/src/EnergyPlus/ZoneEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneEquipmentManager.cc
@@ -3508,8 +3508,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::BBElectric: { // 'ZoneHVAC:Baseboard:RadiantConvective:Electric'
                 SimElecBaseboard(state,
                                  state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                 ActualZoneNum,
-                                 ControlledZoneNum,
+                                 ZoneNum,
                                  FirstHVACIteration,
                                  SysOutputProvided,
                                  state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));

--- a/src/EnergyPlus/ZoneEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneEquipmentManager.cc
@@ -410,8 +410,6 @@ void SizeZoneEquipment(EnergyPlusData &state)
     // SUBROUTINE INFORMATION:
     //       AUTHOR         Fred Buhl
     //       DATE WRITTEN   December 2000
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // Performs the zone sizing calculations and fills the zone sizing
@@ -426,17 +424,11 @@ void SizeZoneEquipment(EnergyPlusData &state)
     using DataHVACGlobals::SmallLoad;
     using DataHVACGlobals::SmallTempDiff;
 
-    // Parameters
     static constexpr std::string_view RoutineName("SizeZoneEquipment");
 
-    // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-    int ControlledZoneNum;                // controlled zone index
-    int ActualZoneNum;                    // index into Zone array (all zones)
     int SupplyAirNode1;                   // node number of 1st zone supply air node
     int SupplyAirNode2;                   // node number of 2nd zone supply air node
     int SupplyAirNode;                    // node number of supply air node for ideal air system
-    int ZoneNode;                         // node number of controlled zone
-    int ReturnNode;                       // node number of controlled zone return node
     Real64 DeltaTemp;                     // difference between supply air temp and zone temp [C]
     Real64 CpAir;                         // heat capacity of air [J/kg-C]
     Real64 SysOutputProvided;             // system sensible output [W]
@@ -462,16 +454,15 @@ void SizeZoneEquipment(EnergyPlusData &state)
         state.dataZoneEquipmentManager->SizeZoneEquipmentOneTimeFlag = false;
     }
 
-    for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+    for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
         if (!state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).IsControlled) continue;
 
-        ActualZoneNum = state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).ActualZoneNum;
-        state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) = 0.0;
-        state.dataHeatBalFanSys->SysDepZoneLoads(ActualZoneNum) = 0.0;
+        state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) = 0.0;
+        state.dataHeatBalFanSys->SysDepZoneLoads(ControlledZoneNum) = 0.0;
         SysOutputProvided = 0.0;
         LatOutputProvided = 0.0;
-        InitSystemOutputRequired(state, ActualZoneNum, true);
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
+        InitSystemOutputRequired(state, ControlledZoneNum, true);
+        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
         SupplyAirNode = 0;
         SupplyAirNode1 = 0;
         SupplyAirNode2 = 0;
@@ -514,7 +505,7 @@ void SizeZoneEquipment(EnergyPlusData &state)
             DOASSysOutputProvided = DOASMassFlowRate * DOASCpAir * (DOASSupplyTemp - Node(ZoneNode).Temp);
             TotDOASSysOutputProvided =
                 DOASMassFlowRate * (PsyHFnTdbW(DOASSupplyTemp, DOASSupplyHumRat) - PsyHFnTdbW(Node(ZoneNode).Temp, Node(ZoneNode).HumRat));
-            UpdateSystemOutputRequired(state, ActualZoneNum, DOASSysOutputProvided, LatOutputProvided);
+            UpdateSystemOutputRequired(state, ControlledZoneNum, DOASSysOutputProvided, LatOutputProvided);
             Node(SupplyAirNode1).Temp = DOASSupplyTemp;
             Node(SupplyAirNode1).HumRat = DOASSupplyHumRat;
             Node(SupplyAirNode1).MassFlowRate = DOASMassFlowRate;
@@ -546,24 +537,24 @@ void SizeZoneEquipment(EnergyPlusData &state)
 
         // Sign convention: SysOutputProvided <0 Supply air is heated on entering zone (zone is cooled)
         //                  SysOutputProvided >0 Supply air is cooled on entering zone (zone is heated)
-        if (!state.dataZoneEnergyDemand->DeadBandOrSetback(ActualZoneNum) &&
-            std::abs(state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputRequired) > SmallLoad) {
+        if (!state.dataZoneEnergyDemand->DeadBandOrSetback(ControlledZoneNum) &&
+            std::abs(state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputRequired) > SmallLoad) {
             // Determine design supply air temperture and design supply air temperature difference
-            if (state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputRequired < 0.0) { // Cooling case
+            if (state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputRequired < 0.0) { // Cooling case
                 // If the user specify the design cooling supply air temperature, then
                 if (state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).ZnCoolDgnSAMethod == SupplyAirTemperature) {
                     Temp = state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolDesTemp;
                     HumRat = state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolDesHumRat;
                     DeltaTemp = Temp - Node(ZoneNode).Temp;
-                    if (state.dataHeatBal->Zone(ActualZoneNum).HasAdjustedReturnTempByITE && !(state.dataGlobal->BeginSimFlag)) {
-                        DeltaTemp = Temp - state.dataHeatBal->Zone(ActualZoneNum).AdjustedReturnTempByITE;
+                    if (state.dataHeatBal->Zone(ControlledZoneNum).HasAdjustedReturnTempByITE && !(state.dataGlobal->BeginSimFlag)) {
+                        DeltaTemp = Temp - state.dataHeatBal->Zone(ControlledZoneNum).AdjustedReturnTempByITE;
                     }
                     // If the user specify the design cooling supply air temperature difference, then
                 } else {
                     DeltaTemp = -std::abs(state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolDesTempDiff);
                     Temp = DeltaTemp + Node(ZoneNode).Temp;
-                    if (state.dataHeatBal->Zone(ActualZoneNum).HasAdjustedReturnTempByITE && !(state.dataGlobal->BeginSimFlag)) {
-                        Temp = DeltaTemp + state.dataHeatBal->Zone(ActualZoneNum).AdjustedReturnTempByITE;
+                    if (state.dataHeatBal->Zone(ControlledZoneNum).HasAdjustedReturnTempByITE && !(state.dataGlobal->BeginSimFlag)) {
+                        Temp = DeltaTemp + state.dataHeatBal->Zone(ControlledZoneNum).AdjustedReturnTempByITE;
                     }
                     HumRat = state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolDesHumRat;
                 }
@@ -582,7 +573,7 @@ void SizeZoneEquipment(EnergyPlusData &state)
             }
 
             Enthalpy = PsyHFnTdbW(Temp, HumRat);
-            SysOutputProvided = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputRequired;
+            SysOutputProvided = state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputRequired;
             CpAir = PsyCpAirFnW(HumRat);
             if (std::abs(DeltaTemp) > SmallTempDiff) {
                 //!!PH/WFB/LKL (UCDV model)        MassFlowRate = SysOutputProvided / (CpAir*DeltaTemp)
@@ -602,7 +593,7 @@ void SizeZoneEquipment(EnergyPlusData &state)
             MassFlowRate = 0.0;
         }
 
-        UpdateSystemOutputRequired(state, ActualZoneNum, SysOutputProvided, LatOutputProvided);
+        UpdateSystemOutputRequired(state, ControlledZoneNum, SysOutputProvided, LatOutputProvided);
 
         if (SysOutputProvided > 0.0) {
             state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).HeatLoad = SysOutputProvided;
@@ -635,7 +626,7 @@ void SizeZoneEquipment(EnergyPlusData &state)
             Node(SupplyAirNode).Enthalpy = Enthalpy;
             Node(SupplyAirNode).MassFlowRate = MassFlowRate;
         } else {
-            state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) = SysOutputProvided;
+            state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) = SysOutputProvided;
         }
     }
 
@@ -643,16 +634,14 @@ void SizeZoneEquipment(EnergyPlusData &state)
 
     CalcZoneLeavingConditions(state, true);
 
-    for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+    for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
         if (!state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).IsControlled) continue;
         // MJW for now - use first return node, make a separate commit to add a dimension to all of the sizing rettemp variables
+        int ReturnNode = 0;
         if (state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).NumReturnNodes > 0) {
             ReturnNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ReturnNode(1);
-        } else {
-            ReturnNode = 0;
         }
-        ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
-        ActualZoneNum = state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).ActualZoneNum;
+        int ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneNode;
         if (ReturnNode > 0) {
             RetTemp = Node(ReturnNode).Temp;
         } else {
@@ -660,32 +649,32 @@ void SizeZoneEquipment(EnergyPlusData &state)
         }
         if (state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).HeatLoad > 0.0) {
             state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).HeatZoneRetTemp = RetTemp;
-            if (state.dataHeatBalFanSys->TempZoneThermostatSetPoint(ActualZoneNum) > 0.0) {
+            if (state.dataHeatBalFanSys->TempZoneThermostatSetPoint(ControlledZoneNum) > 0.0) {
                 state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).HeatTstatTemp =
-                    state.dataHeatBalFanSys->TempZoneThermostatSetPoint(ActualZoneNum);
+                    state.dataHeatBalFanSys->TempZoneThermostatSetPoint(ControlledZoneNum);
             } else {
                 state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).HeatTstatTemp =
-                    state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ActualZoneNum);
+                    state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ControlledZoneNum);
             }
             state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolTstatTemp =
-                state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ActualZoneNum);
+                state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ControlledZoneNum);
         } else if (state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolLoad > 0.0) {
             state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolZoneRetTemp = RetTemp;
-            if (state.dataHeatBalFanSys->TempZoneThermostatSetPoint(ActualZoneNum) > 0.0) {
+            if (state.dataHeatBalFanSys->TempZoneThermostatSetPoint(ControlledZoneNum) > 0.0) {
                 state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolTstatTemp =
-                    state.dataHeatBalFanSys->TempZoneThermostatSetPoint(ActualZoneNum);
+                    state.dataHeatBalFanSys->TempZoneThermostatSetPoint(ControlledZoneNum);
             } else {
                 state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolTstatTemp =
-                    state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ActualZoneNum);
+                    state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ControlledZoneNum);
             }
             state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).HeatTstatTemp =
-                state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ActualZoneNum);
+                state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ControlledZoneNum);
         } else {
             state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolZoneRetTemp = RetTemp;
             state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).HeatTstatTemp =
-                state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ActualZoneNum);
+                state.dataHeatBalFanSys->ZoneThermostatSetPointLo(ControlledZoneNum);
             state.dataSize->CalcZoneSizing(state.dataSize->CurOverallSimDay, ControlledZoneNum).CoolTstatTemp =
-                state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ActualZoneNum);
+                state.dataHeatBalFanSys->ZoneThermostatSetPointHi(ControlledZoneNum);
         }
     }
 }
@@ -771,8 +760,6 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
     // SUBROUTINE INFORMATION:
     //       AUTHOR         Fred Buhl
     //       DATE WRITTEN   December 2000
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // Allocate and fill the ZoneSizing data array.
@@ -785,20 +772,14 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
     using ScheduleManager::GetScheduleMaxValue;
     using ZoneTempPredictorCorrector::VerifyThermostatInZone;
 
-    // Locals
     int NumOfTimeStepInDay; // number of zone time steps in a day
-
-    // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-    int DesDayNum; // design day index
+    int DesDayNum;          // design day index
     // unused  INTEGER :: DesDayEnvrnNum   ! design day index
-    int CtrlZoneNum;          // controlled zone index
     int ZoneSizNum;           // zone sizing input index
     Real64 TotPeopleInZone;   // total (maximum) number of people in a zone
     int PeopleNum;            // index of People structure
     Real64 OAFromPeople(0.0); // min OA calculated from zone occupancy [m3/s]
     Real64 OAFromArea(0.0);   // min OA calculated from zone area and OA flow per area [m3/s]
-    int ZoneIndex;            // index of Zone Sizing zone name in zone array
-    int ZoneSizIndex;         // zone sizing do loop index
     bool ErrorsFound(false);  // Set to true if errors in input, fatal at end of routine
     Real64 SchMax(0.0);       // maximum people multiplier value
     Real64 OAVolumeFlowRate;  // outside air flow rate (m3/s)
@@ -813,8 +794,8 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
         state.dataDaylightingData->spacePowerReductionFactor.dimension(state.dataGlobal->numSpaces, 1.0);
     }
 
-    for (ZoneSizIndex = 1; ZoneSizIndex <= state.dataSize->NumZoneSizingInput; ++ZoneSizIndex) {
-        ZoneIndex = UtilityRoutines::FindItemInList(state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName, state.dataHeatBal->Zone);
+    for (int ZoneSizIndex = 1; ZoneSizIndex <= state.dataSize->NumZoneSizingInput; ++ZoneSizIndex) {
+        int ZoneIndex = UtilityRoutines::FindItemInList(state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName, state.dataHeatBal->Zone);
         if (ZoneIndex == 0) {
             ShowSevereError(state,
                             "SetUpZoneSizingArrays: Sizing:Zone=\"" + state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName +
@@ -884,12 +865,12 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
     }
     // Fill zone sizing arrays from input array
     for (DesDayNum = 1; DesDayNum <= state.dataEnvrn->TotDesDays + state.dataEnvrn->TotRunDesPersDays; ++DesDayNum) {
-        for (CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
+        for (int CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
             if (!state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).IsControlled) continue;
             state.dataSize->ZoneSizing(DesDayNum, CtrlZoneNum).ZoneName = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneName;
-            state.dataSize->ZoneSizing(DesDayNum, CtrlZoneNum).ActualZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ActualZoneNum;
+            state.dataSize->ZoneSizing(DesDayNum, CtrlZoneNum).ZoneNum = CtrlZoneNum;
             state.dataSize->CalcZoneSizing(DesDayNum, CtrlZoneNum).ZoneName = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneName;
-            state.dataSize->CalcZoneSizing(DesDayNum, CtrlZoneNum).ActualZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ActualZoneNum;
+            state.dataSize->CalcZoneSizing(DesDayNum, CtrlZoneNum).ZoneNum = CtrlZoneNum;
             // For each Zone Sizing object, find the corresponding controlled zone
             ZoneSizNum = UtilityRoutines::FindItemInList(
                 state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneName, state.dataSize->ZoneSizingInput, &ZoneSizingInputData::ZoneName);
@@ -971,7 +952,8 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
                                              state.dataSize->ZoneSizingInput(1).ZoneName + "\".");
                     }
                     // Following needs to be implemented first:
-                    //          CALL ShowContinueError(state, '  A better option would be to set up global ZoneList objects for Sizing:Zone objects.')
+                    //          CALL ShowContinueError(state, '  A better option would be to set up global ZoneList objects for Sizing:Zone
+                    //          objects.')
                 }
                 state.dataSize->ZoneSizing(DesDayNum, CtrlZoneNum).ZnCoolDgnSAMethod = state.dataSize->ZoneSizingInput(1).ZnCoolDgnSAMethod;
                 state.dataSize->ZoneSizing(DesDayNum, CtrlZoneNum).ZnHeatDgnSAMethod = state.dataSize->ZoneSizingInput(1).ZnHeatDgnSAMethod;
@@ -1033,12 +1015,12 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
         }
     }
 
-    for (CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
+    for (int CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
         if (!state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).IsControlled) continue;
         state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneName = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneName;
-        state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ActualZoneNum;
+        state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneNum = CtrlZoneNum;
         state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).ZoneName = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneName;
-        state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).ActualZoneNum = state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ActualZoneNum;
+        state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).ZoneNum = CtrlZoneNum;
         ZoneSizNum = UtilityRoutines::FindItemInList(
             state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneName, state.dataSize->ZoneSizingInput, &ZoneSizingInputData::ZoneName);
         if (ZoneSizNum > 0) { // move data from zone sizing input
@@ -1357,13 +1339,12 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
     // Use the max occupancy data from the PEOPLE structure to calculate design min OA for each zone
     // Calculate the zone design minimum outside air flow rate from the 3 Zone Sizing OA inputs and
     // from the specified OA method
-    for (CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
+    for (int CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
         if (!state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).IsControlled) continue;
         // Use the max occupancy data from the PEOPLE structure to calculate design min OA for each zone
         // from the outside air flow per person input
         TotPeopleInZone = 0.0;
         Real64 ZoneMinOccupancy = 0.;
-        ZoneIndex = state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum;
         int DSOAPtr = state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneDesignSpecOAIndex; // index to DesignSpecification:OutdoorAir object
         if ((DSOAPtr > 0) && !dsoaError) {
             auto &thisOAReq = state.dataSize->OARequirements(DSOAPtr);
@@ -1373,7 +1354,7 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
                     std::string thisSpaceName = thisOAReq.dsoaSpaceNames(spaceCounter);
                     int thisSpaceNum = thisOAReq.dsoaSpaceIndexes(spaceCounter);
                     if (thisSpaceNum > 0) {
-                        if (state.dataHeatBal->space(thisSpaceNum).zoneNum != state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum) {
+                        if (state.dataHeatBal->space(thisSpaceNum).zoneNum != CtrlZoneNum) {
                             ShowSevereError(state, "SetUpZoneSizingArrays: DesignSpecification:OutdoorAir:SpaceList=" + thisOAReq.Name);
                             ShowContinueError(state, "is invalid for Sizing:Zone=" + state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneName);
                             ShowContinueError(state, "All spaces in the list must be part of this zone.");
@@ -1384,16 +1365,15 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
             }
 
             state.dataSize->FinalZoneSizing(CtrlZoneNum).DesOAFlowPPer =
-                state.dataSize->OARequirements(DSOAPtr).desFlowPerZonePerson(state, ZoneIndex);
+                state.dataSize->OARequirements(DSOAPtr).desFlowPerZonePerson(state, CtrlZoneNum);
             state.dataSize->FinalZoneSizing(CtrlZoneNum).DesOAFlowPerArea =
-                state.dataSize->OARequirements(DSOAPtr).desFlowPerZoneArea(state, ZoneIndex);
+                state.dataSize->OARequirements(DSOAPtr).desFlowPerZoneArea(state, CtrlZoneNum);
         }
 
         for (PeopleNum = 1; PeopleNum <= state.dataHeatBal->TotPeople; ++PeopleNum) {
-            if (state.dataHeatBal->People(PeopleNum).ZonePtr == state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum) {
-                TotPeopleInZone += (state.dataHeatBal->People(PeopleNum).NumberOfPeople *
-                                    state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum).Multiplier *
-                                    state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum).ListMultiplier);
+            if (state.dataHeatBal->People(PeopleNum).ZonePtr == CtrlZoneNum) {
+                TotPeopleInZone += (state.dataHeatBal->People(PeopleNum).NumberOfPeople * state.dataHeatBal->Zone(CtrlZoneNum).Multiplier *
+                                    state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier);
                 SchMax = GetScheduleMaxValue(state, state.dataHeatBal->People(PeopleNum).NumberOfPeoplePtr);
                 if (SchMax > 0) {
                     state.dataSize->FinalZoneSizing(CtrlZoneNum).ZonePeakOccupancy = TotPeopleInZone * SchMax;
@@ -1405,9 +1385,8 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
             }
         }
         state.dataSize->FinalZoneSizing(CtrlZoneNum).TotalZoneFloorArea =
-            (state.dataHeatBal->Zone(ZoneIndex).FloorArea *
-             state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum).Multiplier *
-             state.dataHeatBal->Zone(state.dataSize->FinalZoneSizing(CtrlZoneNum).ActualZoneNum).ListMultiplier);
+            (state.dataHeatBal->Zone(CtrlZoneNum).FloorArea * state.dataHeatBal->Zone(CtrlZoneNum).Multiplier *
+             state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier);
         OAFromPeople = state.dataSize->FinalZoneSizing(CtrlZoneNum).DesOAFlowPPer * TotPeopleInZone;
         OAFromArea = state.dataSize->FinalZoneSizing(CtrlZoneNum).DesOAFlowPerArea * state.dataSize->FinalZoneSizing(CtrlZoneNum).TotalZoneFloorArea;
         state.dataSize->FinalZoneSizing(CtrlZoneNum).TotPeopleInZone = TotPeopleInZone;
@@ -1420,7 +1399,7 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
         if (MinEz == 0) {
             MinEz = 1.0; // if not calculated assume 1.0 ventilation effectiveness
         }
-        state.dataHeatBal->ZonePreDefRep(ZoneIndex).VozMin =
+        state.dataHeatBal->ZonePreDefRep(CtrlZoneNum).VozMin =
             (ZoneMinOccupancy * state.dataSize->FinalZoneSizing(CtrlZoneNum).DesOAFlowPPer + OAFromArea) / MinEz;
 
         // Calculate the design min OA flow rate for this zone
@@ -1430,7 +1409,7 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
         state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneAirDistributionIndex =
             state.dataSize->FinalZoneSizing(CtrlZoneNum).ZoneAirDistributionIndex; // store for later use
         if (!dsoaError) {
-            OAVolumeFlowRate = DataSizing::calcDesignSpecificationOutdoorAir(state, DSOAPtr, ZoneIndex, UseOccSchFlag, UseMinOASchFlag);
+            OAVolumeFlowRate = DataSizing::calcDesignSpecificationOutdoorAir(state, DSOAPtr, CtrlZoneNum, UseOccSchFlag, UseMinOASchFlag);
         } else {
             OAVolumeFlowRate = 0.0;
         }
@@ -1448,33 +1427,33 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
         // loads are multiplied (in ZoneTempPredictorCorrector.cc). Flow rates derived directly from
         // user inputs need to be explicitly multiplied by the zone multipliers.
         state.dataSize->FinalZoneSizing(CtrlZoneNum).DesCoolMinAirFlow2 =
-            state.dataSize->FinalZoneSizing(CtrlZoneNum).DesCoolMinAirFlowPerArea * state.dataHeatBal->Zone(ZoneIndex).FloorArea *
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataSize->FinalZoneSizing(CtrlZoneNum).DesCoolMinAirFlowPerArea * state.dataHeatBal->Zone(CtrlZoneNum).FloorArea *
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesCoolMinAirFlow2 =
-            state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesCoolMinAirFlowPerArea * state.dataHeatBal->Zone(ZoneIndex).FloorArea *
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesCoolMinAirFlowPerArea * state.dataHeatBal->Zone(CtrlZoneNum).FloorArea *
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->FinalZoneSizing(CtrlZoneNum).DesHeatMaxAirFlow2 =
-            state.dataSize->FinalZoneSizing(CtrlZoneNum).DesHeatMaxAirFlowPerArea * state.dataHeatBal->Zone(ZoneIndex).FloorArea *
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataSize->FinalZoneSizing(CtrlZoneNum).DesHeatMaxAirFlowPerArea * state.dataHeatBal->Zone(CtrlZoneNum).FloorArea *
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesHeatMaxAirFlow2 =
-            state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesHeatMaxAirFlowPerArea * state.dataHeatBal->Zone(ZoneIndex).FloorArea *
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesHeatMaxAirFlowPerArea * state.dataHeatBal->Zone(CtrlZoneNum).FloorArea *
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->FinalZoneSizing(CtrlZoneNum).DesCoolMinAirFlow *=
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesCoolMinAirFlow *=
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->FinalZoneSizing(CtrlZoneNum).DesHeatMaxAirFlow *=
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).DesHeatMaxAirFlow *=
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->FinalZoneSizing(CtrlZoneNum).InpDesCoolAirFlow *=
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).InpDesCoolAirFlow *=
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->FinalZoneSizing(CtrlZoneNum).InpDesHeatAirFlow *=
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
         state.dataSize->CalcFinalZoneSizing(CtrlZoneNum).InpDesHeatAirFlow *=
-            state.dataHeatBal->Zone(ZoneIndex).Multiplier * state.dataHeatBal->Zone(ZoneIndex).ListMultiplier;
+            state.dataHeatBal->Zone(CtrlZoneNum).Multiplier * state.dataHeatBal->Zone(CtrlZoneNum).ListMultiplier;
 
         for (DesDayNum = 1; DesDayNum <= state.dataEnvrn->TotDesDays + state.dataEnvrn->TotRunDesPersDays; ++DesDayNum) {
             state.dataSize->ZoneSizing(DesDayNum, CtrlZoneNum).MinOA = state.dataSize->FinalZoneSizing(CtrlZoneNum).MinOA;
@@ -1500,7 +1479,7 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
     print(state.files.eio, "! <Heating Sizing Factor Information>, Sizing Factor ID, Value\n");
     static constexpr std::string_view Format_991(" Heating Sizing Factor Information, Global, {:12.5N}\n");
     print(state.files.eio, Format_991, state.dataSize->GlobalHeatSizingFactor);
-    for (CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
+    for (int CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
         if (!state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).IsControlled) continue;
         if (state.dataSize->FinalZoneSizing(CtrlZoneNum).HeatSizingFactor != 1.0) {
             static constexpr std::string_view Format_992(" Heating Sizing Factor Information, Zone {}, {:12.5N}\n");
@@ -1513,7 +1492,7 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
     print(state.files.eio, "! <Cooling Sizing Factor Information>, Sizing Factor ID, Value\n");
     static constexpr std::string_view Format_994(" Cooling Sizing Factor Information, Global, {:12.5N}\n");
     print(state.files.eio, Format_994, state.dataSize->GlobalCoolSizingFactor);
-    for (CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
+    for (int CtrlZoneNum = 1; CtrlZoneNum <= state.dataGlobal->NumOfZones; ++CtrlZoneNum) {
         if (!state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).IsControlled) continue;
         if (state.dataSize->FinalZoneSizing(CtrlZoneNum).CoolSizingFactor != 1.0) {
             static constexpr std::string_view Format_995(" Cooling Sizing Factor Information, Zone {}, {:12.5N}\n");
@@ -2972,7 +2951,6 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
     //       MODIFIED       Raustad/Shirey, FSEC, June 2003
     //       MODIFIED       Gu, FSEC, Jan. 2004, Don Shirey, Aug 2009 (LatOutputProvided)
     //                      July 2012, Chandan Sharma - FSEC: Added zone sys avail managers
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // This subroutine is responsible for determining
@@ -3029,16 +3007,6 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
     using ZoneDehumidifier::SimZoneDehumidifier;
     using ZonePlenum::SimAirZonePlenum;
 
-    // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-    int ActualZoneNum;
-    int ControlledZoneNum;
-    int EquipTypeNum;
-    int SupplyAirPathNum;
-    int CompNum;
-    int EquipPtr;
-    int ZoneEquipTypeNum;
-    int ZoneCompNum;
-
     bool SupPathInletChanged(false);
     bool FirstCall; // indicates first call to supply air path components
     bool ErrorFlag;
@@ -3053,9 +3021,9 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
     FirstCall = true;
     ErrorFlag = false;
 
-    for (SupplyAirPathNum = 1; SupplyAirPathNum <= state.dataZoneEquip->NumSupplyAirPaths; ++SupplyAirPathNum) {
+    for (int SupplyAirPathNum = 1; SupplyAirPathNum <= state.dataZoneEquip->NumSupplyAirPaths; ++SupplyAirPathNum) {
 
-        for (CompNum = 1; CompNum <= state.dataZoneEquip->SupplyAirPath(SupplyAirPathNum).NumOfComponents; ++CompNum) {
+        for (int CompNum = 1; CompNum <= state.dataZoneEquip->SupplyAirPath(SupplyAirPathNum).NumOfComponents; ++CompNum) {
 
             switch (state.dataZoneEquip->SupplyAirPath(SupplyAirPathNum).ComponentTypeEnum(CompNum)) {
             case DataZoneEquipment::AirLoopHVACZone::Splitter: { // 'AirLoopHVAC:ZoneSplitter'
@@ -3112,19 +3080,18 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
         }
     }
 
-    for (ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
+    for (int ControlledZoneNum = 1; ControlledZoneNum <= state.dataGlobal->NumOfZones; ++ControlledZoneNum) {
 
         if (!state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).IsControlled) continue;
-        ActualZoneNum = state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum;
 
-        state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) = 0.0;
-        state.dataHeatBalFanSys->SysDepZoneLoads(ActualZoneNum) = 0.0;
+        state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) = 0.0;
+        state.dataHeatBalFanSys->SysDepZoneLoads(ControlledZoneNum) = 0.0;
         state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneExh = 0.0;
         state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ZoneExhBalanced = 0.0;
         state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).PlenumMassFlow = 0.0;
         state.dataSize->CurZoneEqNum = ControlledZoneNum;
 
-        InitSystemOutputRequired(state, ActualZoneNum, FirstHVACIteration, true);
+        InitSystemOutputRequired(state, ControlledZoneNum, FirstHVACIteration, true);
 
         auto &TurnFansOn = state.dataHVACGlobal->TurnFansOn;
         auto &TurnFansOff = state.dataHVACGlobal->TurnFansOff;
@@ -3136,12 +3103,12 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
         TurnZoneFansOnlyOn = false;
         TurnFansOff = false;
 
-        for (EquipTypeNum = 1; EquipTypeNum <= state.dataZoneEquip->ZoneEquipList(ControlledZoneNum).NumOfEquipTypes; ++EquipTypeNum) {
+        for (int EquipTypeNum = 1; EquipTypeNum <= state.dataZoneEquip->ZoneEquipList(ControlledZoneNum).NumOfEquipTypes; ++EquipTypeNum) {
 
             state.dataHVACGlobal->UnbalExhMassFlow = 0.0;
             state.dataHVACGlobal->BalancedExhMassFlow = 0.0;
             state.dataHVACGlobal->PlenumInducedMassFlow = 0.0;
-            EquipPtr = state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipPtr;
+            const int EquipPtr = state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipPtr;
             SysOutputProvided = 0.0;
             LatOutputProvided = 0.0;
             state.dataSize->DataCoolCoilCap = 0.0; // reset global variable used only for heat pumps (i.e., DX cooling and heating coils)
@@ -3168,9 +3135,9 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
                 ZoneEqSizing(ControlledZoneNum).DesignSizeFromParent = false;
             }
 
-            ZoneEquipTypeNum = state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipTypeEnum;
+            const int ZoneEquipTypeNum = state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipTypeEnum;
 
-            ZoneCompNum = state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr);
+            const int ZoneCompNum = state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr);
 
             bool ValidSAMComp = false;
 
@@ -3220,7 +3187,6 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
                                            AirSysOutput,
                                            NonAirSysOutput,
                                            LatOutputProvided,
-                                           ActualZoneNum,
                                            ControlledZoneNum,
                                            state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
@@ -3229,7 +3195,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
                 TurnZoneFansOnlyOn = false;
                 TurnFansOff = false;
 
-                state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) += NonAirSysOutput;
+                state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) += NonAirSysOutput;
                 SysOutputProvided = NonAirSysOutput + AirSysOutput;
             } break;
             case ZoneEquip::VRFTerminalUnit: { // 'ZoneHVAC:TerminalUnit:VariableRefrigerantFlow'
@@ -3254,7 +3220,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::WindowAC: { // 'ZoneHVAC:WindowAirConditioner'
                 SimWindowAC(state,
                             state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                            ActualZoneNum,
+                            ControlledZoneNum,
                             FirstHVACIteration,
                             SysOutputProvided,
                             LatOutputProvided,
@@ -3267,7 +3233,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
                 // 'ZoneHVAC:WaterToAirHeatPump'
                 SimPackagedTerminalUnit(state,
                                         state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                        ActualZoneNum,
+                                        ControlledZoneNum,
                                         FirstHVACIteration,
                                         SysOutputProvided,
                                         LatOutputProvided,
@@ -3299,13 +3265,13 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::ZoneDXDehumidifier: { // 'ZoneHVAC:Dehumidifier:DX'
                 SimZoneDehumidifier(state,
                                     state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                    ActualZoneNum,
+                                    ControlledZoneNum,
                                     FirstHVACIteration,
                                     SysOutputProvided,
                                     LatOutputProvided,
                                     state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
-                state.dataHeatBalFanSys->SysDepZoneLoads(ActualZoneNum) += SysOutputProvided;
+                state.dataHeatBalFanSys->SysDepZoneLoads(ControlledZoneNum) += SysOutputProvided;
 
                 SysOutputProvided = 0.0; // Reset to 0.0 since this equipment is controlled based on zone humidity level (not
                                          // temperature) SysOutputProvided amount was already sent above to
@@ -3314,7 +3280,6 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::FanCoil4Pipe: { // 'ZoneHVAC:FourPipeFanCoil'
                 SimFanCoilUnit(state,
                                state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                               ActualZoneNum,
                                ControlledZoneNum,
                                FirstHVACIteration,
                                SysOutputProvided,
@@ -3324,7 +3289,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::UnitVentilator: { // 'ZoneHVAC:UnitVentilator'
                 SimUnitVentilator(state,
                                   state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                  ActualZoneNum,
+                                  ControlledZoneNum,
                                   FirstHVACIteration,
                                   SysOutputProvided,
                                   LatOutputProvided,
@@ -3333,7 +3298,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::UnitHeater: { // 'ZoneHVAC:UnitHeater'
                 SimUnitHeater(state,
                               state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                              ActualZoneNum,
+                              ControlledZoneNum,
                               FirstHVACIteration,
                               SysOutputProvided,
                               LatOutputProvided,
@@ -3346,66 +3311,60 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
                                 LatOutputProvided,
                                 FirstHVACIteration,
                                 ControlledZoneNum,
-                                ActualZoneNum,
                                 state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
             } break;
             case ZoneEquip::BBWater: { // 'ZoneHVAC:Baseboard:RadiantConvective:Water'
                 SimHWBaseboard(state,
                                state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                               ActualZoneNum,
                                ControlledZoneNum,
                                FirstHVACIteration,
                                SysOutputProvided,
                                state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
-                state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) += SysOutputProvided;
+                state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) += SysOutputProvided;
                 LatOutputProvided = 0.0; // This baseboard does not add/remove any latent heat
             } break;
             case ZoneEquip::BBSteam: { // 'ZoneHVAC:Baseboard:RadiantConvective:Steam'
                 SimSteamBaseboard(state,
                                   state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                  ActualZoneNum,
                                   ControlledZoneNum,
                                   FirstHVACIteration,
                                   SysOutputProvided,
                                   state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
-                state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) += SysOutputProvided;
+                state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) += SysOutputProvided;
                 LatOutputProvided = 0.0; // This baseboard does not add/remove any latent heat
             } break;
             case ZoneEquip::BBWaterConvective: { // 'ZoneHVAC:Baseboard:Convective:Water'
                 SimBaseboard(state,
                              state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                             ActualZoneNum,
                              ControlledZoneNum,
                              FirstHVACIteration,
                              SysOutputProvided,
                              state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
-                state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) += SysOutputProvided;
+                state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) += SysOutputProvided;
                 LatOutputProvided = 0.0; // This baseboard does not add/remove any latent heat
             } break;
             case ZoneEquip::BBElectricConvective: { // 'ZoneHVAC:Baseboard:Convective:Electric'
                 SimElectricBaseboard(state,
                                      state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                     ActualZoneNum,
                                      ControlledZoneNum,
                                      SysOutputProvided,
                                      state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
-                state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) += SysOutputProvided;
+                state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) += SysOutputProvided;
                 LatOutputProvided = 0.0; // This baseboard does not add/remove any latent heat
             } break;
             case ZoneEquip::CoolingPanel: { // 'ZoneHVAC:CoolingPanel:RadiantConvective:Water'
                 SimCoolingPanel(state,
                                 state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                ActualZoneNum,
                                 ControlledZoneNum,
                                 FirstHVACIteration,
                                 SysOutputProvided,
                                 state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
-                state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) += SysOutputProvided;
+                state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) += SysOutputProvided;
                 LatOutputProvided = 0.0; // This cooling panel does not add/remove any latent heat
             } break;
             case ZoneEquip::HiTempRadiant: { // 'ZoneHVAC:HighTemperatureRadiant'
@@ -3458,7 +3417,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::ERVStandAlone: { // 'ZoneHVAC:EnergyRecoveryVentilator'
                 SimStandAloneERV(state,
                                  state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                 ActualZoneNum,
+                                 ControlledZoneNum,
                                  FirstHVACIteration,
                                  SysOutputProvided,
                                  LatOutputProvided,
@@ -3490,7 +3449,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::VentilatedSlab: { // 'ZoneHVAC:VentilatedSlab'
                 SimVentilatedSlab(state,
                                   state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                  ActualZoneNum,
+                                  ControlledZoneNum,
                                   FirstHVACIteration,
                                   SysOutputProvided,
                                   LatOutputProvided,
@@ -3499,7 +3458,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::OutdoorAirUnit: { // 'ZoneHVAC:OutdoorAirUnit'
                 OutdoorAirUnit::SimOutdoorAirUnit(state,
                                                   state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                                  ActualZoneNum,
+                                                  ControlledZoneNum,
                                                   FirstHVACIteration,
                                                   SysOutputProvided,
                                                   LatOutputProvided,
@@ -3508,29 +3467,29 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::BBElectric: { // 'ZoneHVAC:Baseboard:RadiantConvective:Electric'
                 SimElecBaseboard(state,
                                  state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                 ZoneNum,
+                                 ControlledZoneNum,
                                  FirstHVACIteration,
                                  SysOutputProvided,
                                  state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
-                state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) += SysOutputProvided;
+                state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) += SysOutputProvided;
                 LatOutputProvided = 0.0; // This baseboard does not add/remove any latent heat
             } break;
             case ZoneEquip::RefrigerationAirChillerSet: { // 'ZoneHVAC:RefrigerationChillerSet'
                 SimAirChillerSet(state,
                                  state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                 ActualZoneNum,
+                                 ControlledZoneNum,
                                  FirstHVACIteration,
                                  SysOutputProvided,
                                  LatOutputProvided,
                                  state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
 
-                state.dataHeatBalFanSys->NonAirSystemResponse(ActualZoneNum) += SysOutputProvided;
+                state.dataHeatBalFanSys->NonAirSystemResponse(ControlledZoneNum) += SysOutputProvided;
             } break;
             case ZoneEquip::UserDefinedZoneHVACForcedAir: {
                 SimZoneAirUserDefined(state,
                                       state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                      ActualZoneNum,
+                                      ControlledZoneNum,
                                       SysOutputProvided,
                                       LatOutputProvided,
                                       state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
@@ -3538,7 +3497,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::ZoneEvaporativeCoolerUnit: {
                 SimZoneEvaporativeCoolerUnit(state,
                                              state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                             ActualZoneNum,
+                                             ControlledZoneNum,
                                              SysOutputProvided,
                                              LatOutputProvided,
                                              state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
@@ -3546,7 +3505,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
             case ZoneEquip::ZoneHybridEvaporativeCooler: {
                 SimZoneHybridUnitaryAirConditioners(state,
                                                     state.dataZoneEquipmentManager->PrioritySimOrder(EquipTypeNum).EquipName,
-                                                    ActualZoneNum,
+                                                    ControlledZoneNum,
                                                     SysOutputProvided,
                                                     LatOutputProvided,
                                                     state.dataZoneEquip->ZoneEquipList(state.dataSize->CurZoneEqNum).EquipIndex(EquipPtr));
@@ -3571,7 +3530,7 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
                 }
             }
 
-            UpdateSystemOutputRequired(state, ActualZoneNum, SysOutputProvided, LatOutputProvided, EquipTypeNum);
+            UpdateSystemOutputRequired(state, ControlledZoneNum, SysOutputProvided, LatOutputProvided, EquipTypeNum);
             state.dataSize->CurTermUnitSizingNum = 0;
         } // zone loop
     }     // End of controlled zone loop
@@ -3582,11 +3541,11 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
     //  the path inlets
 
     // Process supply air path components in reverse order
-    for (SupplyAirPathNum = 1; SupplyAirPathNum <= state.dataZoneEquip->NumSupplyAirPaths; ++SupplyAirPathNum) {
+    for (int SupplyAirPathNum = 1; SupplyAirPathNum <= state.dataZoneEquip->NumSupplyAirPaths; ++SupplyAirPathNum) {
 
         SupPathInletChanged = false;
 
-        for (CompNum = state.dataZoneEquip->SupplyAirPath(SupplyAirPathNum).NumOfComponents; CompNum >= 1; --CompNum) {
+        for (int CompNum = state.dataZoneEquip->SupplyAirPath(SupplyAirPathNum).NumOfComponents; CompNum >= 1; --CompNum) {
             switch (state.dataZoneEquip->SupplyAirPath(SupplyAirPathNum).ComponentTypeEnum(CompNum)) {
             case DataZoneEquipment::AirLoopHVACZone::Splitter: { // 'AirLoopHVAC:ZoneSplitter'
                 if (!(state.afn->AirflowNetworkFanActivated && state.afn->distribution_simulated)) {
@@ -3635,14 +3594,12 @@ void SimZoneEquipment(EnergyPlusData &state, bool const FirstHVACIteration, bool
     SimReturnAirPath(state);
 }
 
-void SetZoneEquipSimOrder(EnergyPlusData &state, int const ControlledZoneNum, int const ActualZoneNum)
+void SetZoneEquipSimOrder(EnergyPlusData &state, int const ControlledZoneNum)
 {
 
     // SUBROUTINE INFORMATION:
     //       AUTHOR         Russ Taylor
     //       DATE WRITTEN   May 1997
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
     // Set simulation priorities based on user specified priorities and
@@ -3683,9 +3640,9 @@ void SetZoneEquipSimOrder(EnergyPlusData &state, int const ControlledZoneNum, in
             auto &psc(state.dataZoneEquipmentManager->PrioritySimOrder(ComparedEquipTypeNum));
 
             if ((CurEqCoolingPriority > psc.CoolingPriority &&
-                 state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputRequired < 0.0) ||
+                 state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputRequired < 0.0) ||
                 (CurEqHeatingPriority > psc.HeatingPriority &&
-                 state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum).RemainingOutputRequired >= 0.0)) {
+                 state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ControlledZoneNum).RemainingOutputRequired >= 0.0)) {
 
                 // Tuned C++ string swap avoids copying
                 pso.EquipType.swap(psc.EquipType);
@@ -3734,13 +3691,7 @@ void InitSystemOutputRequired(EnergyPlusData &state, int const ZoneNum, bool con
     moisture.UnadjRemainingOutputReqToDehumidSP = moisture.OutputRequiredToDehumidifyingSP;
 
     if (ResetSimOrder) {
-        const int ControlledZoneNum = [&] {
-            for (int i = 1; i <= state.dataGlobal->NumOfZones; ++i) {
-                if (state.dataZoneEquip->ZoneEquipConfig(i).ActualZoneNum == ZoneNum) return i;
-            }
-            return 0;
-        }();
-        SetZoneEquipSimOrder(state, ControlledZoneNum, ZoneNum);
+        SetZoneEquipSimOrder(state, ZoneNum);
     }
 
     // If one sequenced load is allocated, then all have been allocated in InitZoneEquipment
@@ -3756,7 +3707,7 @@ void InitSystemOutputRequired(EnergyPlusData &state, int const ZoneNum, bool con
             moisture.SequencedOutputRequiredToHumidSP = moisture.OutputRequiredToHumidifyingSP;     // array assignment
             moisture.SequencedOutputRequiredToDehumidSP = moisture.OutputRequiredToDehumidifyingSP; // array assignment
         } else if (FirstHVACIteration) {
-            auto loadDistType = state.dataZoneEquip->ZoneEquipList(state.dataHeatBal->Zone(ZoneNum).ZoneEqNum).LoadDistScheme;
+            auto loadDistType = state.dataZoneEquip->ZoneEquipList(ZoneNum).LoadDistScheme;
             if ((loadDistType == DataZoneEquipment::LoadDist::Sequential) || (loadDistType == DataZoneEquipment::LoadDist::Uniform)) {
                 // init each sequenced demand to the full output
                 energy.SequencedOutputRequired = energy.TotalOutputRequired;                        // array assignment
@@ -3806,24 +3757,23 @@ void InitSystemOutputRequired(EnergyPlusData &state, int const ZoneNum, bool con
     DistributeSystemOutputRequired(state, ZoneNum, FirstHVACIteration);
 }
 
-void DistributeSystemOutputRequired(EnergyPlusData &state, int const ActualZoneNum, bool const FirstHVACIteration)
+void DistributeSystemOutputRequired(EnergyPlusData &state, int const ZoneNum, bool const FirstHVACIteration)
 {
     // Distribute zone equipment loads according to load distribution scheme
 
     // Do nothing if this zone is uncontrolled or doing zone sizing
-    if (!state.dataHeatBal->Zone(ActualZoneNum).IsControlled) return;
+    if (!state.dataHeatBal->Zone(ZoneNum).IsControlled) return;
     if (state.dataGlobal->ZoneSizingCalc) return;
 
-    int ctrlZoneNum = state.dataHeatBal->Zone(ActualZoneNum).ZoneEqNum;
     // Do nothing on FirstHVACIteration if not UniformLoading and not SequentialLoading
-    if (FirstHVACIteration && (state.dataZoneEquip->ZoneEquipList(ctrlZoneNum).LoadDistScheme != DataZoneEquipment::LoadDist::Uniform) &&
-        (state.dataZoneEquip->ZoneEquipList(ctrlZoneNum).LoadDistScheme != DataZoneEquipment::LoadDist::Sequential)) {
+    if (FirstHVACIteration && (state.dataZoneEquip->ZoneEquipList(ZoneNum).LoadDistScheme != DataZoneEquipment::LoadDist::Uniform) &&
+        (state.dataZoneEquip->ZoneEquipList(ZoneNum).LoadDistScheme != DataZoneEquipment::LoadDist::Sequential)) {
         return;
     }
 
-    auto &energy(state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ActualZoneNum));
-    auto &moisture(state.dataZoneEnergyDemand->ZoneSysMoistureDemand(ActualZoneNum));
-    auto &thisZEqList(state.dataZoneEquip->ZoneEquipList(ctrlZoneNum));
+    auto &energy(state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ZoneNum));
+    auto &moisture(state.dataZoneEnergyDemand->ZoneSysMoistureDemand(ZoneNum));
+    auto &thisZEqList(state.dataZoneEquip->ZoneEquipList(ZoneNum));
     Real64 heatLoadRatio = 1.0;
     Real64 coolLoadRatio = 1.0;
     Real64 availCap = 0.0;
@@ -4105,7 +4055,6 @@ void UpdateSystemOutputRequired(EnergyPlusData &state,
     //       DATE WRITTEN   Unknown
     //       MODIFIED       B. Griffith Sept 2011, add storage of requirements by sequence
 
-    int ctrlZoneNum = state.dataHeatBal->Zone(ZoneNum).ZoneEqNum;
     auto &energy(state.dataZoneEnergyDemand->ZoneSysEnergyDemand(ZoneNum));
     auto &moisture(state.dataZoneEnergyDemand->ZoneSysMoistureDemand(ZoneNum));
 
@@ -4188,7 +4137,7 @@ void UpdateSystemOutputRequired(EnergyPlusData &state,
     }
 
     // Sensible output updates
-    auto &thisZEqList(state.dataZoneEquip->ZoneEquipList(ctrlZoneNum));
+    auto &thisZEqList(state.dataZoneEquip->ZoneEquipList(ZoneNum));
     switch (thisZEqList.LoadDistScheme) {
     case DataZoneEquipment::LoadDist::Sequential: {
         // Subtract the system output from the unadjusted loads required
@@ -4616,10 +4565,9 @@ void CalcZoneMassBalance(EnergyPlusData &state, bool const FirstHVACIteration)
                     Real64 sysUnbalExhaust = (thisZoneEquip.TotExhaustAirMassFlowRate - thisZoneEquip.ZoneExhBalanced);
                     Real64 sysUnbalancedFlow = sysUnbalExhaust + totalZoneReturnMassFlow - thisZoneEquip.TotInletAirMassFlowRate;
                     if (sysUnbalancedFlow > SmallMassFlow) {
-                        int actualZone = thisZoneEquip.ActualZoneNum;
                         // Now include infiltration, ventilation, and mixing flows (these are all entering the zone, so subtract them)
-                        Real64 incomingFlow = state.dataHeatBalFanSys->OAMFL(actualZone) + state.dataHeatBalFanSys->VAMFL(actualZone) +
-                                              state.dataHeatBalFanSys->MixingMassFlowZone(actualZone);
+                        Real64 incomingFlow = state.dataHeatBalFanSys->OAMFL(zoneNum) + state.dataHeatBalFanSys->VAMFL(zoneNum) +
+                                              state.dataHeatBalFanSys->MixingMassFlowZone(zoneNum);
                         Real64 unbalancedFlow = max(0.0, sysUnbalancedFlow - incomingFlow);
                         if (unbalancedFlow > SmallMassFlow) {
                             // Re-check on volume basis - use current zone density for incoming, standard density for HVAC sys
@@ -4641,9 +4589,9 @@ void CalcZoneMassBalance(EnergyPlusData &state, bool const FirstHVACIteration)
                                                          totalZoneReturnMassFlow / state.dataEnvrn->StdRhoAir));
                                 ShowContinueError(state,
                                                   format("  Infiltration: {:.6R}  Zone Ventilation: {:.6R}  Mixing (incoming): {:.6R}",
-                                                         state.dataHeatBalFanSys->OAMFL(actualZone) / rhoZone,
-                                                         state.dataHeatBalFanSys->VAMFL(actualZone) / rhoZone,
-                                                         state.dataHeatBalFanSys->MixingMassFlowZone(actualZone) / rhoZone));
+                                                         state.dataHeatBalFanSys->OAMFL(zoneNum) / rhoZone,
+                                                         state.dataHeatBalFanSys->VAMFL(zoneNum) / rhoZone,
+                                                         state.dataHeatBalFanSys->MixingMassFlowZone(zoneNum) / rhoZone));
                                 ShowContinueError(
                                     state,
                                     format("  Imbalance (excess outflow): {:.6R}  Total system OA flow (for all airloops serving this zone): {:.6R}",
@@ -4944,8 +4892,6 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
     Real64 CpAir;             // Air heat capacity [J/kg-K]
     Real64 TempRetAir;        // Return air temperature [C]
     Real64 TempZoneAir;       // Zone air temperature [C]
-    int ZoneNum;              // Controlled zone number
-    int ActualZoneNum;        // Zone number
     int ZoneNode;             // Node number of controlled zone
     int ReturnNode;           // Node number of controlled zone's return air
     int ReturnNodeExhaustNum; // Asscoaited exhaust node number, corresponding to the return node
@@ -4959,22 +4905,21 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
     Real64 ZoneMult;          // zone multiplier
     Real64 SumRetAirLatentGainRate;
 
-    for (ZoneNum = 1; ZoneNum <= state.dataGlobal->NumOfZones; ++ZoneNum) {
+    for (int ZoneNum = 1; ZoneNum <= state.dataGlobal->NumOfZones; ++ZoneNum) {
         if (!state.dataZoneEquip->ZoneEquipConfig(ZoneNum).IsControlled) continue;
-        ActualZoneNum = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ActualZoneNum;
         // A return air system may not exist for certain systems; Therefore when no return node exists
         // there is no update.  Of course if there is no return air system then you cannot update
         // the energy for the return air heat gain from the lights statements.
         if (state.dataZoneEquip->ZoneEquipConfig(ZoneNum).NumReturnNodes == 0) continue;
         ZoneNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneNode;
-        ZoneMult = state.dataHeatBal->Zone(ActualZoneNum).Multiplier * state.dataHeatBal->Zone(ActualZoneNum).ListMultiplier;
+        ZoneMult = state.dataHeatBal->Zone(ZoneNum).Multiplier * state.dataHeatBal->Zone(ZoneNum).ListMultiplier;
         for (int nodeCount = 1; nodeCount <= state.dataZoneEquip->ZoneEquipConfig(ZoneNum).NumReturnNodes; ++nodeCount) {
             ReturnNode = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ReturnNode(nodeCount);
             ReturnNodeExhaustNum = state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ReturnNodeExhaustNodeNum(nodeCount);
 
             // RETURN AIR HEAT GAIN from the Lights statement; this heat gain is stored in
             // Add sensible heat gain from refrigerated cases with under case returns
-            QRetAir = SumAllReturnAirConvectionGains(state, ActualZoneNum, ReturnNode);
+            QRetAir = SumAllReturnAirConvectionGains(state, ZoneNum, ReturnNode);
 
             // Need to add the energy to the return air from lights and from airflow windows. Where the heat
             // is added depends on if there is system flow or not.  If there is system flow the heat is added
@@ -4988,8 +4933,8 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
 
             // user defined room air model may feed temp that differs from zone node
             if (allocated(state.dataRoomAirMod->AirPatternZoneInfo)) {
-                if ((state.dataRoomAirMod->AirPatternZoneInfo(ActualZoneNum).IsUsed) && (!state.dataGlobal->BeginEnvrnFlag)) {
-                    TempZoneAir = state.dataRoomAirMod->AirPatternZoneInfo(ActualZoneNum).Tleaving;
+                if ((state.dataRoomAirMod->AirPatternZoneInfo(ZoneNum).IsUsed) && (!state.dataGlobal->BeginEnvrnFlag)) {
+                    TempZoneAir = state.dataRoomAirMod->AirPatternZoneInfo(ZoneNum).Tleaving;
                     TempRetAir = TempZoneAir;
                 } else {
                     TempZoneAir = state.dataLoopNodes->Node(ZoneNode).Temp;
@@ -5005,7 +4950,7 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
             WinGapFlowTtoRA = 0.0;
 
             if (state.dataZoneEquip->ZoneEquipConfig(ZoneNum).ZoneHasAirFlowWindowReturn) {
-                for (SurfNum = state.dataHeatBal->Zone(ActualZoneNum).HTSurfaceFirst; SurfNum <= state.dataHeatBal->Zone(ActualZoneNum).HTSurfaceLast;
+                for (SurfNum = state.dataHeatBal->Zone(ZoneNum).HTSurfaceFirst; SurfNum <= state.dataHeatBal->Zone(ZoneNum).HTSurfaceLast;
                      ++SurfNum) {
                     if (state.dataSurface->SurfWinAirflowThisTS(SurfNum) > 0.0 &&
                         state.dataSurface->SurfWinAirflowDestination(SurfNum) == AirFlowWindow_Destination_ReturnAir) {
@@ -5023,7 +4968,7 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
             // the flag NoHeatToReturnAir is TRUE if the system is zonal only or is central with on/off air flow. In these
             // cases the heat to return air is treated as a zone heat gain and dealt with in CalcZoneSums in
             // MODULE ZoneTempPredictorCorrector.
-            if (!state.dataHeatBal->Zone(ActualZoneNum).NoHeatToReturnAir) {
+            if (!state.dataHeatBal->Zone(ZoneNum).NoHeatToReturnAir) {
                 CpAir = PsyCpAirFnW(state.dataLoopNodes->Node(ZoneNode).HumRat);
                 if (MassFlowRA > 0.0) {
                     if (WinGapFlowToRA > 0.0) {
@@ -5034,8 +4979,7 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
                             // All of return air comes from flow through airflow windows
                             TempRetAir = WinGapTtoRA;
                             // Put heat from window airflow that exceeds return air flow into zone air
-                            state.dataHeatBalFanSys->SysDepZoneLoads(ActualZoneNum) +=
-                                (WinGapFlowToRA - MassFlowRA) * CpAir * (WinGapTtoRA - TempZoneAir);
+                            state.dataHeatBalFanSys->SysDepZoneLoads(ZoneNum) += (WinGapFlowToRA - MassFlowRA) * CpAir * (WinGapTtoRA - TempZoneAir);
                         }
                     }
                     // Add heat-to-return from lights
@@ -5043,12 +4987,12 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
                     if (TempRetAir > RetTempMax) {
                         state.dataLoopNodes->Node(ReturnNode).Temp = RetTempMax;
                         if (!state.dataGlobal->ZoneSizingCalc) {
-                            state.dataHeatBalFanSys->SysDepZoneLoads(ActualZoneNum) += CpAir * MassFlowRA * (TempRetAir - RetTempMax);
+                            state.dataHeatBalFanSys->SysDepZoneLoads(ZoneNum) += CpAir * MassFlowRA * (TempRetAir - RetTempMax);
                         }
                     } else if (TempRetAir < RetTempMin) {
                         state.dataLoopNodes->Node(ReturnNode).Temp = RetTempMin;
                         if (!state.dataGlobal->ZoneSizingCalc) {
-                            state.dataHeatBalFanSys->SysDepZoneLoads(ActualZoneNum) += CpAir * MassFlowRA * (TempRetAir - RetTempMin);
+                            state.dataHeatBalFanSys->SysDepZoneLoads(ZoneNum) += CpAir * MassFlowRA * (TempRetAir - RetTempMin);
                         }
                     } else {
                         state.dataLoopNodes->Node(ReturnNode).Temp = TempRetAir;
@@ -5063,9 +5007,9 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
                 } else { // No return air flow
                     // Assign all heat-to-return from window gap airflow to zone air
                     if (WinGapFlowToRA > 0.0)
-                        state.dataHeatBalFanSys->SysDepZoneLoads(ActualZoneNum) += WinGapFlowToRA * CpAir * (WinGapTtoRA - TempZoneAir);
+                        state.dataHeatBalFanSys->SysDepZoneLoads(ZoneNum) += WinGapFlowToRA * CpAir * (WinGapTtoRA - TempZoneAir);
                     // Assign all heat-to-return from lights to zone air
-                    if (QRetAir > 0.0) state.dataHeatBalFanSys->SysDepZoneLoads(ActualZoneNum) += QRetAir;
+                    if (QRetAir > 0.0) state.dataHeatBalFanSys->SysDepZoneLoads(ZoneNum) += QRetAir;
                     state.dataLoopNodes->Node(ReturnNode).Temp = state.dataLoopNodes->Node(ZoneNode).Temp;
                 }
             } else {
@@ -5077,7 +5021,7 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
             state.dataLoopNodes->Node(ReturnNode).Press = state.dataLoopNodes->Node(ZoneNode).Press;
 
             // Include impact of under case returns for refrigerated display case when updating the return air node humidity
-            if (!state.dataHeatBal->Zone(ActualZoneNum).NoHeatToReturnAir) {
+            if (!state.dataHeatBal->Zone(ZoneNum).NoHeatToReturnAir) {
                 if (MassFlowRA > 0) {
                     SumRetAirLatentGainRate = SumAllReturnAirLatentGains(state, ZoneNum, ReturnNode);
                     H2OHtOfVap = PsyHgAirFnWTdb(state.dataLoopNodes->Node(ZoneNode).HumRat, state.dataLoopNodes->Node(ReturnNode).Temp);
@@ -5086,19 +5030,18 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
                 } else {
                     // If no mass flow rate exists, include the latent HVAC case credit with the latent Zone case credit
                     state.dataLoopNodes->Node(ReturnNode).HumRat = state.dataLoopNodes->Node(ZoneNode).HumRat;
-                    state.dataHeatBal->RefrigCaseCredit(ActualZoneNum).LatCaseCreditToZone +=
-                        state.dataHeatBal->RefrigCaseCredit(ActualZoneNum).LatCaseCreditToHVAC;
+                    state.dataHeatBal->RefrigCaseCredit(ZoneNum).LatCaseCreditToZone +=
+                        state.dataHeatBal->RefrigCaseCredit(ZoneNum).LatCaseCreditToHVAC;
                     // shouldn't the HVAC term be zeroed out then?
                     SumRetAirLatentGainRate = SumAllReturnAirLatentGains(state, ZoneNum, ReturnNode);
-                    state.dataHeatBalFanSys->ZoneLatentGain(ActualZoneNum) += SumRetAirLatentGainRate;
+                    state.dataHeatBalFanSys->ZoneLatentGain(ZoneNum) += SumRetAirLatentGainRate;
                 }
             } else {
                 state.dataLoopNodes->Node(ReturnNode).HumRat = state.dataLoopNodes->Node(ZoneNode).HumRat;
-                state.dataHeatBal->RefrigCaseCredit(ActualZoneNum).LatCaseCreditToZone +=
-                    state.dataHeatBal->RefrigCaseCredit(ActualZoneNum).LatCaseCreditToHVAC;
+                state.dataHeatBal->RefrigCaseCredit(ZoneNum).LatCaseCreditToZone += state.dataHeatBal->RefrigCaseCredit(ZoneNum).LatCaseCreditToHVAC;
                 // shouldn't the HVAC term be zeroed out then?
                 SumRetAirLatentGainRate = SumAllReturnAirLatentGains(state, ZoneNum, ReturnNode);
-                state.dataHeatBalFanSys->ZoneLatentGain(ActualZoneNum) += SumRetAirLatentGainRate;
+                state.dataHeatBalFanSys->ZoneLatentGain(ZoneNum) += SumRetAirLatentGainRate;
             }
 
             state.dataLoopNodes->Node(ReturnNode).Enthalpy =
@@ -5112,7 +5055,7 @@ void CalcZoneLeavingConditions(EnergyPlusData &state, bool const FirstHVACIterat
         } // End of check for a return air node, which implies a return air system.
 
         // Reset current deadband flags, remaining output required, so no impact beyond zone equipment
-        InitSystemOutputRequired(state, ActualZoneNum, FirstHVACIteration, true);
+        InitSystemOutputRequired(state, ZoneNum, FirstHVACIteration, true);
     }
 }
 

--- a/src/EnergyPlus/ZoneEquipmentManager.hh
+++ b/src/EnergyPlus/ZoneEquipmentManager.hh
@@ -95,11 +95,11 @@ namespace ZoneEquipmentManager {
 
     void SimZoneEquipment(EnergyPlusData &state, bool FirstHVACIteration, bool &SimAir);
 
-    void SetZoneEquipSimOrder(EnergyPlusData &state, int ControlledZoneNum, int ActualZoneNum);
+    void SetZoneEquipSimOrder(EnergyPlusData &state, int ControlledZoneNum);
 
     void InitSystemOutputRequired(EnergyPlusData &state, int ZoneNum, bool FirstHVACIteration, bool ResetSimOrder = false);
 
-    void DistributeSystemOutputRequired(EnergyPlusData &state, int ActualZoneNum, bool FirstHVACIteration);
+    void DistributeSystemOutputRequired(EnergyPlusData &state, int ZoneNum, bool FirstHVACIteration);
 
     void UpdateSystemOutputRequired(EnergyPlusData &state,
                                     int ZoneNum,

--- a/tst/EnergyPlus/unit/AirTerminalSingleDuct.unit.cc
+++ b/tst/EnergyPlus/unit/AirTerminalSingleDuct.unit.cc
@@ -638,7 +638,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctVAVReheat_NormalActionTest)
     int constexpr SysNum(1);
     int const InletNode = state->dataSingleDuct->sd_airterminal(SysNum).InletNodeNum;
     int const OutletNode = state->dataSingleDuct->sd_airterminal(SysNum).OutletNodeNum;
-    int const ZonePtr = state->dataSingleDuct->sd_airterminal(SysNum).ActualZoneNum;
+    int const ZonePtr = state->dataSingleDuct->sd_airterminal(SysNum).CtrlZoneNum;
     int const ZoneAirNodeNum = thisZoneEquip.ZoneNode;
     state->dataScheduleMgr->Schedule(state->dataSingleDuct->sd_airterminal(SysNum).SchedPtr).CurrentValue = 1.0; // unit is always available
 
@@ -1767,7 +1767,7 @@ TEST_F(EnergyPlusFixture, VAVHeatCoolReheatAirTerminal_ZoneOAVolumeFlowRateTest)
 
     int ZoneNodeNum = 1;
     int InletNodeNum = thisHeatCoolAT.InletNodeNum;
-    state->dataZoneEquip->ZoneEquipConfig(thisHeatCoolAT.ActualZoneNum).InletNodeAirLoopNum(thisHeatCoolAT.CtrlZoneInNodeIndex) = 1;
+    state->dataZoneEquip->ZoneEquipConfig(thisHeatCoolAT.CtrlZoneNum).InletNodeAirLoopNum(thisHeatCoolAT.CtrlZoneInNodeIndex) = 1;
     // set heating zone and AT unit inlet conditions
     state->dataLoopNodes->Node(ZoneNodeNum).Temp = 20.0;
     state->dataLoopNodes->Node(ZoneNodeNum).HumRat = 0.005;

--- a/tst/EnergyPlus/unit/AirTerminalSingleDuctConstantVolumeNoReheat.unit.cc
+++ b/tst/EnergyPlus/unit/AirTerminalSingleDuctConstantVolumeNoReheat.unit.cc
@@ -332,7 +332,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_Sim)
 
     int constexpr SysNum(1);
     int const InletNode = state->dataSingleDuct->sd_airterminal(SysNum).InletNodeNum;
-    int const ZonePtr = state->dataSingleDuct->sd_airterminal(SysNum).ActualZoneNum;
+    int const ZonePtr = state->dataSingleDuct->sd_airterminal(SysNum).CtrlZoneNum;
     int const ZoneAirNodeNum = state->dataZoneEquip->ZoneEquipConfig(ZonePtr).ZoneNode;
     state->dataScheduleMgr->Schedule(state->dataSingleDuct->sd_airterminal(SysNum).SchedPtr).CurrentValue = 1.0; // unit is always available
 
@@ -524,7 +524,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_OASpecification)
 
     int constexpr SysNum(1);
     int const InletNode = state->dataSingleDuct->sd_airterminal(SysNum).InletNodeNum;
-    int const ZonePtr = state->dataSingleDuct->sd_airterminal(SysNum).ActualZoneNum;
+    int const ZonePtr = state->dataSingleDuct->sd_airterminal(SysNum).CtrlZoneNum;
     int const ZoneAirNodeNum = state->dataZoneEquip->ZoneEquipConfig(ZonePtr).ZoneNode;
 
     // design maximum air mass flow rate
@@ -707,7 +707,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_EMSOverrideAirFlow)
 
     int constexpr SysNum(1);
     int const InletNode = state->dataSingleDuct->sd_airterminal(SysNum).InletNodeNum;
-    int const ZonePtr = state->dataSingleDuct->sd_airterminal(SysNum).ActualZoneNum;
+    int const ZonePtr = state->dataSingleDuct->sd_airterminal(SysNum).CtrlZoneNum;
     int const ZoneAirNodeNum = state->dataZoneEquip->ZoneEquipConfig(ZonePtr).ZoneNode;
     state->dataScheduleMgr->Schedule(state->dataSingleDuct->sd_airterminal(SysNum).SchedPtr).CurrentValue = 1.0; // unit is always available
     // design maximum air mass flow rate
@@ -905,7 +905,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_OAVolumeFlowRateReport
     auto &thisAirLoop = state->dataAirLoop->AirLoopFlow(1);
 
     int const InletNode = thisAirTerminal.InletNodeNum;
-    int const ZonePtr = thisAirTerminal.ActualZoneNum;
+    int const ZonePtr = thisAirTerminal.CtrlZoneNum;
     int const ZoneAirNodeNum = state->dataZoneEquip->ZoneEquipConfig(ZonePtr).ZoneNode;
     state->dataZoneEquip->ZoneEquipConfig(ZonePtr).InletNodeAirLoopNum(1) = 1;
     thisAirTerminal.AirLoopNum = state->dataZoneEquip->ZoneEquipConfig(ZonePtr).InletNodeAirLoopNum(1);
@@ -1080,7 +1080,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_SimSensibleOutPutTest)
 
     int const InletNode = thisAirTerminal.InletNodeNum;
     int const OutletNode = thisAirTerminal.OutletNodeNum;
-    int const ZonePtr = thisAirTerminal.ActualZoneNum;
+    int const ZonePtr = thisAirTerminal.CtrlZoneNum;
     int const ZoneAirNodeNum = state->dataZoneEquip->ZoneEquipConfig(ZonePtr).ZoneNode;
 
     state->dataScheduleMgr->Schedule(thisAirTerminal.SchedPtr).CurrentValue = 1.0; // unit is always available
@@ -1113,7 +1113,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_SimSensibleOutPutTest)
     Real64 NonAirSysOutput = 0.0;
     Real64 LatOutputProvided = 0.0;
     // run single duct simulation
-    SimZoneAirLoopEquipment(*state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZonePtr, ZonePtr);
+    SimZoneAirLoopEquipment(*state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZonePtr);
     // check AT air mass flow rates
     EXPECT_EQ(MassFlowRateMaxAvail, thisAirTerminal.AirMassFlowRateMax);         // design maximum mass flow rate
     EXPECT_EQ(0.0, thisAirTerminal.sd_airterminalInlet.AirMassFlowRateMaxAvail); // maximum available mass flow rate
@@ -1128,7 +1128,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_SimSensibleOutPutTest)
     Real64 SensHeatRateProvided =
         MassFlowRateMaxAvail * CpAir * (state->dataLoopNodes->Node(OutletNode).Temp - state->dataLoopNodes->Node(ZoneAirNodeNum).Temp);
     // run SimulateSingleDuct() function
-    SimZoneAirLoopEquipment(*state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZonePtr, ZonePtr);
+    SimZoneAirLoopEquipment(*state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZonePtr);
     // check air terminal unit air mass flow rates and delivered sensible heating rate
     EXPECT_EQ(MassFlowRateMaxAvail, thisAirTerminal.sd_airterminalInlet.AirMassFlowRate);
     EXPECT_EQ(MassFlowRateMaxAvail, thisAirTerminal.sd_airterminalOutlet.AirMassFlowRate);
@@ -1161,7 +1161,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_SimSensibleOutPutTest)
     NonAirSysOutput = 0.0;
     LatOutputProvided = 0.0;
     // run single duct simulation
-    SimZoneAirLoopEquipment(*state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZonePtr, ZonePtr);
+    SimZoneAirLoopEquipment(*state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZonePtr);
     // check AT air mass flow rates
     EXPECT_EQ(MassFlowRateMaxAvail, thisAirTerminal.AirMassFlowRateMax);         // design maximum mass flow rate
     EXPECT_EQ(0.0, thisAirTerminal.sd_airterminalInlet.AirMassFlowRateMaxAvail); // maximum available mass flow rate
@@ -1177,7 +1177,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_SimSensibleOutPutTest)
     Real64 SensCoolRateProvided =
         MassFlowRateMaxAvail * CpAir * (state->dataLoopNodes->Node(OutletNode).Temp - state->dataLoopNodes->Node(ZoneAirNodeNum).Temp);
     // run SimulateSingleDuct() function
-    SimZoneAirLoopEquipment(*state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZonePtr, ZonePtr);
+    SimZoneAirLoopEquipment(*state, AirDistUnitNum, SysOutputProvided, NonAirSysOutput, LatOutputProvided, FirstHVACIteration, ZonePtr);
     // check air terminal unit air mass flow rates and delivered sensible cooling rate
     EXPECT_EQ(MassFlowRateMaxAvail, thisAirTerminal.sd_airterminalInlet.AirMassFlowRate);
     EXPECT_EQ(MassFlowRateMaxAvail, thisAirTerminal.sd_airterminalOutlet.AirMassFlowRate);

--- a/tst/EnergyPlus/unit/AirTerminalSingleDuctMixer.unit.cc
+++ b/tst/EnergyPlus/unit/AirTerminalSingleDuctMixer.unit.cc
@@ -7762,9 +7762,9 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctMixer_SimFCU_ATMInletSideTest)
     QUnitOut = 0.0;
     QLatOut = 0.0;
 
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
     EXPECT_EQ(state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRateMinAvail, 0.0); // check init value
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     SecondaryAirMassFlowRate = state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRate - PrimaryAirMassFlowRate;
     // check results in heating mode operation
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
@@ -7806,9 +7806,9 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctMixer_SimFCU_ATMInletSideTest)
     QZnReq = zoneSysEnergyDemand.RemainingOutputRequired;
     QUnitOut = 0.0;
     QLatOut = 0.0;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
     EXPECT_EQ(state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRateMinAvail, 0.0); // check init value
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     SecondaryAirMassFlowRate = state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRate - PrimaryAirMassFlowRate;
     // check results in cooling mode operation
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
@@ -8197,8 +8197,8 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctMixer_FCU_NightCycleTest)
     QZnReq = zoneSysEnergyDemand.RemainingOutputRequired;
     QUnitOut = 0.0;
     QLatOut = 0.0;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // check results when the fan coil unit is not available
     EXPECT_NEAR(0.0, QUnitOut, 0.1); // fan coil unit is off
     EXPECT_NEAR(thisFanCoil.PLR, 0.0, 0.00001);
@@ -8224,8 +8224,8 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctMixer_FCU_NightCycleTest)
         state->dataHVACGlobal->ZoneCompTurnFansOn = true;
         state->dataHVACGlobal->ZoneCompTurnFansOff = false;
     }
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     EXPECT_NEAR(QZnReq, QUnitOut, 3.0);
     EXPECT_NEAR(thisFanCoil.PLR, 0.187, 0.001);
     EXPECT_NEAR(state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRate,

--- a/tst/EnergyPlus/unit/AirflowNetworkHVAC.unit.cc
+++ b/tst/EnergyPlus/unit/AirflowNetworkHVAC.unit.cc
@@ -6138,7 +6138,6 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_CheckMultiZoneNodes_NoZoneNode)
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "ATTIC ZONE";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
@@ -6217,7 +6216,6 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_CheckMultiZoneNodes_NoInletNode)
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "ATTIC ZONE";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
@@ -10687,7 +10685,6 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_TestNoZoneEqpSupportZoneERV)
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "ZONE 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
@@ -10869,7 +10866,6 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_TestZoneEqpSupportZoneERV)
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "ZONE 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
@@ -11038,7 +11034,6 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_TestZoneEqpSupportUnbalancedZoneERV)
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "ZONE 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
@@ -11218,7 +11213,6 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_TestNoZoneEqpSupportHPWH)
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "ZONE 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
@@ -11357,7 +11351,6 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_TestZoneEqpSupportHPWH)
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "ZONE 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
@@ -11487,11 +11480,9 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_TestZoneEqpSupportHPWHZoneAndOA)
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "ZONE 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
-    state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
 
     // One AirflowNetwork:MultiZone:Zone object
     state->afn->AirflowNetworkNumOfZones = 1;

--- a/tst/EnergyPlus/unit/BaseboardElectric.unit.cc
+++ b/tst/EnergyPlus/unit/BaseboardElectric.unit.cc
@@ -95,7 +95,7 @@ TEST_F(EnergyPlusFixture, ExerciseBaseboardElectric)
     int zoneNum = 1;
     Real64 powerMet = 0.0;
     int compIndex = 0;
-    BaseboardElectric::SimElectricBaseboard(*state, "ZONE1BASEBOARD", zoneNum, zoneNum, powerMet, compIndex);
+    BaseboardElectric::SimElectricBaseboard(*state, "ZONE1BASEBOARD", zoneNum, powerMet, compIndex);
 }
 
 } // namespace EnergyPlus

--- a/tst/EnergyPlus/unit/DOASEffectOnZoneSizing.unit.cc
+++ b/tst/EnergyPlus/unit/DOASEffectOnZoneSizing.unit.cc
@@ -176,8 +176,8 @@ TEST_F(EnergyPlusFixture, DOASEffectOnZoneSizing_SizeZoneEquipment)
     state->dataSize->CurOverallSimDay = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(2).IsControlled = true;
-    state->dataSize->CalcZoneSizing(1, 1).ActualZoneNum = 1;
-    state->dataSize->CalcZoneSizing(1, 2).ActualZoneNum = 2;
+    state->dataSize->CalcZoneSizing(1, 1).ZoneNum = 1;
+    state->dataSize->CalcZoneSizing(1, 2).ZoneNum = 2;
     state->dataSize->CalcZoneSizing(1, 1).AccountForDOAS = true;
     state->dataSize->CalcZoneSizing(1, 2).AccountForDOAS = true;
     state->dataSize->CurOverallSimDay = 1;
@@ -211,8 +211,6 @@ TEST_F(EnergyPlusFixture, DOASEffectOnZoneSizing_SizeZoneEquipment)
     state->dataZoneEquip->ZoneEquipConfig(2).ExhaustNode(1) = 8;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
     state->dataZoneEquip->ZoneEquipConfig(2).NumReturnNodes = 0;
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
-    state->dataZoneEquip->ZoneEquipConfig(2).ActualZoneNum = 2;
     state->dataSize->CalcZoneSizing(state->dataSize->CurOverallSimDay, 1).DOASHighSetpoint = 14.4;
     state->dataSize->CalcZoneSizing(state->dataSize->CurOverallSimDay, 1).DOASLowSetpoint = 12.2;
     state->dataSize->CalcZoneSizing(state->dataSize->CurOverallSimDay, 2).DOASHighSetpoint = 14.4;

--- a/tst/EnergyPlus/unit/DataZoneEquipment.unit.cc
+++ b/tst/EnergyPlus/unit/DataZoneEquipment.unit.cc
@@ -71,17 +71,17 @@ TEST_F(EnergyPlusFixture, DataZoneEquipment_TestGetSystemNodeNumberForZone)
     state->dataZoneEquip->ZoneEquipConfig.allocate(state->dataGlobal->NumOfZones);
 
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
+    state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
 
     state->dataZoneEquip->ZoneEquipConfig(2).ZoneName = "Zone2";
-    state->dataZoneEquip->ZoneEquipConfig(2).ActualZoneNum = 2;
     state->dataZoneEquip->ZoneEquipConfig(2).ZoneNode = 2;
+    state->dataZoneEquip->ZoneEquipConfig(2).IsControlled = true;
 
     state->dataZoneEquip->ZoneEquipInputsFilled = true;
 
-    EXPECT_EQ(0, GetSystemNodeNumberForZone(*state, "NonExistingZone"));
-    EXPECT_EQ(1, GetSystemNodeNumberForZone(*state, "Zone1"));
+    EXPECT_EQ(0, GetSystemNodeNumberForZone(*state, 0));
+    EXPECT_EQ(1, GetSystemNodeNumberForZone(*state, 1));
 
     state->dataZoneEquip->ZoneEquipConfig.deallocate();
 }

--- a/tst/EnergyPlus/unit/DualDuct.unit.cc
+++ b/tst/EnergyPlus/unit/DualDuct.unit.cc
@@ -98,12 +98,10 @@ TEST_F(EnergyPlusFixture, TestDualDuctOAMassFlowRateUsingStdRhoAir)
     state->dataDualDuct->dd_airterminal(1).CtrlZoneNum = 1;
     state->dataDualDuct->dd_airterminal(1).OARequirementsPtr = 1;
     state->dataDualDuct->dd_airterminal(1).NoOAFlowInputFromUser = false;
-    state->dataDualDuct->dd_airterminal(1).ActualZoneNum = 1;
     state->dataDualDuct->dd_airterminal(1).AirLoopNum = 1;
     state->dataDualDuct->dd_airterminal(2).CtrlZoneNum = 1;
     state->dataDualDuct->dd_airterminal(2).NoOAFlowInputFromUser = false;
     state->dataDualDuct->dd_airterminal(2).OARequirementsPtr = 1;
-    state->dataDualDuct->dd_airterminal(2).ActualZoneNum = 1;
     state->dataDualDuct->dd_airterminal(2).AirLoopNum = 1;
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);

--- a/tst/EnergyPlus/unit/FanCoilUnits.unit.cc
+++ b/tst/EnergyPlus/unit/FanCoilUnits.unit.cc
@@ -1069,7 +1069,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilHeatingTest)
     UpdateScheduleValues(*state);
 
     // Normal heating simulation for fan coil with constant fan, variable water flow
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     // expect inlet and outlet node air mass flow rates are equal
     EXPECT_EQ(state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirInNode).MassFlowRate,
@@ -1078,7 +1078,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilHeatingTest)
     state->dataPlnt->PlantLoop(1).LoopSide(DataPlant::LoopSideLocation::Demand).FlowLock = DataPlant::FlowLock::Locked;
     state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).HeatCoilFluidInletNode).MassFlowRate = 0.2;
     // Simulate with flow lock on and locked flow > demand flow; bypass extra flow
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     EXPECT_NEAR(55.31, state->dataLoopNodes->Node(10).Temp, 0.1);
     // expect inlet and outlet node air mass flow rates are equal
@@ -1086,7 +1086,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilHeatingTest)
               state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirOutNode).MassFlowRate);
     // heating simulation with flow lock on and locked flow < flow required for load; use locked flow
     state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).HeatCoilFluidInletNode).MassFlowRate = 0.05;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(3780.0, QUnitOut, 5.0);
     // expect inlet and outlet node air mass flow rates are equal
     EXPECT_EQ(state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirInNode).MassFlowRate,
@@ -1095,7 +1095,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilHeatingTest)
     QZnReq = 5000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 5000.00;
     state->dataPlnt->PlantLoop(1).LoopSide(DataPlant::LoopSideLocation::Demand).FlowLock = DataPlant::FlowLock::Unlocked;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(4420.0, QUnitOut, 5.0);
     // expect inlet and outlet node air mass flow rates are equal
     EXPECT_EQ(state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirInNode).MassFlowRate,
@@ -1105,7 +1105,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilHeatingTest)
     QZnReq = 80.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 80.00;
     state->dataPlnt->PlantLoop(1).LoopSide(DataPlant::LoopSideLocation::Demand).FlowLock = DataPlant::FlowLock::Unlocked;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     // FC hits the 80 W target load
     EXPECT_NEAR(80.0, QUnitOut, 1.0);
     EXPECT_NEAR(75.0, state->dataFanCoilUnits->FanCoil(1).QUnitOutNoHC, 1.0);
@@ -1120,7 +1120,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilHeatingTest)
     state->dataLoopNodes->Node(state->dataMixedAir->OAMixer(1).RetNode).Temp =
         25.0; // change inlet air condition so off capacity will change to see if QUnitOutNoHC remains fixed
     state->dataLoopNodes->Node(state->dataMixedAir->OAMixer(1).RetNode).Enthalpy = 39000;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     // FC does not hit the 80 W target load since flow is locked at a low value
     EXPECT_NEAR(52.0, QUnitOut, 1.0);
     // off coil capacity is same as just prior to flow being locked
@@ -1133,7 +1133,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilHeatingTest)
 
     // Coil Off Capacity Test #3 - unlock plant flow to ensure that water flow rate would have been different had flow not been locked
     state->dataPlnt->PlantLoop(1).LoopSide(DataPlant::LoopSideLocation::Demand).FlowLock = DataPlant::FlowLock::Unlocked;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     // FC hits the 80 W target load
     EXPECT_NEAR(80.0, QUnitOut, 1.0);
     // actual coil off output when inlet air temp = 25 C and h = 39000 J/kg
@@ -1152,7 +1152,6 @@ TEST_F(EnergyPlusFixture, ElectricCoilFanCoilHeatingTest)
 
     int FanCoilNum(1);
     int ZoneNum(1);
-    int ControlledZoneNum(1);
     bool FirstHVACIteration(true);
     bool ErrorsFound(false);
     Real64 QZnReq(0.0);
@@ -1440,7 +1439,7 @@ TEST_F(EnergyPlusFixture, ElectricCoilFanCoilHeatingTest)
     UpdateScheduleValues(*state);
 
     // Normal heating simulation for fan coil with constant fan, electric heating
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     // expect inlet and outlet node air mass flow rates are equal
     EXPECT_EQ(state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirInNode).MassFlowRate,
@@ -1448,7 +1447,7 @@ TEST_F(EnergyPlusFixture, ElectricCoilFanCoilHeatingTest)
     // normal heating, heating capacity exceeded
     QZnReq = 5000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 5000.00;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(4575.0, QUnitOut, 5.0);
     // expect inlet and outlet node air mass flow rates are equal
     EXPECT_EQ(state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirInNode).MassFlowRate,
@@ -1796,7 +1795,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilCoolingTest)
     state->dataEnvrn->DayOfYear_Schedule = General::OrdinalDay(state->dataEnvrn->Month, state->dataEnvrn->DayOfMonth, 1);
     UpdateScheduleValues(*state);
     // normal cooling simulation for constant fan variable flow fan coil
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     // expect inlet and outlet node air mass flow rates are equal
     EXPECT_EQ(state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirInNode).MassFlowRate,
@@ -1806,7 +1805,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilCoolingTest)
     state->dataPlnt->PlantLoop(2).LoopSide(DataPlant::LoopSideLocation::Demand).FlowLock = DataPlant::FlowLock::Locked;
     state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).CoolCoilFluidInletNode).MassFlowRate = 0.2;
     // cooling simulation with flow lock on and locked flow > flow that meets load; bypass extra flow
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     EXPECT_NEAR(10.86, state->dataLoopNodes->Node(13).Temp, 0.1);
     // expect inlet and outlet node air mass flow rates are equal
@@ -1815,7 +1814,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilCoolingTest)
 
     // cooling simulation with flow lock on and locked flow < flow required for load; use locked flow
     state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).CoolCoilFluidInletNode).MassFlowRate = 0.05;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(-3000.0, QUnitOut, 5.0);
     // expect inlet and outlet node air mass flow rates are equal
     EXPECT_EQ(state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirInNode).MassFlowRate,
@@ -1825,7 +1824,7 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilCoolingTest)
     QZnReq = -5000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -5000.00;
     state->dataPlnt->PlantLoop(2).LoopSide(DataPlant::LoopSideLocation::Demand).FlowLock = DataPlant::FlowLock::Unlocked;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
     EXPECT_NEAR(-4420.0, QUnitOut, 5.0);
     // expect inlet and outlet node air mass flow rates are equal
     EXPECT_EQ(state->dataLoopNodes->Node(state->dataFanCoilUnits->FanCoil(1).AirInNode).MassFlowRate,
@@ -2165,8 +2164,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ASHRAE90VariableFan)
     state->dataEnvrn->StdRhoAir = 1.2;
 
     state->dataGlobal->BeginEnvrnFlag = true;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
 
     // expect full flow and meet capacity
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
@@ -2178,7 +2177,7 @@ TEST_F(EnergyPlusFixture, FanCoil_ASHRAE90VariableFan)
     // expect minimum flow and meet capacity
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 1000.0;
     QZnReq = 1000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     EXPECT_NEAR(state->dataLoopNodes->Node(1).MassFlowRate,
                 state->dataFanCoilUnits->FanCoil(1).MaxAirMassFlow * state->dataFanCoilUnits->FanCoil(1).LowSpeedRatio,
@@ -2190,7 +2189,7 @@ TEST_F(EnergyPlusFixture, FanCoil_ASHRAE90VariableFan)
     // expect modulated flow and meet capacity
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 2500.0;
     QZnReq = 2500.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     EXPECT_GT(state->dataLoopNodes->Node(1).MassFlowRate,
               state->dataFanCoilUnits->FanCoil(1).MaxAirMassFlow * state->dataFanCoilUnits->FanCoil(1).LowSpeedRatio);
@@ -2203,7 +2202,7 @@ TEST_F(EnergyPlusFixture, FanCoil_ASHRAE90VariableFan)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = -5000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -4000.0;
     QZnReq = -4000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     EXPECT_NEAR(state->dataLoopNodes->Node(1).MassFlowRate, state->dataFanCoilUnits->FanCoil(1).MaxAirMassFlow, 0.0000000001);
     // expect inlet and outlet node air mass flow rates are equal
@@ -2214,7 +2213,7 @@ TEST_F(EnergyPlusFixture, FanCoil_ASHRAE90VariableFan)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = -5000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -4255.0;
     QZnReq = -4255.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     EXPECT_NEAR(state->dataLoopNodes->Node(1).MassFlowRate, state->dataFanCoilUnits->FanCoil(1).MaxAirMassFlow, 0.0000000001);
     // expect inlet and outlet node air mass flow rates are equal
@@ -2224,7 +2223,7 @@ TEST_F(EnergyPlusFixture, FanCoil_ASHRAE90VariableFan)
     // expect minimum flow and meet capacity
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -1000.0;
     QZnReq = -1000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     EXPECT_NEAR(state->dataLoopNodes->Node(1).MassFlowRate,
                 state->dataFanCoilUnits->FanCoil(1).MaxAirMassFlow * state->dataFanCoilUnits->FanCoil(1).LowSpeedRatio,
@@ -2236,7 +2235,7 @@ TEST_F(EnergyPlusFixture, FanCoil_ASHRAE90VariableFan)
     // expect modulated flow and meet capacity
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -2500.0;
     QZnReq = -2500.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
     EXPECT_GT(state->dataLoopNodes->Node(1).MassFlowRate,
               state->dataFanCoilUnits->FanCoil(1).MaxAirMassFlow * state->dataFanCoilUnits->FanCoil(1).LowSpeedRatio);
@@ -2907,8 +2906,8 @@ TEST_F(EnergyPlusFixture, FanCoil_CyclingFanMode)
     state->dataEnvrn->StdRhoAir = 1.2;
 
     state->dataGlobal->BeginEnvrnFlag = true;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 3 and near full air and water flow and meet capacity
     EXPECT_EQ(3, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_GT(state->dataFanCoilUnits->FanCoil(1).PLR, 0.95);
@@ -2922,7 +2921,7 @@ TEST_F(EnergyPlusFixture, FanCoil_CyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 1000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = 1000.0;
     QZnReq = 1000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 1 and moderate air and water flow and meet capacity
     EXPECT_EQ(1, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_GT(state->dataFanCoilUnits->FanCoil(1).PLR, 0.6);
@@ -2938,7 +2937,7 @@ TEST_F(EnergyPlusFixture, FanCoil_CyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 2500.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = 2500.0;
     QZnReq = 2500.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 2 and moderate air and water flow and meet capacity
     EXPECT_EQ(2, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_GT(state->dataFanCoilUnits->FanCoil(1).PLR, 0.8);
@@ -2955,7 +2954,7 @@ TEST_F(EnergyPlusFixture, FanCoil_CyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -4000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = -4000.0;
     QZnReq = -4000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 3 and near full air and water flow and meet capacity
     EXPECT_EQ(3, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_GT(state->dataFanCoilUnits->FanCoil(1).PLR, 0.9);
@@ -2970,7 +2969,7 @@ TEST_F(EnergyPlusFixture, FanCoil_CyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -1000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = -1000.0;
     QZnReq = -1000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 1 and moderate air and water flow and meet capacity
     EXPECT_EQ(1, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_GT(state->dataFanCoilUnits->FanCoil(1).PLR, 0.5);
@@ -2986,7 +2985,7 @@ TEST_F(EnergyPlusFixture, FanCoil_CyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -2500.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = -2500.0;
     QZnReq = -2500.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 2 and moderate air and water flow and meet capacity
     EXPECT_EQ(2, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_GT(state->dataFanCoilUnits->FanCoil(1).PLR, 0.75);
@@ -3336,8 +3335,8 @@ TEST_F(EnergyPlusFixture, FanCoil_FanSystemModelCyclingFanMode)
     state->dataEnvrn->StdRhoAir = 1.2;
 
     state->dataGlobal->BeginEnvrnFlag = true;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 3 and near full air and water flow and meet capacity
     EXPECT_EQ(thisFanCoil.SpeedFanSel, 3);
     EXPECT_NEAR(thisFanCoil.PLR, 0.961, 0.001);
@@ -3348,7 +3347,7 @@ TEST_F(EnergyPlusFixture, FanCoil_FanSystemModelCyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 1000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = 1000.0;
     QZnReq = 1000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 1 and moderate air and water flow and meet capacity
     EXPECT_EQ(thisFanCoil.SpeedFanSel, 1);
     EXPECT_NEAR(thisFanCoil.PLR, 0.632, 0.001);
@@ -3359,7 +3358,7 @@ TEST_F(EnergyPlusFixture, FanCoil_FanSystemModelCyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToHeatSP = 2500.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = 2500.0;
     QZnReq = 2500.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 2 and moderate air and water flow and meet capacity
     EXPECT_EQ(thisFanCoil.SpeedFanSel, 2);
     EXPECT_NEAR(thisFanCoil.PLR, 0.850, 0.001);
@@ -3373,7 +3372,7 @@ TEST_F(EnergyPlusFixture, FanCoil_FanSystemModelCyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -4000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = -4000.0;
     QZnReq = -4000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 3 and near full air and water flow and meet capacity
     EXPECT_EQ(3, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_NEAR(state->dataFanCoilUnits->FanCoil(1).PLR, 0.950, 0.001);
@@ -3384,7 +3383,7 @@ TEST_F(EnergyPlusFixture, FanCoil_FanSystemModelCyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -1000.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = -1000.0;
     QZnReq = -1000.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 1 and moderate air and water flow and meet capacity
     EXPECT_EQ(1, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_NEAR(state->dataFanCoilUnits->FanCoil(1).PLR, 0.501, 0.001);
@@ -3395,7 +3394,7 @@ TEST_F(EnergyPlusFixture, FanCoil_FanSystemModelCyclingFanMode)
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputReqToCoolSP = -2500.0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).RemainingOutputRequired = -2500.0;
     QZnReq = -2500.0;
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect fan speed 2 and moderate air and water flow and meet capacity
     EXPECT_EQ(2, state->dataFanCoilUnits->FanCoil(1).SpeedFanSel);
     EXPECT_NEAR(state->dataFanCoilUnits->FanCoil(1).PLR, 0.756, 0.001);
@@ -3706,8 +3705,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElecHeatCoilMultiSpeedFanCyclingFanMode)
     QUnitOut = 0.0;
     QLatOut = 0.0;
     state->dataGlobal->BeginEnvrnFlag = true;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     Real64 expectedAirFlowRate = thisFanCoil.PLR * thisFanCoil.MaxAirMassFlow * thisFanCoil.LowSpeedRatio;
     // expect fan speed 1 and fan and coil cycling to meet load
     EXPECT_EQ(thisFanCoil.SpeedFanSel, 1);
@@ -3723,8 +3722,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElecHeatCoilMultiSpeedFanCyclingFanMode)
     QZnReq = 4000.0;
     QUnitOut = 0.0;
     QLatOut = 0.0;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     expectedAirFlowRate = (1.0 - thisFanCoil.SpeedRatio) * (thisFanCoil.LowSpeedRatio * thisFanCoil.MaxAirMassFlow) +
                           thisFanCoil.SpeedRatio * (thisFanCoil.MedSpeedRatio * thisFanCoil.MaxAirMassFlow);
     // expect fan speed 2 and fan and fancoil cycling b/n speed 1 and 2
@@ -3741,8 +3740,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElecHeatCoilMultiSpeedFanCyclingFanMode)
     QZnReq = 8000.0;
     QUnitOut = 0.0;
     QLatOut = 0.0;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     expectedAirFlowRate = (1.0 - thisFanCoil.SpeedRatio) * (thisFanCoil.MedSpeedRatio * thisFanCoil.MaxAirMassFlow) +
                           thisFanCoil.SpeedRatio * (1.0 * thisFanCoil.MaxAirMassFlow);
     // expect fan speed 3 and fan and fancoil cycling b/n speed 2 and 3
@@ -3759,8 +3758,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElecHeatCoilMultiSpeedFanCyclingFanMode)
     QZnReq = 10200;
     QUnitOut = 0.0;
     QLatOut = 0.0;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     expectedAirFlowRate = thisFanCoil.MaxAirMassFlow;
     // expect fan speed 3 and fancoil running at max speed
     EXPECT_EQ(thisFanCoil.SpeedFanSel, 3);
@@ -4073,8 +4072,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElecHeatCoilMultiSpeedFanContFanMode)
     QUnitOut = 0.0;
     QLatOut = 0.0;
     state->dataGlobal->BeginEnvrnFlag = true;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     Real64 expectedAirFlowRate = thisFanCoil.MaxAirMassFlow * thisFanCoil.LowSpeedRatio;
     // expect fan speed 1, fan runs continuously and only heating coil cycle on/off to meet load
     EXPECT_EQ(thisFanCoil.SpeedFanSel, 1);
@@ -4090,8 +4089,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElecHeatCoilMultiSpeedFanContFanMode)
     QZnReq = 4000.0;
     QUnitOut = 0.0;
     QLatOut = 0.0;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     expectedAirFlowRate = (1.0 - thisFanCoil.SpeedRatio) * (thisFanCoil.LowSpeedRatio * thisFanCoil.MaxAirMassFlow) +
                           thisFanCoil.SpeedRatio * (thisFanCoil.MedSpeedRatio * thisFanCoil.MaxAirMassFlow);
     // expect fan speed 2 and fan and fancoil cycling b/n speed 1 and 2
@@ -4108,8 +4107,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElecHeatCoilMultiSpeedFanContFanMode)
     QZnReq = 8000.0;
     QUnitOut = 0.0;
     QLatOut = 0.0;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     expectedAirFlowRate = (1.0 - thisFanCoil.SpeedRatio) * (thisFanCoil.MedSpeedRatio * thisFanCoil.MaxAirMassFlow) +
                           thisFanCoil.SpeedRatio * (1.0 * thisFanCoil.MaxAirMassFlow);
     // expect fan speed 3 and fan and fancoil cycling b/n speed 2 and 3
@@ -4126,8 +4125,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElecHeatCoilMultiSpeedFanContFanMode)
     QZnReq = 10200;
     QUnitOut = 0.0;
     QLatOut = 0.0;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     expectedAirFlowRate = thisFanCoil.MaxAirMassFlow;
     // expect fan speed 3 and fancoil running at max speed
     EXPECT_EQ(thisFanCoil.SpeedFanSel, 3);
@@ -4439,8 +4438,8 @@ TEST_F(EnergyPlusFixture, FanCoil_CalcFanCoilElecHeatCoilPLRResidual)
     int InletNode = thisFanCoil.AirInNode;
     Real64 QUnitOutMaxLS = 0.0; // low speed maximum output
 
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
 
     state->dataFanCoilUnits->FanCoil(FanCoilNum).SpeedFanSel = 1;
     state->dataFanCoilUnits->FanCoil(FanCoilNum).SpeedFanRatSel = state->dataFanCoilUnits->FanCoil(FanCoilNum).LowSpeedRatio;
@@ -4740,8 +4739,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElectricHeatingCoilASHRAE90VariableFan)
     QUnitOut = 0.0;
     QLatOut = 0.0;
     state->dataGlobal->BeginEnvrnFlag = true;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect output full capacity
     EXPECT_EQ(state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRate, thisFanCoil.MaxAirMassFlow);
     EXPECT_EQ(thisFanCoil.PLR, 1.0);
@@ -4755,8 +4754,8 @@ TEST_F(EnergyPlusFixture, FanCoil_ElectricHeatingCoilASHRAE90VariableFan)
     QUnitOut = 0.0;
     QLatOut = 0.0;
     state->dataGlobal->BeginEnvrnFlag = true;
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // expect part load operation with about 3000W output
     EXPECT_NEAR(state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRate, thisFanCoil.MaxAirMassFlow, 0.00001);
     EXPECT_NEAR(thisFanCoil.PLR, 0.487, 0.001);

--- a/tst/EnergyPlus/unit/FanCoilUnits.unit.cc
+++ b/tst/EnergyPlus/unit/FanCoilUnits.unit.cc
@@ -744,7 +744,6 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilHeatingTest)
 
     int FanCoilNum(1);
     int ZoneNum(1);
-    int ControlledZoneNum(1);
     bool FirstHVACIteration(true);
     bool ErrorsFound(false);
     Real64 QZnReq(0.0);
@@ -1468,7 +1467,6 @@ TEST_F(EnergyPlusFixture, ConstantFanVariableFlowFanCoilCoolingTest)
 
     int FanCoilNum(1);
     int ZoneNum(1);
-    int ControlledZoneNum(1);
     bool FirstHVACIteration(true);
     bool ErrorsFound(false);
     Real64 QZnReq(0.0);

--- a/tst/EnergyPlus/unit/HVACDXSystem.unit.cc
+++ b/tst/EnergyPlus/unit/HVACDXSystem.unit.cc
@@ -537,6 +537,7 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_RHControl)
     state->dataZoneEquip->ZoneEquipConfig(1).NumExhaustNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ExhaustNode.allocate(1);
+    state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
 
     state->dataHVACGlobal->NumPrimaryAirSys = 1;
     state->dataAirSystemsData->PrimaryAirSystems.allocate(1);
@@ -720,6 +721,7 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_LatentDegradation_Test)
     state->dataZoneEquip->ZoneEquipConfig(1).NumExhaustNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ExhaustNode.allocate(1);
+    state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
 
     state->dataHVACGlobal->NumPrimaryAirSys = 1;
     state->dataAirSystemsData->PrimaryAirSystems.allocate(1);
@@ -987,6 +989,7 @@ TEST_F(EnergyPlusFixture, NewDXCoilModel_RHControl)
     state->dataZoneEquip->ZoneEquipConfig(1).NumExhaustNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ExhaustNode.allocate(1);
+    state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
 
     state->dataHVACGlobal->NumPrimaryAirSys = 1;
     state->dataAirSystemsData->PrimaryAirSystems.allocate(1);

--- a/tst/EnergyPlus/unit/HVACStandaloneERV.unit.cc
+++ b/tst/EnergyPlus/unit/HVACStandaloneERV.unit.cc
@@ -110,7 +110,6 @@ TEST_F(EnergyPlusFixture, HVACStandAloneERV_Test1)
     state->dataEnvrn->StdRhoAir = 1.0;
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     state->dataHeatBal->Zone.allocate(1);
     state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;
@@ -222,7 +221,6 @@ TEST_F(EnergyPlusFixture, HVACStandAloneERV_Test2)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     state->dataHeatBal->Zone.allocate(1);
     state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;

--- a/tst/EnergyPlus/unit/HVACUnitaryBypassVAV.unit.cc
+++ b/tst/EnergyPlus/unit/HVACUnitaryBypassVAV.unit.cc
@@ -109,7 +109,6 @@ protected:
         state->dataZoneEquip->NumOfZoneEquipLists = 1;
         state->dataHeatBal->Zone(1).IsControlled = true;
         state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
-        state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
         state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "EAST ZONE";
         state->dataZoneEquip->ZoneEquipConfig(1).EquipListName = "ZONEEQUIPMENT";
         state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 20;
@@ -117,8 +116,7 @@ protected:
         state->dataZoneEquip->ZoneEquipConfig(1).ReturnNode.allocate(1);
         state->dataZoneEquip->ZoneEquipConfig(1).ReturnNode(1) = 21;
         state->dataZoneEquip->ZoneEquipConfig(1).FixedReturnFlow.allocate(1);
-        state->dataHeatBal->Zone(state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum).SystemZoneNodeNumber =
-            state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode;
+        state->dataHeatBal->Zone(1).SystemZoneNodeNumber = state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode;
         state->dataZoneEquip->ZoneEquipConfig(1).ReturnFlowSchedPtrNum = DataGlobalConstants::ScheduleAlwaysOn;
         state->dataZoneEquip->ZoneEquipList(1).Name = "ZONEEQUIPMENT";
         int maxEquipCount = 1;
@@ -190,8 +188,8 @@ protected:
         cbvav.Name = "CBVAVAirLoop";
         cbvav.UnitType = "AirLoopHVAC:UnitaryHeatCool:VAVChangeoverBypass";
         cbvav.SchedPtr = -1;
-        cbvav.ActualZoneNodeNum.allocate(1);
-        cbvav.ActualZoneNodeNum(1) = 1;
+        cbvav.ZoneNodeNum.allocate(1);
+        cbvav.ZoneNodeNum(1) = 1;
         cbvav.DXCoolCoilIndexNum = 1;
         state->dataDXCoils->DXCoil.allocate(1);
         state->dataDXCoils->DXCoilNumericFields.allocate(1);
@@ -681,7 +679,6 @@ TEST_F(EnergyPlusFixture, UnitaryBypassVAV_GetInputZoneEquipment)
     auto &cbvav(state->dataHVACUnitaryBypassVAV->CBVAV(CBVAVNum));
     // should be the second zone in the zone list as well as actual zone number
     EXPECT_EQ(2, cbvav.ControlledZoneNum(CBVAVNum));
-    EXPECT_EQ(2, cbvav.ActualZoneNum(CBVAVNum));
     // reflects sequence number in ZoneHVAC:EquipmentList
     EXPECT_EQ(1, cbvav.ZoneSequenceCoolingNum(cbvav.ZoneSequenceCoolingNum(zoneIndex)));
     EXPECT_EQ(1, cbvav.ZoneSequenceHeatingNum(cbvav.ZoneSequenceHeatingNum(zoneIndex)));

--- a/tst/EnergyPlus/unit/HVACUnitaryBypassVAV.unit.cc
+++ b/tst/EnergyPlus/unit/HVACUnitaryBypassVAV.unit.cc
@@ -188,8 +188,8 @@ protected:
         cbvav.Name = "CBVAVAirLoop";
         cbvav.UnitType = "AirLoopHVAC:UnitaryHeatCool:VAVChangeoverBypass";
         cbvav.SchedPtr = -1;
-        cbvav.ZoneNodeNum.allocate(1);
-        cbvav.ZoneNodeNum(1) = 1;
+        cbvav.ControlledZoneNodeNum.allocate(1);
+        cbvav.ControlledZoneNodeNum(1) = 1;
         cbvav.DXCoolCoilIndexNum = 1;
         state->dataDXCoils->DXCoil.allocate(1);
         state->dataDXCoils->DXCoilNumericFields.allocate(1);

--- a/tst/EnergyPlus/unit/HVACVariableRefrigerantFlow.unit.cc
+++ b/tst/EnergyPlus/unit/HVACVariableRefrigerantFlow.unit.cc
@@ -228,7 +228,6 @@ protected:
 
         auto &thisZoneEqConfig(state->dataZoneEquip->ZoneEquipConfig(zoneNum));
         thisZoneEqConfig.IsControlled = true;
-        thisZoneEqConfig.ActualZoneNum = 1;
         thisZoneEqConfig.ZoneName = "ZONE1";
         thisZoneEqConfig.EquipListName = "ZONE1EQUIPMENT";
         thisZoneEqConfig.ZoneNode = zoneNode;

--- a/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
@@ -482,7 +482,6 @@ TEST_F(EnergyPlusFixture, HeatBalanceManager_ZoneAirMassFlowConservationData2)
     state->dataZoneEquip->ZoneEquipConfig.allocate(state->dataGlobal->NumOfZones);
 
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).NumExhaustNodes = 1;
@@ -509,7 +508,6 @@ TEST_F(EnergyPlusFixture, HeatBalanceManager_ZoneAirMassFlowConservationData2)
     state->dataZoneEquip->ZoneEquipConfig(1).ReturnNodeInletNum(1) = 1;
 
     state->dataZoneEquip->ZoneEquipConfig(2).ZoneName = "Zone 2";
-    state->dataZoneEquip->ZoneEquipConfig(2).ActualZoneNum = 2;
     state->dataZoneEquip->ZoneEquipConfig(2).NumExhaustNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(2).ExhaustNode.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(2).NumInletNodes = 1;
@@ -1228,7 +1226,6 @@ TEST_F(EnergyPlusFixture, HeatBalanceManager_TestZonePropertyLocalEnv)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "LIVING ZONE";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     std::vector<int> controlledZoneEquipConfigNums;
     controlledZoneEquipConfigNums.push_back(1);
     state->dataHeatBal->Zone(1).IsControlled = true;

--- a/tst/EnergyPlus/unit/HeatBalanceSurfaceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceSurfaceManager.unit.cc
@@ -739,9 +739,7 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfTempCalcHeatBalanceI
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "LIVING ZONE";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataHeatBal->Zone(1).IsControlled = true;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode(1) = 1;
@@ -1299,11 +1297,9 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfTempCalcHeatBalanceI
     EXPECT_FALSE(has_err_output(true));
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     std::vector<int> controlledZoneEquipConfigNums;
     controlledZoneEquipConfigNums.push_back(1);
     state->dataHeatBal->Zone(1).IsControlled = true;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode(1) = 1;
@@ -1828,7 +1824,6 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfPropertyLocalEnv)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "LIVING ZONE";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     std::vector<int> controlledZoneEquipConfigNums;
     controlledZoneEquipConfigNums.push_back(1);
     state->dataHeatBal->Zone(1).IsControlled = true;
@@ -2408,7 +2403,6 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfPropertySrdSurfLWR)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "LIVING ZONE";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     std::vector<int> controlledZoneEquipConfigNums;
     controlledZoneEquipConfigNums.push_back(1);
     state->dataHeatBal->Zone(1).IsControlled = true;
@@ -2984,11 +2978,9 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfTempCalcHeatBalanceA
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "LIVING ZONE";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     std::vector<int> controlledZoneEquipConfigNums;
     controlledZoneEquipConfigNums.push_back(1);
     state->dataHeatBal->Zone(1).IsControlled = true;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode(1) = 1;
@@ -4687,9 +4679,7 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestTDDSurfWinHeatGain)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(2);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Daylit Zone";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataHeatBal->Zone(1).IsControlled = true;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode(1) = 1;
@@ -4702,9 +4692,7 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestTDDSurfWinHeatGain)
     state->dataZoneEquip->ZoneEquipConfig(1).ReturnNode(1) = 4;
     state->dataZoneEquip->ZoneEquipConfig(1).FixedReturnFlow.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(2).ZoneName = "Daylit Attic Zone";
-    state->dataZoneEquip->ZoneEquipConfig(2).ActualZoneNum = 2;
     state->dataHeatBal->Zone(2).IsControlled = true;
-    state->dataHeatBal->Zone(2).ZoneEqNum = 2;
     state->dataZoneEquip->ZoneEquipConfig(2).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(2).InletNode.allocate(2);
     state->dataZoneEquip->ZoneEquipConfig(2).InletNode(1) = 6;
@@ -5830,7 +5818,6 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfPropertySurfToGndLWR
     auto &zoneEquipConfig = state->dataZoneEquip->ZoneEquipConfig(1);
 
     zoneEquipConfig.ZoneName = "LIVING ZONE";
-    zoneEquipConfig.ActualZoneNum = 1;
     zoneEquipConfig.NumInletNodes = 2;
     zoneEquipConfig.InletNode.allocate(2);
     zoneEquipConfig.InletNode(1) = 1;
@@ -7076,7 +7063,6 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfPropertyViewFactorsR
     auto &zoneEquipConfig = state->dataZoneEquip->ZoneEquipConfig(1);
 
     zoneEquipConfig.ZoneName = "LIVING ZONE";
-    zoneEquipConfig.ActualZoneNum = 1;
     zoneEquipConfig.NumInletNodes = 2;
     zoneEquipConfig.InletNode.allocate(2);
     zoneEquipConfig.InletNode(1) = 1;

--- a/tst/EnergyPlus/unit/HybridModel.unit.cc
+++ b/tst/EnergyPlus/unit/HybridModel.unit.cc
@@ -176,7 +176,6 @@ TEST_F(EnergyPlusFixture, HybridModel_CorrectZoneAirTempTest)
     state->dataRoomAirMod->ZoneDVMixedFlag.allocate(1);
     state->dataHeatBal->ZnAirRpt.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataHeatBal->ZoneIntGain.allocate(1);
     state->dataSize->ZoneEqSizing.allocate(1);
 
@@ -240,7 +239,6 @@ TEST_F(EnergyPlusFixture, HybridModel_CorrectZoneAirTempTest)
     state->dataZonePlenum->NumZoneReturnPlenums = 0;
     state->dataZonePlenum->NumZoneSupplyPlenums = 0;
     state->dataHeatBal->Zone(1).IsControlled = true;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataHeatBal->Zone(1).Multiplier = 1;
     state->dataHeatBal->Zone(1).SystemZoneNodeNumber = 1;
     state->dataHeatBal->Zone(1).HTSurfaceFirst = 0; // No HT surface here.
@@ -677,7 +675,6 @@ TEST_F(EnergyPlusFixture, HybridModel_CorrectZoneContaminantsTest)
     state->dataRoomAirMod->ZoneDVMixedFlag.allocate(1);
     state->dataHeatBal->ZnAirRpt.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataSize->ZoneEqSizing.allocate(1);
 
     // CorrectZoneContaminants variable initialization
@@ -730,7 +727,6 @@ TEST_F(EnergyPlusFixture, HybridModel_CorrectZoneContaminantsTest)
     state->dataZonePlenum->NumZoneReturnPlenums = 0;
     state->dataZonePlenum->NumZoneSupplyPlenums = 0;
     state->dataHeatBal->Zone(1).IsControlled = true;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataHeatBal->Zone(1).Multiplier = 1;
     state->dataHeatBal->Zone(1).SystemZoneNodeNumber = 1;
     state->dataHeatBal->Zone(1).HTSurfaceFirst = 0;

--- a/tst/EnergyPlus/unit/MixedAir.unit.cc
+++ b/tst/EnergyPlus/unit/MixedAir.unit.cc
@@ -1513,7 +1513,6 @@ TEST_F(EnergyPlusFixture, MixedAir_MissingHIghRHControlInputTest)
     state->dataHeatBal->Zone(1).Name = "ZONE1";
     state->dataGlobal->NumOfZones = 1;
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNodeAirLoopNum.allocate(1);
@@ -1647,7 +1646,6 @@ TEST_F(EnergyPlusFixture, MixedAir_HIghRHControlTest)
     state->dataHeatBal->Zone(1).Name = "ZONE1";
     state->dataGlobal->NumOfZones = 1;
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNodeAirLoopNum.allocate(1);

--- a/tst/EnergyPlus/unit/PurchasedAirManager.unit.cc
+++ b/tst/EnergyPlus/unit/PurchasedAirManager.unit.cc
@@ -834,11 +834,11 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_EMSOverrideTest)
     state->dataLoopNodes->Node(2).Temp = 25.0;
     state->dataLoopNodes->Node(2).HumRat = 0.001;
 
-    InitPurchasedAir(*state, 1, FirstHVACIteration, 1, 1);
+    InitPurchasedAir(*state, 1, 1);
     Real64 SysOutputProvided;
     Real64 MoistOutputProvided;
 
-    CalcPurchAirLoads(*state, 1, SysOutputProvided, MoistOutputProvided, 1, 1);
+    CalcPurchAirLoads(*state, 1, SysOutputProvided, MoistOutputProvided, 1);
 
     EXPECT_EQ(state->dataPurchasedAirMgr->PurchAir(1).EMSValueMassFlowRate, 0.0);
     EXPECT_EQ(state->dataPurchasedAirMgr->PurchAir(1).EMSValueSupplyTemp, 0.0);
@@ -931,11 +931,11 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_NoCapacityTest)
         state->dataPurchasedAirMgr->GetPurchAirInputFlag = false;
     }
 
-    InitPurchasedAir(*state, 1, FirstHVACIteration, 1, 1);
+    InitPurchasedAir(*state, 1, 1);
     Real64 SysOutputProvided;
     Real64 MoistOutputProvided;
 
-    CalcPurchAirLoads(*state, 1, SysOutputProvided, MoistOutputProvided, 1, 1);
+    CalcPurchAirLoads(*state, 1, SysOutputProvided, MoistOutputProvided, 1);
 
     EXPECT_EQ(SysOutputProvided, 0.0);
     // #8365 Supply air mass flow rate should be zero during heating mode when capacity is limited to zero
@@ -1094,7 +1094,7 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_EMSOverrideTest_Revised)
     state->dataLoopNodes->Node(2).Temp = 25.0;
     state->dataLoopNodes->Node(2).HumRat = 0.001;
 
-    InitPurchasedAir(*state, 1, FirstHVACIteration, 1, 1);
+    InitPurchasedAir(*state, 1, 1);
     Real64 SysOutputProvided;
     Real64 MoistOutputProvided;
 
@@ -1105,7 +1105,7 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_EMSOverrideTest_Revised)
     state->dataPurchasedAirMgr->PurchAir(1).OutdoorAirNodeNum = 2;
     state->dataPurchasedAirMgr->PurchAir(1).ZoneRecircAirNodeNum = 1;
 
-    CalcPurchAirLoads(*state, 1, SysOutputProvided, MoistOutputProvided, 1, 1);
+    CalcPurchAirLoads(*state, 1, SysOutputProvided, MoistOutputProvided, 1);
 
     EXPECT_EQ(state->dataPurchasedAirMgr->PurchAir(1).EMSValueSupplyTemp, 18.0);
     EXPECT_EQ(state->dataPurchasedAirMgr->PurchAir(1).EMSValueSupplyHumRat, 0.01);
@@ -1267,7 +1267,7 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_EMSOverrideTest_Revised_ZeroFlow)
     state->dataLoopNodes->Node(2).Temp = 25.0;
     state->dataLoopNodes->Node(2).HumRat = 0.001;
 
-    InitPurchasedAir(*state, 1, FirstHVACIteration, 1, 1);
+    InitPurchasedAir(*state, 1, 1);
     Real64 SysOutputProvided;
     Real64 MoistOutputProvided;
 
@@ -1278,7 +1278,7 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_EMSOverrideTest_Revised_ZeroFlow)
     state->dataPurchasedAirMgr->PurchAir(1).OutdoorAirNodeNum = 2;
     state->dataPurchasedAirMgr->PurchAir(1).ZoneRecircAirNodeNum = 1;
 
-    CalcPurchAirLoads(*state, 1, SysOutputProvided, MoistOutputProvided, 1, 1);
+    CalcPurchAirLoads(*state, 1, SysOutputProvided, MoistOutputProvided, 1);
 
     EXPECT_EQ(SysOutputProvided, 0.0);
     EXPECT_EQ(MoistOutputProvided, 0.0);

--- a/tst/EnergyPlus/unit/PurchasedAirManager.unit.cc
+++ b/tst/EnergyPlus/unit/PurchasedAirManager.unit.cc
@@ -822,8 +822,6 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_EMSOverrideTest)
     EMSManager::GetEMSInput(*state);
     state->dataEMSMgr->FinishProcessingUserInput = true;
 
-    bool FirstHVACIteration(true);
-
     if (state->dataPurchasedAirMgr->GetPurchAirInputFlag) {
         GetPurchasedAir(*state);
         state->dataPurchasedAirMgr->GetPurchAirInputFlag = false;
@@ -1080,8 +1078,6 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_EMSOverrideTest_Revised)
 
     state->dataEMSMgr->FinishProcessingUserInput = true;
 
-    bool FirstHVACIteration(true);
-
     if (state->dataPurchasedAirMgr->GetPurchAirInputFlag) {
         GetPurchasedAir(*state);
         state->dataPurchasedAirMgr->GetPurchAirInputFlag = false;
@@ -1252,8 +1248,6 @@ TEST_F(ZoneIdealLoadsTest, IdealLoads_EMSOverrideTest_Revised_ZeroFlow)
     EMSManager::CheckIfAnyEMS(*state); // get EMS input
 
     state->dataEMSMgr->FinishProcessingUserInput = true;
-
-    bool FirstHVACIteration(true);
 
     if (state->dataPurchasedAirMgr->GetPurchAirInputFlag) {
         GetPurchasedAir(*state);

--- a/tst/EnergyPlus/unit/ReportCoilSelection.unit.cc
+++ b/tst/EnergyPlus/unit/ReportCoilSelection.unit.cc
@@ -463,7 +463,6 @@ TEST_F(EnergyPlusFixture, ReportCoilSelection_ZoneEqCoil)
     state->dataSize->TermUnitFinalZoneSizing(state->dataSize->CurTermUnitSizingNum).DesHeatCoilInTempTU = RatedCoilInDb;
     state->dataSize->TermUnitFinalZoneSizing(state->dataSize->CurTermUnitSizingNum).DesHeatCoilInHumRatTU = RatedCoilInHumRat;
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ZoneName = state->dataHeatBal->Zone(1).Name;
     state->dataSize->FinalZoneSizing.allocate(1);
     state->dataSize->FinalZoneSizing(curZoneEqNum).HeatDesDay = "Heat Design Day";
@@ -708,7 +707,6 @@ TEST_F(EnergyPlusFixture, ReportCoilSelection_ZoneEqCoolingCoil)
     curZoneEqNum = 1;
     state->dataSize->ZoneEqSizing.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(curZoneEqNum).ZoneName = state->dataHeatBal->Zone(1).Name;
     state->dataSize->FinalZoneSizing.allocate(1);
     state->dataSize->FinalZoneSizing(curZoneEqNum).CoolDesDay = "Cool Design Day";

--- a/tst/EnergyPlus/unit/RoomAirflowNetwork.unit.cc
+++ b/tst/EnergyPlus/unit/RoomAirflowNetwork.unit.cc
@@ -248,7 +248,6 @@ TEST_F(RoomAirflowNetworkTest, RAFNTest)
     state->dataZoneEquip->ZoneEquipList(ZoneNum).EquipName(1) = "ZoneHVAC";
 
     state->dataZoneEquip->ZoneEquipConfig(ZoneNum).NumInletNodes = 1;
-    state->dataZoneEquip->ZoneEquipConfig(ZoneNum).ActualZoneNum = ZoneNum;
     state->dataZoneEquip->ZoneEquipConfig(ZoneNum).InletNode.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(ZoneNum).InletNode(1) = 1;
     state->dataLoopNodes->NodeID.allocate(state->dataLoopNodes->NumOfNodes);

--- a/tst/EnergyPlus/unit/SZVAVModel.unit.cc
+++ b/tst/EnergyPlus/unit/SZVAVModel.unit.cc
@@ -734,8 +734,8 @@ TEST_F(EnergyPlusFixture, SZVAV_FanCoilUnit_Testing)
     QUnitOut = 0.0;
     QLatOut = 0.0;
     // init
-    InitFanCoilUnits(*state, FanCoilNum, ZoneNum, ZoneNum);
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
+    InitFanCoilUnits(*state, FanCoilNum, ZoneNum);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, QLatOut);
     // heating mode tests
     CoolingLoad = false;
     HeatingLoad = true;

--- a/tst/EnergyPlus/unit/SingleDuct.unit.cc
+++ b/tst/EnergyPlus/unit/SingleDuct.unit.cc
@@ -1339,7 +1339,6 @@ TEST_F(EnergyPlusFixture, TestOAMassFlowRateUsingStdRhoAir)
 
     state->dataHeatBal->Zone(1).FloorArea = 10.0;
     state->dataSingleDuct->sd_airterminal(1).CtrlZoneNum = 1;
-    state->dataSingleDuct->sd_airterminal(1).ActualZoneNum = 1;
     state->dataSingleDuct->sd_airterminal(1).NoOAFlowInputFromUser = false;
     state->dataSingleDuct->sd_airterminal(1).OARequirementsPtr = 1;
     state->dataSingleDuct->sd_airterminal(1).AirLoopNum = 1;
@@ -2543,7 +2542,6 @@ TEST_F(EnergyPlusFixture, TerminalUnitMixerInitTest)
     state->dataSingleDuct->SysATMixer(ATMixerNum).MixedAirOutNode = 3;
     state->dataSingleDuct->SysATMixer(ATMixerNum).AirLoopNum = 1;
     state->dataSingleDuct->SysATMixer(ATMixerNum).ZoneNum = 1;
-    state->dataSingleDuct->SysATMixer(ATMixerNum).ZoneEqNum = 1;
     state->dataSingleDuct->SysATMixer(ATMixerNum).NoOAFlowInputFromUser = false;
     state->dataSingleDuct->SysATMixer(ATMixerNum).OARequirementsPtr = 1;
 
@@ -2606,7 +2604,6 @@ TEST_F(EnergyPlusFixture, TerminalUnitMixerInitTest2)
     state->dataSingleDuct->SysATMixer(ATMixerNum).MixedAirOutNode = 3;
     state->dataSingleDuct->SysATMixer(ATMixerNum).AirLoopNum = 1;
     state->dataSingleDuct->SysATMixer(ATMixerNum).ZoneNum = 1;
-    state->dataSingleDuct->SysATMixer(ATMixerNum).ZoneEqNum = 1;
     state->dataSingleDuct->SysATMixer(ATMixerNum).NoOAFlowInputFromUser = false;
     state->dataSingleDuct->SysATMixer(ATMixerNum).OARequirementsPtr = 1;
 
@@ -3003,8 +3000,8 @@ TEST_F(EnergyPlusFixture, VAVConstantVolTU_Reheat_Sizing)
     bool FirstHVACIteration = true;
     state->dataSingleDuct->sd_airterminal(SysNum).SimConstVol(*state,
                                                               FirstHVACIteration,
-                                                              state->dataSingleDuct->sd_airterminal(SysNum).ActualZoneNum,
-                                                              state->dataSingleDuct->sd_airterminal(SysNum).CtrlZoneNum);
+                                                              state->dataSingleDuct->sd_airterminal(SysNum).CtrlZoneNum,
+                                                              state->dataSingleDuct->sd_airterminal(SysNum).CtrlZoneInNodeIndex);
     // TermUnitSizing(state.dataSize->CurTermUnitSizingNum).AirVolFlow =
     //     max(state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).NonAirSysDesHeatVolFlow,
     //         this->MaxAirVolFlowRate * this->ZoneTurndownMinAirFrac);

--- a/tst/EnergyPlus/unit/SystemAvailabilityManager.unit.cc
+++ b/tst/EnergyPlus/unit/SystemAvailabilityManager.unit.cc
@@ -276,27 +276,21 @@ TEST_F(EnergyPlusFixture, SysAvailManager_OptimumStart)
     state->dataZoneEquip->ZoneEquipConfig.allocate(state->dataGlobal->NumOfZones);
 
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
 
     state->dataZoneEquip->ZoneEquipConfig(2).ZoneName = "Zone 2";
-    state->dataZoneEquip->ZoneEquipConfig(2).ActualZoneNum = 2;
     state->dataZoneEquip->ZoneEquipConfig(2).ZoneNode = 2;
 
     state->dataZoneEquip->ZoneEquipConfig(3).ZoneName = "Zone 3";
-    state->dataZoneEquip->ZoneEquipConfig(3).ActualZoneNum = 3;
     state->dataZoneEquip->ZoneEquipConfig(3).ZoneNode = 3;
 
     state->dataZoneEquip->ZoneEquipConfig(4).ZoneName = "Zone 4";
-    state->dataZoneEquip->ZoneEquipConfig(4).ActualZoneNum = 4;
     state->dataZoneEquip->ZoneEquipConfig(4).ZoneNode = 4;
 
     state->dataZoneEquip->ZoneEquipConfig(5).ZoneName = "Zone 5";
-    state->dataZoneEquip->ZoneEquipConfig(5).ActualZoneNum = 5;
     state->dataZoneEquip->ZoneEquipConfig(5).ZoneNode = 5;
 
     state->dataZoneEquip->ZoneEquipConfig(6).ZoneName = "Zone 6";
-    state->dataZoneEquip->ZoneEquipConfig(6).ActualZoneNum = 6;
     state->dataZoneEquip->ZoneEquipConfig(6).ZoneNode = 6;
 
     state->dataZoneEquip->ZoneEquipInputsFilled = true;
@@ -466,7 +460,7 @@ TEST_F(EnergyPlusFixture, SysAvailManager_HybridVentilation_OT_CO2Control)
     state->dataHeatBalFanSys->TempZoneThermostatSetPoint.allocate(1);
 
     state->dataSystemAvailabilityManager->HybridVentData(1).Name = "HybridControl";
-    state->dataSystemAvailabilityManager->HybridVentData(1).ActualZoneNum = 1;
+    state->dataSystemAvailabilityManager->HybridVentData(1).ControlledZoneNum = 1;
     state->dataSystemAvailabilityManager->HybridVentData(1).AirLoopNum = 1;
     state->dataSystemAvailabilityManager->HybridVentData(1).ControlModeSchedPtr = 1;
     state->dataSystemAvailabilityManager->HybridVentData(1).UseRainIndicator = false;
@@ -810,7 +804,6 @@ TEST_F(EnergyPlusFixture, SysAvailManager_NightCycleSys_CalcNCycSysAvailMgr)
     state->dataAirLoop->AirToZoneNodeInfo(1).CoolCtrlZoneNums(1) = 1;
     state->dataZoneEquip->ZoneEquipConfig.allocate(state->dataGlobal->NumOfZones);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "SPACE1-1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
 
     state->dataSystemAvailabilityManager->NightCycleData(1).Name = "System Avail";

--- a/tst/EnergyPlus/unit/SystemReports.unit.cc
+++ b/tst/EnergyPlus/unit/SystemReports.unit.cc
@@ -260,7 +260,6 @@ TEST_F(EnergyPlusFixture, ReportMaxVentilationLoads_ZoneEquip)
 
     // Set up controlled zone equipment with just enough info for the ventilation report test
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneDesignSpecOAIndex = 1;
     state->dataHeatBal->Zone(1).Volume = 10.0;
     state->dataZoneEquip->ZoneEquipConfig(1).EquipListIndex = 1;

--- a/tst/EnergyPlus/unit/UnitarySystem.unit.cc
+++ b/tst/EnergyPlus/unit/UnitarySystem.unit.cc
@@ -125,7 +125,6 @@ protected:
         state->dataZoneEquip->NumOfZoneEquipLists = 1;
         state->dataHeatBal->Zone(1).IsControlled = true;
         state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
-        state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
         state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "EAST ZONE";
         state->dataZoneEquip->ZoneEquipConfig(1).EquipListName = "ZONE2EQUIPMENT";
         state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode = 1;
@@ -133,8 +132,7 @@ protected:
         state->dataZoneEquip->ZoneEquipConfig(1).ReturnNode.allocate(1);
         state->dataZoneEquip->ZoneEquipConfig(1).ReturnNode(1) = 21;
         state->dataZoneEquip->ZoneEquipConfig(1).FixedReturnFlow.allocate(1);
-        state->dataHeatBal->Zone(state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum).SystemZoneNodeNumber =
-            state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode;
+        state->dataHeatBal->Zone(1).SystemZoneNodeNumber = state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode;
         state->dataZoneEquip->ZoneEquipConfig(1).ReturnFlowSchedPtrNum = DataGlobalConstants::ScheduleAlwaysOn;
         state->dataZoneEquip->ZoneEquipList(1).Name = "ZONE2EQUIPMENT";
         int maxEquipCount = 1;
@@ -11070,7 +11068,6 @@ TEST_F(EnergyPlusFixture, UnitarySystemModel_MultiSpeedCoils_SingleMode)
     state->dataSize->ZoneEqSizing.deallocate();
     state->dataSize->ZoneEqSizing.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     HeatBalanceManager::GetZoneData(*state, ErrorsFound); // read zone data
     EXPECT_FALSE(ErrorsFound);                            // expect no errors

--- a/tst/EnergyPlus/unit/WaterCoils.unit.cc
+++ b/tst/EnergyPlus/unit/WaterCoils.unit.cc
@@ -1444,7 +1444,6 @@ TEST_F(WaterCoilsTest, FanCoilCoolingWaterFlowTest)
     state->dataSize->PlantSizData(1).DeltaT = 12;
     int FanCoilNum(1);
     int ZoneNum(1);
-    int ControlledZoneNum(1);
     bool FirstHVACIteration(true);
     bool ErrorsFound(false);
     Real64 QZnReq(0.0);
@@ -1778,7 +1777,7 @@ TEST_F(WaterCoilsTest, FanCoilCoolingWaterFlowTest)
     state->dataWaterCoils->WaterCoil(2).MaxWaterVolFlowRate = DataSizing::AutoSize;
 
     // normal cooling simulation for constant fan variable flow fan coil
-    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, ControlledZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
+    Sim4PipeFanCoil(*state, FanCoilNum, ZoneNum, FirstHVACIteration, QUnitOut, LatOutputProvided);
 
     // Expect final design air volume flow rate to equal the user-specified air volume flow rate from the ZoneHVAC:FourPipeFanCoil object
     EXPECT_EQ(state->dataWaterCoils->WaterCoil(2).DesAirVolFlowRate, 0.5);

--- a/tst/EnergyPlus/unit/WindowManager.unit.cc
+++ b/tst/EnergyPlus/unit/WindowManager.unit.cc
@@ -488,8 +488,6 @@ TEST_F(EnergyPlusFixture, WindowManager_RefAirTempTest)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataHeatBal->Zone(1).IsControlled = true;
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
@@ -2756,7 +2754,6 @@ TEST_F(EnergyPlusFixture, WindowManager_SrdLWRTest)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     std::vector<int> controlledZoneEquipConfigNums;
     controlledZoneEquipConfigNums.push_back(1);
 

--- a/tst/EnergyPlus/unit/ZoneContaminantPredictorCorrector.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneContaminantPredictorCorrector.unit.cc
@@ -171,7 +171,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_AddMDotOATest)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
@@ -189,7 +188,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_AddMDotOATest)
 
     state->dataHeatBal->Zone.allocate(1);
     state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataSize->ZoneEqSizing.allocate(1);
     state->dataSize->CurZoneEqNum = 1;
     state->dataHeatBal->Zone(1).Multiplier = 1.0;
@@ -325,7 +323,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_CorrectZoneContamina
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
@@ -343,7 +340,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_CorrectZoneContamina
 
     state->dataHeatBal->Zone.allocate(1);
     state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataSize->ZoneEqSizing.allocate(1);
     state->dataSize->CurZoneEqNum = 1;
     state->dataHeatBal->Zone(1).Multiplier = 1.0;
@@ -474,7 +470,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneCO2ControlT
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(3);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
@@ -489,7 +484,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneCO2ControlT
     state->dataZoneEquip->ZoneEquipConfig(1).FixedReturnFlow.allocate(1);
 
     state->dataZoneEquip->ZoneEquipConfig(2).ZoneName = "Zone 2";
-    state->dataZoneEquip->ZoneEquipConfig(2).ActualZoneNum = 2;
 
     state->dataZoneEquip->ZoneEquipConfig(2).NumInletNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(2).InletNode.allocate(1);
@@ -501,7 +495,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneCO2ControlT
     state->dataZoneEquip->ZoneEquipConfig(2).FixedReturnFlow.allocate(1);
 
     state->dataZoneEquip->ZoneEquipConfig(3).ZoneName = "Zone 3";
-    state->dataZoneEquip->ZoneEquipConfig(3).ActualZoneNum = 3;
 
     state->dataZoneEquip->ZoneEquipConfig(3).NumInletNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(3).InletNode.allocate(1);
@@ -516,7 +509,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneCO2ControlT
 
     state->dataHeatBal->Zone.allocate(3);
     state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataSize->ZoneEqSizing.allocate(3);
     state->dataSize->CurZoneEqNum = 1;
     state->dataHeatBal->Zone(1).Multiplier = 1.0;
@@ -524,13 +516,11 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneCO2ControlT
     state->dataHeatBal->Zone(1).SystemZoneNodeNumber = 5;
     state->dataHeatBal->Zone(1).ZoneVolCapMultpMoist = 1.0;
     state->dataHeatBal->Zone(2).Name = state->dataZoneEquip->ZoneEquipConfig(2).ZoneName;
-    state->dataHeatBal->Zone(2).ZoneEqNum = 1;
     state->dataHeatBal->Zone(2).Multiplier = 1.0;
     state->dataHeatBal->Zone(2).Volume = 1000.0;
     state->dataHeatBal->Zone(2).SystemZoneNodeNumber = 5;
     state->dataHeatBal->Zone(2).ZoneVolCapMultpMoist = 1.0;
     state->dataHeatBal->Zone(3).Name = state->dataZoneEquip->ZoneEquipConfig(3).ZoneName;
-    state->dataHeatBal->Zone(3).ZoneEqNum = 1;
     state->dataHeatBal->Zone(3).Multiplier = 1.0;
     state->dataHeatBal->Zone(3).Volume = 1000.0;
     state->dataHeatBal->Zone(3).SystemZoneNodeNumber = 5;
@@ -679,7 +669,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneGCControlTe
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(3);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
@@ -694,7 +683,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneGCControlTe
     state->dataZoneEquip->ZoneEquipConfig(1).FixedReturnFlow.allocate(1);
 
     state->dataZoneEquip->ZoneEquipConfig(2).ZoneName = "Zone 2";
-    state->dataZoneEquip->ZoneEquipConfig(2).ActualZoneNum = 2;
 
     state->dataZoneEquip->ZoneEquipConfig(2).NumInletNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(2).InletNode.allocate(1);
@@ -706,7 +694,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneGCControlTe
     state->dataZoneEquip->ZoneEquipConfig(2).FixedReturnFlow.allocate(1);
 
     state->dataZoneEquip->ZoneEquipConfig(3).ZoneName = "Zone 3";
-    state->dataZoneEquip->ZoneEquipConfig(3).ActualZoneNum = 3;
 
     state->dataZoneEquip->ZoneEquipConfig(3).NumInletNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(3).InletNode.allocate(1);
@@ -721,7 +708,6 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneGCControlTe
 
     state->dataHeatBal->Zone.allocate(3);
     state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataSize->ZoneEqSizing.allocate(3);
     state->dataSize->CurZoneEqNum = 1;
     state->dataHeatBal->Zone(1).Multiplier = 1.0;
@@ -729,13 +715,11 @@ TEST_F(EnergyPlusFixture, ZoneContaminantPredictorCorrector_MultiZoneGCControlTe
     state->dataHeatBal->Zone(1).SystemZoneNodeNumber = 5;
     state->dataHeatBal->Zone(1).ZoneVolCapMultpMoist = 1.0;
     state->dataHeatBal->Zone(2).Name = state->dataZoneEquip->ZoneEquipConfig(2).ZoneName;
-    state->dataHeatBal->Zone(2).ZoneEqNum = 1;
     state->dataHeatBal->Zone(2).Multiplier = 1.0;
     state->dataHeatBal->Zone(2).Volume = 1000.0;
     state->dataHeatBal->Zone(2).SystemZoneNodeNumber = 5;
     state->dataHeatBal->Zone(2).ZoneVolCapMultpMoist = 1.0;
     state->dataHeatBal->Zone(3).Name = state->dataZoneEquip->ZoneEquipConfig(3).ZoneName;
-    state->dataHeatBal->Zone(3).ZoneEqNum = 1;
     state->dataHeatBal->Zone(3).Multiplier = 1.0;
     state->dataHeatBal->Zone(3).Volume = 1000.0;
     state->dataHeatBal->Zone(3).SystemZoneNodeNumber = 5;

--- a/tst/EnergyPlus/unit/ZoneEquipmentManager.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneEquipmentManager.unit.cc
@@ -1919,7 +1919,7 @@ TEST_F(EnergyPlusFixture, ZoneEquipmentManager_DistributeSequentialLoad_MixedEqu
     // Sequential Test 2 - Heating, FirstHVACIteration = false
     firstHVACIteration = false;
     InitSystemOutputRequired(*state, ZoneNum, firstHVACIteration);
-    SetZoneEquipSimOrder(*state, ZoneNum, ZoneNum);
+    SetZoneEquipSimOrder(*state, ZoneNum);
     DistributeSystemOutputRequired(*state, ZoneNum, firstHVACIteration);
     // Equipment 1 provides 100W of heating
     Real64 SysOutputProvided = 100.0;
@@ -2204,7 +2204,7 @@ TEST_F(EnergyPlusFixture, ZoneEquipmentManager_RezeroZoneSizingArrays)
             thisSizingType.CoolAirDesMethod = 1;
             thisSizingType.HeatAirDesMethod = 1;
             thisSizingType.DOASControlStrategy = 1;
-            thisSizingType.ActualZoneNum = 1;
+            thisSizingType.ZoneNum = 1;
             thisSizingType.TimeStepNumAtHeatMax = 1;
             thisSizingType.TimeStepNumAtCoolMax = 1;
             thisSizingType.HeatDDNum = 1;
@@ -2399,7 +2399,7 @@ TEST_F(EnergyPlusFixture, ZoneEquipmentManager_RezeroZoneSizingArrays)
             thisSizingType2.CoolAirDesMethod = 1;
             thisSizingType2.HeatAirDesMethod = 1;
             thisSizingType2.DOASControlStrategy = 1;
-            thisSizingType2.ActualZoneNum = 1;
+            thisSizingType2.ZoneNum = 1;
             thisSizingType2.TimeStepNumAtHeatMax = 1;
             thisSizingType2.TimeStepNumAtCoolMax = 1;
             thisSizingType2.HeatDDNum = 1;
@@ -4491,7 +4491,6 @@ TEST_F(EnergyPlusFixture, CZoeEquipmentManager_CalcZoneLeavingConditions_Test)
     state->dataHeatBal->space(1).Name = "LIVING ZONE";
     state->dataHeatBal->Zone(1).spaceIndexes.emplace_back(1);
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumExhaustNodes = 1;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).ReturnNode.allocate(state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes);
@@ -4587,7 +4586,7 @@ TEST_F(EnergyPlusFixture, ZoneEquipmentManager_SizeZoneEquipment_NoLoadTest)
     state->dataHeatBalFanSys->ZoneThermostatSetPointLo(1) = 22.;
     state->dataHeatBalFanSys->ZoneThermostatSetPointHi(1) = 24.;
     state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
-    state->dataSize->CalcZoneSizing(1, 1).ActualZoneNum = 1;
+    state->dataSize->CalcZoneSizing(1, 1).ZoneNum = 1;
     state->dataSize->CurOverallSimDay = 1;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).TotalOutputRequired = 0;
     state->dataZoneEnergyDemand->ZoneSysEnergyDemand(1).OutputRequiredToHeatingSP = -3600;
@@ -4604,7 +4603,6 @@ TEST_F(EnergyPlusFixture, ZoneEquipmentManager_SizeZoneEquipment_NoLoadTest)
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode(2) = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).ExhaustNode(1) = 3;
     state->dataZoneEquip->ZoneEquipConfig(1).NumReturnNodes = 0;
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
     state->dataEnvrn->StdBaroPress = 101325.;
     state->dataSize->CalcFinalZoneSizing(1).MinOA = 0.1;
     state->dataSize->CalcFinalZoneSizing(1).OutTempAtHeatPeak = 28;

--- a/tst/EnergyPlus/unit/ZoneHVACEvaporativeCooler.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneHVACEvaporativeCooler.unit.cc
@@ -102,7 +102,6 @@ protected:
         state->dataHeatBalFanSys->ZoneThermostatSetPointHi.allocate(1);
 
         state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "One Zone";
-        state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
         state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 1;
         state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(1);
         state->dataZoneEquip->ZoneEquipConfig(1).InletNode(1) = 3;
@@ -116,11 +115,9 @@ protected:
         state->dataZoneEquip->ZoneEquipConfig(1).IsControlled = true;
 
         state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;
-        state->dataHeatBal->Zone(1).ZoneEqNum = 1;
         state->dataHeatBal->Zone(1).Multiplier = 1.0;
         state->dataHeatBal->Zone(1).Volume = 1000.0;
-        state->dataHeatBal->Zone(state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum).SystemZoneNodeNumber =
-            state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode;
+        state->dataHeatBal->Zone(1).SystemZoneNodeNumber = state->dataZoneEquip->ZoneEquipConfig(1).ZoneNode;
         state->dataHeatBal->Zone(1).ZoneVolCapMultpMoist = 1.0;
 
         state->dataZoneEquip->ZoneEquipList(1).Name = "ZONEHVACEVAPEQUIPMENT";

--- a/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
@@ -105,7 +105,6 @@ TEST_F(EnergyPlusFixture, ZoneTempPredictorCorrector_CorrectZoneHumRatTest)
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
@@ -124,7 +123,6 @@ TEST_F(EnergyPlusFixture, ZoneTempPredictorCorrector_CorrectZoneHumRatTest)
     state->dataHeatBal->Zone.allocate(1);
     state->dataHybridModel->HybridModelZone.allocate(1);
     state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataSize->ZoneEqSizing.allocate(1);
     state->dataSize->CurZoneEqNum = 1;
     state->dataHeatBal->Zone(1).Multiplier = 1.0;
@@ -1002,7 +1000,6 @@ TEST_F(EnergyPlusFixture, ZoneTempPredictorCorrector_CalcZoneSums_SurfConvection
 
     state->dataZoneEquip->ZoneEquipConfig.allocate(1);
     state->dataZoneEquip->ZoneEquipConfig(1).ZoneName = "Zone 1";
-    state->dataZoneEquip->ZoneEquipConfig(1).ActualZoneNum = 1;
 
     state->dataZoneEquip->ZoneEquipConfig(1).NumInletNodes = 2;
     state->dataZoneEquip->ZoneEquipConfig(1).InletNode.allocate(2);
@@ -1018,7 +1015,6 @@ TEST_F(EnergyPlusFixture, ZoneTempPredictorCorrector_CalcZoneSums_SurfConvection
 
     state->dataHeatBal->Zone.allocate(1);
     state->dataHeatBal->Zone(1).Name = state->dataZoneEquip->ZoneEquipConfig(1).ZoneName;
-    state->dataHeatBal->Zone(1).ZoneEqNum = 1;
     state->dataHeatBal->Zone(1).IsControlled = true;
     state->dataSize->ZoneEqSizing.allocate(1);
     state->dataSize->CurZoneEqNum = 1;


### PR DESCRIPTION
Pull request overview
---------------------
Fixes https://github.com/NREL/EnergyPlus/issues/6278

 - Eliminates the duplicate tracking of `ZoneEquipConfig,ActualZoneNum` vs `ControlledZoneNum` vs `Zone.ZoneEqNum`. One can see [here in`GetZoneEquipmentData`](https://github.com/NREL/EnergyPlus/blob/6e02a12bb76472532821e6eab4f22eee748afbc6/src/EnergyPlus/DataZoneEquipment.cc#L324-L327) that all three are set to the same value:
 ```
            Zone(ControlledZoneNum).IsControlled = true;
            Zone(ControlledZoneNum).ZoneEqNum = ControlledZoneNum;
            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).IsControlled = true;
            state.dataZoneEquip->ZoneEquipConfig(ControlledZoneNum).ActualZoneNum = ControlledZoneNum;
```
- Delete `Zone.ZoneEqNum` and  `ZoneEquipConfig,ActualZoneNum`.
- Collapse functions with two zone number arguments down to one. e.g.:
`InitZoneAirLoopEquipment(state, AirDistUnitNum, ControlledZoneNum, ActualZoneNum);` to `InitZoneAirLoopEquipment(state, AirDistUnitNum, ZoneNum);`
- Change various occurrences of `ActualZoneNum` to `ZoneNum` or similar for clarity.
- Remove searches through `ZoneEquipConfg` to find matching control zones during input processing in Furnace and UnitarySystem.
- This is preliminary groundwork for #9394 


### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [x] Perform a Code Review on GitHub
 - [x] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [x] CI status: all green or justified
 - [x] Check that performance is not impacted (CI Linux results include performance check)
 - [x] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
