### PR TITLE
Remove Optionals from CurveManager

### DIFF
--- a/scripts/dev/check_formatting.bat
+++ b/scripts/dev/check_formatting.bat
@@ -1,0 +1,21 @@
+@echo off
+
+rem Windows batch file version of the format checker script. Basically, the
+rem same caveats apply here as apply to the shell script version. This version
+rem does assume that the clang-format executable is in the path, which is
+rem different than the shell script.
+
+set exts=.cc .hh .cpp .hpp .c .h
+set dirs=src\EnergyPlus\ tst\EnergyPlus\unit\
+
+for %%d in (%dirs%) do (
+  echo ***Processing files in directory: %%d
+  for %%x in (%exts%) do call:check %%d %%x
+)
+
+goto:eof
+
+:check
+for /r %~1 %%f in (*%~2) do clang-format --dry-run --Werror --style=file %%f
+goto:eof
+

--- a/src/EnergyPlus/Coils/CoilCoolingDXCurveFitSpeed.cc
+++ b/src/EnergyPlus/Coils/CoilCoolingDXCurveFitSpeed.cc
@@ -184,7 +184,7 @@ void CoilCoolingDXCurveFitSpeed::instantiateFromInputSpec(EnergyPlus::EnergyPlus
             ShowContinueError(state, "..." + fieldName + "=\"" + curveName + "\" has out of range values.");
             ShowContinueError(state, format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
             ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-            Curve::SetCurveOutputMinMaxValues(state, this->indexPLRFPLF, errorsFound, 0.7, _);
+            Curve::SetCurveOutputMinValue(state, this->indexPLRFPLF, errorsFound, 0.7);
         }
 
         if (MaxCurveVal > 1.0) {
@@ -192,7 +192,7 @@ void CoilCoolingDXCurveFitSpeed::instantiateFromInputSpec(EnergyPlus::EnergyPlus
             ShowContinueError(state, "..." + fieldName + " = " + curveName + " has out of range value.");
             ShowContinueError(state, format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
             ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-            Curve::SetCurveOutputMinMaxValues(state, this->indexPLRFPLF, errorsFound, _, 1.0);
+            Curve::SetCurveOutputMaxValue(state, this->indexPLRFPLF, errorsFound, 1.0);
         }
     }
 

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -2797,43 +2797,131 @@ namespace Curve {
     }
 
     Real64 Curve::BtwxtTableInterpolation(EnergyPlusData &state,
-                                          Real64 const Var1,                      // 1st independent variable
-                                          ObjexxFCL::Optional<Real64 const> Var2, // 2nd independent variable
-                                          ObjexxFCL::Optional<Real64 const> Var3, // 3rd independent variable
-                                          ObjexxFCL::Optional<Real64 const> Var4, // 4th independent variable
-                                          ObjexxFCL::Optional<Real64 const> Var5, // 5th independent variable
-                                          ObjexxFCL::Optional<Real64 const> Var6  // 6th independent variable
+                                          const Real64 Var1 // 1st independent variable
     )
     {
         // TODO: Generalize for N-dims
-        Real64 var = Var1;
-        var = max(min(var, this->inputLimits[0].max), this->inputLimits[0].min);
-        std::vector<double> target{var};
-        if (present(Var2)) {
-            var = Var2;
-            var = max(min(var, this->inputLimits[1].max), this->inputLimits[1].min);
-            target.push_back(var);
-        }
-        if (present(Var3)) {
-            var = Var3;
-            var = max(min(var, this->inputLimits[2].max), this->inputLimits[2].min);
-            target.push_back(var);
-        }
-        if (present(Var4)) {
-            var = Var4;
-            var = max(min(var, this->inputLimits[3].max), this->inputLimits[3].min);
-            target.push_back(var);
-        }
-        if (present(Var5)) {
-            var = Var5;
-            var = max(min(var, this->inputLimits[4].max), this->inputLimits[4].min);
-            target.push_back(var);
-        }
-        if (present(Var6)) {
-            var = Var6;
-            var = max(min(var, this->inputLimits[5].max), this->inputLimits[5].min);
-            target.push_back(var);
-        }
+        std::vector<double> target{max(min(Var1, this->inputLimits[0].max), this->inputLimits[0].min)};
+
+        std::string contextString = format("Table:Lookup \"{}\"", this->Name);
+        std::pair<EnergyPlusData *, std::string> callbackPair{&state, contextString};
+        Btwxt::setMessageCallback(BtwxtMessageCallback, &callbackPair);
+        Real64 TableValue = state.dataCurveManager->btwxtManager.getGridValue(this->TableIndex, this->GridValueIndex, target);
+
+        if (this->outputLimits.minPresent) TableValue = max(TableValue, this->outputLimits.min);
+        if (this->outputLimits.maxPresent) TableValue = min(TableValue, this->outputLimits.max);
+
+        return TableValue;
+    }
+
+    Real64 Curve::BtwxtTableInterpolation(EnergyPlusData &state,
+                                          const Real64 Var1, // 1st independent variable
+                                          const Real64 Var2  // 2nd independent variable
+    )
+    {
+        // TODO: Generalize for N-dims
+        std::vector<double> target{max(min(Var1, this->inputLimits[0].max), this->inputLimits[0].min),
+                                   max(min(Var2, this->inputLimits[1].max), this->inputLimits[1].min)};
+
+        std::string contextString = format("Table:Lookup \"{}\"", this->Name);
+        std::pair<EnergyPlusData *, std::string> callbackPair{&state, contextString};
+        Btwxt::setMessageCallback(BtwxtMessageCallback, &callbackPair);
+        Real64 TableValue = state.dataCurveManager->btwxtManager.getGridValue(this->TableIndex, this->GridValueIndex, target);
+
+        if (this->outputLimits.minPresent) TableValue = max(TableValue, this->outputLimits.min);
+        if (this->outputLimits.maxPresent) TableValue = min(TableValue, this->outputLimits.max);
+
+        return TableValue;
+    }
+
+    Real64 Curve::BtwxtTableInterpolation(EnergyPlusData &state,
+                                          const Real64 Var1, // 1st independent variable
+                                          const Real64 Var2, // 2nd independent variable
+                                          const Real64 Var3  // 3rd independent variable
+    )
+    {
+        // TODO: Generalize for N-dims
+        std::vector<double> target{max(min(Var1, this->inputLimits[0].max), this->inputLimits[0].min),
+                                   max(min(Var2, this->inputLimits[1].max), this->inputLimits[1].min),
+                                   max(min(Var3, this->inputLimits[2].max), this->inputLimits[2].min)};
+
+        std::string contextString = format("Table:Lookup \"{}\"", this->Name);
+        std::pair<EnergyPlusData *, std::string> callbackPair{&state, contextString};
+        Btwxt::setMessageCallback(BtwxtMessageCallback, &callbackPair);
+        Real64 TableValue = state.dataCurveManager->btwxtManager.getGridValue(this->TableIndex, this->GridValueIndex, target);
+
+        if (this->outputLimits.minPresent) TableValue = max(TableValue, this->outputLimits.min);
+        if (this->outputLimits.maxPresent) TableValue = min(TableValue, this->outputLimits.max);
+
+        return TableValue;
+    }
+
+    Real64 Curve::BtwxtTableInterpolation(EnergyPlusData &state,
+                                          const Real64 Var1, // 1st independent variable
+                                          const Real64 Var2, // 2nd independent variable
+                                          const Real64 Var3, // 3rd independent variable
+                                          const Real64 Var4  // 4th independent variable
+    )
+    {
+        // TODO: Generalize for N-dims
+        std::vector<double> target{max(min(Var1, this->inputLimits[0].max), this->inputLimits[0].min),
+                                   max(min(Var2, this->inputLimits[1].max), this->inputLimits[1].min),
+                                   max(min(Var3, this->inputLimits[2].max), this->inputLimits[2].min),
+                                   max(min(Var4, this->inputLimits[3].max), this->inputLimits[3].min)};
+
+        std::string contextString = format("Table:Lookup \"{}\"", this->Name);
+        std::pair<EnergyPlusData *, std::string> callbackPair{&state, contextString};
+        Btwxt::setMessageCallback(BtwxtMessageCallback, &callbackPair);
+        Real64 TableValue = state.dataCurveManager->btwxtManager.getGridValue(this->TableIndex, this->GridValueIndex, target);
+
+        if (this->outputLimits.minPresent) TableValue = max(TableValue, this->outputLimits.min);
+        if (this->outputLimits.maxPresent) TableValue = min(TableValue, this->outputLimits.max);
+
+        return TableValue;
+    }
+
+    Real64 Curve::BtwxtTableInterpolation(EnergyPlusData &state,
+                                          const Real64 Var1, // 1st independent variable
+                                          const Real64 Var2, // 2nd independent variable
+                                          const Real64 Var3, // 3rd independent variable
+                                          const Real64 Var4, // 4th independent variable
+                                          const Real64 Var5  // 5th independent variable
+    )
+    {
+        // TODO: Generalize for N-dims
+        std::vector<double> target{max(min(Var1, this->inputLimits[0].max), this->inputLimits[0].min),
+                                   max(min(Var2, this->inputLimits[1].max), this->inputLimits[1].min),
+                                   max(min(Var3, this->inputLimits[2].max), this->inputLimits[2].min),
+                                   max(min(Var4, this->inputLimits[3].max), this->inputLimits[3].min),
+                                   max(min(Var5, this->inputLimits[4].max), this->inputLimits[4].min)};
+
+        std::string contextString = format("Table:Lookup \"{}\"", this->Name);
+        std::pair<EnergyPlusData *, std::string> callbackPair{&state, contextString};
+        Btwxt::setMessageCallback(BtwxtMessageCallback, &callbackPair);
+        Real64 TableValue = state.dataCurveManager->btwxtManager.getGridValue(this->TableIndex, this->GridValueIndex, target);
+
+        if (this->outputLimits.minPresent) TableValue = max(TableValue, this->outputLimits.min);
+        if (this->outputLimits.maxPresent) TableValue = min(TableValue, this->outputLimits.max);
+
+        return TableValue;
+    }
+
+    Real64 Curve::BtwxtTableInterpolation(EnergyPlusData &state,
+                                          const Real64 Var1, // 1st independent variable
+                                          const Real64 Var2, // 2nd independent variable
+                                          const Real64 Var3, // 3rd independent variable
+                                          const Real64 Var4, // 4th independent variable
+                                          const Real64 Var5, // 5th independent variable
+                                          const Real64 Var6  // 6th independent variable
+    )
+    {
+        // TODO: Generalize for N-dims
+        std::vector<double> target{max(min(Var1, this->inputLimits[0].max), this->inputLimits[0].min),
+                                   max(min(Var2, this->inputLimits[1].max), this->inputLimits[1].min),
+                                   max(min(Var3, this->inputLimits[2].max), this->inputLimits[2].min),
+                                   max(min(Var4, this->inputLimits[3].max), this->inputLimits[3].min),
+                                   max(min(Var5, this->inputLimits[4].max), this->inputLimits[4].min),
+                                   max(min(Var6, this->inputLimits[5].max), this->inputLimits[5].min)};
 
         std::string contextString = format("Table:Lookup \"{}\"", this->Name);
         std::pair<EnergyPlusData *, std::string> callbackPair{&state, contextString};
@@ -3019,19 +3107,9 @@ namespace Curve {
     }
 
     void GetCurveMinMaxValues(EnergyPlusData &state,
-                              int const CurveIndex,                // index of curve in curve array
-                              Real64 &Var1Min,                     // Minimum values of 1st independent variable
-                              Real64 &Var1Max,                     // Maximum values of 1st independent variable
-                              ObjexxFCL::Optional<Real64> Var2Min, // Minimum values of 2nd independent variable
-                              ObjexxFCL::Optional<Real64> Var2Max, // Maximum values of 2nd independent variable
-                              ObjexxFCL::Optional<Real64> Var3Min, // Minimum values of 3rd independent variable
-                              ObjexxFCL::Optional<Real64> Var3Max, // Maximum values of 3rd independent variable
-                              ObjexxFCL::Optional<Real64> Var4Min, // Minimum values of 4th independent variable
-                              ObjexxFCL::Optional<Real64> Var4Max, // Maximum values of 4th independent variable
-                              ObjexxFCL::Optional<Real64> Var5Min, // Minimum values of 5th independent variable
-                              ObjexxFCL::Optional<Real64> Var5Max, // Maximum values of 5th independent variable
-                              ObjexxFCL::Optional<Real64> Var6Min, // Minimum values of 6th independent variable
-                              ObjexxFCL::Optional<Real64> Var6Max  // Maximum values of 6th independent variable
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max       // Maximum values of 1st independent variable
     )
     {
 
@@ -3048,23 +3126,183 @@ namespace Curve {
         Curve *thisCurve = state.dataCurveManager->PerfCurve(CurveIndex);
         Var1Min = thisCurve->inputLimits[0].min;
         Var1Max = thisCurve->inputLimits[0].max;
-        if (present(Var2Min)) Var2Min = thisCurve->inputLimits[1].min;
-        if (present(Var2Max)) Var2Max = thisCurve->inputLimits[1].max;
-        if (present(Var3Min)) Var3Min = thisCurve->inputLimits[2].min;
-        if (present(Var3Max)) Var3Max = thisCurve->inputLimits[2].max;
-        if (present(Var4Min)) Var4Min = thisCurve->inputLimits[3].min;
-        if (present(Var4Max)) Var4Max = thisCurve->inputLimits[3].max;
-        if (present(Var5Min)) Var5Min = thisCurve->inputLimits[4].min;
-        if (present(Var5Max)) Var5Max = thisCurve->inputLimits[4].max;
-        if (present(Var6Min)) Var6Min = thisCurve->inputLimits[5].min;
-        if (present(Var6Max)) Var6Max = thisCurve->inputLimits[5].max;
     }
 
-    void SetCurveOutputMinMaxValues(EnergyPlusData &state,
-                                    int const CurveIndex,                       // index of curve in curve array
-                                    bool &ErrorsFound,                          // TRUE when errors occur
-                                    ObjexxFCL::Optional<Real64 const> CurveMin, // Minimum value of curve output
-                                    ObjexxFCL::Optional<Real64 const> CurveMax  // Maximum values of curve output
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max       // Maximum values of 2nd independent variable
+    )
+    {
+
+        // FUNCTION INFORMATION:
+        //       AUTHOR         Lixing Gu
+        //       DATE WRITTEN   July 2006
+        //       MODIFIED       B. Griffith Aug 2006 add third independent variable
+        //       RE-ENGINEERED  na
+
+        // PURPOSE OF THIS FUNCTION:
+        // Given the curve index, returns the minimum and maximum values specified in the input
+        // for the independent variables of the performance curve.
+
+        Curve *thisCurve = state.dataCurveManager->PerfCurve(CurveIndex);
+        Var1Min = thisCurve->inputLimits[0].min;
+        Var1Max = thisCurve->inputLimits[0].max;
+        Var2Min = thisCurve->inputLimits[1].min;
+        Var2Max = thisCurve->inputLimits[1].max;
+    }
+
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max,      // Maximum values of 2nd independent variable
+                              Real64 &Var3Min,      // Minimum values of 3rd independent variable
+                              Real64 &Var3Max       // Maximum values of 3rd independent variable
+    )
+    {
+
+        // FUNCTION INFORMATION:
+        //       AUTHOR         Lixing Gu
+        //       DATE WRITTEN   July 2006
+        //       MODIFIED       B. Griffith Aug 2006 add third independent variable
+        //       RE-ENGINEERED  na
+
+        // PURPOSE OF THIS FUNCTION:
+        // Given the curve index, returns the minimum and maximum values specified in the input
+        // for the independent variables of the performance curve.
+
+        Curve *thisCurve = state.dataCurveManager->PerfCurve(CurveIndex);
+        Var1Min = thisCurve->inputLimits[0].min;
+        Var1Max = thisCurve->inputLimits[0].max;
+        Var2Min = thisCurve->inputLimits[1].min;
+        Var2Max = thisCurve->inputLimits[1].max;
+        Var3Min = thisCurve->inputLimits[2].min;
+        Var3Max = thisCurve->inputLimits[2].max;
+    }
+
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max,      // Maximum values of 2nd independent variable
+                              Real64 &Var3Min,      // Minimum values of 3rd independent variable
+                              Real64 &Var3Max,      // Maximum values of 3rd independent variable
+                              Real64 &Var4Min,      // Minimum values of 4th independent variable
+                              Real64 &Var4Max       // Maximum values of 4th independent variable
+    )
+    {
+
+        // FUNCTION INFORMATION:
+        //       AUTHOR         Lixing Gu
+        //       DATE WRITTEN   July 2006
+        //       MODIFIED       B. Griffith Aug 2006 add third independent variable
+        //       RE-ENGINEERED  na
+
+        // PURPOSE OF THIS FUNCTION:
+        // Given the curve index, returns the minimum and maximum values specified in the input
+        // for the independent variables of the performance curve.
+
+        Curve *thisCurve = state.dataCurveManager->PerfCurve(CurveIndex);
+        Var1Min = thisCurve->inputLimits[0].min;
+        Var1Max = thisCurve->inputLimits[0].max;
+        Var2Min = thisCurve->inputLimits[1].min;
+        Var2Max = thisCurve->inputLimits[1].max;
+        Var3Min = thisCurve->inputLimits[2].min;
+        Var3Max = thisCurve->inputLimits[2].max;
+        Var4Min = thisCurve->inputLimits[3].min;
+        Var4Max = thisCurve->inputLimits[3].max;
+    }
+
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max,      // Maximum values of 2nd independent variable
+                              Real64 &Var3Min,      // Minimum values of 3rd independent variable
+                              Real64 &Var3Max,      // Maximum values of 3rd independent variable
+                              Real64 &Var4Min,      // Minimum values of 4th independent variable
+                              Real64 &Var4Max,      // Maximum values of 4th independent variable
+                              Real64 &Var5Min,      // Minimum values of 5th independent variable
+                              Real64 &Var5Max       // Maximum values of 5th independent variable
+    )
+    {
+
+        // FUNCTION INFORMATION:
+        //       AUTHOR         Lixing Gu
+        //       DATE WRITTEN   July 2006
+        //       MODIFIED       B. Griffith Aug 2006 add third independent variable
+        //       RE-ENGINEERED  na
+
+        // PURPOSE OF THIS FUNCTION:
+        // Given the curve index, returns the minimum and maximum values specified in the input
+        // for the independent variables of the performance curve.
+
+        Curve *thisCurve = state.dataCurveManager->PerfCurve(CurveIndex);
+        Var1Min = thisCurve->inputLimits[0].min;
+        Var1Max = thisCurve->inputLimits[0].max;
+        Var2Min = thisCurve->inputLimits[1].min;
+        Var2Max = thisCurve->inputLimits[1].max;
+        Var3Min = thisCurve->inputLimits[2].min;
+        Var3Max = thisCurve->inputLimits[2].max;
+        Var4Min = thisCurve->inputLimits[3].min;
+        Var4Max = thisCurve->inputLimits[3].max;
+        Var5Min = thisCurve->inputLimits[4].min;
+        Var5Max = thisCurve->inputLimits[4].max;
+    }
+
+    
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max,      // Maximum values of 2nd independent variable
+                              Real64 &Var3Min,      // Minimum values of 3rd independent variable
+                              Real64 &Var3Max,      // Maximum values of 3rd independent variable
+                              Real64 &Var4Min,      // Minimum values of 4th independent variable
+                              Real64 &Var4Max,      // Maximum values of 4th independent variable
+                              Real64 &Var5Min,      // Minimum values of 5th independent variable
+                              Real64 &Var5Max,      // Maximum values of 5th independent variable
+                              Real64 &Var6Min,      // Minimum values of 6th independent variable
+                              Real64 &Var6Max       // Maximum values of 6th independent variable
+    )
+    {
+
+        // FUNCTION INFORMATION:
+        //       AUTHOR         Lixing Gu
+        //       DATE WRITTEN   July 2006
+        //       MODIFIED       B. Griffith Aug 2006 add third independent variable
+        //       RE-ENGINEERED  na
+
+        // PURPOSE OF THIS FUNCTION:
+        // Given the curve index, returns the minimum and maximum values specified in the input
+        // for the independent variables of the performance curve.
+
+        Curve *thisCurve = state.dataCurveManager->PerfCurve(CurveIndex);
+        Var1Min = thisCurve->inputLimits[0].min;
+        Var1Max = thisCurve->inputLimits[0].max;
+        Var2Min = thisCurve->inputLimits[1].min;
+        Var2Max = thisCurve->inputLimits[1].max;
+        Var3Min = thisCurve->inputLimits[2].min;
+        Var3Max = thisCurve->inputLimits[2].max;
+        Var4Min = thisCurve->inputLimits[3].min;
+        Var4Max = thisCurve->inputLimits[3].max;
+        Var5Min = thisCurve->inputLimits[4].min;
+        Var5Max = thisCurve->inputLimits[4].max;
+        Var6Min = thisCurve->inputLimits[5].min;
+        Var6Max = thisCurve->inputLimits[5].max;
+    }
+
+    void SetCurveOutputMinValue(EnergyPlusData &state,
+                                int const CurveIndex, // index of curve in curve array
+                                bool &ErrorsFound,    // TRUE when errors occur
+                                const Real64 CurveMin // Minimum value of curve output
     )
     {
 
@@ -3080,14 +3318,37 @@ namespace Curve {
 
         if (CurveIndex > 0 && CurveIndex <= state.dataCurveManager->NumCurves) {
             Curve *thisCurve = state.dataCurveManager->PerfCurve(CurveIndex);
-            if (present(CurveMin)) {
-                thisCurve->outputLimits.min = CurveMin;
-                thisCurve->outputLimits.minPresent = true;
-            }
-            if (present(CurveMax)) {
-                thisCurve->outputLimits.max = CurveMax;
-                thisCurve->outputLimits.maxPresent = true;
-            }
+            thisCurve->outputLimits.min = CurveMin;
+            thisCurve->outputLimits.minPresent = true;
+        } else {
+            ShowSevereError(
+                state,
+                format("SetCurveOutputMinValue: CurveIndex=[{}] not in range of curves=[1:{}].", CurveIndex, state.dataCurveManager->NumCurves));
+            ErrorsFound = true;
+        }
+    }
+
+    void SetCurveOutputMaxValue(EnergyPlusData &state,
+                               int const CurveIndex, // index of curve in curve array
+                               bool &ErrorsFound,    // TRUE when errors occur
+                               const Real64 CurveMax // Maximum values of curve output
+    )
+    {
+
+        // FUNCTION INFORMATION:
+        //       AUTHOR         Richard Raustad
+        //       DATE WRITTEN   Feb 2009
+        //       MODIFIED       na
+        //       RE-ENGINEERED  na
+
+        // PURPOSE OF THIS FUNCTION:
+        // Given the curve index, sets the minimum and maximum possible value for this curve.
+        // Certain curve types have set limits (e.g., PLF curve should not be greater than 1 or less than 0.7).
+
+        if (CurveIndex > 0 && CurveIndex <= state.dataCurveManager->NumCurves) {
+            Curve *thisCurve = state.dataCurveManager->PerfCurve(CurveIndex);
+            thisCurve->outputLimits.max = CurveMax;
+            thisCurve->outputLimits.maxPresent = true;
         } else {
             ShowSevereError(
                 state,

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -3256,7 +3256,6 @@ namespace Curve {
         Var5Max = thisCurve->inputLimits[4].max;
     }
 
-    
     void GetCurveMinMaxValues(EnergyPlusData &state,
                               int const CurveIndex, // index of curve in curve array
                               Real64 &Var1Min,      // Minimum values of 1st independent variable
@@ -3329,9 +3328,9 @@ namespace Curve {
     }
 
     void SetCurveOutputMaxValue(EnergyPlusData &state,
-                               int const CurveIndex, // index of curve in curve array
-                               bool &ErrorsFound,    // TRUE when errors occur
-                               const Real64 CurveMax // Maximum values of curve output
+                                int const CurveIndex, // index of curve in curve array
+                                bool &ErrorsFound,    // TRUE when errors occur
+                                const Real64 CurveMax // Maximum values of curve output
     )
     {
 

--- a/src/EnergyPlus/CurveManager.hh
+++ b/src/EnergyPlus/CurveManager.hh
@@ -56,7 +56,6 @@
 #include <ObjexxFCL/Array1D.hh>
 #include <ObjexxFCL/Array2D.hh>
 #include <ObjexxFCL/Array2S.hh>
-#include <ObjexxFCL/Optional.hh>
 
 #include <nlohmann/json.hpp>
 
@@ -175,12 +174,37 @@ namespace Curve {
         Real64 value(EnergyPlusData &state, Real64 V1, Real64 V2, Real64 V3, Real64 V4, Real64 V5, Real64 V6);
         Real64 valueFallback(EnergyPlusData &state, Real64 V1, Real64 V2, Real64 V3, Real64 V4, Real64 V5);
         Real64 BtwxtTableInterpolation(EnergyPlusData &state,
-                                       Real64 Var1,                                // 1st independent variable
-                                       ObjexxFCL::Optional<Real64 const> Var2 = _, // 2nd independent variable
-                                       ObjexxFCL::Optional<Real64 const> Var3 = _, // 3rd independent variable
-                                       ObjexxFCL::Optional<Real64 const> Var4 = _, // 4th independent variable
-                                       ObjexxFCL::Optional<Real64 const> Var5 = _, // 5th independent variable
-                                       ObjexxFCL::Optional<Real64 const> Var6 = _);
+                                       const Real64 Var1 // 1st independent variable
+        );
+        Real64 BtwxtTableInterpolation(EnergyPlusData &state,
+                                       const Real64 Var1, // 1st independent variable
+                                       const Real64 Var2  // 2nd independent variable
+        );
+        Real64 BtwxtTableInterpolation(EnergyPlusData &state,
+                                       const Real64 Var1, // 1st independent variable
+                                       const Real64 Var2, // 2nd independent variable
+                                       const Real64 Var3  // 3rd independent variable
+        );
+        Real64 BtwxtTableInterpolation(EnergyPlusData &state,
+                                       const Real64 Var1, // 1st independent variable
+                                       const Real64 Var2, // 2nd independent variable
+                                       const Real64 Var3, // 3rd independent variable
+                                       const Real64 Var4  // 4th independent variable
+        );
+        Real64 BtwxtTableInterpolation(EnergyPlusData &state,
+                                       const Real64 Var1, // 1st independent variable
+                                       const Real64 Var2, // 2nd independent variable
+                                       const Real64 Var3, // 3rd independent variable
+                                       const Real64 Var4, // 4th independent variable
+                                       const Real64 Var5 // 5th independent variable
+        );
+        Real64 BtwxtTableInterpolation(EnergyPlusData &state,
+                                       const Real64 Var1, // 1st independent variable
+                                       const Real64 Var2, // 2nd independent variable
+                                       const Real64 Var3, // 3rd independent variable
+                                       const Real64 Var4, // 4th independent variable
+                                       const Real64 Var5, // 5th independent variable
+                                       const Real64 Var6);
     };
 
     // Table file objects
@@ -306,26 +330,81 @@ namespace Curve {
     );
 
     void GetCurveMinMaxValues(EnergyPlusData &state,
-                              int CurveIndex,                          // index of curve in curve array
-                              Real64 &Var1Min,                         // Minimum values of 1st independent variable
-                              Real64 &Var1Max,                         // Maximum values of 1st independent variable
-                              ObjexxFCL::Optional<Real64> Var2Min = _, // Minimum values of 2nd independent variable
-                              ObjexxFCL::Optional<Real64> Var2Max = _, // Maximum values of 2nd independent variable
-                              ObjexxFCL::Optional<Real64> Var3Min = _, // Minimum values of 3rd independent variable
-                              ObjexxFCL::Optional<Real64> Var3Max = _, // Maximum values of 3rd independent variable
-                              ObjexxFCL::Optional<Real64> Var4Min = _, // Minimum values of 4th independent variable
-                              ObjexxFCL::Optional<Real64> Var4Max = _, // Maximum values of 4th independent variable
-                              ObjexxFCL::Optional<Real64> Var5Min = _, // Minimum values of 5th independent variable
-                              ObjexxFCL::Optional<Real64> Var5Max = _, // Maximum values of 5th independent variable
-                              ObjexxFCL::Optional<Real64> Var6Min = _, // Minimum values of 6th independent variable
-                              ObjexxFCL::Optional<Real64> Var6Max = _  // Maximum values of 6th independent variable
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max       // Maximum values of 1st independent variable
     );
 
-    void SetCurveOutputMinMaxValues(EnergyPlusData &state,
-                                    int CurveIndex,                                 // index of curve in curve array
-                                    bool &ErrorsFound,                              // TRUE when errors occur
-                                    ObjexxFCL::Optional<Real64 const> CurveMin = _, // Minimum value of curve output
-                                    ObjexxFCL::Optional<Real64 const> CurveMax = _  // Maximum values of curve output
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max       // Maximum values of 2nd independent variable
+    );
+
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max,      // Maximum values of 2nd independent variable
+                              Real64 &Var3Min,      // Minimum values of 3rd independent variable
+                              Real64 &Var3Max       // Maximum values of 3rd independent variable
+    );
+
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max,      // Maximum values of 2nd independent variable
+                              Real64 &Var3Min,      // Minimum values of 3rd independent variable
+                              Real64 &Var3Max,      // Maximum values of 3rd independent variable
+                              Real64 &Var4Min,      // Minimum values of 4th independent variable
+                              Real64 &Var4Max       // Maximum values of 4th independent variable
+    );
+
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max,      // Maximum values of 2nd independent variable
+                              Real64 &Var3Min,      // Minimum values of 3rd independent variable
+                              Real64 &Var3Max,      // Maximum values of 3rd independent variable
+                              Real64 &Var4Min,      // Minimum values of 4th independent variable
+                              Real64 &Var4Max,      // Maximum values of 4th independent variable
+                              Real64 &Var5Min,      // Minimum values of 5th independent variable
+                              Real64 &Var5Max       // Maximum values of 5th independent variable
+    );
+
+    void GetCurveMinMaxValues(EnergyPlusData &state,
+                              int const CurveIndex, // index of curve in curve array
+                              Real64 &Var1Min,      // Minimum values of 1st independent variable
+                              Real64 &Var1Max,      // Maximum values of 1st independent variable
+                              Real64 &Var2Min,      // Minimum values of 2nd independent variable
+                              Real64 &Var2Max,      // Maximum values of 2nd independent variable
+                              Real64 &Var3Min,      // Minimum values of 3rd independent variable
+                              Real64 &Var3Max,      // Maximum values of 3rd independent variable
+                              Real64 &Var4Min,      // Minimum values of 4th independent variable
+                              Real64 &Var4Max,      // Maximum values of 4th independent variable
+                              Real64 &Var5Min,      // Minimum values of 5th independent variable
+                              Real64 &Var5Max,      // Maximum values of 5th independent variable
+                              Real64 &Var6Min,      // Minimum values of 6th independent variable
+                              Real64 &Var6Max       // Maximum values of 6th independent variable
+    );
+
+    void SetCurveOutputMinValue(EnergyPlusData &state,
+                                int CurveIndex,       // index of curve in curve array
+                                bool &ErrorsFound,    // TRUE when errors occur
+                                const Real64 CurveMin // Minimum value of curve output
+    );
+
+    void SetCurveOutputMaxValue(EnergyPlusData &state,
+                                int CurveIndex,       // index of curve in curve array
+                                bool &ErrorsFound,    // TRUE when errors occur
+                                const Real64 CurveMax // Maximum values of curve output
     );
 
     void GetPressureSystemInput(EnergyPlusData &state);

--- a/src/EnergyPlus/CurveManager.hh
+++ b/src/EnergyPlus/CurveManager.hh
@@ -196,7 +196,7 @@ namespace Curve {
                                        const Real64 Var2, // 2nd independent variable
                                        const Real64 Var3, // 3rd independent variable
                                        const Real64 Var4, // 4th independent variable
-                                       const Real64 Var5 // 5th independent variable
+                                       const Real64 Var5  // 5th independent variable
         );
         Real64 BtwxtTableInterpolation(EnergyPlusData &state,
                                        const Real64 Var1, // 1st independent variable

--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -725,7 +725,6 @@ void GetDXCoils(EnergyPlusData &state)
     using Curve::checkCurveIsNormalizedToOne;
     using Curve::CurveValue;
     using Curve::GetCurveIndex;
-    using Curve::SetCurveOutputMinMaxValues;
     using DataSizing::AutoSize;
     using EMSManager::ManageEMS;
 
@@ -1150,7 +1149,7 @@ void GetDXCoils(EnergyPlusData &state)
                     ShowContinueError(state,
                                       format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                     ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7, _);
+                    Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7);
                 }
 
                 if (MaxCurveVal > 1.0) {
@@ -1160,7 +1159,7 @@ void GetDXCoils(EnergyPlusData &state)
                     ShowContinueError(state,
                                       format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                     ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, _, 1.0);
+                    Curve::SetCurveOutputMaxValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 1.0);
                 }
             }
         }
