### PR TITLE
Remove remaining meaningful global variables

### DIFF
--- a/src/EnergyPlus/Data/CommonIncludes.hh
+++ b/src/EnergyPlus/Data/CommonIncludes.hh
@@ -303,6 +303,7 @@
 #include <EnergyPlus/WindowComplexManager.hh>
 #include <EnergyPlus/WindowEquivalentLayer.hh>
 #include <EnergyPlus/WindowManager.hh>
+#include <EnergyPlus/WindowManagerExteriorData.hh>
 #include <EnergyPlus/ZoneAirLoopEquipmentManager.hh>
 #include <EnergyPlus/ZoneContaminantPredictorCorrector.hh>
 #include <EnergyPlus/ZoneDehumidifier.hh>

--- a/src/EnergyPlus/Data/EnergyPlusData.cc
+++ b/src/EnergyPlus/Data/EnergyPlusData.cc
@@ -295,6 +295,7 @@ EnergyPlusData::EnergyPlusData()
     this->dataWindowEquivLayer = std::make_unique<WindowEquivLayerData>();
     this->dataWindowEquivalentLayer = std::make_unique<WindowEquivalentLayerData>();
     this->dataWindowManager = std::make_unique<WindowManagerData>();
+    this->dataWindowManagerExterior = std::make_unique<WindowManagerExteriorData>();
     this->dataZoneAirLoopEquipmentManager = std::make_unique<ZoneAirLoopEquipmentManagerData>();
     this->dataZoneContaminantPredictorCorrector = std::make_unique<ZoneContaminantPredictorCorrectorData>();
     this->dataZoneCtrls = std::make_unique<DataZoneControlsData>();
@@ -552,6 +553,7 @@ void EnergyPlusData::clear_state()
     this->dataWindowEquivLayer->clear_state();
     this->dataWindowEquivalentLayer->clear_state();
     this->dataWindowManager->clear_state();
+    this->dataWindowManagerExterior->clear_state();
     this->dataZoneAirLoopEquipmentManager->clear_state();
     this->dataZoneContaminantPredictorCorrector->clear_state();
     this->dataZoneCtrls->clear_state();

--- a/src/EnergyPlus/Data/EnergyPlusData.hh
+++ b/src/EnergyPlus/Data/EnergyPlusData.hh
@@ -307,6 +307,7 @@ struct WindowComplexManagerData;
 struct WindowEquivLayerData;
 struct WindowEquivalentLayerData;
 struct WindowManagerData;
+struct WindowManagerExteriorData;
 struct ZoneAirLoopEquipmentManagerData;
 struct ZoneContaminantPredictorCorrectorData;
 struct ZoneDehumidifierData;
@@ -565,6 +566,7 @@ struct EnergyPlusData : BaseGlobalStruct
     std::unique_ptr<WindowEquivLayerData> dataWindowEquivLayer;
     std::unique_ptr<WindowEquivalentLayerData> dataWindowEquivalentLayer;
     std::unique_ptr<WindowManagerData> dataWindowManager;
+    std::unique_ptr<WindowManagerExteriorData> dataWindowManagerExterior;
     std::unique_ptr<ZoneAirLoopEquipmentManagerData> dataZoneAirLoopEquipmentManager;
     std::unique_ptr<ZoneContaminantPredictorCorrectorData> dataZoneContaminantPredictorCorrector;
     std::unique_ptr<ZoneDehumidifierData> dataZoneDehumidifier;

--- a/src/EnergyPlus/EMSManager.cc
+++ b/src/EnergyPlus/EMSManager.cc
@@ -115,15 +115,15 @@ namespace EMSManager {
                                                                                                   "BEGINZONETIMESTEPAFTERINITHEATBALANCE",
                                                                                                   "BEGINZONETIMESTEPBEFORESETCURRENTWEATHER"};
 
