### PR TITLE
#9303 - Effectively static link fortran utilities (and make them work on M1)

### DIFF
--- a/cmake/Fortran.cmake
+++ b/cmake/Fortran.cmake
@@ -10,7 +10,47 @@ if(APPLE)
     if(NOT "Ninja" STREQUAL ${CMAKE_GENERATOR})
       target_compile_options(fortran_project_options INTERFACE -cpp)
     endif()
+
+    # `-static` isn't possible on mac. From gcc man page:
+    # > This option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static.
+    # > Since neither a static version of libSystem.dylib nor crt0.o are provided, this option is not useful to most people.
+
+    # master of gcc has a fix via a new `-static-libquadmath` but it's not even in gcc 12.2.0. So instead we have to do all kinds of shenanigans
+
+    enable_language(Fortran)  # Needed to populate ${CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES}
+    # Debug:
+    # set(Fortran_VERBOSE "-v")
+    # Find the static libquadmath maually
+    find_library(static-libquadmath NAMES quadmath.a libquadmath.a REQUIRED PATHS ${CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES})
+    message(STATUS "Found static-libquadmath at ${static-libquadmath} by searching in CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES=${CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES}")
+    target_compile_options(fortran_project_options INTERFACE
+      ${Fortran_VERBOSE}
+    )
+    target_link_options(fortran_project_options INTERFACE
+      ${Fortran_VERBOSE}
+      -nodefaultlibs
+      -static-libgfortran
+      -lgfortran
+      -static-libgcc
+      -lgcc
+      -lemutls_w
+      ${static-libquadmath}
+      -lSystem
+    )
+
+    message(DEBUG "CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES-${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
+    #    => CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES-gfortran;emutls_w;gcc;quadmath;emutls_w;gcc;gcc
+    list(REMOVE_DUPLICATES CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES)
+    list(TRANSFORM CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES REPLACE "quadmath" " ${static-libquadmath}")
+    message(DEBUG "CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES-${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
+
+    # We unset this so that CMake doesn't try to read -lquadmath etc
+    unset(CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES)
+
+    # We could technically just set it to TRUE here. But it shouldn't do anything anyways, and it's a fallback
+    # set(FORTRAN_STATIC_EXE TRUE)
   endif()
+
 elseif(UNIX)
   set(FORTRAN_SKIP_RPATH TRUE)
   if(CMAKE_Fortran_COMPILER MATCHES "ifort")

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -533,6 +533,7 @@ if(APPLE)
 
   # You need at least one "install(..." command for it to be registered as a component
   install(CODE "MESSAGE(\"Creating symlinks.\")" COMPONENT Symlinks)
+  install(FILES "${PROJECT_SOURCE_DIR}/doc/man/energyplus.1" DESTINATION "./" COMPONENT Symlinks)
 
   # Custom installer icon. Has to be .icns on mac, .ico on windows, not supported on Unix
   set(CPACK_IFW_PACKAGE_ICON "${PROJECT_SOURCE_DIR}/release/ep.icns")
@@ -602,7 +603,7 @@ elseif(UNIX)
 
   # You need at least one "install(..." command for it to be registered as a component
   install(CODE "MESSAGE(\"Creating symlinks.\")" COMPONENT Symlinks)
-  install(FILES doc/man/energyplus.1 DESTINATION "./")
+  install(FILES "${PROJECT_SOURCE_DIR}/doc/man/energyplus.1" DESTINATION "./" COMPONENT Symlinks)
 endif()
 
 # TODO: Unused now

--- a/cmake/qtifw/install_unix_createsymlinks.qs
+++ b/cmake/qtifw/install_unix_createsymlinks.qs
@@ -68,7 +68,9 @@ function Component()
 
       // man page:
       linktarget = "/usr/local/share/man/man1";
-      component.addElevatedOperation("Execute", "ln", "-sf", "@TargetDir@/energyplus.1", linktarget,
+      component.addElevatedOperation("Execute", "mkdir", "-p", linktarget);
+
+      component.addElevatedOperation("Execute", "ln", "-sf", "@TargetDir@/energyplus.1", linktarget + "/energyplus.1",
                                      "UNDOEXECUTE", "rm", linktarget + "/energyplus.1");
 
     }


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #9303
 - This removes any doubt I had regarding the fact that the 22.2.0-RC2 did not contain libgcc_s.1.dylib until v22.2.0-IOFreeze
 - Tested at https://github.com/jmarrec/EnergyPlus/releases/tag/9303_Fortran_UtilitiesLinking and locally on an M1 mac (LOTS of warning suppressed, and fortran utilities work)

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