@@ -1729,7 +1728,7 @@ void GetDXCoils(EnergyPlusData &state)
                                         state,
                                         format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                                     ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                                    SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(PerfModeNum), ErrorsFound, 0.7, _);
+                                    Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(PerfModeNum), ErrorsFound, 0.7);
                                 }
 
                                 if (MaxCurveVal > 1.0) {
@@ -1739,7 +1738,7 @@ void GetDXCoils(EnergyPlusData &state)
                                         state,
                                         format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                                     ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                                    SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(PerfModeNum), ErrorsFound, _, 1.0);
+                                    Curve::SetCurveOutputMaxValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(PerfModeNum), ErrorsFound, 1.0);
                                 }
                             }
                         }
@@ -2218,7 +2217,7 @@ void GetDXCoils(EnergyPlusData &state)
                     ShowContinueError(state,
                                       format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                     ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7, _);
+                    Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7);
                 }
 
                 if (MaxCurveVal > 1.0) {
@@ -2228,7 +2227,7 @@ void GetDXCoils(EnergyPlusData &state)
                     ShowContinueError(state,
                                       format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                     ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, _, 1.0);
+                    Curve::SetCurveOutputMaxValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 1.0);
                 }
             }
         }
@@ -2687,7 +2686,7 @@ void GetDXCoils(EnergyPlusData &state)
                     ShowContinueError(state,
                                       format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                     ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7, _);
