### PR TITLE
Test shadow calculation warning preprocessor directives in unit test

### DIFF
--- a/tst/EnergyPlus/unit/SolarShading.unit.cc
+++ b/tst/EnergyPlus/unit/SolarShading.unit.cc
@@ -3879,9 +3879,21 @@ TEST_F(EnergyPlusFixture, SolarShadingTest_Warn_Pixel_Count_and_TM_Schedule)
 
     SolarShading::GetShadowingInput(*state);
 
-    EXPECT_EQ(state->dataErrTracking->TotalWarningErrors, 0);
-    // Now expect one severe error from GetShadowInput()
-    EXPECT_EQ(state->dataErrTracking->TotalSevereErrors, 1);
-    // There should be a severe warning reported about the PixelCounting and the scheduled shading surface tm values > 0.0 combination.
-    EXPECT_EQ(state->dataErrTracking->LastSevereError, "The Shading Calculation Method of choice is \"PixelCounting\"; ");
+#ifdef EP_NO_OPENGL
+    EXPECT_EQ(state->dataErrTracking->TotalWarningErrors, 1);
+    EXPECT_EQ(state->dataErrTracking->TotalSevereErrors, 0);
+    EXPECT_EQ(state->dataErrTracking->LastSevereError, "");
+#else
+    if (!Pumbra::Penumbra::isValidContext()) {
+        EXPECT_EQ(state->dataErrTracking->TotalWarningErrors, 1);
+        EXPECT_EQ(state->dataErrTracking->TotalSevereErrors, 0);
+        EXPECT_EQ(state->dataErrTracking->LastSevereError, "");
+    } else {
+        EXPECT_EQ(state->dataErrTracking->TotalWarningErrors, 0);
+        // Now expect one severe error from GetShadowInput()
+        EXPECT_EQ(state->dataErrTracking->TotalSevereErrors, 1);
+        // There should be a severe warning reported about the PixelCounting and the scheduled shading surface tm values > 0.0 combination.
+        EXPECT_EQ(state->dataErrTracking->LastSevereError, "The Shading Calculation Method of choice is \"PixelCounting\"; ");
+    }
+#endif
 }


### PR DESCRIPTION
Pull request overview
---------------------
 - Tries to fix the CI unit test failure message in #9653
 - Discussions are [here](https://github.com/NREL/EnergyPlus/pull/9653#issuecomment-1248181726). 
 - The issue is that the unit test was successful on local PCs; but on the CI machine (Win64-Windows-10-VisualStudio-16) it failed:
```
EnergyPlusFixture.SolarShadingTest_Warn_Pixel_Count_and_TM_Schedule	1.11899
	Note: Google Test filter = EnergyPlusFixture.SolarShadingTest_Warn_Pixel_Count_and_TM_Schedule
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from EnergyPlusFixture
[ RUN ] EnergyPlusFixture.SolarShadingTest_Warn_Pixel_Count_and_TM_Schedule
C:\ci\runs\clone_branch\tst\EnergyPlus\unit\SolarShading.unit.cc(3882): error: Expected equality of these values:
state->dataErrTracking->TotalWarningErrors
Which is: 1
0
C:\ci\runs\clone_branch\tst\EnergyPlus\unit\SolarShading.unit.cc(3884): error: Expected equality of these values:
state->dataErrTracking->TotalSevereErrors
Which is: 0
1
C:\ci\runs\clone_branch\tst\EnergyPlus\unit\SolarShading.unit.cc(3886): error: Expected equality of these values:
state->dataErrTracking->LastSevereError
Which is: ""
"The Shading Calculation Method of choice is \"PixelCounting\"; "
[ FAILED ] EnergyPlusFixture.SolarShadingTest_Warn_Pixel_Count_and_TM_Schedule (742 ms)
[----------] 1 test from EnergyPlusFixture (742 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (742 ms total)
[ PASSED ] 0 tests.
[ FAILED ] 1 test, listed below:
[ FAILED ] EnergyPlusFixture.SolarShadingTest_Warn_Pixel_Count_and_TM_Schedule

1 FAILED TEST
```

**NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE**

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
