### PR TITLE
Build EnergyPlus on Ubuntu 22.04

### DIFF
--- a/third_party/Windows-CalcEngine/cmake/WCECompilerFlags.cmake
+++ b/third_party/Windows-CalcEngine/cmake/WCECompilerFlags.cmake
@@ -12,9 +12,9 @@ IF ( CMAKE_COMPILER_IS_GNUCXX OR "x${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" ) 
     ADD_CXX_DEFINITIONS("-pipe") # Faster compiler processing
     # set (CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
     if( MINGW )
-        ADD_CXX_DEFINITIONS("-std=gnu++11") # Enable C++11 features in g++
+        ADD_CXX_DEFINITIONS("-std=gnu++17") # Enable C++17 features in g++
     else()
-        ADD_CXX_DEFINITIONS("-std=c++11") # Enable C++11 features in g++
+        ADD_CXX_DEFINITIONS("-std=c++17") # Enable C++17 features in g++
         ADD_CXX_DEFINITIONS("-fPIC")
     endif()
     ADD_CXX_DEFINITIONS("-pedantic") # Turn on warnings about constructs/situations that may be non-portable or outside of the standard


### PR DESCRIPTION
Pull request overview
---------------------
Soon we'll need to move away from Ubuntu 18.04 (EOL next spring) and add Ubuntu 22.04.  In a random incident, @gibslee found that EnergyPlus hits build issues on a raw 22.04 box, so this PR should start addressing those.  Once I get a successful build locally I'll add 22.04 to our GitHub Actions runners and make sure they are happy before merging this.

This isn't a pressing PR, as technically we could release both 22.2 and 23.1 under the supported Ubuntu 18.04 and 20.04 versions, but it would be nice to get it building on 22.04 at least shortly after 22.2 is released.

I already worked through one issue where Windows Calc Engine was explicitly setting `-std=c++11` and I was getting "std::optional is only available in c++17" errors.  Once I fixed that, I started getting Boost Point is used uninitialized in the Kiva third party code, so that's the next issue.  It feels like gcc 11.2 is quite strict, so there may be a good series of things to get everything building happily.