+                    Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7);
                 }
 
                 if (MaxCurveVal > 1.0) {
@@ -2697,7 +2696,7 @@ void GetDXCoils(EnergyPlusData &state)
                     ShowContinueError(state,
                                       format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                     ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, _, 1.0);
+                    Curve::SetCurveOutputMaxValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 1.0);
                 }
             }
         }
@@ -3500,7 +3499,7 @@ void GetDXCoils(EnergyPlusData &state)
                         ShowContinueError(state,
                                           format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                         ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7, _);
+                        Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7);
                     }
 
                     if (MaxCurveVal > 1.0) {
@@ -3510,7 +3509,7 @@ void GetDXCoils(EnergyPlusData &state)
                         ShowContinueError(state,
                                           format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                         ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, _, 1.0);
+                        Curve::SetCurveOutputMaxValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 1.0);
                     }
                 }
             }
@@ -3887,7 +3886,7 @@ void GetDXCoils(EnergyPlusData &state)
                         ShowContinueError(state,
                                           format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                         ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7, _);
+                        Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7);
                     }
 
                     if (MaxCurveVal > 1.0) {
@@ -3897,7 +3896,7 @@ void GetDXCoils(EnergyPlusData &state)
                         ShowContinueError(state,
                                           format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                         ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, _, 1.0);
+                        Curve::SetCurveOutputMaxValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 1.0);
                     }
                 }
             }
