### PR TITLE
Quick cleaning in General.cc

### DIFF
--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -1053,30 +1053,6 @@ void EncodeMonDayHrMin(int &Item,       // word containing encoded month, day, h
     Item = ((Month * 100 + Day) * 100 + Hour) * 100 + Minute;
 }
 
-int LogicalToInteger(bool const Flag)
-{
-    // SUBROUTINE INFORMATION:
-    //       AUTHOR         Dimitri Curtil
-    //       DATE WRITTEN   November 2004
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
-
-    // PURPOSE OF THIS FUNCTION:
-    // This subroutine uses an input logical and makes
-    // an integer (true=1, false=0)
-
-    // Return value
-    int LogicalToInteger;
-
-    if (Flag) {
-        LogicalToInteger = 1;
-    } else {
-        LogicalToInteger = 0;
-    }
-
-    return LogicalToInteger;
-}
-
 Real64 GetCurrentHVACTime(EnergyPlusData &state)
 {
     // SUBROUTINE INFORMATION:

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -1025,49 +1025,6 @@ void DecodeMonDayHrMin(int const Item, // word containing encoded month, day, ho
     Minute = mod(TmpItem, DecHr);
 }
 
-int DetermineMinuteForReporting(EnergyPlusData &state, OutputProcessor::TimeStepType t_timeStepType) // kind of reporting, Zone Timestep or System
-{
-
-    // FUNCTION INFORMATION:
-    //       AUTHOR         Linda Lawrie
-    //       DATE WRITTEN   January 2012
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
-
-    // PURPOSE OF THIS FUNCTION:
-    // When reporting peaks, minutes are used but not necessarily easily calculated.
-
-    // METHODOLOGY EMPLOYED:
-    // Could use the access to the minute as OP (OutputProcessor) does but uses
-    // external calculation.
-
-    // Using/Aliasing
-    auto &SysTimeElapsed = state.dataHVACGlobal->SysTimeElapsed;
-    auto &TimeStepSys = state.dataHVACGlobal->TimeStepSys;
-
-    // Return value
-    int ActualTimeMin; // calculated Minute for reporting
-
-    // FUNCTION PARAMETER DEFINITIONS:
-    Real64 constexpr FracToMin(60.0);
-
-    // FUNCTION LOCAL VARIABLE DECLARATIONS:
-    Real64 ActualTimeS; // Start of current interval (HVAC time step)
-    Real64 ActualTimeE; // End of current interval (HVAC time step)
-    int ActualTimeHrS;
-
-    if (t_timeStepType == OutputProcessor::TimeStepType::System) {
-        ActualTimeS = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + SysTimeElapsed;
-        ActualTimeE = ActualTimeS + TimeStepSys;
-        ActualTimeHrS = int(ActualTimeS);
-        ActualTimeMin = nint((ActualTimeE - ActualTimeHrS) * FracToMin);
-    } else {
-        ActualTimeMin = (state.dataGlobal->CurrentTime - int(state.dataGlobal->CurrentTime)) * FracToMin;
-    }
-
-    return ActualTimeMin;
-}
-
 void EncodeMonDayHrMin(int &Item,       // word containing encoded month, day, hour, minute
                        int const Month, // month in integer format (1:12)
                        int const Day,   // day in integer format (1:31)

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -1053,86 +1053,6 @@ void EncodeMonDayHrMin(int &Item,       // word containing encoded month, day, h
     Item = ((Month * 100 + Day) * 100 + Hour) * 100 + Minute;
 }
 
-Real64 GetCurrentHVACTime(EnergyPlusData &state)
-{
-    // SUBROUTINE INFORMATION:
-    //       AUTHOR         Dimitri Curtil
-    //       DATE WRITTEN   November 2004
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
-
-    // PURPOSE OF THIS FUNCTION:
-    // This routine returns the time in seconds at the end of the current HVAC step.
-
-    // Using/Aliasing
-    auto &SysTimeElapsed = state.dataHVACGlobal->SysTimeElapsed;
-    auto &TimeStepSys = state.dataHVACGlobal->TimeStepSys;
-
-    // Return value
-    Real64 GetCurrentHVACTime;
-
-    // FUNCTION LOCAL VARIABLE DECLARATIONS:
-    Real64 CurrentHVACTime;
-
-    // This is the correct formula that does not use MinutesPerSystemTimeStep, which would
-    // erronously truncate all sub-minute system time steps down to the closest full minute.
-    // Maybe later TimeStepZone, TimeStepSys and SysTimeElapsed could also be specified
-    // as real.
-    CurrentHVACTime = (state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone) + SysTimeElapsed + TimeStepSys;
-    GetCurrentHVACTime = CurrentHVACTime * DataGlobalConstants::SecInHour;
-
-    return GetCurrentHVACTime;
-}
-
-Real64 GetPreviousHVACTime(EnergyPlusData &state)
-{
-    // SUBROUTINE INFORMATION:
-    //       AUTHOR         Dimitri Curtil
-    //       DATE WRITTEN   November 2004
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
-
-    // PURPOSE OF THIS FUNCTION:
-    // This routine returns the time in seconds at the beginning of the current HVAC step.
-
-    // Using/Aliasing
-    auto &SysTimeElapsed = state.dataHVACGlobal->SysTimeElapsed;
-
-    // Return value
-    Real64 GetPreviousHVACTime;
-
-    // FUNCTION LOCAL VARIABLE DECLARATIONS:
-    Real64 PreviousHVACTime;
-
-    // This is the correct formula that does not use MinutesPerSystemTimeStep, which would
-    // erronously truncate all sub-minute system time steps down to the closest full minute.
-    PreviousHVACTime = (state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone) + SysTimeElapsed;
-    GetPreviousHVACTime = PreviousHVACTime * DataGlobalConstants::SecInHour;
-
-    return GetPreviousHVACTime;
-}
-
-std::string CreateHVACTimeIntervalString(EnergyPlusData &state)
-{
-
-    // FUNCTION INFORMATION:
-    //       AUTHOR         Dimitri Curtil
-    //       DATE WRITTEN   January 2005
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
-
-    // PURPOSE OF THIS FUNCTION:
-    // This function creates the time stamp with the current time interval for the HVAC
-    // time step.
-
-    // Return value
-    std::string OutputString;
-
-    OutputString = CreateTimeIntervalString(GetPreviousHVACTime(state), GetCurrentHVACTime(state));
-
-    return OutputString;
-}
-
 std::string CreateTimeString(Real64 const Time) // Time in seconds
 {
 
@@ -1159,32 +1079,6 @@ std::string CreateTimeString(Real64 const Time) // Time in seconds
     // TimeStamp written with formatting
     // "hh:mm:ss.s"
     return fmt::format("{:02d}:{:02d}:{:04.1f}", Hours, Minutes, Seconds);
-}
-
-std::string CreateTimeIntervalString(Real64 const StartTime, // Start of current interval in seconds
-                                     Real64 const EndTime    // End of current interval in seconds
-)
-{
-
-    // FUNCTION INFORMATION:
-    //       AUTHOR         Dimitri Curtil
-    //       DATE WRITTEN   January 2005
-    //       MODIFIED       na
-    //       RE-ENGINEERED  na
-
-    // PURPOSE OF THIS FUNCTION:
-    // This function creates the time stamp with the current time interval from start and end
-    // time values specified in seconds.
-    // Inspired by similar function CreateSysTimeIntervalString() in General.cc
-
-    // FUNCTION LOCAL VARIABLE DECLARATIONS:
-    std::string TimeStmpS; // Character representation of start of interval
-    std::string TimeStmpE; // Character representation of end of interval
-
-    TimeStmpS = CreateTimeString(StartTime);
-    TimeStmpE = CreateTimeString(EndTime);
-
-    return TimeStmpS + " - " + TimeStmpE;
 }
 
 void ParseTime(Real64 const Time, // Time value in seconds

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -1615,23 +1615,6 @@ void CheckCreatedZoneItemName(EnergyPlusData &state,
     }
 }
 
-// This is from OpenStudio
-std::vector<std::string> splitString(const std::string &string, char delimiter)
-{
-    std::vector<std::string> results;
-    if (!string.empty()) { // Only do work if there is work to do
-        std::stringstream stream(string);
-        std::string substring;
-        while (std::getline(stream, substring, delimiter)) { // Loop and fill the results vector
-            results.push_back(substring);
-        }
-        if (*(string.end() - 1) == ',') { // Add an empty string if the last char is the delimiter
-            results.emplace_back();
-        }
-    }
-    return results;
-}
-
 bool isReportPeriodBeginning(EnergyPlusData &state, const int periodIdx)
 {
     int currentDate;

--- a/src/EnergyPlus/General.hh
+++ b/src/EnergyPlus/General.hh
@@ -64,11 +64,6 @@ namespace EnergyPlus {
 // Forward declarations
 struct EnergyPlusData;
 
-// Forward declaration
-namespace OutputProcessor {
-    enum class TimeStepType;
-}
-
 namespace WeatherManager {
     enum class DateType;
     struct ReportPeriodData;
@@ -194,10 +189,6 @@ namespace General {
                            int &Hour,  // hour in integer format (1-24)
                            int &Minute // minute in integer format (0:59)
     );
-
-    // TODO: this probably shouldn't be here
-    int DetermineMinuteForReporting(EnergyPlusData &state,
-                                    OutputProcessor::TimeStepType t_timeStepType); // kind of reporting, Zone Timestep or System
 
     void EncodeMonDayHrMin(int &Item, // word containing encoded month, day, hour, minute
                            int Month, // month in integer format (1:12)

--- a/src/EnergyPlus/General.hh
+++ b/src/EnergyPlus/General.hh
@@ -222,14 +222,6 @@ namespace General {
                         ObjexxFCL::Optional_string Option1 = _,
                         ObjexxFCL::Optional_string Option2 = _);
 
-    inline void ReallocateRealArray(Array1D<Real64> &Array,
-                                    int &ArrayMax,     // Current and resultant dimension for Array
-                                    int const ArrayInc // increment for redimension
-    )
-    {
-        Array.redimension(ArrayMax += ArrayInc, 0.0);
-    }
-
     void CheckCreatedZoneItemName(EnergyPlusData &state,
                                   std::string_view calledFrom,              // routine called from
                                   std::string const &CurrentObject,         // object being parsed

--- a/src/EnergyPlus/General.hh
+++ b/src/EnergyPlus/General.hh
@@ -253,8 +253,6 @@ namespace General {
         CheckCreatedZoneItemName(state, calledFrom, CurrentObject, ZoneName, MaxZoneNameLength, ItemName, ItemNames, NumItems, ResultName, errFlag);
     }
 
-    std::vector<std::string> splitString(const std::string &string, char delimiter);
-
     bool isReportPeriodBeginning(EnergyPlusData &state, int periodIdx);
 
     void findReportPeriodIdx(EnergyPlusData &state,

--- a/src/EnergyPlus/General.hh
+++ b/src/EnergyPlus/General.hh
@@ -97,8 +97,6 @@ namespace General {
         }
     }
 
-    std::string &strip_trailing_zeros(std::string &InputString);
-
     void MovingAvg(Array1D<Real64> &DataIn, int NumItemsInAvg);
 
     void ProcessDateString(EnergyPlusData &state,
@@ -291,31 +289,7 @@ struct GeneralData : BaseGlobalStruct
 
     void clear_state() override
     {
-        this->GetReportInput = true;
-        this->SurfVert = false;
-        this->SurfDet = false;
-        this->SurfDetWVert = false;
-        this->DXFReport = false;
-        this->DXFWFReport = false;
-        this->VRMLReport = false;
-        this->CostInfo = false;
-        this->ViewFactorInfo = false;
-        this->Constructions = false;
-        this->Materials = false;
-        this->LineRpt = false;
-        this->VarDict = false;
-        this->EMSoutput = false;
-        this->XNext = 0.0;
-        this->DXFOption1.clear();
-        this->DXFOption2.clear();
-        this->DXFWFOption1.clear();
-        this->DXFWFOption2.clear();
-        this->VRMLOption1.clear();
-        this->VRMLOption2.clear();
-        this->ViewRptOption1.clear();
-        this->LineRptOption1.clear();
-        this->VarDictOption1.clear();
-        this->VarDictOption2.clear();
+        new (this) GeneralData();
     }
 };
 

--- a/src/EnergyPlus/General.hh
+++ b/src/EnergyPlus/General.hh
@@ -197,17 +197,7 @@ namespace General {
                            int Minute // minute in integer format (0:59)
     );
 
-    Real64 GetCurrentHVACTime(EnergyPlusData &state);
-
-    Real64 GetPreviousHVACTime(EnergyPlusData &state);
-
-    std::string CreateHVACTimeIntervalString(EnergyPlusData &state);
-
     std::string CreateTimeString(Real64 Time); // Time in seconds
-
-    std::string CreateTimeIntervalString(Real64 StartTime, // Start of current interval in seconds
-                                         Real64 EndTime    // End of current interval in seconds
-    );
 
     void ParseTime(Real64 Time,    // Time value in seconds
                    int &Hours,     // Number of hours

--- a/src/EnergyPlus/General.hh
+++ b/src/EnergyPlus/General.hh
@@ -197,8 +197,6 @@ namespace General {
                            int Minute // minute in integer format (0:59)
     );
 
-    int LogicalToInteger(bool Flag);
-
     Real64 GetCurrentHVACTime(EnergyPlusData &state);
 
     Real64 GetPreviousHVACTime(EnergyPlusData &state);

--- a/src/EnergyPlus/HVACControllers.cc
+++ b/src/EnergyPlus/HVACControllers.cc
@@ -2309,18 +2309,18 @@ void TraceIterationStamp(EnergyPlusData &state,
     // Note that we do not go to the next line
     print(TraceFile,
           "{},{},{},{},{},{},{},{},{},{},{},{},",
-          state.dataGlobal->ZoneSizingCalc ? 1 : 0,
-          state.dataGlobal->SysSizingCalc ? 1 : 0,
+          static_cast<int>(state.dataGlobal->ZoneSizingCalc),
+          static_cast<int>(state.dataGlobal->SysSizingCalc),
           state.dataEnvrn->CurEnvirNum,
-          state.dataGlobal->WarmupFlag ? 1 : 0,
+          static_cast<int>(state.dataGlobal->WarmupFlag),
           CreateHVACTimeString(state),
           MakeHVACTimeIntervalString(state),
-          state.dataGlobal->BeginTimeStepFlag ? 1 : 0,
-          state.dataHVACGlobal->FirstTimeStepSysFlag ? 1 : 0,
-          FirstHVACIteration ? 1 : 0,
+          static_cast<int>(state.dataGlobal->BeginTimeStepFlag),
+          static_cast<int>(state.dataHVACGlobal->FirstTimeStepSysFlag),
+          static_cast<int>(FirstHVACIteration),
           AirLoopPass,
           AirLoopNumCalls,
-          AirLoopConverged ? 1 : 0);
+          static_cast<int>(AirLoopConverged));
 }
 
 void TraceAirLoopController(EnergyPlusData &state, InputOutputFile &TraceFile, int const ControlNum)
@@ -2431,11 +2431,11 @@ void TraceIndividualController(EnergyPlusData &state,
     print(TraceFile,
           "{},{},{},{},{},{},{},{},",
           state.dataEnvrn->CurEnvirNum,
-          state.dataGlobal->WarmupFlag ? 1 : 0,
+          static_cast<int>(state.dataGlobal->WarmupFlag),
           CreateHVACTimeString(state),
           MakeHVACTimeIntervalString(state),
           AirLoopPass,
-          FirstHVACIteration ? 1 : 0,
+          static_cast<int>(FirstHVACIteration),
           Operation,
           ControllerProps.NumCalcCalls);
 
@@ -2454,7 +2454,7 @@ void TraceIndividualController(EnergyPlusData &state,
               ' ',
               ' ',
               ControllerProps.Mode,
-              IsConvergedFlag ? 1 : 0,
+              static_cast<int>(IsConvergedFlag),
               ControllerProps.NextActuatedValue);
         // X | Y | setpoint | DeltaSensed = Y - YRoot | Offset | Mode | IsConvergedFlag
 
@@ -2479,7 +2479,7 @@ void TraceIndividualController(EnergyPlusData &state,
               ControllerProps.DeltaSensed,
               ControllerProps.Offset,
               ControllerProps.Mode,
-              IsConvergedFlag ? 1 : 0,
+              static_cast<int>(IsConvergedFlag),
               ControllerProps.NextActuatedValue);
 
         // X | Y | setpoint | DeltaSensed = Y - YRoot | Offset | Mode | IsConvergedFlag
@@ -2505,7 +2505,7 @@ void TraceIndividualController(EnergyPlusData &state,
               ControllerProps.DeltaSensed,
               ControllerProps.Offset,
               ControllerProps.Mode,
-              IsConvergedFlag ? 1 : 0,
+              static_cast<int>(IsConvergedFlag),
               ControllerProps.NextActuatedValue);
 
         // X | Y | setpoint | DeltaSensed = Y - YRoot | Offset | Mode | IsConvergedFlag

--- a/src/EnergyPlus/HVACControllers.cc
+++ b/src/EnergyPlus/HVACControllers.cc
@@ -2530,7 +2530,6 @@ void TraceIndividualController(EnergyPlusData &state,
     TraceFile.flush();
 }
 
-
 Real64 GetCurrentHVACTime(EnergyPlusData &state)
 {
     // SUBROUTINE INFORMATION:
@@ -2546,7 +2545,8 @@ Real64 GetCurrentHVACTime(EnergyPlusData &state)
     // erronously truncate all sub-minute system time steps down to the closest full minute.
     // Maybe later TimeStepZone, TimeStepSys and SysTimeElapsed could also be specified
     // as real.
-    Real64 const CurrentHVACTime = (state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone) + state.dataHVACGlobal->SysTimeElapsed + state.dataHVACGlobal->TimeStepSys;
+    Real64 const CurrentHVACTime =
+        (state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone) + state.dataHVACGlobal->SysTimeElapsed + state.dataHVACGlobal->TimeStepSys;
     return CurrentHVACTime * DataGlobalConstants::SecInHour;
 }
 

--- a/src/EnergyPlus/HVACControllers.cc
+++ b/src/EnergyPlus/HVACControllers.cc
@@ -2530,6 +2530,43 @@ void TraceIndividualController(EnergyPlusData &state,
     TraceFile.flush();
 }
 
+
+Real64 GetCurrentHVACTime(EnergyPlusData &state)
+{
+    // SUBROUTINE INFORMATION:
+    //       AUTHOR         Dimitri Curtil
+    //       DATE WRITTEN   November 2004
+    //       MODIFIED       na
+    //       RE-ENGINEERED  na
+
+    // PURPOSE OF THIS FUNCTION:
+    // This routine returns the time in seconds at the end of the current HVAC step.
+
+    // This is the correct formula that does not use MinutesPerSystemTimeStep, which would
+    // erronously truncate all sub-minute system time steps down to the closest full minute.
+    // Maybe later TimeStepZone, TimeStepSys and SysTimeElapsed could also be specified
+    // as real.
+    Real64 const CurrentHVACTime = (state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone) + state.dataHVACGlobal->SysTimeElapsed + state.dataHVACGlobal->TimeStepSys;
+    return CurrentHVACTime * DataGlobalConstants::SecInHour;
+}
+
+Real64 GetPreviousHVACTime(EnergyPlusData &state)
+{
+    // SUBROUTINE INFORMATION:
+    //       AUTHOR         Dimitri Curtil
+    //       DATE WRITTEN   November 2004
+    //       MODIFIED       na
+    //       RE-ENGINEERED  na
+
+    // PURPOSE OF THIS FUNCTION:
+    // This routine returns the time in seconds at the beginning of the current HVAC step.
+
+    // This is the correct formula that does not use MinutesPerSystemTimeStep, which would
+    // erronously truncate all sub-minute system time steps down to the closest full minute.
+    Real64 const PreviousHVACTime = (state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone) + state.dataHVACGlobal->SysTimeElapsed;
+    return PreviousHVACTime * DataGlobalConstants::SecInHour;
+}
+
 std::string CreateHVACTimeString(EnergyPlusData &state)
 {
 
@@ -2541,7 +2578,7 @@ std::string CreateHVACTimeString(EnergyPlusData &state)
     // This function creates a string describing the current time stamp of the system
     // time step.
 
-    std::string Buffer = General::CreateTimeString(General::GetCurrentHVACTime(state));
+    std::string Buffer = General::CreateTimeString(GetCurrentHVACTime(state));
     return state.dataEnvrn->CurMnDy + ' ' + stripped(Buffer);
 }
 
@@ -2572,7 +2609,7 @@ std::string MakeHVACTimeIntervalString(EnergyPlusData &state)
     // This function creates a string describing the current time interval of the system
     // time step.
 
-    return stripped(General::CreateHVACTimeIntervalString(state));
+    return format("{} - {}", General::CreateTimeString(GetPreviousHVACTime(state)), General::CreateTimeString(GetCurrentHVACTime(state)));
 }
 
 void CheckControllerListOrder(EnergyPlusData &state)

--- a/src/EnergyPlus/HVACControllers.cc
+++ b/src/EnergyPlus/HVACControllers.cc
@@ -2309,18 +2309,18 @@ void TraceIterationStamp(EnergyPlusData &state,
     // Note that we do not go to the next line
     print(TraceFile,
           "{},{},{},{},{},{},{},{},{},{},{},{},",
-          General::LogicalToInteger(state.dataGlobal->ZoneSizingCalc),
-          General::LogicalToInteger(state.dataGlobal->SysSizingCalc),
+          state.dataGlobal->ZoneSizingCalc ? 1 : 0,
+          state.dataGlobal->SysSizingCalc ? 1 : 0,
           state.dataEnvrn->CurEnvirNum,
-          General::LogicalToInteger(state.dataGlobal->WarmupFlag),
+          state.dataGlobal->WarmupFlag ? 1 : 0,
           CreateHVACTimeString(state),
           MakeHVACTimeIntervalString(state),
-          General::LogicalToInteger(state.dataGlobal->BeginTimeStepFlag),
-          General::LogicalToInteger(state.dataHVACGlobal->FirstTimeStepSysFlag),
-          General::LogicalToInteger(FirstHVACIteration),
+          state.dataGlobal->BeginTimeStepFlag ? 1 : 0,
+          state.dataHVACGlobal->FirstTimeStepSysFlag ? 1 : 0,
+          FirstHVACIteration ? 1 : 0,
           AirLoopPass,
           AirLoopNumCalls,
-          General::LogicalToInteger(AirLoopConverged));
+          AirLoopConverged ? 1 : 0);
 }
 
 void TraceAirLoopController(EnergyPlusData &state, InputOutputFile &TraceFile, int const ControlNum)
@@ -2431,11 +2431,11 @@ void TraceIndividualController(EnergyPlusData &state,
     print(TraceFile,
           "{},{},{},{},{},{},{},{},",
           state.dataEnvrn->CurEnvirNum,
-          General::LogicalToInteger(state.dataGlobal->WarmupFlag),
+          state.dataGlobal->WarmupFlag ? 1 : 0,
           CreateHVACTimeString(state),
           MakeHVACTimeIntervalString(state),
           AirLoopPass,
-          General::LogicalToInteger(FirstHVACIteration),
+          FirstHVACIteration ? 1 : 0,
           Operation,
           ControllerProps.NumCalcCalls);
 
@@ -2454,7 +2454,7 @@ void TraceIndividualController(EnergyPlusData &state,
               ' ',
               ' ',
               ControllerProps.Mode,
-              General::LogicalToInteger(IsConvergedFlag),
+              IsConvergedFlag ? 1 : 0,
               ControllerProps.NextActuatedValue);
         // X | Y | setpoint | DeltaSensed = Y - YRoot | Offset | Mode | IsConvergedFlag
 
@@ -2479,7 +2479,7 @@ void TraceIndividualController(EnergyPlusData &state,
               ControllerProps.DeltaSensed,
               ControllerProps.Offset,
               ControllerProps.Mode,
-              General::LogicalToInteger(IsConvergedFlag),
+              IsConvergedFlag ? 1 : 0,
               ControllerProps.NextActuatedValue);
 
         // X | Y | setpoint | DeltaSensed = Y - YRoot | Offset | Mode | IsConvergedFlag
@@ -2505,7 +2505,7 @@ void TraceIndividualController(EnergyPlusData &state,
               ControllerProps.DeltaSensed,
               ControllerProps.Offset,
               ControllerProps.Mode,
-              General::LogicalToInteger(IsConvergedFlag),
+              IsConvergedFlag ? 1 : 0,
               ControllerProps.NextActuatedValue);
 
         // X | Y | setpoint | DeltaSensed = Y - YRoot | Offset | Mode | IsConvergedFlag

--- a/src/EnergyPlus/HVACControllers.hh
+++ b/src/EnergyPlus/HVACControllers.hh
@@ -315,6 +315,10 @@ namespace HVACControllers {
                                    DataHVACControllers::ControllerOperation Operation, // Operation to execute
                                    bool IsConvergedFlag);
 
+    Real64 GetCurrentHVACTime(EnergyPlusData &state);
+
+    Real64 GetPreviousHVACTime(EnergyPlusData &state);
+
     std::string CreateHVACTimeString(EnergyPlusData &state);
 
     std::string CreateHVACStepFullString(EnergyPlusData &state);

--- a/src/EnergyPlus/HeatBalanceAirManager.cc
+++ b/src/EnergyPlus/HeatBalanceAirManager.cc
@@ -278,7 +278,6 @@ void GetSimpleAirModelInputs(EnergyPlusData &state, bool &ErrorsFound) // IF err
     // This subroutine gets the input for the "simple" air flow model.
 
     // Using/Aliasing
-    using General::CheckCreatedZoneItemName;
     using ScheduleManager::CheckScheduleValueMinMax;
     using ScheduleManager::GetScheduleIndex;
     using ScheduleManager::GetScheduleMinValue;

--- a/src/EnergyPlus/InternalHeatGains.cc
+++ b/src/EnergyPlus/InternalHeatGains.cc
@@ -190,7 +190,6 @@ namespace InternalHeatGains {
 
         // Using/Aliasing
         using namespace ScheduleManager;
-        using General::CheckCreatedZoneItemName;
 
         using namespace OutputReportPredefined;
         using namespace DataLoopNode;

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -149,31 +149,8 @@ namespace OutputProcessor {
         // PURPOSE OF THIS FUNCTION:
         // When reporting peaks, minutes are used but not necessarily easily calculated.
 
-        // METHODOLOGY EMPLOYED:
-        // Could use the access to the minute as OP (OutputProcessor) does but uses
-        // external calculation.
-
-        // Return value
-        int ActualTimeMin; // calculated Minute for reporting
-
-        // FUNCTION PARAMETER DEFINITIONS:
         Real64 constexpr FracToMin(60.0);
-
-        // FUNCTION LOCAL VARIABLE DECLARATIONS:
-        Real64 ActualTimeS; // Start of current interval (HVAC time step)
-        Real64 ActualTimeE; // End of current interval (HVAC time step)
-        int ActualTimeHrS;
-
-        if (t_timeStepType == OutputProcessor::TimeStepType::System) {
-            ActualTimeS = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + state.dataHVACGlobal->SysTimeElapsed;
-            ActualTimeE = ActualTimeS + state.dataHVACGlobal->TimeStepSys;
-            ActualTimeHrS = int(ActualTimeS);
-            ActualTimeMin = nint((ActualTimeE - ActualTimeHrS) * FracToMin);
-        } else {
-            ActualTimeMin = (state.dataGlobal->CurrentTime - int(state.dataGlobal->CurrentTime)) * FracToMin;
-        }
-
-        return ActualTimeMin;
+        return ((state.dataGlobal->CurrentTime + state.dataHVACGlobal->SysTimeElapsed) - int(state.dataGlobal->CurrentTime)) * FracToMin;
     }
 
     void InitializeOutput(EnergyPlusData &state)
@@ -187,29 +164,6 @@ namespace OutputProcessor {
 
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine initializes the OutputProcessor data structures.
-
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-        // na
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
 
         auto &op(state.dataOutputProcessor);
 
@@ -277,7 +231,7 @@ namespace OutputProcessor {
 
         op->TimeStepZoneSec = double(state.dataGlobal->MinutesPerTimeStep) * 60.0;
 
-        InitializeMeters(state);
+        state.files.mtd.ensure_open(state, "InitializeMeters", state.files.outputControl.mtd);
     }
 
     void SetupTimePointers(EnergyPlusData &state,
@@ -682,52 +636,33 @@ namespace OutputProcessor {
         // Prior to calling this routine, the basic value string will be
         // produced, but DecodeMonDayHrMin will not have been called.
 
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
-        using General::DecodeMonDayHrMin;
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
         // SUBROUTINE PARAMETER DEFINITIONS:
         static constexpr std::string_view DayFormat("{},{:2},{:2}");
         static constexpr std::string_view MonthFormat("{},{:2},{:2},{:2}");
         static constexpr std::string_view EnvrnFormat("{},{:2},{:2},{:2},{:2}");
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         int Mon;
         int Day;
         int Hour;
         int Minute;
-        std::string StrOut;
-
-        DecodeMonDayHrMin(DateValue, Mon, Day, Hour, Minute);
+        General::DecodeMonDayHrMin(DateValue, Mon, Day, Hour, Minute);
 
         switch (ReportFreq) {
         case ReportingFrequency::Daily:
-            StrOut = format(DayFormat, strip(String), Hour, Minute);
-            break;
+            String = format(DayFormat, strip(String), Hour, Minute);
+            return;
         case ReportingFrequency::Monthly:
-            StrOut = format(MonthFormat, strip(String), Day, Hour, Minute);
-            break;
+            String = format(MonthFormat, strip(String), Day, Hour, Minute);
+            return;
         case ReportingFrequency::Yearly:
         case ReportingFrequency::Simulation:
-            StrOut = format(EnvrnFormat, strip(String), Mon, Day, Hour, Minute);
-            break;
+            String = format(EnvrnFormat, strip(String), Mon, Day, Hour, Minute);
+            return;
         default: // Each, TimeStep, Hourly dont have this
-            StrOut = std::string();
-            break;
+            String = std::string();
+            return;
         }
-
-        String = StrOut;
     }
 
     TimeStepType ValidateTimeStepType(EnergyPlusData &state,
@@ -776,39 +711,13 @@ namespace OutputProcessor {
         // METHODOLOGY EMPLOYED:
         // Look it up in a list of valid index types.
 
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Return value
-        std::string StandardTimeStepTypeKey;
-
-        // Locals
-        // FUNCTION ARGUMENT DEFINITIONS:
-
-        // FUNCTION PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // FUNCTION LOCAL VARIABLE DECLARATIONS:
-        // na
-
         if (timeStepType == TimeStepType::Zone) {
-            StandardTimeStepTypeKey = "Zone";
+            return "Zone";
         } else if (timeStepType == TimeStepType::System) {
-            StandardTimeStepTypeKey = "HVAC";
+            return "HVAC";
         } else {
-            StandardTimeStepTypeKey = "UNKW";
+            return "UNKW";
         }
-
-        return StandardTimeStepTypeKey;
     }
 
     StoreType validateVariableType(EnergyPlusData &state, OutputProcessor::SOVStoreType const VariableTypeKey)
@@ -855,37 +764,12 @@ namespace OutputProcessor {
         // METHODOLOGY EMPLOYED:
         // From variable type value, produce proper string.
 
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Return value
-        // na
-
-        // Locals
-        // FUNCTION ARGUMENT DEFINITIONS:
-
-        // FUNCTION PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // FUNCTION LOCAL VARIABLE DECLARATIONS:
-        // na
-
+        // TODO: Use a constexpr std::array<std::string_view, ... for this
         switch (VariableType) {
         case StoreType::Averaged:
             return "Average";
-            break;
         case StoreType::Summed:
             return "Sum";
-            break;
         default:
             return "Unknown";
         }
@@ -894,47 +778,6 @@ namespace OutputProcessor {
     // *****************************************************************************
     // The following routines implement Energy Meters in EnergyPlus.
     // *****************************************************************************
-
-    void InitializeMeters(EnergyPlusData &state)
-    {
-
-        // SUBROUTINE INFORMATION:
-        //       AUTHOR         Linda Lawrie
-        //       DATE WRITTEN   January 2001
-        //       MODIFIED       na
-        //       RE-ENGINEERED  na
-
-        // PURPOSE OF THIS SUBROUTINE:
-        // This subroutine creates the set of meters in EnergyPlus.  In this initial
-        // implementation, it is a static set of meters.
-
-        // METHODOLOGY EMPLOYED:
-        // Allocate the static set.  Use "AddMeter" with appropriate arguments that will
-        // allow expansion later.
-
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-        // na
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-
-        state.files.mtd.ensure_open(state, "InitializeMeters", state.files.outputControl.mtd);
-    }
 
     void GetCustomMeterInput(EnergyPlusData &state, bool &ErrorsFound)
     {
@@ -1011,20 +854,6 @@ namespace OutputProcessor {
         //    A5,  \field Report Variable or Meter Name 1
         //         \required-field
         // <etc>
-
-        // Using/Aliasing
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         auto &op(state.dataOutputProcessor);
@@ -2378,10 +2207,9 @@ namespace OutputProcessor {
         // and we need to add WATER (for m3/gal, etc)
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-        std::string UC_ResourceType;
 
         ErrorsFound = false;
-        UC_ResourceType = UtilityRoutines::MakeUPPERCase(ResourceType);
+        std::string UC_ResourceType = UtilityRoutines::MakeUPPERCase(ResourceType);
 
         CodeForIPUnits = RT_IPUnits::OtherJ;
         if (has(UC_ResourceType, "ELEC")) {
@@ -2404,8 +2232,8 @@ namespace OutputProcessor {
         }
         //  write(outputfiledebug,*) 'resourcetype=',TRIM(resourcetype)
         //  write(outputfiledebug,*) 'ipunits type=',CodeForIPUnits
-        if (!(MtrUnits == OutputProcessor::Unit::kg) && !(MtrUnits == OutputProcessor::Unit::J) && !(MtrUnits == OutputProcessor::Unit::m3) &&
-            !(MtrUnits == OutputProcessor::Unit::L)) {
+        if (MtrUnits != OutputProcessor::Unit::kg && MtrUnits != OutputProcessor::Unit::J && MtrUnits != OutputProcessor::Unit::m3 &&
+            MtrUnits != OutputProcessor::Unit::L) {
             ShowWarningError(state,
                              format("DetermineMeterIPUnits: Meter units not recognized for IP Units conversion=[{}].", unitEnumToString(MtrUnits)));
             ErrorsFound = true;
@@ -2428,24 +2256,6 @@ namespace OutputProcessor {
         // METHODOLOGY EMPLOYED:
         // Goes thru the number of meters, setting min/max as appropriate.  Uses timestamp
         // from calling program.
-
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         auto &op(state.dataOutputProcessor);
@@ -2546,64 +2356,44 @@ namespace OutputProcessor {
         // METHODOLOGY EMPLOYED:
         // Cycle through the meters and reset all accumulating values
 
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-        int Meter; // Loop Control
-        int Loop;  // Loop Variable
         auto &op(state.dataOutputProcessor);
 
-        for (Meter = 1; Meter <= op->NumEnergyMeters; ++Meter) {
-            op->EnergyMeters(Meter).HRValue = 0.0;
+        for (auto &m : op->EnergyMeters) {
+            m.HRValue = 0.0;
 
-            op->EnergyMeters(Meter).DYValue = 0.0;
-            op->EnergyMeters(Meter).DYMaxVal = MaxSetValue;
-            op->EnergyMeters(Meter).DYMaxValDate = 0;
-            op->EnergyMeters(Meter).DYMinVal = MinSetValue;
-            op->EnergyMeters(Meter).DYMinValDate = 0;
+            m.DYValue = 0.0;
+            m.DYMaxVal = MaxSetValue;
+            m.DYMaxValDate = 0;
+            m.DYMinVal = MinSetValue;
+            m.DYMinValDate = 0;
 
-            op->EnergyMeters(Meter).MNValue = 0.0;
-            op->EnergyMeters(Meter).MNMaxVal = MaxSetValue;
-            op->EnergyMeters(Meter).MNMaxValDate = 0;
-            op->EnergyMeters(Meter).MNMinVal = MinSetValue;
-            op->EnergyMeters(Meter).MNMinValDate = 0;
+            m.MNValue = 0.0;
+            m.MNMaxVal = MaxSetValue;
+            m.MNMaxValDate = 0;
+            m.MNMinVal = MinSetValue;
+            m.MNMinValDate = 0;
 
-            op->EnergyMeters(Meter).YRValue = 0.0;
-            op->EnergyMeters(Meter).YRMaxVal = MaxSetValue;
-            op->EnergyMeters(Meter).YRMaxValDate = 0;
-            op->EnergyMeters(Meter).YRMinVal = MinSetValue;
-            op->EnergyMeters(Meter).YRMinValDate = 0;
+            m.YRValue = 0.0;
+            m.YRMaxVal = MaxSetValue;
+            m.YRMaxValDate = 0;
+            m.YRMinVal = MinSetValue;
+            m.YRMinValDate = 0;
 
-            op->EnergyMeters(Meter).SMValue = 0.0;
-            op->EnergyMeters(Meter).SMMaxVal = MaxSetValue;
-            op->EnergyMeters(Meter).SMMaxValDate = 0;
-            op->EnergyMeters(Meter).SMMinVal = MinSetValue;
-            op->EnergyMeters(Meter).SMMinValDate = 0;
+            m.SMValue = 0.0;
+            m.SMMaxVal = MaxSetValue;
+            m.SMMaxValDate = 0;
+            m.SMMinVal = MinSetValue;
+            m.SMMinValDate = 0;
 
-            op->EnergyMeters(Meter).FinYrSMValue = 0.0;
-            op->EnergyMeters(Meter).FinYrSMMaxVal = MaxSetValue;
-            op->EnergyMeters(Meter).FinYrSMMaxValDate = 0;
-            op->EnergyMeters(Meter).FinYrSMMinVal = MinSetValue;
-            op->EnergyMeters(Meter).FinYrSMMinValDate = 0;
+            m.FinYrSMValue = 0.0;
+            m.FinYrSMMaxVal = MaxSetValue;
+            m.FinYrSMMaxValDate = 0;
+            m.FinYrSMMinVal = MinSetValue;
+            m.FinYrSMMinValDate = 0;
         }
 
-        for (Loop = 1; Loop <= op->NumOfRVariable; ++Loop) {
+        for (int Loop = 1; Loop <= op->NumOfRVariable; ++Loop) {
             auto &rVar(op->RVariableTypes(Loop).VarPtr);
             if (rVar.frequency == ReportingFrequency::Monthly || rVar.frequency == ReportingFrequency::Yearly ||
                 rVar.frequency == ReportingFrequency::Simulation) {
@@ -2612,7 +2402,7 @@ namespace OutputProcessor {
             }
         }
 
-        for (Loop = 1; Loop <= op->NumOfIVariable; ++Loop) {
+        for (int Loop = 1; Loop <= op->NumOfIVariable; ++Loop) {
             auto &iVar(op->IVariableTypes(Loop).VarPtr);
             if (iVar.frequency == ReportingFrequency::Monthly || iVar.frequency == ReportingFrequency::Yearly ||
                 iVar.frequency == ReportingFrequency::Simulation) {
@@ -2639,24 +2429,6 @@ namespace OutputProcessor {
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine reports on the meters that have been requested for
         // reporting on each time step.
-
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         int Loop; // Loop Control
@@ -2767,25 +2539,6 @@ namespace OutputProcessor {
         // This subroutine reports on the meters that have been requested for
         // reporting on each hour.
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-        // na
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         int Loop; // Loop Control
         bool PrintTimeStamp;
@@ -2868,25 +2621,6 @@ namespace OutputProcessor {
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine reports on the meters that have been requested for
         // reporting on each day.
-
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-        // na
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         int Loop; // Loop Control
@@ -2972,25 +2706,6 @@ namespace OutputProcessor {
         // This subroutine reports on the meters that have been requested for
         // reporting on each month.
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-        // na
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         int Loop; // Loop Control
         bool PrintTimeStamp;
@@ -3063,25 +2778,6 @@ namespace OutputProcessor {
         // This subroutine reports on the meters that have been requested for
         // reporting on each year.
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-        // na
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         int Loop; // Loop Control
         bool PrintTimeStamp;
@@ -3148,27 +2844,6 @@ namespace OutputProcessor {
         // PURPOSE OF THIS SUBROUTINE:
         // This subroutine reports on the meters that have been requested for
         // reporting on each environment/run period.
-
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
-        // using namespace OutputReportPredefined;
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-        // na
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         int Loop; // Loop Control
@@ -3253,181 +2928,95 @@ namespace OutputProcessor {
         // for SM (Simulation period) meters, the value of the last calculation is stored
         // in the data structure.
 
-        // Using/Aliasing
-        using namespace OutputReportPredefined;
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-        int Loop; // Loop Control
         auto &op(state.dataOutputProcessor);
 
-        for (Loop = 1; Loop <= op->NumEnergyMeters; ++Loop) {
-            OutputProcessor::RT_IPUnits const RT_forIPUnits(op->EnergyMeters(Loop).RT_forIPUnits);
+        for (auto &m : op->EnergyMeters) {
+            OutputProcessor::RT_IPUnits const RT_forIPUnits(m.RT_forIPUnits);
             if (RT_forIPUnits == RT_IPUnits::Electricity) {
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMelecannual,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMValue * DataGlobalConstants::convertJtoGJ);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMelecminvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMelecminvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMinValDate));
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMelecmaxvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMelecmaxvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMaxValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMelecannual, m.Name, m.FinYrSMValue * DataGlobalConstants::convertJtoGJ);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMelecminvalue, m.Name, m.FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMelecminvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMinValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMelecmaxvalue, m.Name, m.FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMelecmaxvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMaxValDate));
             } else if (RT_forIPUnits == RT_IPUnits::Gas) {
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMgasannual,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMValue * DataGlobalConstants::convertJtoGJ);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMgasminvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMgasminvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMinValDate));
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMgasmaxvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMgasmaxvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMaxValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMgasannual, m.Name, m.FinYrSMValue * DataGlobalConstants::convertJtoGJ);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMgasminvalue, m.Name, m.FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMgasminvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMinValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMgasmaxvalue, m.Name, m.FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMgasmaxvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMaxValDate));
             } else if (RT_forIPUnits == RT_IPUnits::Cooling) {
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMcoolannual,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMValue * DataGlobalConstants::convertJtoGJ);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMcoolminvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMcoolminvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMinValDate));
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMcoolmaxvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMcoolmaxvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMaxValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMcoolannual, m.Name, m.FinYrSMValue * DataGlobalConstants::convertJtoGJ);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMcoolminvalue, m.Name, m.FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMcoolminvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMinValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMcoolmaxvalue, m.Name, m.FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMcoolmaxvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMaxValDate));
             } else if (RT_forIPUnits == RT_IPUnits::Water) {
-                PreDefTableEntry(
-                    state, state.dataOutRptPredefined->pdchEMwaterannual, op->EnergyMeters(Loop).Name, op->EnergyMeters(Loop).FinYrSMValue);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMwaterminvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMwaterminvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMinValDate));
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMwatermaxvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMwatermaxvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMaxValDate));
+                OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchEMwaterannual, m.Name, m.FinYrSMValue);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMwaterminvalue, m.Name, m.FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMwaterminvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMinValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMwatermaxvalue, m.Name, m.FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMwatermaxvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMaxValDate));
             } else if (RT_forIPUnits == RT_IPUnits::OtherKG) {
-                PreDefTableEntry(
-                    state, state.dataOutRptPredefined->pdchEMotherKGannual, op->EnergyMeters(Loop).Name, op->EnergyMeters(Loop).FinYrSMValue);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherKGminvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec,
-                                 3);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherKGminvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMinValDate));
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherKGmaxvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec,
-                                 3);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherKGmaxvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMaxValDate));
+                OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchEMotherKGannual, m.Name, m.FinYrSMValue);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherKGminvalue, m.Name, m.FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec, 3);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherKGminvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMinValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherKGmaxvalue, m.Name, m.FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec, 3);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherKGmaxvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMaxValDate));
             } else if (RT_forIPUnits == RT_IPUnits::OtherM3) {
-                PreDefTableEntry(
-                    state, state.dataOutRptPredefined->pdchEMotherM3annual, op->EnergyMeters(Loop).Name, op->EnergyMeters(Loop).FinYrSMValue, 3);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherM3minvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec,
-                                 3);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherM3minvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMinValDate));
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherM3maxvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec,
-                                 3);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherM3maxvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMaxValDate));
+                OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchEMotherM3annual, m.Name, m.FinYrSMValue, 3);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherM3minvalue, m.Name, m.FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec, 3);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherM3minvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMinValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherM3maxvalue, m.Name, m.FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec, 3);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherM3maxvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMaxValDate));
             } else if (RT_forIPUnits == RT_IPUnits::OtherL) {
-                PreDefTableEntry(
-                    state, state.dataOutRptPredefined->pdchEMotherLannual, op->EnergyMeters(Loop).Name, op->EnergyMeters(Loop).FinYrSMValue, 3);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherLminvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec,
-                                 3);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherLminvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMinValDate));
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherLmaxvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec,
-                                 3);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherLmaxvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMaxValDate));
+                OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchEMotherLannual, m.Name, m.FinYrSMValue, 3);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherLminvalue, m.Name, m.FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec, 3);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherLminvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMinValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherLmaxvalue, m.Name, m.FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec, 3);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherLmaxvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMaxValDate));
             } else {
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherJannual,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMValue * DataGlobalConstants::convertJtoGJ);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherJminvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherJminvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMinValDate));
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherJmaxvalue,
-                                 op->EnergyMeters(Loop).Name,
-                                 op->EnergyMeters(Loop).FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
-                PreDefTableEntry(state,
-                                 state.dataOutRptPredefined->pdchEMotherJmaxvaluetime,
-                                 op->EnergyMeters(Loop).Name,
-                                 DateToStringWithMonth(op->EnergyMeters(Loop).FinYrSMMaxValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherJannual, m.Name, m.FinYrSMValue * DataGlobalConstants::convertJtoGJ);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherJminvalue, m.Name, m.FinYrSMMinVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherJminvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMinValDate));
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherJmaxvalue, m.Name, m.FinYrSMMaxVal / state.dataGlobal->TimeStepZoneSec);
+                OutputReportPredefined::PreDefTableEntry(
+                    state, state.dataOutRptPredefined->pdchEMotherJmaxvaluetime, m.Name, DateToStringWithMonth(m.FinYrSMMaxValDate));
             }
         }
     }
