### PR TITLE
Updated with regressions main branch

### DIFF
--- a/.decent_ci.yaml
+++ b/.decent_ci.yaml
@@ -2,8 +2,8 @@ results_repository : NREL/EnergyPlusBuildResults
 results_path : _posts
 results_base_url : https://nrel.github.io/EnergyPlusBuildResults
 regression_repository : NREL/EnergyPlusRegressionTool
-regression_branch : master # this is the branch of NREL/EnergyPlusRegressionTool to use
-regression_baseline_default : develop # this is the branch to use as the baseline for regressions
+regression_branch : main # this is the branch of NREL/EnergyPlusRegressionTool to use
+regression_baseline_default : develop # this is the NREL/EnergyPlus branch to use as the baseline for regressions
 regression_baseline_develop : ""
 regression_baseline_master : ""
 notification_recipients:

--- a/cmake/RunRegression.cmake
+++ b/cmake/RunRegression.cmake
@@ -12,6 +12,6 @@ get_filename_component(IDF_NAME "${IDF_FILE}" NAME_WE)
 
 execute_process(
   COMMAND
-    ${PYTHON_EXECUTABLE} "${REGRESSION_SCRIPT_PATH}/epregressions/diffs/ci_compare_script.py" "${IDF_NAME}"
+    ${PYTHON_EXECUTABLE} "${REGRESSION_SCRIPT_PATH}/energyplus_regressions/diffs/ci_compare_script.py" "${IDF_NAME}"
     "${REGRESSION_BASELINE_PATH}/testfiles/${IDF_NAME}" "${BINARY_DIR}/testfiles/${IDF_NAME}" ${REGRESSION_BASELINE_SHA} ${COMMIT_SHA} true
     "${DEVICE_ID}")


### PR DESCRIPTION
Pull request overview
---------------------
The EnergyPlus Regressions repo was updated in two (relevant) ways here:
 - The default branch is now `main`
 - The source folder is renamed from `epregressions` to `energyplus_regressions` to be unified with our other Python tooling

As of now, the `master` branch over there will be left as-is, so that it won't immediately break anything.  It will be deleted at an undetermined point in the future.

The main changes needed here to accompany this are included in this PR:
 - Point our cmake regression script to use the now renamed folder in the checked out regression repo
 - Point Decent CI to check out the `main` branch now

This should be merged in as soon as Decent is happy with it.  Then as others pull develop into their branch, we will slowly lose dependence on the `master` branch over there.

"Expecting no disruption and all clean CI", he says knowing full well it will probably crash and burn in hilarious fashion.
