### PR TITLE
Simplify Fluid Caching

### DIFF
--- a/src/EnergyPlus/FluidProperties.cc
+++ b/src/EnergyPlus/FluidProperties.cc
@@ -7487,7 +7487,7 @@ namespace FluidProperties {
             GlycolIndex = GlycolNum;
         }
 
-        int constexpr SpecificHeatPrecisionBits = 24;
+        int constexpr SpecificHeatPrecisionBits = 16;
         std::uint64_t constexpr SpecificHeatMask = (FluidPropsGlycolData::SpecificHeatCacheSize - 1);
         std::uint64_t constexpr SpecificHeatShift = 64 - 12 - SpecificHeatPrecisionBits;
 

--- a/src/EnergyPlus/FluidProperties.hh
+++ b/src/EnergyPlus/FluidProperties.hh
@@ -245,7 +245,7 @@ namespace FluidProperties {
 
 #ifdef EP_cache_GlycolSpecificHeat
         struct SpecificHeatCacheEntry {
-            std::uint64_t tagTemp = 0;
+            std::uint64_t tagTemp = 0x8000000000000000; // Initialize with something that is not a valid tag
             Real64 specificHeat = 0.0;
         };
 

--- a/src/EnergyPlus/FluidProperties.hh
+++ b/src/EnergyPlus/FluidProperties.hh
@@ -245,7 +245,7 @@ namespace FluidProperties {
 
 #ifdef EP_cache_GlycolSpecificHeat
         struct SpecificHeatCacheEntry {
-            std::uint64_t tagTemp = 0x8000000000000000; // Initialize with something that is not a valid tag
+	    std::uint64_t tagTemp = 0; // 0x8000000000000000 Initialize with something that is not a valid tag
             Real64 specificHeat = 0.0;
         };
 
@@ -260,6 +260,9 @@ namespace FluidProperties {
               CondLowTempIndex(0), CondHighTempIndex(0), ViscDataPresent(false), NumViscTempPts(0), ViscLowTempValue(0.0), ViscHighTempValue(0.0),
               ViscLowTempIndex(0), ViscHighTempIndex(0)
         {
+#ifdef EP_cache_GlycolSpecificHeat
+            specificHeatCache[0].tagTemp = 0x8000000000000000; // 0 is a valid tag for entry 0, so need to initialize with something else;
+#endif 		
         }
     };
 


### PR DESCRIPTION
After the recent move of the Glycol specific heat cache to `state` and resulting slight slowdown, I tried a different caching approach in which each Glycol had its own small cache rather than all Glycol's sharing a single large one. 

I didn't get the speedups I was looking for (in fact, there are some small "noise" slowdowns) but there are also some "big" diffs which seem unrelated. 

This PR is not so much for merging at this point, it's for getting some help looking at those diffs.