@@ -3524,28 +3113,6 @@ namespace OutputProcessor {
         // PURPOSE OF THIS SUBROUTINE:
         // Writes the meter details report.  This shows which variables are on
         // meters as well as the meter contents.
-
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-        // na
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
 
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         auto &op(state.dataOutputProcessor);
@@ -3737,6 +3304,7 @@ namespace OutputProcessor {
             ShowSevereError(state, format("Nonexistent end use passed to addEndUseSpaceType={}", EndUseName));
         }
     }
+
     void WriteTimeStampFormatData(
         EnergyPlusData &state,
         InputOutputFile &outputFile,
@@ -3766,27 +3334,6 @@ namespace OutputProcessor {
         // Much of the code in this function was embedded in earlier versions of EnergyPlus
         // and was moved to this location to simplify maintenance and to allow for data output
         // to the SQL database
-
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
-        // Locals
-        // FUNCTION ARGUMENT DEFINITIONS:
-
-        // FUNCTION PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // FUNCTION LOCAL VARIABLE DECLARATIONS:
 
         assert(reportIDString.length() + DayOfSimChr.length() + (DayType.present() ? DayType().length() : 0u) + 26 <
                N_WriteTimeStampFormatData); // Check will fit in stamp size
@@ -3943,25 +3490,6 @@ namespace OutputProcessor {
         // This subroutine writes the ESO data dictionary information to the output files
         // and the SQL database
 
-        // METHODOLOGY EMPLOYED:
-
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         std::string FreqString;
         auto &op(state.dataOutputProcessor);
@@ -4057,26 +3585,6 @@ namespace OutputProcessor {
         // and was moved here for the purposes of ease of maintenance and to allow easy
         // data reporting to the SQL database
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         std::string UnitsString = unitEnumToString(unit);
 
@@ -4159,29 +3667,6 @@ namespace OutputProcessor {
         // SQL database. Much of the code here was an included in earlier versions
         // of the UpdateDataandReport subroutine. The code was moved to facilitate
         // easier maintenance and writing of data to the SQL database.
-
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-        // na
 
         if (realVar.Report && realVar.frequency == reportType && realVar.Stored) {
             if (realVar.NumStored > 0.0) {
@@ -4518,29 +4003,6 @@ namespace OutputProcessor {
         // of the UpdateDataandReport subroutine. The code was moved to facilitate
         // easier maintenance and writing of data to the SQL database.
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-        // na
-
         if (state.dataSysVars->UpdateDataDuringWarmupExternalInterface && !state.dataSysVars->ReportDuringWarmup) return;
 
         if (intVar.Report && intVar.frequency == reportType && intVar.Stored) {
@@ -4671,23 +4133,6 @@ namespace OutputProcessor {
         // grouped.  It does this by parsing the meter name and then assigns a
         // indexGroupKey based on the name
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Return value
-        int DetermineIndexGroupKeyFromMeterName;
-
-        // Locals
-        // FUNCTION ARGUMENT DEFINITIONS:
-
-        // FUNCTION LOCAL VARIABLE DECLARATIONS:
-
         // Facility indices are in the 100s
         if (has(meterName, "Electricity:Facility")) {
             state.dataOutputProcessor->indexGroupKey = 100;
@@ -4723,9 +4168,7 @@ namespace OutputProcessor {
             state.dataOutputProcessor->indexGroupKey = -11;
         }
 
-        DetermineIndexGroupKeyFromMeterName = state.dataOutputProcessor->indexGroupKey;
-
-        return DetermineIndexGroupKeyFromMeterName;
+        return state.dataOutputProcessor->indexGroupKey;
     }
 
     std::string DetermineIndexGroupFromMeterGroup(MeterType const &meter) // the meter
@@ -4741,22 +4184,8 @@ namespace OutputProcessor {
         // This function attemps to determine how a meter variable should be
         // grouped.  It does this by parsing the meter group
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
         // Return value
         std::string indexGroup;
-
-        // Locals
-        // FUNCTION ARGUMENT DEFINITIONS:
-
-        // FUNCTION LOCAL VARIABLE DECLARATIONS:
 
         if (len(meter.Group) > 0) {
             indexGroup = meter.Group;
@@ -4801,24 +4230,6 @@ namespace OutputProcessor {
         // given a variable type and variable index,
         // assign the pointers the values passed in.
 
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Locals
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-        // na
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         auto &op(state.dataOutputProcessor);
 
@@ -4855,157 +4266,108 @@ namespace OutputProcessor {
     std::string unitEnumToString(EnergyPlus::OutputProcessor::Unit const unitIn)
     {
         // J.Glazer - August/September 2017
+        // TODO: Use a constexpr array of string views
         switch (unitIn) {
         case OutputProcessor::Unit::J:
             return "J";
-            break;
         case OutputProcessor::Unit::W:
             return "W";
-            break;
         case OutputProcessor::Unit::C:
             return "C";
-            break;
         case OutputProcessor::Unit::None:
             return "";
-            break;
         case OutputProcessor::Unit::kg:
             return "kg";
-            break;
         case OutputProcessor::Unit::W_m2:
             return "W/m2";
-            break;
         case OutputProcessor::Unit::m3:
             return "m3";
-            break;
         case OutputProcessor::Unit::hr:
             return "hr";
-            break;
         case OutputProcessor::Unit::kg_s:
             return "kg/s";
-            break;
         case OutputProcessor::Unit::deg:
             return "deg";
-            break;
         case OutputProcessor::Unit::m3_s:
             return "m3/s";
-            break;
         case OutputProcessor::Unit::W_m2K:
             return "W/m2-K";
-            break;
         case OutputProcessor::Unit::kgWater_kgDryAir:
             return "kgWater/kgDryAir";
-            break;
         case OutputProcessor::Unit::Perc:
             return "%";
-            break;
         case OutputProcessor::Unit::m_s:
             return "m/s";
-            break;
         case OutputProcessor::Unit::lux:
             return "lux";
-            break;
         case OutputProcessor::Unit::kgWater_s:
             return "kgWater/s";
-            break;
         case OutputProcessor::Unit::rad:
             return "rad";
-            break;
         case OutputProcessor::Unit::Pa:
             return "Pa";
-            break;
         case OutputProcessor::Unit::J_kg:
             return "J/kg";
-            break;
         case OutputProcessor::Unit::m:
             return "m";
-            break;
         case OutputProcessor::Unit::lum_W:
             return "lum/W";
-            break;
         case OutputProcessor::Unit::kg_m3:
             return "kg/m3";
-            break;
         case OutputProcessor::Unit::L:
             return "L";
-            break;
         case OutputProcessor::Unit::ach:
             return "ach";
-            break;
         case OutputProcessor::Unit::m2:
             return "m2";
-            break;
         case OutputProcessor::Unit::deltaC:
             return "deltaC";
-            break;
         case OutputProcessor::Unit::J_kgK:
             return "J/kg-K";
-            break;
         case OutputProcessor::Unit::W_W:
             return "W/W";
-            break;
         case OutputProcessor::Unit::clo:
             return "clo";
-            break;
         case OutputProcessor::Unit::W_mK:
             return "W/m-K";
-            break;
         case OutputProcessor::Unit::W_K:
             return "W/K";
-            break;
         case OutputProcessor::Unit::K_W:
             return "K/W";
-            break;
         case OutputProcessor::Unit::ppm:
             return "ppm";
-            break;
         case OutputProcessor::Unit::kg_kg:
             return "kg/kg";
-            break;
         case OutputProcessor::Unit::s:
             return "s";
-            break;
         case OutputProcessor::Unit::cd_m2:
             return "cd/m2";
-            break;
         case OutputProcessor::Unit::kmol_s:
             return "kmol/s";
-            break;
         case OutputProcessor::Unit::K_m:
             return "K/m";
-            break;
         case OutputProcessor::Unit::min:
             return "min";
-            break;
         case OutputProcessor::Unit::J_kgWater:
             return "J/kgWater";
-            break;
         case OutputProcessor::Unit::rev_min:
             return "rev/min";
-            break;
         case OutputProcessor::Unit::kg_m2s:
             return "kg/m2-s";
-            break;
         case OutputProcessor::Unit::J_m2:
             return "J/m2";
-            break;
         case OutputProcessor::Unit::A:
             return "A";
-            break;
         case OutputProcessor::Unit::V:
             return "V";
-            break;
         case OutputProcessor::Unit::W_m2C:
             return "W/m2-C";
-            break;
         case OutputProcessor::Unit::Ah:
             return "Ah";
-            break;
         case OutputProcessor::Unit::Btu_h_W:
             return "Btu/h-W";
-            break;
         default:
             return "unknown";
-            break;
         }
     }
 
@@ -5117,13 +4479,7 @@ namespace OutputProcessor {
 
 } // namespace OutputProcessor
 
-//==============================================================================================
-// *****************************************************************************
-// These routines are available outside the OutputProcessor Module (i.e. calling
-// routines do not have to "USE OutputProcessor".  But each of these routines
-// will use the OutputProcessor and take advantage that everything is PUBLIC
-// within the OutputProcessor.
-// *****************************************************************************
+// TODO: Probably move these to a different location
 
 void SetupOutputVariable(EnergyPlusData &state,
                          std::string_view const VariableName,                    // String Name of variable (with units)

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -153,10 +153,6 @@ namespace OutputProcessor {
         // Could use the access to the minute as OP (OutputProcessor) does but uses
         // external calculation.
 
-        // Using/Aliasing
-        auto &SysTimeElapsed = state.dataHVACGlobal->SysTimeElapsed;
-        auto &TimeStepSys = state.dataHVACGlobal->TimeStepSys;
-
         // Return value
         int ActualTimeMin; // calculated Minute for reporting
 
@@ -169,8 +165,8 @@ namespace OutputProcessor {
         int ActualTimeHrS;
 
         if (t_timeStepType == OutputProcessor::TimeStepType::System) {
-            ActualTimeS = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + SysTimeElapsed;
-            ActualTimeE = ActualTimeS + TimeStepSys;
+            ActualTimeS = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + state.dataHVACGlobal->SysTimeElapsed;
+            ActualTimeE = ActualTimeS + state.dataHVACGlobal->TimeStepSys;
             ActualTimeHrS = int(ActualTimeS);
             ActualTimeMin = nint((ActualTimeE - ActualTimeHrS) * FracToMin);
         } else {

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -4598,27 +4598,6 @@ namespace OutputProcessor {
         // of the UpdateDataandReport subroutine. The code was moved to facilitate
         // easier maintenance and writing of data to the SQL database.
 
-        // METHODOLOGY EMPLOYED:
-        // na
-
-        // REFERENCES:
-        // na
-
-        // Using/Aliasing
-        using General::strip_trailing_zeros;
-
-        // Locals
-
-        // SUBROUTINE ARGUMENT DEFINITIONS:
-
-        // SUBROUTINE PARAMETER DEFINITIONS:
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
         // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
         std::string NumberOut; // Character for producing "number out"
         std::string MaxOut;    // Character for Max out string
@@ -4634,8 +4613,7 @@ namespace OutputProcessor {
         if (repValue == 0.0) {
             NumberOut = "0.0";
         } else {
-            NumberOut = format("{:N}", repVal);
-            strip_trailing_zeros(strip(NumberOut));
+            NumberOut = format("{:f}", repVal);
         }
 
         // Append the min and max strings with date information

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -137,7 +137,7 @@ namespace OutputProcessor {
         state.dataOutputProcessor->IVariableTypes.redimension(state.dataOutputProcessor->MaxIVariable += IVarAllocInc);
     }
 
-    int DetermineMinuteForReporting(EnergyPlusData &state, TimeStepType t_timeStepType) // kind of reporting, Zone Timestep or System
+    int DetermineMinuteForReporting(EnergyPlusData &state)
     {
 
         // FUNCTION INFORMATION:

--- a/src/EnergyPlus/OutputProcessor.hh
+++ b/src/EnergyPlus/OutputProcessor.hh
@@ -603,8 +603,6 @@ namespace OutputProcessor {
     // The following routines implement Energy Meters in EnergyPlus.
     // *****************************************************************************
 
-    void InitializeMeters(EnergyPlusData &state);
-
     void GetCustomMeterInput(EnergyPlusData &state, bool &ErrorsFound);
 
     void

--- a/src/EnergyPlus/OutputProcessor.hh
+++ b/src/EnergyPlus/OutputProcessor.hh
@@ -550,6 +550,9 @@ namespace OutputProcessor {
         Array1D_string spaceTypeName; // Array of space type names
     };
 
+    int DetermineMinuteForReporting(EnergyPlusData &state,
+                                    OutputProcessor::TimeStepType t_timeStepType); // kind of reporting, Zone Timestep or System
+
     void InitializeOutput(EnergyPlusData &state);
 
     void SetupTimePointers(EnergyPlusData &state,

--- a/src/EnergyPlus/OutputProcessor.hh
+++ b/src/EnergyPlus/OutputProcessor.hh
@@ -550,8 +550,7 @@ namespace OutputProcessor {
         Array1D_string spaceTypeName; // Array of space type names
     };
 
-    int DetermineMinuteForReporting(EnergyPlusData &state,
-                                    OutputProcessor::TimeStepType t_timeStepType); // kind of reporting, Zone Timestep or System
+    int DetermineMinuteForReporting(EnergyPlusData &state);
 
     void InitializeOutput(EnergyPlusData &state);
 

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -3610,7 +3610,6 @@ void GatherMonthlyResultsForTimestep(EnergyPlusData &state, OutputProcessor::Tim
 
     // Using/Aliasing
     auto &TimeStepSys = state.dataHVACGlobal->TimeStepSys;
-    using General::DetermineMinuteForReporting;
     using General::EncodeMonDayHrMin;
 
     // Locals
@@ -3715,7 +3714,7 @@ void GatherMonthlyResultsForTimestep(EnergyPlusData &state, OutputProcessor::Tim
                 newDuration = 0.0;
                 activeNewValue = false;
                 // the current timestamp
-                minuteCalculated = DetermineMinuteForReporting(state, t_timeStepType);
+                minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
                 //      minuteCalculated = (CurrentTime - INT(CurrentTime))*60
                 //      IF (t_timeStepType .EQ. OutputProcessor::TimeStepType::TimeStepSystem) minuteCalculated = minuteCalculated +
                 //      SysTimeElapsed * 60 minuteCalculated = INT((TimeStep-1) * TimeStepZone * 60) + INT((SysTimeElapsed + TimeStepSys) * 60)
@@ -4260,7 +4259,6 @@ void GatherPeakDemandForTimestep(EnergyPlusData &state, OutputProcessor::TimeSte
     using DataStringGlobals::CharComma;
     using DataStringGlobals::CharSpace;
     using DataStringGlobals::CharTab;
-    using General::DetermineMinuteForReporting;
     using General::EncodeMonDayHrMin;
 
     // Locals
@@ -4296,7 +4294,7 @@ void GatherPeakDemandForTimestep(EnergyPlusData &state, OutputProcessor::TimeSte
                     ort->gatherDemandTotal(iResource) = curDemandValue;
                     // save the time that the peak demand occurred
                     //        minuteCalculated = (CurrentTime - INT(CurrentTime))*60
-                    minuteCalculated = DetermineMinuteForReporting(state, t_timeStepType);
+                    minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
                     EncodeMonDayHrMin(
                         timestepTimeStamp, state.dataEnvrn->Month, state.dataEnvrn->DayOfMonth, state.dataGlobal->HourOfDay, minuteCalculated);
                     ort->gatherDemandTimeStamp(iResource) = timestepTimeStamp;
@@ -4640,7 +4638,6 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
 
     // Using/Aliasing
     auto &TimeStepSys = state.dataHVACGlobal->TimeStepSys;
-    using General::DetermineMinuteForReporting;
     using General::EncodeMonDayHrMin;
 
     auto &Zone(state.dataHeatBal->Zone);
@@ -4860,7 +4857,7 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
                 //      ActualtimeE = ActualTimeS+TimeStepSys
                 //      ActualTimeHrS=INT(ActualTimeS)
                 //      ActualTimeMin=NINT((ActualtimeE - ActualTimeHrS)*FracToMin)
-                ActualTimeMin = DetermineMinuteForReporting(state, t_timeStepType);
+                ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
                 EncodeMonDayHrMin(state.dataOutRptTab->timestepTimeStampGHGR,
                                   state.dataEnvrn->Month,
                                   state.dataEnvrn->DayOfMonth,
@@ -4973,7 +4970,7 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
                 //      ActualtimeE = ActualTimeS+TimeStepSys
                 //      ActualTimeHrS=INT(ActualTimeS)
                 //      ActualTimeMin=NINT((ActualtimeE - ActualTimeHrS)*FracToMin)
-                ActualTimeMin = DetermineMinuteForReporting(state, t_timeStepType);
+                ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
                 EncodeMonDayHrMin(state.dataOutRptTab->timestepTimeStampGHGR,
                                   state.dataEnvrn->Month,
                                   state.dataEnvrn->DayOfMonth,
@@ -5094,7 +5091,7 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
         //  ActualtimeE = ActualTimeS+TimeStepSys
         //  ActualTimeHrS=INT(ActualTimeS)
         //  ActualTimeMin=NINT((ActualtimeE - ActualTimeHrS)*FracToMin)
-        ActualTimeMin = DetermineMinuteForReporting(state, t_timeStepType);
+        ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
         EncodeMonDayHrMin(state.dataOutRptTab->timestepTimeStampGHGR,
                           state.dataEnvrn->Month,
                           state.dataEnvrn->DayOfMonth,
@@ -5200,7 +5197,7 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
         //  ActualtimeE = ActualTimeS+TimeStepSys
         //  ActualTimeHrS=INT(ActualTimeS)
         //  ActualTimeMin=NINT((ActualtimeE - ActualTimeHrS)*FracToMin)
-        ActualTimeMin = DetermineMinuteForReporting(state, t_timeStepType);
+        ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
         EncodeMonDayHrMin(state.dataOutRptTab->timestepTimeStampGHGR,
                           state.dataEnvrn->Month,
                           state.dataEnvrn->DayOfMonth,

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -3714,7 +3714,7 @@ void GatherMonthlyResultsForTimestep(EnergyPlusData &state, OutputProcessor::Tim
                 newDuration = 0.0;
                 activeNewValue = false;
                 // the current timestamp
-                minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
+                minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state);
                 //      minuteCalculated = (CurrentTime - INT(CurrentTime))*60
                 //      IF (t_timeStepType .EQ. OutputProcessor::TimeStepType::TimeStepSystem) minuteCalculated = minuteCalculated +
                 //      SysTimeElapsed * 60 minuteCalculated = INT((TimeStep-1) * TimeStepZone * 60) + INT((SysTimeElapsed + TimeStepSys) * 60)
@@ -4294,7 +4294,7 @@ void GatherPeakDemandForTimestep(EnergyPlusData &state, OutputProcessor::TimeSte
                     ort->gatherDemandTotal(iResource) = curDemandValue;
                     // save the time that the peak demand occurred
                     //        minuteCalculated = (CurrentTime - INT(CurrentTime))*60
-                    minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
+                    minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state);
                     EncodeMonDayHrMin(
                         timestepTimeStamp, state.dataEnvrn->Month, state.dataEnvrn->DayOfMonth, state.dataGlobal->HourOfDay, minuteCalculated);
                     ort->gatherDemandTimeStamp(iResource) = timestepTimeStamp;
@@ -4857,7 +4857,7 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
                 //      ActualtimeE = ActualTimeS+TimeStepSys
                 //      ActualTimeHrS=INT(ActualTimeS)
                 //      ActualTimeMin=NINT((ActualtimeE - ActualTimeHrS)*FracToMin)
-                ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
+                ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state);
                 EncodeMonDayHrMin(state.dataOutRptTab->timestepTimeStampGHGR,
                                   state.dataEnvrn->Month,
                                   state.dataEnvrn->DayOfMonth,
@@ -4970,7 +4970,7 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
                 //      ActualtimeE = ActualTimeS+TimeStepSys
                 //      ActualTimeHrS=INT(ActualTimeS)
                 //      ActualTimeMin=NINT((ActualtimeE - ActualTimeHrS)*FracToMin)
-                ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
+                ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state);
                 EncodeMonDayHrMin(state.dataOutRptTab->timestepTimeStampGHGR,
                                   state.dataEnvrn->Month,
                                   state.dataEnvrn->DayOfMonth,
@@ -5091,7 +5091,7 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
         //  ActualtimeE = ActualTimeS+TimeStepSys
         //  ActualTimeHrS=INT(ActualTimeS)
         //  ActualTimeMin=NINT((ActualtimeE - ActualTimeHrS)*FracToMin)
-        ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
+        ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state);
         EncodeMonDayHrMin(state.dataOutRptTab->timestepTimeStampGHGR,
                           state.dataEnvrn->Month,
                           state.dataEnvrn->DayOfMonth,
@@ -5197,7 +5197,7 @@ void GatherHeatGainReport(EnergyPlusData &state, OutputProcessor::TimeStepType t
         //  ActualtimeE = ActualTimeS+TimeStepSys
         //  ActualTimeHrS=INT(ActualTimeS)
         //  ActualTimeMin=NINT((ActualtimeE - ActualTimeHrS)*FracToMin)
-        ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state, t_timeStepType);
+        ActualTimeMin = OutputProcessor::DetermineMinuteForReporting(state);
         EncodeMonDayHrMin(state.dataOutRptTab->timestepTimeStampGHGR,
                           state.dataEnvrn->Month,
                           state.dataEnvrn->DayOfMonth,

--- a/src/EnergyPlus/OutputReportTabularAnnual.cc
+++ b/src/EnergyPlus/OutputReportTabularAnnual.cc
@@ -359,7 +359,7 @@ void AnnualTable::gatherForTimestep(EnergyPlusData &state, OutputProcessor::Time
                     Real64 newDuration = 0.0;
                     bool activeNewValue = false;
                     // the current timestamp
-                    int minuteCalculated = General::DetermineMinuteForReporting(state, kindOfTimeStep);
+                    int minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state, kindOfTimeStep);
                     General::EncodeMonDayHrMin(
                         timestepTimeStamp, state.dataEnvrn->Month, state.dataEnvrn->DayOfMonth, state.dataGlobal->HourOfDay, minuteCalculated);
                     // perform the selected aggregation type

--- a/src/EnergyPlus/OutputReportTabularAnnual.cc
+++ b/src/EnergyPlus/OutputReportTabularAnnual.cc
@@ -359,7 +359,7 @@ void AnnualTable::gatherForTimestep(EnergyPlusData &state, OutputProcessor::Time
                     Real64 newDuration = 0.0;
                     bool activeNewValue = false;
                     // the current timestamp
-                    int minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state, kindOfTimeStep);
+                    int minuteCalculated = OutputProcessor::DetermineMinuteForReporting(state);
                     General::EncodeMonDayHrMin(
                         timestepTimeStamp, state.dataEnvrn->Month, state.dataEnvrn->DayOfMonth, state.dataGlobal->HourOfDay, minuteCalculated);
                     // perform the selected aggregation type

--- a/src/EnergyPlus/SimAirServingZones.cc
+++ b/src/EnergyPlus/SimAirServingZones.cc
@@ -2416,7 +2416,6 @@ void SimAirLoops(EnergyPlusData &state, bool const FirstHVACIteration, bool &Sim
     // REFERENCES: None
 
     // Using/Aliasing
-    using General::GetPreviousHVACTime;
     using HVACInterfaceManager::UpdateHVACInterface;
 
     // Locals
@@ -2481,7 +2480,7 @@ void SimAirLoops(EnergyPlusData &state, bool const FirstHVACIteration, bool &Sim
     // reflect the numerical work. The condition to detect a new HVAC time step is essentially
     // based on the time stamp at the beginning of the current HVAC step (expressed in seconds).
     if (FirstHVACIteration) {
-        rxTime = GetPreviousHVACTime(state);
+        rxTime = HVACControllers::GetPreviousHVACTime(state);
         if (state.dataSimAirServingZones->SavedPreviousHVACTime != rxTime) {
             state.dataSimAirServingZones->SavedPreviousHVACTime = rxTime;
             state.dataSimAirServingZones->salIterTot = 0;

--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -4214,7 +4214,6 @@ void CLIPPOLY(EnergyPlusData &state,
     // METHODOLOGY EMPLOYED:
     // The Sutherland-Hodgman algorithm for polygon clipping is employed.
 
-    using General::ReallocateRealArray;
     using General::SafeDivide;
 
     typedef Array2D<Int64>::size_type size_type;

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -1687,8 +1687,6 @@ void ShowRecurringErrors(EnergyPlusData &state)
     // Using/Aliasing
     using namespace DataErrorTracking;
 
-    using General::strip_trailing_zeros;
-
     static constexpr std::string_view StatMessageStart(" **   ~~~   ** ");
 
     int Loop;
@@ -1739,20 +1737,17 @@ void ShowRecurringErrors(EnergyPlusData &state)
             }
             StatMessage = "";
             if (error.ReportMax) {
-                MaxOut = format("{:.6R}", error.MaxValue);
-                strip_trailing_zeros(MaxOut);
+                MaxOut = format("{:.6f}", error.MaxValue);
                 StatMessage += "  Max=" + MaxOut;
                 if (!error.MaxUnits.empty()) StatMessage += ' ' + error.MaxUnits;
             }
             if (error.ReportMin) {
-                MinOut = format("{:.6R}", error.MinValue);
-                strip_trailing_zeros(MinOut);
+                MinOut = format("{:.6f}", error.MinValue);
                 StatMessage += "  Min=" + MinOut;
                 if (!error.MinUnits.empty()) StatMessage += ' ' + error.MinUnits;
             }
             if (error.ReportSum) {
-                SumOut = format("{:.6R}", error.SumValue);
-                strip_trailing_zeros(SumOut);
+                SumOut = format("{:.6f}", error.SumValue);
                 StatMessage += "  Sum=" + SumOut;
                 if (!error.SumUnits.empty()) StatMessage += ' ' + error.SumUnits;
             }

--- a/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.cc
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.cc
@@ -19,17 +19,6 @@ namespace ObjexxFCL {
 
 // Modifier /////
 
-// Lowercase a string
-std::string &
-lowercase( std::string & s )
-{
-	std::string::size_type const s_len( s.length() );
-	for ( std::string::size_type i = 0; i < s_len; ++i ) {
-		lowercase( s[ i ] );
-	}
-	return s;
-}
-
 // Uppercase a string
 std::string &
 uppercase( std::string & s )
@@ -37,18 +26,6 @@ uppercase( std::string & s )
 	std::string::size_type const s_len( s.length() );
 	for ( std::string::size_type i = 0; i < s_len; ++i ) {
 		uppercase( s[ i ] );
-	}
-	return s;
-}
-
-// Right Justify a string
-std::string &
-rjustify( std::string & s )
-{
-	std::string::size_type const s_len_trim( len_trim( s ) );
-	std::string::size_type const off( s.length() - s_len_trim );
-	if ( off > 0 ) {
-		s.erase( s_len_trim ).insert( 0, off, ' ' );
 	}
 	return s;
 }
@@ -80,21 +57,6 @@ strip( std::string & s, std::string const & chars )
 		} else {
 			if ( ie < s.length() - 1 ) s.erase( ie + 1 );
 			if ( ib > 0 ) s.erase( 0, ib );
-		}
-	}
-	return s;
-}
-
-// Strip Specified Characters from a string's Left Tail
-std::string &
-lstrip( std::string & s, std::string const & chars )
-{
-	if ( ! s.empty() ) {
-		std::string::size_type const ib( s.find_first_not_of( chars ) );
-		if ( ib == std::string::npos ) { // All of string is from chars
-			s.clear();
-		} else if ( ib > 0 ) {
-			s.erase( 0, ib );
 		}
 	}
 	return s;
@@ -132,21 +94,6 @@ strip( std::string & s )
 	return s;
 }
 
-// Strip Space from a string's Left Tail
-std::string &
-lstrip( std::string & s )
-{
-	if ( ! s.empty() ) {
-		std::string::size_type const ib( s.find_first_not_of( ' ' ) );
-		if ( ib == std::string::npos ) { // All of string is ' '
-			s.clear();
-		} else if ( ib > 0 ) {
-			s.erase( 0, ib );
-		}
-	}
-	return s;
-}
-
 // Strip Space from a string's Right Tail
 std::string &
 rstrip( std::string & s )
@@ -165,32 +112,6 @@ rstrip( std::string & s )
 // Size a string to a Specified Length
 std::string &
 size( std::string & s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	if ( s_len < len ) { // Pad
-		s.append( len - s_len, ' ' );
-	} else if ( s_len > len ) { // Truncate
-		s.erase( len );
-	}
-	return s;
-}
-
-// Left-Size a string to a Specified Length
-std::string &
-lsize( std::string & s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	if ( s_len < len ) { // Left pad
-		s.insert( 0, len - s_len, ' ' );
-	} else if ( s_len > len ) { // Left truncate
-		s.erase( 0, s_len - len );
-	}
-	return s;
-}
-
-// Right-Size a string to a Specified Length
-std::string &
-rsize( std::string & s, std::string::size_type const len )
 {
 	std::string::size_type const s_len( s.length() );
 	if ( s_len < len ) { // Pad
@@ -257,16 +178,6 @@ std::string &overlay(std::string &s, std::string_view const t,
 }
 
 // Generator /////
-
-// Lowercased Copy of a string
-std::string lowercased(std::string_view const s) {
-  std::string t(s);
-  std::string::size_type const t_len(t.length());
-  for (std::string::size_type i = 0; i < t_len; ++i) {
-    lowercase(t[i]);
-  }
-  return t;
-}
 
 // Uppercased Copy of a string
 std::string uppercased(std::string_view const s) {
@@ -348,36 +259,6 @@ std::string stripped(std::string_view const s, std::string_view const chars) {
   }
 }
 
-// Specified Characters Stripped from a string's Left Tail Copy of a string
-std::string lstripped(std::string_view const s, std::string_view const chars) {
-  if (s.empty()) {
-    return std::string{};
-  } else {
-    std::string::size_type const ib(s.find_first_not_of(chars));
-    if (ib == std::string::npos) { // All of string is from chars
-      return std::string();        // Return empty string
-    } else if (ib > 0) {
-      return std::string{s.substr(ib)};
-    } else {
-      return std::string{s};
-    }
-  }
-}
-
-// Specified Characters Stripped from a string's Right Tail Copy of a string
-std::string rstripped(std::string_view const s, std::string_view const chars) {
-  if (s.empty()) {
-    return std::string{};
-  } else {
-    std::string::size_type const ie(s.find_last_not_of(chars));
-    if (ie == std::string::npos) { // All of string is from chars
-      return std::string();        // Return empty string
-    } else {
-      return std::string{s.substr(0, ie + 1)};
-    }
-  }
-}
-
 // Space Stripped from a string's Tails Copy of a string
 std::string stripped(std::string_view const s) {
   if (s.empty()) {
@@ -390,36 +271,6 @@ std::string stripped(std::string_view const s) {
       return std::string();          // Return empty string
     } else {
       return std::string{s.substr(ib, ie - ib + 1)};
-    }
-  }
-}
-
-// Space Stripped from a string's Left Tail Copy of a string
-std::string lstripped(std::string_view const s) {
-  if (s.empty()) {
-    return std::string{};
-  } else {
-    std::string::size_type const ib(s.find_first_not_of(' '));
-    if (ib == std::string::npos) { // All of string is ' '
-      return std::string();        // Return empty string
-    } else if (ib > 0) {
-      return std::string{s.substr(ib)};
-    } else {
-      return std::string{s};
-    }
-  }
-}
-
-// Space Stripped from a string's Right Tail Copy of a string
-std::string rstripped(std::string_view const s) {
-  if (s.empty()) {
-    return std::string{};
-  } else {
-    std::string::size_type const ie(s.find_last_not_of(' '));
-    if (ie == std::string::npos) { // All of string is ' '
-      return std::string();        // Return empty string
-    } else {
-      return std::string{s.substr(0, ie + 1)};
     }
   }
 }
@@ -453,30 +304,6 @@ std::string sized(std::string_view const s, std::string::size_type const len) {
   }
 }
 
-// Left-Sized to a Specified Length Copy of a string
-std::string lsized(std::string_view const s, std::string::size_type const len) {
-  std::string::size_type const s_len(s.length());
-  if (s_len < len) { // Left-padded
-    return std::string(len - s_len, ' ') + std::string{s};
-  } else if (s_len == len) { // Unchanged
-    return std::string{s};
-  } else { // Truncated
-    return std::string{s.substr(s_len - len)};
-  }
-}
-
-// Right-Sized to a Specified Length Copy of a string
-std::string rsized(std::string_view const s, std::string::size_type const len) {
-  std::string::size_type const s_len(s.length());
-  if (s_len < len) { // Right-padded
-    return std::string{s} + std::string(len - s_len, ' ');
-  } else if (s_len == len) { // Unchanged
-    return std::string{s};
-  } else { // Truncated
-    return std::string{s.substr(0, len)};
-  }
-}
-
 // Centered String to Specified Length
 std::string centered(std::string_view const s,
                      std::string::size_type const len) {
@@ -492,32 +319,6 @@ std::string centered(std::string_view const s,
     std::string::size_type const off((t_len - len) / 2);
     return t.substr(off, len);
   }
-}
-
-// Removed Repeat Characters from a Possibly Unsorted string Preserving Order Copy of a string
-std::string uniqued(std::string_view const s) {
-  std::string u;
-  std::string::size_type const s_len(s.length());
-  for (std::string::size_type i = 0; i < s_len; ++i) {
-    if (u.find(s[i]) == std::string::npos) {
-      u.push_back(s[i]);
-    }
-  }
-  return u;
-}
-
-// Overlayed string with Another string, Expanding Size as Needed
-std::string overlayed(std::string_view const s, std::string_view const t,
-                      std::string::size_type const pos) {
-  std::string::size_type const s_len(s.length());
-  std::string::size_type const t_len(t.length());
-  std::string::size_type const l_len(pos +
-                                     t_len); // Lower bound on new string length
-  std::string o(s);
-  if (l_len > s_len)
-    o.resize(l_len, ' ');   // Expand
-  o.replace(pos, t_len, t); // Overlay the string
-  return o;
 }
 
 // Repeated Copies

--- a/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.hh
+++ b/third_party/ObjexxFCL/src/ObjexxFCL/string.functions.hh
@@ -802,41 +802,13 @@ ichar( std::string_view const s )
 	return ( ! s.empty() ? static_cast< int >( s[ 0 ] ) : 0 );
 }
 
-// One-Character string of a Given ASCII Integer Value
-inline
-std::string
-achar( int const i )
-{
-	return std::string( 1, static_cast< char >( i ) );
-}
-
 // Conversion to Numeric Types /////
 
-// Type of a string for Type Supporting Stream Input
-template< typename T >
-inline
-T
-type_of( std::string_view const s ) // Check is_type first
-{
-	std::istringstream t_stream( trimmed_whitespace( s ) );
-	T t;
-	t_stream >> t;
-	return ( t_stream && t_stream.eof() ? t : T() );
-}
-
 // Modifier /////
-
-// Lowercase a string
-std::string &
-lowercase( std::string & s );
 
 // Uppercase a string
 std::string &
 uppercase( std::string & s );
-
-// Right Justify a string
-std::string &
-rjustify( std::string & s );
 
 // Trim Trailing Space from a string
 std::string &
@@ -846,10 +818,6 @@ trim( std::string & s );
 std::string &
 strip( std::string & s, std::string const & chars );
 
-// Strip Specified Characters from a string's Left Tail
-std::string &
-lstrip( std::string & s, std::string const & chars );
-
 // Strip Specified Characters from a string's Right Tail
 std::string &
 rstrip( std::string & s, std::string const & chars );
@@ -857,10 +825,6 @@ rstrip( std::string & s, std::string const & chars );
 // Strip Space from a string's Tails
 std::string &
 strip( std::string & s );
-
-// Strip Space from a string's Left Tail
-std::string &
-lstrip( std::string & s );
 
 // Strip Space from a string's Right Tail
 std::string &
@@ -876,26 +840,6 @@ pad( std::string & s, std::string::size_type const len )
 	return s;
 }
 
-// Left-Pad a string to a Specified Length
-inline
-std::string &
-lpad( std::string & s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	if ( s_len < len ) s.insert( static_cast< std::string::size_type >( 0 ), len - s_len, ' ' ); // Left-pad
-	return s;
-}
-
-// Right-Pad a string to a Specified Length
-inline
-std::string &
-rpad( std::string & s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	if ( s_len < len ) s.append( len - s_len, ' ' ); // Pad
-	return s;
-}
-
 // Pare a string to a Specified Length
 inline
 std::string &
@@ -905,36 +849,9 @@ pare( std::string & s, std::string::size_type const len )
 	return s;
 }
 
-// Left-Pare a string to a Specified Length
-inline
-std::string &
-lpare( std::string & s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	if ( s_len > len ) s.erase( 0, s_len - len ); // Pare
-	return s;
-}
-
-// Right-Pare a string to a Specified Length
-inline
-std::string &
-rpare( std::string & s, std::string::size_type const len )
-{
-	if ( s.length() > len ) s.erase( len ); // Pare
-	return s;
-}
-
 // Size a string to a Specified Length
 std::string &
 size( std::string & s, std::string::size_type const len );
-
-// Left-Size a string to a Specified Length
-std::string &
-lsize( std::string & s, std::string::size_type const len );
-
-// Right-Size a string to a Specified Length
-std::string &
-rsize( std::string & s, std::string::size_type const len );
 
 // Center a string wrt its Whitespace
 std::string &
@@ -975,10 +892,6 @@ blank( std::string::size_type const len )
 	return std::string( len, ' ' );
 }
 
-// Lowercased Copy of a string
-std::string
-lowercased( std::string_view const s );
-
 // Uppercased Copy of a string
 std::string
 uppercased( std::string_view const s );
@@ -1003,93 +916,17 @@ trimmed_whitespace( std::string_view const s );
 std::string
 stripped( std::string_view const s, std::string_view const chars );
 
-// Specified Characters Stripped from a string's Left Tail Copy of a string
-std::string
-lstripped( std::string_view const s, std::string_view const chars );
-
-// Specified Characters Stripped from a string's Right Tail Copy of a string
-std::string
-rstripped( std::string_view const s, std::string_view const chars );
-
 // Space Stripped from a string's Tails Copy of a string
 std::string
 stripped( std::string_view const s );
-
-// Space Stripped from a string's Left Tail Copy of a string
-std::string
-lstripped( std::string_view const s );
-
-// Space Stripped from a string's Right Tail Copy of a string
-std::string
-rstripped( std::string_view const s );
 
 // Whitespace Stripped from a string's Tails Copy of a string
 std::string
 stripped_whitespace( std::string_view const s );
 
-// Padded to a Specified Length Copy of a string
-inline
-std::string
-padded( std::string_view const s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	return ( s_len < len ? std::string{s} + std::string( len - s_len, ' ' ) : std::string{s} );
-}
-
-// Left-Padded to a Specified Length Copy of a string
-inline
-std::string
-lpadded( std::string_view const s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	return ( s_len < len ? std::string( len - s_len, ' ' ).append( s ) : std::string{s} );
-}
-
-// Right-Padded to a Specified Length Copy of a string
-inline
-std::string
-rpadded( std::string_view const s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	return ( s_len < len ? std::string{s} + std::string( len - s_len, ' ' ) : std::string{s} );
-}
-
-// Pared to a Specified Length Copy of a string
-inline
-std::string
-pared( std::string_view const s, std::string::size_type const len )
-{
-	return ( s.length() > len ? std::string( s, 0, len ) : std::string{s} );
-}
-
-// Left-Pared to a Specified Length Copy of a string
-inline
-std::string
-lpared( std::string_view const s, std::string::size_type const len )
-{
-	std::string::size_type const s_len( s.length() );
-	return ( s_len > len ? std::string( s, s_len - len, std::string::npos ) : std::string{s} );
-}
-
-// Right-Pared to a Specified Length Copy of a string
-inline
-std::string
-rpared( std::string_view const s, std::string::size_type const len )
-{
-	return ( s.length() > len ? std::string( s, 0, len ) : std::string{s} );
-}
-
 // Sized to a Specified Length Copy of a string
 std::string
 sized( std::string_view const s, std::string::size_type const len );
-
-// Left-Sized to a Specified Length Copy of a string
-std::string
-lsized( std::string_view const s, std::string::size_type const len );
-
-// Right-Sized to a Specified Length Copy of a string
-std::string
-rsized( std::string_view const s, std::string::size_type const len );
 
 // Centered in a string of Specified Length Copy of a string
 std::string
@@ -1102,10 +939,6 @@ centered( std::string_view const s )
 {
 	return centered( stripped_whitespace( s ), s.length() );
 }
-
-// Removed Repeat Characters from a Possibly Unsorted string Preserving Order Copy of a string
-std::string
-uniqued( std::string_view const s );
 
 // Substring Replaced Copy of a string
 inline
@@ -1120,14 +953,6 @@ replaced( std::string_view const s, std::string_view const a, std::string_view c
 // Overlayed string with Another string, Expanding Size as Needed
 std::string
 overlayed( std::string_view const s, std::string_view const t, std::string::size_type const pos = 0 );
-
-// Overlayed string with Another string, Expanding Size as Needed
-inline
-std::string
-overlaid( std::string_view const s, std::string_view const t, std::string::size_type const pos = 0 )
-{
-	return overlayed( s, t, pos );
-}
 
 // Repeated Copies
 std::string
@@ -1166,79 +991,6 @@ operator +( std::string const & s, char const * const t )
 }
 
 // Conversion To std::string
-
-// string of a Template Argument Type Supporting Stream Output
-template< typename T >
-inline
-std::string
-string_of( T const & t )
-{
-	std::ostringstream t_stream;
-	t_stream << std::uppercase << std::setprecision( TypeTraits< T >::precision ) << t;
-	return t_stream.str();
-}
-
-// string of a Template Argument Type Supporting Stream Output
-template< typename T >
-inline
-std::string
-string_of(
- T const & t,
- int const p // Precision
-)
-{
-	std::ostringstream t_stream;
-	t_stream << std::uppercase << std::setprecision( p ) << t;
-	return t_stream.str();
-}
-
-// Left-Justified string of a Template Argument Type Supporting Stream Output
-template< typename T >
-inline
-std::string
-lstring_of(
- T const & t,
- int const w, // Minimum width
- char const f = ' ' // Fill character
-)
-{
-	std::ostringstream t_stream;
-	t_stream << std::left << std::uppercase
-	 << std::setw( w ) << std::setfill( f ) << std::setprecision( TypeTraits< T >::precision ) << t;
-	return t_stream.str();
-}
-
-// Right-Justified General Format string of a Template Argument Type Supporting Stream Output
-template< typename T >
-inline
-std::string
-general_string_of(
- T const & t,
- int const w = TypeTraits< T >::iwidth, // Minimum width
- std::streamsize const p = TypeTraits< T >::precision // Precision
-)
-{
-	std::ostringstream t_stream;
-	t_stream << std::right << std::uppercase << std::showpoint
-	 << std::setw( w ) << std::setprecision( p ) << t;
-	return t_stream.str();
-}
-
-// Right-Justified Fixed Format string of a Template Argument Type Supporting Stream Output
-template< typename T >
-inline
-std::string
-fixed_string_of(
- T const & t,
- int const w = TypeTraits< T >::iwidth, // Minimum width
- std::streamsize const p = TypeTraits< T >::precision // Precision
-)
-{
-	std::ostringstream t_stream;
-	t_stream << std::right << std::uppercase << std::fixed << std::showpoint
-	 << std::setw( w ) << std::setprecision( p ) << t;
-	return t_stream.str();
-}
 
 } // ObjexxFCL
 

--- a/tst/EnergyPlus/unit/General.unit.cc
+++ b/tst/EnergyPlus/unit/General.unit.cc
@@ -226,25 +226,6 @@ TEST_F(EnergyPlusFixture, General_CreateTimeString)
     }
 }
 
-TEST_F(EnergyPlusFixture, General_CreateTimeIntervalString)
-{
-    { // Time = 0 - 1
-        EXPECT_EQ("00:00:00.0 - 00:00:01.0", General::CreateTimeIntervalString(0, 1));
-    }
-    { // Time = 0 - 0
-        EXPECT_EQ("00:00:00.0 - 00:00:00.0", General::CreateTimeIntervalString(0, 0));
-    }
-    { // Time = 1 - 0
-        EXPECT_EQ("00:00:01.0 - 00:00:00.0", General::CreateTimeIntervalString(1, 0));
-    }
-    { // Time = 1 - 59
-        EXPECT_EQ("00:00:01.0 - 00:00:59.0", General::CreateTimeIntervalString(1, 59));
-    }
-    { // Time = 59 - 59.9
-        EXPECT_EQ("00:00:59.0 - 00:00:59.9", General::CreateTimeIntervalString(59, 59.9));
-    }
-}
-
 TEST_F(EnergyPlusFixture, General_SolveRootTest)
 {
     // New feature: Multiple solvers

--- a/tst/EnergyPlus/unit/OutputProcessor.unit.cc
+++ b/tst/EnergyPlus/unit/OutputProcessor.unit.cc
@@ -1041,13 +1041,13 @@ namespace OutputProcessor {
             1, 1, "Zone", "Environment", "Site Outdoor Air Drybulb Temperature", 1, "C", 1, false);
 
         WriteReportIntegerData(*state, 1, "1", 999.9, StoreType::Summed, 1, ReportingFrequency::TimeStep, 0, 0, 0, 0);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,999.9"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,999.900000"}, "\n")));
 
         WriteReportIntegerData(*state, 1, "1", 999.9, StoreType::Summed, 1, ReportingFrequency::EachCall, 0, 0, 0, 0);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,999.9"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,999.900000"}, "\n")));
 
         WriteReportIntegerData(*state, 1, "1", 999.9, StoreType::Summed, 1, ReportingFrequency::Hourly, 0, 0, 0, 0);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,999.9"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,999.900000"}, "\n")));
 
         WriteReportIntegerData(
             *state, 1, "1", 616771620.98702729, StoreType::Summed, 1, ReportingFrequency::Daily, 4283136, 12210110, 4283196, 12212460);
@@ -1062,31 +1062,31 @@ namespace OutputProcessor {
         EXPECT_TRUE(compare_eso_stream(delimited_string({"1,616771620.987027,4283136,12,21, 1,10,4283196,12,21,24,60"}, "\n")));
 
         WriteReportIntegerData(*state, 1, "1", 616771620.98702729, StoreType::Averaged, 10, ReportingFrequency::TimeStep, 0, 0, 0, 0);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.0987027"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.098703"}, "\n")));
 
         WriteReportIntegerData(*state, 1, "1", 616771620.98702729, StoreType::Averaged, 10, ReportingFrequency::EachCall, 0, 0, 0, 0);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.0987027"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.098703"}, "\n")));
 
         WriteReportIntegerData(*state, 1, "1", 616771620.98702729, StoreType::Averaged, 10, ReportingFrequency::Hourly, 0, 0, 0, 0);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.0987027"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.098703"}, "\n")));
 
         WriteReportIntegerData(
             *state, 1, "1", 616771620.98702729, StoreType::Averaged, 10, ReportingFrequency::Daily, 4283136, 12210110, 4283196, 12212460);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.0987027,4283136, 1,10,4283196,24,60"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.098703,4283136, 1,10,4283196,24,60"}, "\n")));
 
         WriteReportIntegerData(
             *state, 1, "1", 616771620.98702729, StoreType::Averaged, 10, ReportingFrequency::Monthly, 4283136, 12210110, 4283196, 12212460);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.0987027,4283136,21, 1,10,4283196,21,24,60"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.098703,4283136,21, 1,10,4283196,21,24,60"}, "\n")));
 
         WriteReportIntegerData(
             *state, 1, "1", 616771620.98702729, StoreType::Averaged, 10, ReportingFrequency::Simulation, 4283136, 12210110, 4283196, 12212460);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.0987027,4283136,12,21, 1,10,4283196,12,21,24,60"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,61677162.098703,4283136,12,21, 1,10,4283196,12,21,24,60"}, "\n")));
 
         WriteReportIntegerData(*state, 1, "1", 0, StoreType::Summed, 1, ReportingFrequency::TimeStep, 0, 0, 0, 0);
         EXPECT_TRUE(compare_eso_stream(delimited_string({"1,0.0"}, "\n")));
 
         WriteReportIntegerData(*state, 1, "1", 25.75, StoreType::Averaged, 720, ReportingFrequency::Monthly, 0, 4010115, 1, 4011560);
