### PR TITLE
#Fix 9436 -  TIMESTAMP Column in Custom Monthly Report Tables under both peak heating and peak cooling report has a trailing space

### DIFF
--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -7534,7 +7534,7 @@ void WriteMonthlyTables(EnergyPlusData &state)
                             curConversionFactor *= 3600.0;
                         }
                         columnHead(columnRecount - 1) = ort->MonthlyColumns(curCol).varName + curAggString + " [" + curUnits + ']';
-                        columnHead(columnRecount) = ort->MonthlyColumns(curCol).varName + " {TIMESTAMP} ";
+                        columnHead(columnRecount) = ort->MonthlyColumns(curCol).varName + " {TIMESTAMP}";
                         minVal = storedMaxVal;
                         maxVal = storedMinVal;
                         for (lMonth = 1; lMonth <= 12; ++lMonth) {

--- a/src/EnergyPlus/OutputReportTabularAnnual.cc
+++ b/src/EnergyPlus/OutputReportTabularAnnual.cc
@@ -836,7 +836,7 @@ void AnnualTable::writeTable(EnergyPlusData &state, OutputReportTabular::UnitsSt
             }
             fixUnitsPerSecond(curUnits, curConversionFactor);
             columnHead(columnRecount - 1) = fldStIt->m_colHead + curAggString + " [" + curUnits + ']';
-            columnHead(columnRecount) = fldStIt->m_colHead + " {TIMESTAMP} ";
+            columnHead(columnRecount) = fldStIt->m_colHead + " {TIMESTAMP}";
             minVal = storedMaxVal;
             maxVal = storedMinVal;
             for (unsigned int row = 0; row != m_objectNames.size(); row++) { // loop through by row.

--- a/src/Transition/OutputRulesFiles/OutputChanges22-1-0-to-22-2-0.md
+++ b/src/Transition/OutputRulesFiles/OutputChanges22-1-0-to-22-2-0.md
@@ -100,9 +100,13 @@ The Adaptive Comfort Summary/Report was renamed to match the HTML:
 
 See pull request [#9461](https://github.com/NREL/EnergyPlus/pull/9461) for more details.
 
+### Output:Table:Monthly and Output:Table:Annual
+
+In `Output:Table:Monthly` and `Output:Table:Annual`, variables with an aggregation type such as `Maximum`, `Minimum`, `MaximumDuringHoursShown`, and `MinimumDuringHoursShown` produce an extra `<Variable of Meter Name> {TIMESTAMP}` column that had an extra trailing space in the SQL. That extra trailing space was removed. cf [#9647](https://github.com/NREL/EnergyPlus/pull/9647)
+
 ### Latent Sizing
 
-New report variables were added to identify results associated with latent heat energy transfer. These reports include the zone air system sensible heat ratio (i.e., sensible heat transfer divided by total heat transfer) and zone air vapor pressure difference (i.e., difference of zone air vapor pressure from saturated air vapor pressure at the current temperature). 
+New report variables were added to identify results associated with latent heat energy transfer. These reports include the zone air system sensible heat ratio (i.e., sensible heat transfer divided by total heat transfer) and zone air vapor pressure difference (i.e., difference of zone air vapor pressure from saturated air vapor pressure at the current temperature).
 
     Zone Air System Latent Heating Energy
     Zone Air System Latent Cooling Energy
@@ -110,7 +114,7 @@ New report variables were added to identify results associated with latent heat 
     Zone Air System Latent Cooling Rate
     Zone Air System Sensible Heat Ratio
     Zone Air Vapor Pressure Difference
-    
+
 New results were added to the zone sizing results file eplusout.zsz
 
     Des Latent Heat Load [W]

--- a/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
+++ b/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
@@ -10132,6 +10132,20 @@ TEST_F(SQLiteFixture, OutputReportTabularMonthly_CurlyBraces)
         std::string colHeader = col[0];
         EXPECT_TRUE(false) << "Missing braces in monthly table for : " << colHeader;
     }
+
+    // Test for #9436
+    auto extraSpaceAfterBracesHeaders = queryResult(
+        R"(SELECT DISTINCT(ColumnName) FROM TabularDataWithStrings
+             WHERE ReportName LIKE "MONTHLY EXAMPLE%"
+             AND ColumnName LIKE "%} %")",
+        "TabularDataWithStrings");
+    state->dataSQLiteProcedures->sqlite->sqliteCommit();
+
+    // Should be none!
+    for (auto &col : extraSpaceAfterBracesHeaders) {
+        std::string colHeader = col[0];
+        ADD_FAILURE() << "Extra space after brace in monthly table for : '" << colHeader << "'";
+    }
 }
 
 TEST_F(EnergyPlusFixture, OutputReportTabularTest_WarningMultiplePeopleObj)


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #9436

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