@@ -4352,7 +4351,7 @@ void GetDXCoils(EnergyPlusData &state)
                         ShowContinueError(state,
                                           format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                         ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(PerfModeNum), ErrorsFound, 0.7, _);
+                        Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(PerfModeNum), ErrorsFound, 0.7);
                     }
 
                     if (MaxCurveVal > 1.0) {
@@ -4363,7 +4362,7 @@ void GetDXCoils(EnergyPlusData &state)
                         ShowContinueError(state,
                                           format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                         ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).MSPLFFPLR(I), ErrorsFound, _, 1.0);
+                        Curve::SetCurveOutputMaxValue(state, state.dataDXCoils->DXCoil(DXCoilNum).MSPLFFPLR(I), ErrorsFound, 1.0);
                     }
                 }
             }
@@ -4910,8 +4909,8 @@ void GetDXCoils(EnergyPlusData &state)
                         ShowContinueError(state,
                                           format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                         ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7, _);
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).MSPLFFPLR(I), ErrorsFound, 0.7, _);
+                        Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).PLFFPLR(1), ErrorsFound, 0.7);
+                        Curve::SetCurveOutputMinValue(state, state.dataDXCoils->DXCoil(DXCoilNum).MSPLFFPLR(I), ErrorsFound, 0.7);
                     }
 
                     if (MaxCurveVal > 1.0) {
@@ -4922,7 +4921,7 @@ void GetDXCoils(EnergyPlusData &state)
                         ShowContinueError(state,
                                           format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                         ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                        SetCurveOutputMinMaxValues(state, state.dataDXCoils->DXCoil(DXCoilNum).MSPLFFPLR(I), ErrorsFound, _, 1.0);
+                        Curve::SetCurveOutputMaxValue(state, state.dataDXCoils->DXCoil(DXCoilNum).MSPLFFPLR(I), ErrorsFound, 1.0);
                     }
                 }
             }