-    std::array<std::string_view, static_cast<int>(SPControlType::Num)> controlTypeName{"Temperature Setpoint",
-                                                                                       "Temperature Minimum Setpoint",
-                                                                                       "Temperature Maximum Setpoint",
-                                                                                       "Humidity Ratio Setpoint",
-                                                                                       "Humidity Ratio Minimum Setpoint",
-                                                                                       "Humidity Ratio Maximum Setpoint",
-                                                                                       "Mass Flow Rate Setpoint",
-                                                                                       "Mass Flow Rate Minimum Available Setpoint",
-                                                                                       "Mass Flow Rate Maximum Available Setpoint"};
+    constexpr std::array<std::string_view, static_cast<int>(SPControlType::Num)> controlTypeName{"Temperature Setpoint",
+                                                                                                 "Temperature Minimum Setpoint",
+                                                                                                 "Temperature Maximum Setpoint",
+                                                                                                 "Humidity Ratio Setpoint",
+                                                                                                 "Humidity Ratio Minimum Setpoint",
+                                                                                                 "Humidity Ratio Maximum Setpoint",
+                                                                                                 "Mass Flow Rate Setpoint",
+                                                                                                 "Mass Flow Rate Minimum Available Setpoint",
+                                                                                                 "Mass Flow Rate Maximum Available Setpoint"};
 
     void CheckIfAnyEMS(EnergyPlusData &state)
     {

--- a/src/EnergyPlus/ExhaustAirSystemManager.cc
+++ b/src/EnergyPlus/ExhaustAirSystemManager.cc
@@ -79,10 +79,6 @@ namespace EnergyPlus {
 namespace ExhaustAirSystemManager {
     // Module containing the routines dealing with the AirLoopHVAC:ExhaustSystem
 
-    std::map<int, int> mixerIndexMap;
-
-    bool mappingDone = false;
-
     static constexpr std::array<std::string_view, static_cast<int>(ZoneExhaustControl::FlowControlType::Num)> flowControlTypeNamesUC = {
         "SCHEDULED", "FOLLOWSUPPLY"};
 
@@ -444,7 +440,7 @@ namespace ExhaustAirSystemManager {
             // get the mixer inlet node index
             int zoneMixerIndex = thisExhSys.ZoneMixerIndex;
             for (int i = 1; i <= state.dataMixerComponent->MixerCond(zoneMixerIndex).NumInletNodes; ++i) {
-                int exhLegIndex = mixerIndexMap[state.dataMixerComponent->MixerCond(zoneMixerIndex).InletNode(i)];
+                int exhLegIndex = state.dataExhAirSystemMrg->mixerIndexMap[state.dataMixerComponent->MixerCond(zoneMixerIndex).InletNode(i)];
                 CalcZoneHVACExhaustControl(state, exhLegIndex, flowRatio);
             }
 
@@ -538,8 +534,8 @@ namespace ExhaustAirSystemManager {
                                                                         DataLoopNode::ObjectIsParent);
                 thisExhCtrl.OutletNodeNum = outletNodeNum;
 
-                if (!mappingDone) {
-                    mixerIndexMap.emplace(outletNodeNum, exhCtrlNum);
+                if (!state.dataExhAirSystemMrg->mappingDone) {
+                    state.dataExhAirSystemMrg->mixerIndexMap.emplace(outletNodeNum, exhCtrlNum);
                 }
 
                 Real64 designExhaustFlowRate = ip->getRealFieldValue(objectFields, objectSchemaProps, "design_exhaust_flow_rate");
@@ -670,7 +666,7 @@ namespace ExhaustAirSystemManager {
             state.dataZoneEquip->NumZoneExhaustControls = numZoneExhaustControls; // or exhCtrlNum
 
             // Done with creating a map that contains a table of for each zone to exhasut controls
-            mappingDone = true;
+            state.dataExhAirSystemMrg->mappingDone = true;
         } else {
             // If no exhaust systems are defined, then do something <or nothing>:
         }
@@ -707,7 +703,7 @@ namespace ExhaustAirSystemManager {
         int OutletNode = thisExhCtrl.OutletNodeNum;
         auto &thisExhInlet = state.dataLoopNodes->Node(InletNode);
         auto &thisExhOutlet = state.dataLoopNodes->Node(OutletNode);
-        Real64 MassFlow = thisExhInlet.MassFlowRate;
+        Real64 MassFlow;
         Real64 Tin = state.dataZoneTempPredictorCorrector->zoneHeatBalance(thisExhCtrl.ZoneNum).ZT;
         Real64 thisExhCtrlAvailScheVal = ScheduleManager::GetCurrentScheduleValue(state, thisExhCtrl.AvailScheduleNum);
 
@@ -740,21 +736,16 @@ namespace ExhaustAirSystemManager {
                 FlowFrac = MinFlowFrac;
             }
 
-            bool runExhaust = true;
             if (thisExhCtrlAvailScheVal > 0.0) { // available
                 if (thisExhCtrl.MinZoneTempLimitScheduleNum > 0) {
                     if (Tin >= ScheduleManager::GetCurrentScheduleValue(state, thisExhCtrl.MinZoneTempLimitScheduleNum)) {
-                        runExhaust = true;
                     } else {
-                        runExhaust = false;
                         FlowFrac = MinFlowFrac;
                     }
                 } else {
-                    runExhaust = true;
                     // flow not changed
                 }
             } else {
-                runExhaust = false;
                 FlowFrac = 0.0; // directly set flow rate to zero.
             }
 

--- a/src/EnergyPlus/ExhaustAirSystemManager.hh
+++ b/src/EnergyPlus/ExhaustAirSystemManager.hh
@@ -150,12 +150,12 @@ namespace ExhaustAirSystemManager {
 
 struct ExhaustAirSystemMgr : BaseGlobalStruct
 {
-
     bool GetInputFlag = true;
-
+    std::map<int, int> mixerIndexMap;
+    bool mappingDone = false;
     void clear_state() override
     {
-        this->GetInputFlag = true;
+        new (this) ExhaustAirSystemMgr();
     }
 };
 
@@ -166,7 +166,7 @@ struct ExhaustControlSystemMgr : BaseGlobalStruct
 
     void clear_state() override
     {
-        this->GetInputFlag = true;
+        new (this) ExhaustControlSystemMgr();
     }
 };
 

--- a/src/EnergyPlus/FluidProperties.cc
+++ b/src/EnergyPlus/FluidProperties.cc
@@ -102,15 +102,9 @@ namespace FluidProperties {
     // supplying the same data for concentrations of 0.0 and 1.0 only.
     // Temperature data has to be supplied in ascending order only.
 
-#ifdef EP_cache_GlycolSpecificHeat
-    std::array<cached_tsh, t_sh_cache_size> cached_t_sh;
-#endif
-
     void InitializeGlycRoutines()
     {
-#ifdef EP_cache_GlycolSpecificHeat
-        cached_t_sh.fill({});
-#endif
+        // TODO: Delete this, the cache is now part of state and initialized with the state constructor
     }
 
     void GetFluidPropertiesData(EnergyPlusData &state)
@@ -935,7 +929,7 @@ namespace FluidProperties {
                 if (InData == NumOfSatFluidPropArrays) {
                     ShowSevereError(state, format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                     ShowContinueError(state,
-                                      format("No Gas/Fluid Saturation Pressure found. Need properties with {}=\"Pressure\" and {}=\"FluidGas\".",
+                                      format(R"(No Gas/Fluid Saturation Pressure found. Need properties with {}="Pressure" and {}="FluidGas".)",
                                              cAlphaFieldNames(2),
                                              cAlphaFieldNames(3)));
                     ErrorsFound = true;
@@ -1015,11 +1009,10 @@ namespace FluidProperties {
                 // If it made it all the way to the last input occurrence and didn't find a match, then no sat fluid enthalpy data found
                 if (InData == NumOfSatFluidPropArrays) {
                     ShowSevereError(state, format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
-                    ShowContinueError(
-                        state,
-                        format("No Saturated Fluid Enthalpy found. Need properties to be entered with {}=\"Enthalpy\" and {}=\"Fluid\".",
-                               cAlphaFieldNames(2),
-                               cAlphaFieldNames(3)));
+                    ShowContinueError(state,
+                                      format(R"(No Saturated Fluid Enthalpy found. Need properties to be entered with {}="Enthalpy" and {}="Fluid".)",
+                                             cAlphaFieldNames(2),
+                                             cAlphaFieldNames(3)));
                     ErrorsFound = true;
                 }
 
@@ -1102,7 +1095,7 @@ namespace FluidProperties {
                     ShowSevereError(state, format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                     ShowContinueError(
                         state,
-                        format("No Saturated Gas/Fluid Enthalpy found. Need properties to be entered with {}=\"Enthalpy\" and {}=\"FluidGas\".",
+                        format(R"(No Saturated Gas/Fluid Enthalpy found. Need properties to be entered with {}="Enthalpy" and {}="FluidGas".)",
                                cAlphaFieldNames(2),
                                cAlphaFieldNames(3)));
                     ErrorsFound = true;
@@ -1184,7 +1177,7 @@ namespace FluidProperties {
                     ShowSevereError(state, format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                     ShowContinueError(
                         state,
-                        format("No Saturated Fluid Specific Heat found. Need properties to be entered with {}=\"SpecificHeat\" and {}=\"Fluid\".",
+                        format(R"(No Saturated Fluid Specific Heat found. Need properties to be entered with {}="SpecificHeat" and {}="Fluid".)",
                                cAlphaFieldNames(2),
                                cAlphaFieldNames(3)));
                     ErrorsFound = true;
@@ -1271,7 +1264,7 @@ namespace FluidProperties {
                     ShowContinueError(
                         state,
                         format(
-                            "No Saturated Gas/Fluid Specific Heat found. Need properties to be entered with {}=\"SpecificHeat\" and {}=\"FluidGas\".",
+                            R"(No Saturated Gas/Fluid Specific Heat found. Need properties to be entered with {}="SpecificHeat" and {}="FluidGas".)",
                             cAlphaFieldNames(2),
                             cAlphaFieldNames(3)));
                     ErrorsFound = true;
@@ -1352,7 +1345,7 @@ namespace FluidProperties {
                 if (InData == NumOfSatFluidPropArrays) {
                     ShowSevereError(state, format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                     ShowContinueError(state,
-                                      format("No Saturated Fluid Density found. Need properties to be entered with {}=\"Density\" and {}=\"Fluid\".",
+                                      format(R"(No Saturated Fluid Density found. Need properties to be entered with {}="Density" and {}="Fluid".)",
                                              cAlphaFieldNames(2),
                                              cAlphaFieldNames(3)));
                     ErrorsFound = true;
@@ -1437,7 +1430,7 @@ namespace FluidProperties {
                     ShowSevereError(state, format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                     ShowSevereError(
                         state,
-                        format("No Saturated Gas/Fluid Density found. Need properties to be entered with {}=\"Density\" and {}=\"FluidGas\".",
+                        format(R"(No Saturated Gas/Fluid Density found. Need properties to be entered with {}="Density" and {}="FluidGas".)",
                                cAlphaFieldNames(2),
                                cAlphaFieldNames(3)));
                     ErrorsFound = true;
@@ -1492,8 +1485,8 @@ namespace FluidProperties {
                             ShowWarningError(state,
                                              format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                             ShowContinueError(
-                                state, format("{}=\"{}\", but {}=\"{}\" is not valid.", cAlphaFieldNames(3), Fluid, cAlphaFieldNames(2), Alphas(2)));
-                            ShowContinueError(state, format("Valid choices are \"{}\", \"{}\", \"{}\".", Enthalpy, SpecificHeat, Density));
+                                state, format(R"({}="{}", but {}="{}" is not valid.)", cAlphaFieldNames(3), Fluid, cAlphaFieldNames(2), Alphas(2)));
+                            ShowContinueError(state, format(R"(Valid choices are "{}", "{}", "{}".)", Enthalpy, SpecificHeat, Density));
                             ShowContinueError(state,
                                               "This fluid property will not be processed "
                                               "mor available for the simulation.");
@@ -1507,9 +1500,9 @@ namespace FluidProperties {
                             ShowWarningError(state,
                                              format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                             ShowContinueError(
-                                state, format("{}=\"{}\", but {}=\"{}\" is not valid.", cAlphaFieldNames(3), Fluid, cAlphaFieldNames(2), Alphas(2)));
+                                state, format(R"({}="{}", but {}="{}" is not valid.)", cAlphaFieldNames(3), Fluid, cAlphaFieldNames(2), Alphas(2)));
                             ShowContinueError(state,
-                                              format("Valid choices are \"{}\", \"{}\", \"{}\", \"{}\".", Pressure, Enthalpy, SpecificHeat, Density));
+                                              format(R"(Valid choices are "{}", "{}", "{}", "{}".)", Pressure, Enthalpy, SpecificHeat, Density));
                             ShowContinueError(state, "This fluid property will not be processed nor available for the simulation.");
                         }
                         ++iTemp;
@@ -1519,7 +1512,7 @@ namespace FluidProperties {
                         ShowWarningError(state,
                                          format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                         ShowContinueError(state, format("{}=\"{}\" is not valid.", cAlphaFieldNames(3), Alphas(3)));
-                        ShowContinueError(state, format("Valid choices are \"{}\", \"{}\".", Fluid, GasFluid));
+                        ShowContinueError(state, format(R"(Valid choices are "{}", "{}".)", Fluid, GasFluid));
                         ShowContinueError(state,
                                           "This fluid property will not be processed nor "
                                           "available for the simulation.");
@@ -1796,7 +1789,7 @@ namespace FluidProperties {
                         ShowWarningError(state,
                                          format("{}{} Name={}", RoutineName, CurrentModuleObject, state.dataFluidProps->RefrigData(Loop).Name));
                         ShowContinueError(state, format("{}=\"{}\" is not valid.", cAlphaFieldNames(2), Alphas(2)));
-                        ShowContinueError(state, format("Valid choices are \"{}\", \"{}\".", Enthalpy, Density));
+                        ShowContinueError(state, format(R"(Valid choices are "{}", "{}".)", Enthalpy, Density));
                         ShowContinueError(state, format("Pressure value of this item=[{:.2R}].", Numbers(1)));
                         ShowContinueError(state, "This fluid property will not be processed nor available for the simulation.");
                     }
@@ -5107,7 +5100,7 @@ namespace FluidProperties {
         for (GlycolNum = 1; GlycolNum <= state.dataFluidProps->NumOfGlycols; ++GlycolNum) {
             GlycolIndex = 0; // used in routine calls -- value is returned when first 0
             // Lay out the basic values:
-            if (state.dataFluidProps->GlycolData(GlycolNum).GlycolName != "") {
+            if (!state.dataFluidProps->GlycolData(GlycolNum).GlycolName.empty()) {
                 print(state.files.debug,
                       "Glycol={}, Mixture fluid={}\n",
                       state.dataFluidProps->GlycolData(GlycolNum).Name,
@@ -7463,6 +7456,34 @@ namespace FluidProperties {
 
 //*****************************************************************************
 #ifdef EP_cache_GlycolSpecificHeat
+    Real64 GetSpecificHeatGlycol(EnergyPlusData &state,
+                                 std::string_view const Glycol,    // carries in substance name
+                                 Real64 const Temperature,         // actual temperature given as input
+                                 int &GlycolIndex,                 // Index to Glycol Properties
+                                 std::string_view const CalledFrom // routine this function was called from (error messages)
+    )
+    {
+        std::uint64_t constexpr Grid_Shift = 64 - 12 - t_sh_precision_bits;
+
+        double const t(Temperature + 1000 * GlycolIndex);
+
+        DISABLE_WARNING_PUSH
+        DISABLE_WARNING_STRICT_ALIASING
+        DISABLE_WARNING_UNINITIALIZED
+        std::uint64_t const T_tag(*reinterpret_cast<std::uint64_t const *>(&t) >> Grid_Shift);
+        DISABLE_WARNING_POP
+
+        std::uint64_t const hash(T_tag & t_sh_cache_mask);
+        auto &cTsh(state.dataFluidProps->cached_t_sh[hash]);
+
+        if (cTsh.iT != T_tag) {
+            cTsh.iT = T_tag;
+            cTsh.sh = GetSpecificHeatGlycol_raw(state, Glycol, Temperature, GlycolIndex, CalledFrom);
+        }
+
+        return cTsh.sh; // saturation pressure {Pascals}
+    }
+
     Real64 GetSpecificHeatGlycol_raw(EnergyPlusData &state,
                                      std::string_view const Glycol,    // carries in substance name
                                      Real64 const Temperature,         // actual temperature given as input
@@ -8182,141 +8203,6 @@ namespace FluidProperties {
         ShowFatalError(state, "GetInterpValue: Temperatures for fluid property data too close together, division by zero");
     }
 
-    //*****************************************************************************
-
-    Real64 GetQualityRefrig(EnergyPlusData &state,
-                            std::string const &Refrigerant,   // carries in substance name
-                            Real64 const Temperature,         // actual temperature given as input
-                            Real64 const Enthalpy,            // actual enthalpy given as input
-                            int &RefrigIndex,                 // Index to Refrigerant Properties
-                            std::string_view const CalledFrom // routine this function was called from (error messages)
-    )
-    {
-
-        // FUNCTION INFORMATION:
-        //       AUTHOR         Rick Strand
-        //       DATE WRITTEN   May 2000
-        //       MODIFIED       Simon Rees (May 2002)
-        //       RE-ENGINEERED  na
-
-        // PURPOSE OF THIS FUNCTION:
-        // This function determines the quality of a refrigerant in the saturate
-        // region based on its temperature and enthalpy
-
-        // METHODOLOGY EMPLOYED:
-        // Just checks to see whether or not the refrigerant name coming in can
-        // be found in the refrigerant derived type.  If so, the "reverse" of the
-        // GetSatEnthalpyRefrig function is performed.
-
-        // REFERENCES:
-        // na
-
-        // USE STATEMENTS:
-        // na
-
-        // Return value
-        Real64 ReturnValue;
-
-        // Locals
-        // FUNCTION ARGUMENT DEFINITIONS:
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // FUNCTION LOCAL VARIABLE DECLARATIONS:
-        Real64 SatVapEnthalpy;  // value of enthalpy at hi index value for given Quality
-        Real64 SatLiqEnthalpy;  // value of enthalpy at TempIndex index value for given Quality
-        int RefrigNum;          // index for refrigerant under consideration
-        int HiTempIndex;        // array index for temp above input temp
-        int LoTempIndex;        // array index for temp below input temp
-        Real64 TempInterpRatio; // ratio to interpolate in temperature domain
-
-        if (state.dataFluidProps->GetInput) {
-            GetFluidPropertiesData(state);
-            state.dataFluidProps->GetInput = false;
-        }
-
-        RefrigNum = 0;
-        if (state.dataFluidProps->NumOfRefrigerants == 0) {
-            ReportFatalRefrigerantErrors(
-                state, state.dataFluidProps->NumOfRefrigerants, RefrigNum, true, Refrigerant, "GetQualityRefrig", "enthalpy", CalledFrom);
-        }
-
-        // Find which refrigerant (index) is being requested and then determine
-        // where the temperature is within the temperature array
-        if (RefrigIndex > 0) {
-            RefrigNum = RefrigIndex;
-        } else {
-            // Find which refrigerant (index) is being requested
-            RefrigNum = FindRefrigerant(state, Refrigerant);
-            if (RefrigNum == 0) {
-                ReportFatalRefrigerantErrors(
-                    state, state.dataFluidProps->NumOfRefrigerants, RefrigNum, true, Refrigerant, "GetQualityRefrig", "enthalpy", CalledFrom);
-            }
-            RefrigIndex = RefrigNum;
-        }
-        auto const &refrig(state.dataFluidProps->RefrigData(RefrigNum));
-
-        LoTempIndex = FindArrayIndex(Temperature, refrig.HTemps, refrig.HfLowTempIndex, refrig.HfHighTempIndex);
-        HiTempIndex = LoTempIndex + 1;
-
-        // check on the data bounds and adjust indices to give clamped return value
-        if (LoTempIndex == 0) {
-            SatLiqEnthalpy = refrig.HfValues(refrig.HfLowTempIndex);
-            SatVapEnthalpy = refrig.HfgValues(refrig.HfLowTempIndex);
-            // Temperature supplied is out of bounds--produce an error message...
-            if (!state.dataGlobal->WarmupFlag)
-                ShowRecurringWarningErrorAtEnd(state,
-                                               "GetQualityRefrig: ** Temperature for requested quality is below the range of data supplied **",
-                                               state.dataFluidProps->TempLoRangeErrIndexGetQualityRefrig,
-                                               Temperature,
-                                               Temperature,
-                                               _,
-                                               "{C}",
-                                               "{C}");
-
-        } else if (HiTempIndex > refrig.NumHPoints) {
-            SatLiqEnthalpy = refrig.HfValues(refrig.HfHighTempIndex);
-            SatVapEnthalpy = refrig.HfgValues(refrig.HfHighTempIndex);
-            // Temperature supplied is out of bounds--produce an error message...
-            if (!state.dataGlobal->WarmupFlag)
-                ShowRecurringWarningErrorAtEnd(state,
-                                               "GetQualityRefrig: ** Temperature requested quality is above the range of data supplied **",
-                                               state.dataFluidProps->TempHiRangeErrIndexGetQualityRefrig,
-                                               Temperature,
-                                               Temperature,
-                                               _,
-                                               "{C}",
-                                               "{C}");
-
-        } else { // in normal range work out interpolated liq and gas enthalpies
-            TempInterpRatio = (Temperature - refrig.HTemps(LoTempIndex)) / (refrig.HTemps(HiTempIndex) - refrig.HTemps(LoTempIndex));
-            SatLiqEnthalpy = TempInterpRatio * refrig.HfValues(HiTempIndex) + (1.0 - TempInterpRatio) * refrig.HfValues(LoTempIndex);
-            SatVapEnthalpy = TempInterpRatio * refrig.HfgValues(HiTempIndex) + (1.0 - TempInterpRatio) * refrig.HfgValues(LoTempIndex);
-        }
-
-        // calculate final quality value from enthalpy ratio
-        ReturnValue = (Enthalpy - SatLiqEnthalpy) / (SatVapEnthalpy - SatLiqEnthalpy);
-
-        // final check to bound returned quality value
-        if (ReturnValue < 0.0) {
-            //    CALL ShowRecurringWarningErrorAtEnd(state, 'GetQualityRefrig: ** '//  &
-            //                   'Quality is less than zero in GetQualityRefrig; Quality reset to 0.0 **')
-            ReturnValue = 0.0;
-        } else if (ReturnValue > 1.0) {
-            //    CALL ShowRecurringWarningErrorAtEnd(state, 'GetQualityRefrig: ** '//  &
-            //                   'Quality is greater than one in GetQualityRefrig; refrigerant is superheated **')
-            ReturnValue = 2.0;
-        }
-
-        return ReturnValue;
-    }
-
-    //*****************************************************************************
-
     int FindRefrigerant(EnergyPlusData &state, std::string_view const Refrigerant) // carries in substance name
     {
 
@@ -8501,8 +8387,8 @@ namespace FluidProperties {
         assert(LowBound >= l);
         assert(LowBound <= UpperBound);
         assert(UpperBound <= Array.u());
-        assert(Array.size() > 0u); // Empty arrays are not currently supported
-        assert(l > 0);             // Returning 0 for Value smaller than lowest doesn't make sense if l() <= 0
+        assert(!Array.empty()); // Empty arrays are not currently supported
+        assert(l > 0);          // Returning 0 for Value smaller than lowest doesn't make sense if l() <= 0
         size_type beg(LowBound - l);
         if (Value < Array[beg]) {
             return 0;
@@ -8549,8 +8435,8 @@ namespace FluidProperties {
         // Linear indexing used to assure we are bit shifting positive values where behavior is assured
         // std::lower_bound was 4x slower for the small (~100) array sizes seen in EnergyPlus use
         typedef Array1D<Real64>::size_type size_type;
-        assert(Array.size() > 0u); // Empty arrays are not currently supported
-        assert(Array.l() > 0);     // Returning 0 for Value smaller than lowest doesn't make sense if l() <= 0
+        assert(!Array.empty()); // Empty arrays are not currently supported
+        assert(Array.l() > 0);  // Returning 0 for Value smaller than lowest doesn't make sense if l() <= 0
         if (Value < Array[0]) {
             return 0;
         } else {

--- a/src/EnergyPlus/FluidProperties.cc
+++ b/src/EnergyPlus/FluidProperties.cc
@@ -102,29 +102,9 @@ namespace FluidProperties {
     // supplying the same data for concentrations of 0.0 and 1.0 only.
     // Temperature data has to be supplied in ascending order only.
 
-    // Data
-    // MODULE PARAMETER DEFINITIONS
-
-    // DERIVED TYPE DEFINITIONS
-
-    // INTERFACE BLOCK SPECIFICATIONS
-    // na
-
-    // MODULE VARIABLE DECLARATIONS
-
-    // ACCESSIBLE SPECIFICATIONS OF MODULE SUBROUTINES OR FUNCTONS:
-
-    // Object Data
-
 #ifdef EP_cache_GlycolSpecificHeat
     std::array<cached_tsh, t_sh_cache_size> cached_t_sh;
 #endif
-    // Data Initializer Forward Declarations
-    // See GetFluidPropertiesData "SUBROUTINE LOCAL DATA" for actual data.
-
-    // MODULE SUBROUTINES:
-
-    // Functions
 
     void InitializeGlycRoutines()
     {

--- a/src/EnergyPlus/FluidProperties.hh
+++ b/src/EnergyPlus/FluidProperties.hh
@@ -69,11 +69,6 @@ struct EnergyPlusData;
 
 namespace FluidProperties {
 
-    // Using/Aliasing
-
-    // Data
-    // MODULE PARAMETER DEFINITIONS
-
     int constexpr EthyleneGlycolIndex = -2;
     int constexpr PropyleneGlycolIndex = -1;
     int constexpr iRefri = 1;
@@ -100,21 +95,11 @@ namespace FluidProperties {
     constexpr static std::string_view EthyleneGlycol("EthyleneGlycol");
     constexpr static std::string_view PropyleneGlycol("PropyleneGlycol");
 
-    // DERIVED TYPE DEFINITIONS
-
-    // INTERFACE BLOCK SPECIFICATIONS
-    // na
-
-    // MODULE VARIABLE DECLARATIONS
-
 #ifdef EP_cache_GlycolSpecificHeat
     int constexpr t_sh_cache_size = 1024 * 1024;
     int constexpr t_sh_precision_bits = 24;
     std::uint64_t constexpr t_sh_cache_mask = (t_sh_cache_size - 1);
 #endif
-    // ACCESSIBLE SPECIFICATIONS OF MODULE SUBROUTINES OR FUNCTIONS:
-
-    // Types
 
     struct FluidPropsRefrigerantData
     {
@@ -364,15 +349,10 @@ namespace FluidProperties {
 #ifdef EP_cache_GlycolSpecificHeat
     extern std::array<FluidProperties::cached_tsh, t_sh_cache_size> cached_t_sh;
 #endif
-    // Object Data
-
-    // Functions
 
     void InitializeGlycRoutines();
 
     void GetFluidPropertiesData(EnergyPlusData &state);
-
-    //*****************************************************************************
 
     template <size_t NumOfTemps, size_t NumOfConcs>
     void InterpDefValuesForGlycolConc(
@@ -383,8 +363,6 @@ namespace FluidProperties {
         Array1D<Real64> &InterpData                                                // interpolated output data at proper concentration
     );
 
-    //*****************************************************************************
-
     void InterpValuesForGlycolConc(EnergyPlusData &state,
                                    int NumOfConcs,                     // number of concentrations (dimension of raw data)
                                    int NumOfTemps,                     // number of temperatures (dimension of raw data)
@@ -394,23 +372,13 @@ namespace FluidProperties {
                                    Array1D<Real64> &InterpData         // interpolated output data at proper concentration
     );
 
-    //*****************************************************************************
-
     void InitializeGlycolTempLimits(EnergyPlusData &state, bool &ErrorsFound); // set to true if errors found here
-
-    //*****************************************************************************
 
     void InitializeRefrigerantLimits(EnergyPlusData &state, bool &ErrorsFound); // set to true if errors found here
 
-    //*****************************************************************************
-
     void ReportAndTestGlycols(EnergyPlusData &state);
 
-    //*****************************************************************************
-
     void ReportAndTestRefrigerants(EnergyPlusData &state);
-
-    //*****************************************************************************
 
     Real64 GetSatPressureRefrig(EnergyPlusData &state,
                                 std::string_view const Refrigerant, // carries in substance name
@@ -419,16 +387,12 @@ namespace FluidProperties {
                                 std::string_view const CalledFrom   // routine this function was called from (error messages)
     );
 
-    //*****************************************************************************
-
     Real64 GetSatTemperatureRefrig(EnergyPlusData &state,
                                    std::string_view const Refrigerant, // carries in substance name
                                    Real64 Pressure,                    // actual temperature given as input
                                    int &RefrigIndex,                   // Index to Refrigerant Properties
                                    std::string_view const CalledFrom   // routine this function was called from (error messages)
     );
-
-    //*****************************************************************************
 
     Real64 GetSatEnthalpyRefrig(EnergyPlusData &state,
                                 std::string_view const Refrigerant, // carries in substance name
@@ -438,8 +402,6 @@ namespace FluidProperties {
                                 std::string_view const CalledFrom   // routine this function was called from (error messages)
     );
 
-    //*****************************************************************************
-
     Real64 GetSatDensityRefrig(EnergyPlusData &state,
                                std::string_view const Refrigerant, // carries in substance name
                                Real64 Temperature,                 // actual temperature given as input
@@ -447,8 +409,6 @@ namespace FluidProperties {
                                int &RefrigIndex,                   // Index to Refrigerant Properties
                                std::string_view const CalledFrom   // routine this function was called from (error messages)
     );
-
-    //*****************************************************************************
 
     Real64 GetSatSpecificHeatRefrig(EnergyPlusData &state,
                                     std::string_view const Refrigerant, // carries in substance name
@@ -458,8 +418,6 @@ namespace FluidProperties {
                                     std::string_view const CalledFrom   // routine this function was called from (error messages)
     );
 
-    //*****************************************************************************
-
     Real64 GetSupHeatEnthalpyRefrig(EnergyPlusData &state,
                                     std::string_view const Refrigerant, // carries in substance name
                                     Real64 Temperature,                 // actual temperature given as input
@@ -468,8 +426,6 @@ namespace FluidProperties {
                                     std::string_view const CalledFrom   // routine this function was called from (error messages)
     );
 
-    //*****************************************************************************
-
     Real64 GetSupHeatPressureRefrig(EnergyPlusData &state,
                                     std::string_view const Refrigerant, // carries in substance name
                                     Real64 Temperature,                 // actual temperature given as input
@@ -477,8 +433,6 @@ namespace FluidProperties {
                                     int &RefrigIndex,                   // Index to Refrigerant Properties
                                     std::string_view const CalledFrom   // routine this function was called from (error messages)
     );
-
-    //*****************************************************************************
 
     Real64 GetSupHeatTempRefrig(EnergyPlusData &state,
                                 std::string_view const Refrigerant, // carries in substance name
@@ -498,7 +452,6 @@ namespace FluidProperties {
                                    std::string_view const CalledFrom   // routine this function was called from (error messages)
     );
 
-//*****************************************************************************
 #ifdef EP_cache_GlycolSpecificHeat
     Real64 GetSpecificHeatGlycol_raw(EnergyPlusData &state,
                                      std::string_view const Glycol,    // carries in substance name
@@ -543,16 +496,12 @@ namespace FluidProperties {
     );
 #endif
 
-    //*****************************************************************************
-
     Real64 GetDensityGlycol(EnergyPlusData &state,
                             std::string_view const Glycol,    // carries in substance name
                             Real64 Temperature,               // actual temperature given as input
                             int &GlycolIndex,                 // Index to Glycol Properties
                             std::string_view const CalledFrom // routine this function was called from (error messages)
     );
-
-    //*****************************************************************************
 
     Real64 GetConductivityGlycol(EnergyPlusData &state,
                                  std::string_view const Glycol,    // carries in substance name
@@ -561,16 +510,12 @@ namespace FluidProperties {
                                  std::string_view const CalledFrom // routine this function was called from (error messages)
     );
 
-    //*****************************************************************************
-
     Real64 GetViscosityGlycol(EnergyPlusData &state,
                               std::string_view const Glycol,    // carries in substance name
                               Real64 Temperature,               // actual temperature given as input
                               int &GlycolIndex,                 // Index to Glycol Properties
                               std::string_view const CalledFrom // routine this function was called from (error messages)
     );
-
-    //*****************************************************************************
 
     void GetInterpValue_error(EnergyPlusData &state);
 
@@ -597,26 +542,8 @@ namespace FluidProperties {
         // REFERENCES:
         // Any basic engineering mathematic text.
 
-        // USE STATEMENTS:
-        // na
-
-        // Return value
-        // na
-
-        // Locals
-        // FUNCTION ARGUMENT DEFINITIONS:
-
         // SUBROUTINE PARAMETER DEFINITIONS:
         Real64 constexpr TempToler(0.001); // Some reasonable value for comparisons
-
-        // INTERFACE BLOCK SPECIFICATIONS:
-        // na
-
-        // DERIVED TYPE DEFINITIONS:
-        // na
-
-        // FUNCTION LOCAL VARIABLE DECLARATIONS:
-        // na
 
         if (std::abs(Thi - Tlo) > TempToler) {
             return Xhi - (((Thi - Tact) / (Thi - Tlo)) * (Xhi - Xlo));
@@ -636,8 +563,6 @@ namespace FluidProperties {
         return Xhi - (((Thi - Tact) / (Thi - Tlo)) * (Xhi - Xlo));
     }
 
-    //*****************************************************************************
-
     Real64 GetQualityRefrig(EnergyPlusData &state,
                             std::string const &Refrigerant,   // carries in substance name
                             Real64 Temperature,               // actual temperature given as input
@@ -646,19 +571,11 @@ namespace FluidProperties {
                             std::string_view const CalledFrom // routine this function was called from (error messages)
     );
 
-    //*****************************************************************************
-
     int FindRefrigerant(EnergyPlusData &state, std::string_view const Rrefrigerant); // carries in substance name
-
-    //*****************************************************************************
 
     int FindGlycol(EnergyPlusData &state, std::string_view const Glycol); // carries in substance name
 
-    //*****************************************************************************
-
     std::string GetGlycolNameByIndex(EnergyPlusData &state, int Idx); // carries in substance index
-
-    //*****************************************************************************
 
     int FindArrayIndex(Real64 Value,                 // Value to be placed/found within the array of values
                        Array1D<Real64> const &Array, // Array of values in ascending order
@@ -670,8 +587,6 @@ namespace FluidProperties {
                        Array1D<Real64> const &Array // Array of values in ascending order
     );
 
-    //*****************************************************************************
-
     Real64 GetInterpolatedSatProp(EnergyPlusData &state,
                                   Real64 Temperature,                // Saturation Temp.
                                   Array1D<Real64> const &PropTemps,  // Array of temperature at which props are available
@@ -682,8 +597,6 @@ namespace FluidProperties {
                                   int LowBound,                      // Valid values lower bound (set by calling program)
                                   int UpperBound                     // Valid values upper bound (set by calling program)
     );
-
-    //*****************************************************************************
 
     int CheckFluidPropertyName(EnergyPlusData &state,
                                std::string const &NameToCheck); // Name from input(?) to be checked against valid FluidPropertyNames

--- a/src/EnergyPlus/FluidProperties.hh
+++ b/src/EnergyPlus/FluidProperties.hh
@@ -71,8 +71,6 @@ namespace FluidProperties {
 
     int constexpr EthyleneGlycolIndex = -2;
     int constexpr PropyleneGlycolIndex = -1;
-    int constexpr iRefri = 1;
-    int constexpr iGlyco = 1;
 
     constexpr int DefaultNumGlyTemps(33);                  // Temperature dimension of default glycol data
     constexpr int DefaultNumGlyConcs(10);                  // Concentration dimension of default glycol data
@@ -346,10 +344,6 @@ namespace FluidProperties {
         }
     };
 
-#ifdef EP_cache_GlycolSpecificHeat
-    extern std::array<FluidProperties::cached_tsh, t_sh_cache_size> cached_t_sh;
-#endif
-
     void InitializeGlycRoutines();
 
     void GetFluidPropertiesData(EnergyPlusData &state);
@@ -381,140 +375,111 @@ namespace FluidProperties {
     void ReportAndTestRefrigerants(EnergyPlusData &state);
 
     Real64 GetSatPressureRefrig(EnergyPlusData &state,
-                                std::string_view const Refrigerant, // carries in substance name
-                                Real64 Temperature,                 // actual temperature given as input
-                                int &RefrigIndex,                   // Index to Refrigerant Properties
-                                std::string_view const CalledFrom   // routine this function was called from (error messages)
+                                std::string_view Refrigerant, // carries in substance name
+                                Real64 Temperature,           // actual temperature given as input
+                                int &RefrigIndex,             // Index to Refrigerant Properties
+                                std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
     Real64 GetSatTemperatureRefrig(EnergyPlusData &state,
-                                   std::string_view const Refrigerant, // carries in substance name
-                                   Real64 Pressure,                    // actual temperature given as input
-                                   int &RefrigIndex,                   // Index to Refrigerant Properties
-                                   std::string_view const CalledFrom   // routine this function was called from (error messages)
+                                   std::string_view Refrigerant, // carries in substance name
+                                   Real64 Pressure,              // actual temperature given as input
+                                   int &RefrigIndex,             // Index to Refrigerant Properties
+                                   std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
     Real64 GetSatEnthalpyRefrig(EnergyPlusData &state,
-                                std::string_view const Refrigerant, // carries in substance name
-                                Real64 Temperature,                 // actual temperature given as input
-                                Real64 Quality,                     // actual quality given as input
-                                int &RefrigIndex,                   // Index to Refrigerant Properties
-                                std::string_view const CalledFrom   // routine this function was called from (error messages)
+                                std::string_view Refrigerant, // carries in substance name
+                                Real64 Temperature,           // actual temperature given as input
+                                Real64 Quality,               // actual quality given as input
+                                int &RefrigIndex,             // Index to Refrigerant Properties
+                                std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
     Real64 GetSatDensityRefrig(EnergyPlusData &state,
-                               std::string_view const Refrigerant, // carries in substance name
-                               Real64 Temperature,                 // actual temperature given as input
-                               Real64 Quality,                     // actual quality given as input
-                               int &RefrigIndex,                   // Index to Refrigerant Properties
-                               std::string_view const CalledFrom   // routine this function was called from (error messages)
+                               std::string_view Refrigerant, // carries in substance name
+                               Real64 Temperature,           // actual temperature given as input
+                               Real64 Quality,               // actual quality given as input
+                               int &RefrigIndex,             // Index to Refrigerant Properties
+                               std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
     Real64 GetSatSpecificHeatRefrig(EnergyPlusData &state,
-                                    std::string_view const Refrigerant, // carries in substance name
-                                    Real64 Temperature,                 // actual temperature given as input
-                                    Real64 Quality,                     // actual quality given as input
-                                    int &RefrigIndex,                   // Index to Refrigerant Properties
-                                    std::string_view const CalledFrom   // routine this function was called from (error messages)
+                                    std::string_view Refrigerant, // carries in substance name
+                                    Real64 Temperature,           // actual temperature given as input
+                                    Real64 Quality,               // actual quality given as input
+                                    int &RefrigIndex,             // Index to Refrigerant Properties
+                                    std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
     Real64 GetSupHeatEnthalpyRefrig(EnergyPlusData &state,
-                                    std::string_view const Refrigerant, // carries in substance name
-                                    Real64 Temperature,                 // actual temperature given as input
-                                    Real64 Pressure,                    // actual pressure given as input
-                                    int &RefrigIndex,                   // Index to Refrigerant Properties
-                                    std::string_view const CalledFrom   // routine this function was called from (error messages)
+                                    std::string_view Refrigerant, // carries in substance name
+                                    Real64 Temperature,           // actual temperature given as input
+                                    Real64 Pressure,              // actual pressure given as input
+                                    int &RefrigIndex,             // Index to Refrigerant Properties
+                                    std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
     Real64 GetSupHeatPressureRefrig(EnergyPlusData &state,
-                                    std::string_view const Refrigerant, // carries in substance name
-                                    Real64 Temperature,                 // actual temperature given as input
-                                    Real64 Enthalpy,                    // actual enthalpy given as input
-                                    int &RefrigIndex,                   // Index to Refrigerant Properties
-                                    std::string_view const CalledFrom   // routine this function was called from (error messages)
+                                    std::string_view Refrigerant, // carries in substance name
+                                    Real64 Temperature,           // actual temperature given as input
+                                    Real64 Enthalpy,              // actual enthalpy given as input
+                                    int &RefrigIndex,             // Index to Refrigerant Properties
+                                    std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
     Real64 GetSupHeatTempRefrig(EnergyPlusData &state,
-                                std::string_view const Refrigerant, // carries in substance name
-                                Real64 Pressure,                    // actual pressure given as input
-                                Real64 Enthalpy,                    // actual enthalpy given as input
-                                Real64 TempLow,                     // lower bound of temperature in the iteration
-                                Real64 TempUp,                      // upper bound of temperature in the iteration
-                                int &RefrigIndex,                   // Index to Refrigerant Properties
-                                std::string_view const CalledFrom   // routine this function was called from (error messages)
+                                std::string_view Refrigerant, // carries in substance name
+                                Real64 Pressure,              // actual pressure given as input
+                                Real64 Enthalpy,              // actual enthalpy given as input
+                                Real64 TempLow,               // lower bound of temperature in the iteration
+                                Real64 TempUp,                // upper bound of temperature in the iteration
+                                int &RefrigIndex,             // Index to Refrigerant Properties
+                                std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
     Real64 GetSupHeatDensityRefrig(EnergyPlusData &state,
-                                   std::string_view const Refrigerant, // carries in substance name
-                                   Real64 Temperature,                 // actual temperature given as input
-                                   Real64 Pressure,                    // actual pressure given as input
-                                   int &RefrigIndex,                   // Index to Refrigerant Properties
-                                   std::string_view const CalledFrom   // routine this function was called from (error messages)
+                                   std::string_view Refrigerant, // carries in substance name
+                                   Real64 Temperature,           // actual temperature given as input
+                                   Real64 Pressure,              // actual pressure given as input
+                                   int &RefrigIndex,             // Index to Refrigerant Properties
+                                   std::string_view CalledFrom   // routine this function was called from (error messages)
     );
 
 #ifdef EP_cache_GlycolSpecificHeat
     Real64 GetSpecificHeatGlycol_raw(EnergyPlusData &state,
-                                     std::string_view const Glycol,    // carries in substance name
-                                     Real64 const Temperature,         // actual temperature given as input
-                                     int &GlycolIndex,                 // Index to Glycol Properties
-                                     std::string_view const CalledFrom // routine this function was called from (error messages)
-    );
-
-    inline Real64 GetSpecificHeatGlycol(EnergyPlusData &state,
-                                        std::string_view const Glycol,    // carries in substance name
-                                        Real64 const Temperature,         // actual temperature given as input
-                                        int &GlycolIndex,                 // Index to Glycol Properties
-                                        std::string_view const CalledFrom // routine this function was called from (error messages)
-    )
-    {
-        std::uint64_t constexpr Grid_Shift = 64 - 12 - t_sh_precision_bits;
-
-        double const t(Temperature + 1000 * GlycolIndex);
-
-        DISABLE_WARNING_PUSH
-        DISABLE_WARNING_STRICT_ALIASING
-        DISABLE_WARNING_UNINITIALIZED
-        std::uint64_t const T_tag(*reinterpret_cast<std::uint64_t const *>(&t) >> Grid_Shift);
-        DISABLE_WARNING_POP
-
-        std::uint64_t const hash(T_tag & t_sh_cache_mask);
-        auto &cTsh(cached_t_sh[hash]);
-
-        if (cTsh.iT != T_tag) {
-            cTsh.iT = T_tag;
-            cTsh.sh = GetSpecificHeatGlycol_raw(state, Glycol, Temperature, GlycolIndex, CalledFrom);
-        }
-
-        return cTsh.sh; // saturation pressure {Pascals}
-    }
-#else
-    Real64 GetSpecificHeatGlycol(EnergyPlusData &state,
-                                 std::string_view const Glycol,    // carries in substance name
-                                 Real64 const Temperature,         // actual temperature given as input
-                                 int &GlycolIndex,                 // Index to Glycol Properties
-                                 std::string_view const CalledFrom // routine this function was called from (error messages)
+                                     std::string_view Glycol,    // carries in substance name
+                                     Real64 Temperature,         // actual temperature given as input
+                                     int &GlycolIndex,           // Index to Glycol Properties
+                                     std::string_view CalledFrom // routine this function was called from (error messages)
     );
 #endif
+    Real64 GetSpecificHeatGlycol(EnergyPlusData &state,
+                                 std::string_view Glycol,    // carries in substance name
+                                 Real64 Temperature,         // actual temperature given as input
+                                 int &GlycolIndex,           // Index to Glycol Properties
+                                 std::string_view CalledFrom // routine this function was called from (error messages)
+    );
 
     Real64 GetDensityGlycol(EnergyPlusData &state,
-                            std::string_view const Glycol,    // carries in substance name
-                            Real64 Temperature,               // actual temperature given as input
-                            int &GlycolIndex,                 // Index to Glycol Properties
-                            std::string_view const CalledFrom // routine this function was called from (error messages)
+                            std::string_view Glycol,    // carries in substance name
+                            Real64 Temperature,         // actual temperature given as input
+                            int &GlycolIndex,           // Index to Glycol Properties
+                            std::string_view CalledFrom // routine this function was called from (error messages)
     );
 
     Real64 GetConductivityGlycol(EnergyPlusData &state,
-                                 std::string_view const Glycol,    // carries in substance name
-                                 Real64 Temperature,               // actual temperature given as input
-                                 int &GlycolIndex,                 // Index to Glycol Properties
-                                 std::string_view const CalledFrom // routine this function was called from (error messages)
+                                 std::string_view Glycol,    // carries in substance name
+                                 Real64 Temperature,         // actual temperature given as input
+                                 int &GlycolIndex,           // Index to Glycol Properties
+                                 std::string_view CalledFrom // routine this function was called from (error messages)
     );
 
     Real64 GetViscosityGlycol(EnergyPlusData &state,
-                              std::string_view const Glycol,    // carries in substance name
-                              Real64 Temperature,               // actual temperature given as input
-                              int &GlycolIndex,                 // Index to Glycol Properties
-                              std::string_view const CalledFrom // routine this function was called from (error messages)
+                              std::string_view Glycol,    // carries in substance name
+                              Real64 Temperature,         // actual temperature given as input
+                              int &GlycolIndex,           // Index to Glycol Properties
+                              std::string_view CalledFrom // routine this function was called from (error messages)
     );
 
     void GetInterpValue_error(EnergyPlusData &state);
@@ -564,16 +529,16 @@ namespace FluidProperties {
     }
 
     Real64 GetQualityRefrig(EnergyPlusData &state,
-                            std::string const &Refrigerant,   // carries in substance name
-                            Real64 Temperature,               // actual temperature given as input
-                            Real64 Enthalpy,                  // actual enthalpy given as input
-                            int &RefrigIndex,                 // Index to Refrigerant Properties
-                            std::string_view const CalledFrom // routine this function was called from (error messages)
+                            std::string const &Refrigerant, // carries in substance name
+                            Real64 Temperature,             // actual temperature given as input
+                            Real64 Enthalpy,                // actual enthalpy given as input
+                            int &RefrigIndex,               // Index to Refrigerant Properties
+                            std::string_view CalledFrom     // routine this function was called from (error messages)
     );
 
-    int FindRefrigerant(EnergyPlusData &state, std::string_view const Rrefrigerant); // carries in substance name
+    int FindRefrigerant(EnergyPlusData &state, std::string_view Rrefrigerant); // carries in substance name
 
-    int FindGlycol(EnergyPlusData &state, std::string_view const Glycol); // carries in substance name
+    int FindGlycol(EnergyPlusData &state, std::string_view Glycol); // carries in substance name
 
     std::string GetGlycolNameByIndex(EnergyPlusData &state, int Idx); // carries in substance index
 
@@ -588,14 +553,14 @@ namespace FluidProperties {
     );
 
     Real64 GetInterpolatedSatProp(EnergyPlusData &state,
-                                  Real64 Temperature,                // Saturation Temp.
-                                  Array1D<Real64> const &PropTemps,  // Array of temperature at which props are available
-                                  Array1D<Real64> const &LiqProp,    // Array of saturated liquid properties
-                                  Array1D<Real64> const &VapProp,    // Array of saturatedvapour properties
-                                  Real64 Quality,                    // Quality
-                                  std::string_view const CalledFrom, // routine this function was called from (error messages)
-                                  int LowBound,                      // Valid values lower bound (set by calling program)
-                                  int UpperBound                     // Valid values upper bound (set by calling program)
+                                  Real64 Temperature,               // Saturation Temp.
+                                  Array1D<Real64> const &PropTemps, // Array of temperature at which props are available
+                                  Array1D<Real64> const &LiqProp,   // Array of saturated liquid properties
+                                  Array1D<Real64> const &VapProp,   // Array of saturatedvapour properties
+                                  Real64 Quality,                   // Quality
+                                  std::string_view CalledFrom,      // routine this function was called from (error messages)
+                                  int LowBound,                     // Valid values lower bound (set by calling program)
+                                  int UpperBound                    // Valid values upper bound (set by calling program)
     );
 
     int CheckFluidPropertyName(EnergyPlusData &state,
@@ -604,23 +569,23 @@ namespace FluidProperties {
     void ReportOrphanFluids(EnergyPlusData &state);
 
     void ReportFatalGlycolErrors(EnergyPlusData &state,
-                                 int NumGlycols,                     // Number of Glycols in input/data
-                                 int GlycolNum,                      // Glycol Index
-                                 bool DataPresent,                   // data is present for this fluid.
-                                 std::string_view const GlycolName,  // Name being reported
-                                 std::string_view const RoutineName, // Routine name to show
-                                 std::string_view const Property,    // Property being requested
-                                 std::string_view const CalledFrom   // original called from (external to fluid properties)
+                                 int NumGlycols,               // Number of Glycols in input/data
+                                 int GlycolNum,                // Glycol Index
+                                 bool DataPresent,             // data is present for this fluid.
+                                 std::string_view GlycolName,  // Name being reported
+                                 std::string_view RoutineName, // Routine name to show
+                                 std::string_view Property,    // Property being requested
+                                 std::string_view CalledFrom   // original called from (external to fluid properties)
     );
 
     void ReportFatalRefrigerantErrors(EnergyPlusData &state,
-                                      int NumRefrigerants,                    // Number of Refrigerants in input/data
-                                      int RefrigerantNum,                     // Refrigerant Index
-                                      bool DataPresent,                       // data is present for this fluid.
-                                      std::string_view const RefrigerantName, // Name being reported
-                                      std::string_view const RoutineName,     // Routine name to show
-                                      std::string_view const Property,        // Property being requested
-                                      std::string_view const CalledFrom       // original called from (external to fluid properties)
+                                      int NumRefrigerants,              // Number of Refrigerants in input/data
+                                      int RefrigerantNum,               // Refrigerant Index
+                                      bool DataPresent,                 // data is present for this fluid.
+                                      std::string_view RefrigerantName, // Name being reported
+                                      std::string_view RoutineName,     // Routine name to show
+                                      std::string_view Property,        // Property being requested
+                                      std::string_view CalledFrom       // original called from (external to fluid properties)
     );
 
     void GetFluidDensityTemperatureLimits(EnergyPlusData &state, int FluidIndex, Real64 &MinTempLimit, Real64 &MaxTempLimit);
@@ -693,38 +658,13 @@ struct FluidPropertiesData : BaseGlobalStruct
     int TempRangeErrCountGetInterpolatedSatProp = 0;
     int TempRangeErrIndexGetInterpolatedSatProp = 0;
 
+#ifdef EP_cache_GlycolSpecificHeat
+    std::array<FluidProperties::cached_tsh, FluidProperties::t_sh_cache_size> cached_t_sh;
+#endif
+
     void clear_state() override
     {
-        this->GetInput = true;
-        this->NumOfRefrigerants = 0;
-        this->NumOfGlycols = 0;
-        this->DebugReportGlycols = false;
-        this->DebugReportRefrigerants = false;
-        this->GlycolErrorLimitTest = 1;
-        this->RefrigerantErrorLimitTest = 1;
-        this->RefrigUsed.deallocate();
-        this->GlycolUsed.deallocate();
-
-        this->RefrigData.deallocate();
-        this->RefrigErrorTracking.deallocate();
-        this->GlyRawData.deallocate();
-        this->GlycolData.deallocate();
-        this->GlycolErrorTracking.deallocate();
-
-        this->SatErrCountGetSupHeatEnthalpyRefrig = 0;
-        this->SatErrCountGetSupHeatDensityRefrig = 0;
-        this->HighTempLimitErrGetSpecificHeatGlycol_raw = 0;
-        this->LowTempLimitErrGetSpecificHeatGlycol_raw = 0;
-        this->HighTempLimitErrGetDensityGlycol = 0;
-        this->LowTempLimitErrGetDensityGlycol = 0;
-        this->HighTempLimitErrGetConductivityGlycol = 0;
-        this->LowTempLimitErrGetConductivityGlycol = 0;
-        this->HighTempLimitErrGetViscosityGlycol = 0;
-        this->LowTempLimitErrGetViscosityGlycol = 0;
-        this->TempLoRangeErrIndexGetQualityRefrig = 0;
-        this->TempHiRangeErrIndexGetQualityRefrig = 0;
-        this->TempRangeErrCountGetInterpolatedSatProp = 0;
-        this->TempRangeErrIndexGetInterpolatedSatProp = 0;
+        new (this) FluidPropertiesData();
     }
 };
 

--- a/src/EnergyPlus/HeatBalanceSurfaceManager.cc
+++ b/src/EnergyPlus/HeatBalanceSurfaceManager.cc
@@ -3269,7 +3269,7 @@ void InitSolarHeatGains(EnergyPlusData &state)
                             Real64 Phi = incomingAngle.second;
 
                             std::shared_ptr<CMultiLayerScattered> aLayer =
-                                CWindowConstructionsSimplified::instance().getEquivalentLayer(state, WavelengthRange::Solar, ConstrNum);
+                                CWindowConstructionsSimplified::instance(state).getEquivalentLayer(state, WavelengthRange::Solar, ConstrNum);
 
                             size_t totLayers = aLayer->getNumOfLayers();
                             for (size_t Lay = 1; Lay <= totLayers; ++Lay) {

--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -8601,7 +8601,7 @@ void CalcInteriorSolarDistributionWCESimple(EnergyPlusData &state)
             int ConstrNum = state.dataSurface->Surface(SurfNum2).Construction;
             if (state.dataSurface->Surface(SurfNum2).activeShadedConstruction > 0)
                 ConstrNum = state.dataSurface->Surface(SurfNum2).activeShadedConstruction;
-            auto aLayer = CWindowConstructionsSimplified::instance().getEquivalentLayer(state, WavelengthRange::Solar, ConstrNum);
+            auto aLayer = CWindowConstructionsSimplified::instance(state).getEquivalentLayer(state, WavelengthRange::Solar, ConstrNum);
 
             ///////////////////////////////////////////////
             // Solar absorbed in window layers

--- a/src/EnergyPlus/WindowManagerExteriorData.cc
+++ b/src/EnergyPlus/WindowManagerExteriorData.cc
@@ -202,17 +202,12 @@ namespace WindowManager {
         return aSampleData;
     }
 
-    ///////////////////////////////////////////////////////////////////////////////
-    //   CWindowConstructionsSimplified
-    ///////////////////////////////////////////////////////////////////////////////
-    std::unique_ptr<CWindowConstructionsSimplified> CWindowConstructionsSimplified::p_inst = nullptr;
-
-    CWindowConstructionsSimplified &CWindowConstructionsSimplified::instance()
+    CWindowConstructionsSimplified &CWindowConstructionsSimplified::instance(EnergyPlusData &state)
     {
-        if (p_inst == nullptr) {
-            p_inst = std::unique_ptr<CWindowConstructionsSimplified>(new CWindowConstructionsSimplified());
+        if (state.dataWindowManagerExterior->p_inst == nullptr) {
+            state.dataWindowManagerExterior->p_inst = std::unique_ptr<CWindowConstructionsSimplified>(new CWindowConstructionsSimplified());
         }
-        return *p_inst;
+        return *state.dataWindowManagerExterior->p_inst;
     }
 
     CWindowConstructionsSimplified::CWindowConstructionsSimplified()
@@ -254,7 +249,6 @@ namespace WindowManager {
 
     void CWindowConstructionsSimplified::clearState()
     {
-        p_inst = nullptr;
     }
 
     IGU_Layers CWindowConstructionsSimplified::getLayers(EnergyPlusData &state, WavelengthRange const t_Range, int const t_ConstrNum) const

--- a/src/EnergyPlus/WindowManagerExteriorData.hh
+++ b/src/EnergyPlus/WindowManagerExteriorData.hh
@@ -58,6 +58,7 @@
 #include <EnergyPlus/EnergyPlus.hh>
 #include <EnergyPlus/Material.hh>
 #include <EnergyPlus/Vectors.hh>
+#include <WCEMultiLayerOptics.hpp>
 
 namespace EnergyPlus {
 
@@ -140,21 +141,18 @@ namespace WindowManager {
     class CWindowConstructionsSimplified
     {
     public:
-        static CWindowConstructionsSimplified &instance();
+        static CWindowConstructionsSimplified &instance(EnergyPlusData &state);
 
-        void pushLayer(FenestrationCommon::WavelengthRange const t_Range, int const t_ConstrNum, const SingleLayerOptics::CScatteringLayer &t_Layer);
+        void pushLayer(FenestrationCommon::WavelengthRange const t_Range, int t_ConstrNum, const SingleLayerOptics::CScatteringLayer &t_Layer);
 
         std::shared_ptr<MultiLayerOptics::CMultiLayerScattered>
-        getEquivalentLayer(EnergyPlusData &state, FenestrationCommon::WavelengthRange const t_Range, int const t_ConstrNum);
+        getEquivalentLayer(EnergyPlusData &state, FenestrationCommon::WavelengthRange t_Range, int t_ConstrNum);
 
         static void clearState();
-
-    private:
         CWindowConstructionsSimplified();
 
-        IGU_Layers getLayers(EnergyPlusData &state, FenestrationCommon::WavelengthRange const t_Range, int const t_ConstrNum) const;
-
-        static std::unique_ptr<CWindowConstructionsSimplified> p_inst;
+    private:
+        IGU_Layers getLayers(EnergyPlusData &state, FenestrationCommon::WavelengthRange t_Range, int t_ConstrNum) const;
 
         // Need separate layer properties for Solar and Visible range
         std::map<FenestrationCommon::WavelengthRange, Layers_Map> m_Layers;
@@ -162,6 +160,15 @@ namespace WindowManager {
     };
 
 } // namespace WindowManager
+
+struct WindowManagerExteriorData : BaseGlobalStruct
+{
+    std::unique_ptr<WindowManager::CWindowConstructionsSimplified> p_inst;
+    void clear_state() override
+    {
+        new (this) WindowManagerExteriorData();
+    }
+};
 
 } // namespace EnergyPlus
 

--- a/src/EnergyPlus/WindowManagerExteriorOptical.cc
+++ b/src/EnergyPlus/WindowManagerExteriorOptical.cc
@@ -183,7 +183,7 @@ namespace WindowManager {
         state.dataHeatBal->NumSurfaceScreens = state.dataHeatBal->TotScreens;
         if (state.dataHeatBal->NumSurfaceScreens > 0) CalcWindowScreenProperties(state);
 
-        auto &aWinConstSimp = CWindowConstructionsSimplified::instance();
+        auto &aWinConstSimp = CWindowConstructionsSimplified::instance(state);
         for (auto ConstrNum = 1; ConstrNum <= state.dataHeatBal->TotConstructs; ++ConstrNum) {
             auto &construction(state.dataConstruction->Construct(ConstrNum));
             if (construction.isGlazingConstruction(state)) {
@@ -275,7 +275,7 @@ namespace WindowManager {
     Real64 GetSolarTransDirectHemispherical(EnergyPlusData &state, int ConstrNum)
     {
         const auto aWinConstSimp =
-            CWindowConstructionsSimplified::instance().getEquivalentLayer(state, FenestrationCommon::WavelengthRange::Solar, ConstrNum);
+            CWindowConstructionsSimplified::instance(state).getEquivalentLayer(state, FenestrationCommon::WavelengthRange::Solar, ConstrNum);
         return aWinConstSimp->getPropertySimple(
             0.3, 2.5, FenestrationCommon::PropertySimple::T, FenestrationCommon::Side::Front, FenestrationCommon::Scattering::DirectHemispherical);
     }
@@ -283,7 +283,7 @@ namespace WindowManager {
     Real64 GetVisibleTransDirectHemispherical(EnergyPlusData &state, int ConstrNum)
     {
         const auto aWinConstSimp =
-            CWindowConstructionsSimplified::instance().getEquivalentLayer(state, FenestrationCommon::WavelengthRange::Visible, ConstrNum);
+            CWindowConstructionsSimplified::instance(state).getEquivalentLayer(state, FenestrationCommon::WavelengthRange::Visible, ConstrNum);
         return aWinConstSimp->getPropertySimple(
             0.38, 0.78, FenestrationCommon::PropertySimple::T, FenestrationCommon::Side::Front, FenestrationCommon::Scattering::DirectHemispherical);
     }

--- a/src/EnergyPlus/WindowManagerExteriorThermal.cc
+++ b/src/EnergyPlus/WindowManagerExteriorThermal.cc
@@ -650,7 +650,7 @@ namespace WindowManager {
             auto &surface(state.dataSurface->Surface(m_SurfNum));
             const auto ConstrNum{getActiveConstructionNumber(state, surface, m_SurfNum)};
             std::shared_ptr<MultiLayerOptics::CMultiLayerScattered> aLayer =
-                CWindowConstructionsSimplified::instance().getEquivalentLayer(state, FenestrationCommon::WavelengthRange::Solar, ConstrNum);
+                CWindowConstructionsSimplified::instance(state).getEquivalentLayer(state, FenestrationCommon::WavelengthRange::Solar, ConstrNum);
 
             // Report is done for normal incidence
             constexpr Real64 Theta{0.0};

--- a/tst/EnergyPlus/unit/WinCalcEngine.unit.cc
+++ b/tst/EnergyPlus/unit/WinCalcEngine.unit.cc
@@ -101,7 +101,7 @@ TEST_F(EnergyPlusFixture, DISABLED_WCEClear)
     WindowManager::InitWindowOpticalCalculations(*state);
     HeatBalanceManager::InitHeatBalance(*state);
 
-    auto aWinConstSimp = WindowManager::CWindowConstructionsSimplified::instance();
+    auto aWinConstSimp = WindowManager::CWindowConstructionsSimplified::instance(*state);
     auto solarLayer = aWinConstSimp.getEquivalentLayer(*state, FenestrationCommon::WavelengthRange::Solar, 1);
 
     constexpr Real64 minLambda{0.3};
@@ -197,7 +197,7 @@ TEST_F(EnergyPlusFixture, DISABLED_WCEVenetian)
     WindowManager::InitWindowOpticalCalculations(*state);
     HeatBalanceManager::InitHeatBalance(*state);
 
-    auto aWinConstSimp = WindowManager::CWindowConstructionsSimplified::instance();
+    auto aWinConstSimp = WindowManager::CWindowConstructionsSimplified::instance(*state);
     auto solarLayer = aWinConstSimp.getEquivalentLayer(*state, FenestrationCommon::WavelengthRange::Solar, 1);
 
     constexpr Real64 minLambda{0.3};
@@ -276,7 +276,7 @@ TEST_F(EnergyPlusFixture, DISABLED_WCEShade)
     WindowManager::InitWindowOpticalCalculations(*state);
     HeatBalanceManager::InitHeatBalance(*state);
 
-    auto aWinConstSimp = WindowManager::CWindowConstructionsSimplified::instance();
+    auto aWinConstSimp = WindowManager::CWindowConstructionsSimplified::instance(*state);
     auto solarLayer = aWinConstSimp.getEquivalentLayer(*state, FenestrationCommon::WavelengthRange::Solar, 1);
 
     constexpr Real64 minLambda{0.3};


### PR DESCRIPTION
...and tiny cleanup elsewhere.  I was able to identify that we have 9 non-const global variables in EnergyPlus:
 - a std::map in the 205 chiller code for the btwxt interpolation methods, not fixed here
 - the log level variable in the btwxt header, not fixed here
 - a control type name in the EMS Manager code, not a problem but still fixed here.
 - 2 variables in the exhaust air system manager code, which could be very problematic and were fixed here
 - the fluid property glycol property cache array, ~~which could be very problematic as a global, but requires a deeper fix than I wanted to give at the moment~~ which I moved to state
 - the cin, cout, and cerr stream variables, which are fine as they are.

So for this PR, I quickly marked the control type name array as constexpr to fix that one.  I moved the 2 exhaust variables to state to fix them.  ~~I started to move the glycol cache, but it's unforunately used inside inline header functions, and it became annoying to address.~~  And I moved the glycol cache to state as well.  