### PR TITLE
Check and Enforce Limits on Schedule for SetpointManager:OutdoorAirReset

### DIFF
--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -6148,7 +6148,7 @@ void DefineOutsideAirSetPointManager::calculate(EnergyPlusData &state)
                 ShowSevereError(state,
                                 format("Schedule Values for the Outside Air Setpoint Manager = {} are something other than 1 or 2.", this->Name));
                 ShowContinueError(state, format("...the value for the schedule currently is {}", SchedVal));
-                ShowContinueError(state, format("...the value is being interpreted as 1 for this run but should be fixed."));
+                ShowContinueError(state, "...the value is being interpreted as 1 for this run but should be fixed.");
             } else {
                 ShowRecurringSevereErrorAtEnd(
                     state,

--- a/src/EnergyPlus/SetPointManager.hh
+++ b/src/EnergyPlus/SetPointManager.hh
@@ -230,28 +230,21 @@ namespace SetPointManager {
     struct DefineOutsideAirSetPointManager : SPBase // Derived type for Outside Air Setpoint Manager Data
     {
         // Members
-        Real64 OutLowSetPt1;  // 1st setpoint at outside low
-        Real64 OutLow1;       // 1st Outside low
-        Real64 OutHighSetPt1; // 1st setpoint at outside high
-        Real64 OutHigh1;      // 1st Outside high
-        std::string Sched;    // Optional schedule
-        int SchedPtr;         // Schedule index
-        Real64 OutLowSetPt2;  // 2nd setpoint at outside low (optional)
-        Real64 OutLow2;       // 2nd Outside low (optional)
-        Real64 OutHighSetPt2; // 2nd setpoint at outside high (optional)
-        Real64 OutHigh2;      // 2nd Outside high (optional)
-        int NumCtrlNodes;
+        Real64 OutLowSetPt1 = 0.0;         // 1st setpoint at outside low
+        Real64 OutLow1 = 0.0;              // 1st Outside low
+        Real64 OutHighSetPt1 = 0.0;        // 1st setpoint at outside high
+        Real64 OutHigh1 = 0.0;             // 1st Outside high
+        int SchedPtr = 0;                  // Schedule index
+        int invalidSchedValErrorIndex = 0; // index for recurring error when schedule is not 1 or 2
+        int setPtErrorCount = 0;           // countfor recurring error when schedule is not 1 or 2
+        Real64 OutLowSetPt2 = 0.0;         // 2nd setpoint at outside low (optional)
+        Real64 OutLow2 = 0.0;              // 2nd Outside low (optional)
+        Real64 OutHighSetPt2 = 0.0;        // 2nd setpoint at outside high (optional)
+        Real64 OutHigh2 = 0.0;             // 2nd Outside high (optional)
+        int NumCtrlNodes = 0;
         std::string CtrlNodeListName;
         Array1D_int CtrlNodes;
-        Real64 SetPt; // current setpoint value
-
-        // Default Constructor
-        DefineOutsideAirSetPointManager()
-            : OutLowSetPt1(0.0), OutLow1(0.0), OutHighSetPt1(0.0), OutHigh1(0.0), SchedPtr(0), OutLowSetPt2(0.0), OutLow2(0.0), OutHighSetPt2(0.0),
-              OutHigh2(0.0), NumCtrlNodes(0), SetPt(0.0)
-
-        {
-        }
+        Real64 SetPt = 0.0; // current setpoint value
 
         void calculate(EnergyPlusData &state);
     };

--- a/tst/EnergyPlus/unit/SetPointManager.unit.cc
+++ b/tst/EnergyPlus/unit/SetPointManager.unit.cc
@@ -1723,3 +1723,117 @@ TEST_F(EnergyPlusFixture, SetPointManager_SystemNodeResetHumRatTest)
     Real64 SetPt = SpAtLowRefHumRat - ((HumRat - LowRefHumRat) / (HighRefHumRat - LowRefHumRat)) * (SpAtLowRefHumRat - SpAtHighRefHumRat);
     EXPECT_EQ(SetPt, state->dataLoopNodes->Node(2).HumRatSetPoint);
 }
+
+TEST_F(EnergyPlusFixture, SetPointManager_OutdoorAirResetCalculateSchedValTest)
+{
+    bool ErrorsFound = false;
+    Real64 expectedAnswer;
+    static constexpr Real64 allowableTolerance = 0.001;
+
+    std::string const idf_objects = delimited_string({
+        "  SetpointManager:OutdoorAirReset,",
+        "    OA Reset Manager 1,      !- Name",
+        "    MinimumTemperature,      !- Control Variable",
+        "    50.0,                    !- Setpoint at Outdoor Low Temperature {C}",
+        "    10.0,                    !- Outdoor Low Temperature {C}",
+        "    40.0,                    !- Setpoint at Outdoor High Temperature {C}",
+        "    20.0,                    !- Outdoor High Temperature {C}",
+        "    HW Supply Outlet Node,   !- Setpoint Node or NodeList Name",
+        "    Schedule 1,              !- Schedule",
+        "    55.0,                    !- Setpoint at Outdoor Low Temperature {C}",
+        "    5.0,                     !- Outdoor Low Temperature {C}",
+        "    45.0,                    !- Setpoint at Outdoor High Temperature {C}",
+        "    15.0;                    !- Outdoor High Temperature {C}",
+        "  SetpointManager:OutdoorAirReset,",
+        "    OA Reset Manager 2,      !- Name",
+        "    MinimumTemperature,      !- Control Variable",
+        "    50.0,                    !- Setpoint at Outdoor Low Temperature {C}",
+        "    10.0,                    !- Outdoor Low Temperature {C}",
+        "    40.0,                    !- Setpoint at Outdoor High Temperature {C}",
+        "    20.0,                    !- Outdoor High Temperature {C}",
+        "    HW Supply Outlet Node,   !- Setpoint Node or NodeList Name",
+        "    Schedule 2,              !- Schedule",
+        "    55.0,                    !- Setpoint at Outdoor Low Temperature {C}",
+        "    5.0,                     !- Outdoor Low Temperature {C}",
+        "    45.0,                    !- Setpoint at Outdoor High Temperature {C}",
+        "    15.0;                    !- Outdoor High Temperature {C}",
+        "  SetpointManager:OutdoorAirReset,",
+        "    OA Reset Manager 3,      !- Name",
+        "    MinimumTemperature,      !- Control Variable",
+        "    50.0,                    !- Setpoint at Outdoor Low Temperature {C}",
+        "    10.0,                    !- Outdoor Low Temperature {C}",
+        "    40.0,                    !- Setpoint at Outdoor High Temperature {C}",
+        "    20.0,                    !- Outdoor High Temperature {C}",
+        "    HW Supply Outlet Node,   !- Setpoint Node or NodeList Name",
+        "    Schedule 3,              !- Schedule",
+        "    55.0,                    !- Setpoint at Outdoor Low Temperature {C}",
+        "    5.0,                     !- Outdoor Low Temperature {C}",
+        "    45.0,                    !- Setpoint at Outdoor High Temperature {C}",
+        "    15.0;                    !- Outdoor High Temperature {C}",
+        "  ScheduleTypeLimits,",
+        "    Control Type,            !- Name",
+        "    0,                       !- Lower Limit Value",
+        "    4,                       !- Upper Limit Value",
+        "    DISCRETE;                !- Numeric Type",
+        " Schedule:Compact,",
+        "   Schedule 1,       !- Name",
+        "   Control Type,     !- Schedule Type Limits Name",
+        "   Through: 12/31,   !- Field 1",
+        "   For: Alldays,     !- Field 2",
+        "   Until: 24:00,1;   !- Field 3",
+        " Schedule:Compact,",
+        "   Schedule 2,       !- Name",
+        "   Control Type,     !- Schedule Type Limits Name",
+        "   Through: 12/31,   !- Field 1",
+        "   For: Alldays,     !- Field 2",
+        "   Until: 24:00,2;   !- Field 3",
+        " Schedule:Compact,",
+        "   Schedule 3,       !- Name",
+        "   Control Type,     !- Schedule Type Limits Name",
+        "   Through: 12/31,   !- Field 1",
+        "   For: Alldays,     !- Field 2",
+        "   Until: 24:00,1.7; !- Field 3",
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+    EXPECT_FALSE(ErrorsFound); // zones are specified in the idf snippet
+
+    state->dataGlobal->NumOfTimeStepInHour = 1;
+    state->dataGlobal->MinutesPerTimeStep = 60;
+    state->dataGlobal->HourOfDay = 1;
+    state->dataGlobal->TimeStep = 1;
+    state->dataGlobal->DayOfSim = 1;
+    state->dataEnvrn->DSTIndicator = 0;
+    state->dataEnvrn->DayOfYear_Schedule = 1;
+    state->dataEnvrn->DayOfWeek = 1;
+    state->dataEnvrn->HolidayIndex = 0;
+
+    ScheduleManager::ProcessScheduleInput(*state);
+    SetPointManager::GetSetPointManagerInputs(*state);
+
+    // Set general data for all tests
+    state->dataEnvrn->OutDryBulbTemp = 7.0;
+    ScheduleManager::UpdateScheduleValues(*state);
+
+    // Test 1: First outdoor air reset setpoint manager--should use the first set of setpoint data
+    expectedAnswer = 50.0;
+    state->dataSetPointManager->OutAirSetPtMgr(1).calculate(*state);
+    EXPECT_NEAR(state->dataSetPointManager->OutAirSetPtMgr(1).SetPt, expectedAnswer, allowableTolerance);
+
+    // Test 2: Second outdoor air reset setpoint manager--should use the second set of setpoint data
+    expectedAnswer = 53.0;
+    state->dataSetPointManager->OutAirSetPtMgr(2).calculate(*state);
+    EXPECT_NEAR(state->dataSetPointManager->OutAirSetPtMgr(2).SetPt, expectedAnswer, allowableTolerance);
+
+    // Test 3: Third outdoor air reset setpoint manager--should result in an error and use the first set of setpoint data
+    expectedAnswer = 50.0;
+    state->dataSetPointManager->OutAirSetPtMgr(3).calculate(*state);
+    EXPECT_NEAR(state->dataSetPointManager->OutAirSetPtMgr(3).SetPt, expectedAnswer, allowableTolerance);
+
+    std::string const error_string3 = delimited_string({
+        "   ** Severe  ** Schedule Values for the Outside Air Setpoint Manager = OA RESET MANAGER 3 are something other than 1 or 2.",
+        "   **   ~~~   ** ...the value for the schedule currently is 1.7",
+        "   **   ~~~   ** ...the value is being interpreted as 1 for this run but should be fixed.",
+    });
+    EXPECT_TRUE(compare_err_stream(error_string3, true));
+}


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8424 
 - For SetpointManager:OutdoorAirReset, there is the option to have a second set of setpoint control parameters.  The decision for which set of parameters to use is based on a schedule.  The schedule should really only ever be 1 or 2.  In the code, basically if the schedule wasn't 2, it always used the first set of parameters.  However, this could lead to the wrong set of parameters being used without any warning if the value of the schedule value wasn't either 1 or 2.  The code was updated to check for the schedule values when the SetpointManager:OutdoorAirReset is read in to avoid situations where the schedule has a value of less than 1 or greater than 2.  Also, when the setpoint is actually evaluated, if the value isn't 1 or 2 (but is between those two values), an error message is produced to alert the user that the results may not be what the user anticipate due to a faulty schedule value.  Differences in the output are not expected as all of the test input files are correctly defined and do not run into this situation.  A unit test and minor code improvements for readability are also part of this work.

**NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE**

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