--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
@@ -1388,7 +1388,6 @@ void GetVRFInputData(EnergyPlusData &state, bool &ErrorsFound)
     using Curve::checkCurveIsNormalizedToOne;
     using Curve::CurveValue;
     using Curve::GetCurveIndex;
-    using Curve::SetCurveOutputMinMaxValues;
     using DXCoils::GetDXCoilIndex;
     using Fans::GetFanAvailSchPtr;
     using Fans::GetFanDesignVolumeFlowRate;
@@ -1802,7 +1801,7 @@ void GetVRFInputData(EnergyPlusData &state, bool &ErrorsFound)
                     ShowContinueError(state,
                                       format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                     ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataHVACVarRefFlow->VRF(VRFNum).CoolPLFFPLR, ErrorsFound, 0.7, _);
+                    Curve::SetCurveOutputMinValue(state, state.dataHVACVarRefFlow->VRF(VRFNum).CoolPLFFPLR, ErrorsFound, 0.7);
                 }
 
                 if (MaxCurveVal > 1.0) {
@@ -1812,7 +1811,7 @@ void GetVRFInputData(EnergyPlusData &state, bool &ErrorsFound)
                     ShowContinueError(state,
                                       format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                     ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataHVACVarRefFlow->VRF(VRFNum).CoolPLFFPLR, ErrorsFound, _, 1.0);
+                    Curve::SetCurveOutputMaxValue(state, state.dataHVACVarRefFlow->VRF(VRFNum).CoolPLFFPLR, ErrorsFound, 1.0);
                 }
             }
         }