-        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,0.3E-01,0, 1, 1,15,1, 1,15,60"}, "\n")));
+        EXPECT_TRUE(compare_eso_stream(delimited_string({"1,0.035764,0, 1, 1,15,1, 1,15,60"}, "\n")));
 
         auto reportDataResults = queryResult("SELECT * FROM ReportData;", "ReportData");
         auto reportExtendedDataResults = queryResult("SELECT * FROM ReportExtendedData;", "ReportExtendedData");


### PR DESCRIPTION
Pull request overview
---------------------
This is just a quick pass through General.cc looking for low-hanging fruit to move/remove. 

- strip_trailing_zeros removed.  
  - I really dislike doing too many string operations just to manipulate how we are presenting data.  
  - I understand some care should be given to making our outputs readable, and **_maybe_** I could be convinced that we want to round to a practical precision, but converting strings to numbers and processing them just to remove trailing zeros seems like too much.  
  - This change only causes some ERR diffs that I hope are reasonable.

```diff
--- 
+++ 
@@ -20,7 +20,7 @@
    *************  **   ~~~   **   This error occurred 143 total times;
    *************  **   ~~~   **   during Warmup 0 times;
    *************  **   ~~~   **   during Sizing 0 times.
-   *************  **   ~~~   **   Max=-18.8 [C]  Min=-18.8 [C]
+   *************  **   ~~~   **   Max=-18.800000 [C]  Min=-18.800000 [C]
    *************
    ************* EnergyPlus Warmup Error Summary. During Warmup: 0 Warning; 0 Severe Errors.
    ************* EnergyPlus Sizing Error Summary. During Sizing: 0 Warning; 0 Severe Errors.
```

- Several functions just moved to better locations, for example if they were only ever used in one module, they now live there.
- Some other functions were eliminated, such as `LogicalToInteger`, which was only used in a small number of places, and can easily be replaced with a `? 1 : 0`.

I am not emotionally connected with these changes, it was just a quick pass while waiting on the curve branch to merge.  So if people hate the numeric change then the last commit can be reverted, or this whole thing can be tabled and we'll do it another time.