@@ -2013,7 +2012,7 @@ void GetVRFInputData(EnergyPlusData &state, bool &ErrorsFound)
                     ShowContinueError(state,
                                       format("...Curve minimum must be >= 0.7, curve min at PLR = {:.2T} is {:.3T}", MinCurvePLR, MinCurveVal));
                     ShowContinueError(state, "...Setting curve minimum to 0.7 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataHVACVarRefFlow->VRF(VRFNum).HeatPLFFPLR, ErrorsFound, 0.7, _);
+                    Curve::SetCurveOutputMaxValue(state, state.dataHVACVarRefFlow->VRF(VRFNum).HeatPLFFPLR, ErrorsFound, 0.7);
                 }
 
                 if (MaxCurveVal > 1.0) {
@@ -2023,7 +2022,7 @@ void GetVRFInputData(EnergyPlusData &state, bool &ErrorsFound)
                     ShowContinueError(state,
                                       format("...Curve maximum must be <= 1.0, curve max at PLR = {:.2T} is {:.3T}", MaxCurvePLR, MaxCurveVal));
                     ShowContinueError(state, "...Setting curve maximum to 1.0 and simulation continues.");
-                    SetCurveOutputMinMaxValues(state, state.dataHVACVarRefFlow->VRF(VRFNum).HeatPLFFPLR, ErrorsFound, _, 1.0);
+                    Curve::SetCurveOutputMaxValue(state, state.dataHVACVarRefFlow->VRF(VRFNum).HeatPLFFPLR, ErrorsFound, 1.0);
                 }
             }
         }

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -279,7 +279,6 @@ namespace VariableSpeedCoils {
         using namespace OutputReportPredefined;
         using Curve::CurveValue;
         using Curve::GetCurveIndex;
-        using Curve::SetCurveOutputMinMaxValues;
 
         using OutAirNodeManager::CheckOutAirNodeNumber;
         using ScheduleManager::GetScheduleIndex;


### PR DESCRIPTION
Pull request overview
---------------------
Since a broader refactor seems likely, this is a small PR to remove optionals from CurveManager.cc and CurveManager.hh and leave the interface as intact as possible. `SetCurveOutputMinMaxValues` wasn't ever getting used to set both, so I did go ahead and split that into two functions, but there's still some redundancy there that could probably be rethought.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
