### PR TITLE
Protect lookup in zone index to avoid crash in debug

### DIFF
--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -10991,15 +10991,15 @@ void WriteVeriSumTable(EnergyPlusData &state)
                     curArea += frameArea;
                 }
                 int const zonePt = thisSurf.Zone;
-                auto const &thisZone = state.dataHeatBal->Zone(zonePt);
 
-                bool const isConditioned = (zonePt > 0) && (thisZone.SystemZoneNodeNumber > 0);
+                bool const isConditioned = (zonePt > 0) && (state.dataHeatBal->Zone(zonePt).SystemZoneNodeNumber > 0);
                 if ((thisSurf.Tilt >= 60.0) && (thisSurf.Tilt <= 120.0)) {
                     // vertical walls and windows
                     switch (thisSurf.Class) {
                     case SurfaceClass::Wall:
                     case SurfaceClass::Floor:
                     case SurfaceClass::Roof: {
+                        auto const &thisZone = state.dataHeatBal->Zone(zonePt);
                         Real64 const mult = thisZone.Multiplier * thisZone.ListMultiplier;
                         if ((curAzimuth >= 315.0) || (curAzimuth < 45.0)) {
                             wallAreaN += curArea * mult;
@@ -11038,6 +11038,7 @@ void WriteVeriSumTable(EnergyPlusData &state)
                     } break;
                     case SurfaceClass::Window:
                     case SurfaceClass::TDD_Dome: {
+                        auto const &thisZone = state.dataHeatBal->Zone(zonePt);
                         Real64 const mult = thisZone.Multiplier * thisZone.ListMultiplier * thisSurf.Multiplier;
                         if ((curAzimuth >= 315.0) || (curAzimuth < 45.0)) {
                             windowAreaN += curArea * mult;
@@ -11068,6 +11069,7 @@ void WriteVeriSumTable(EnergyPlusData &state)
                     case SurfaceClass::Wall:
                     case SurfaceClass::Floor:
                     case SurfaceClass::Roof: {
+                        auto const &thisZone = state.dataHeatBal->Zone(zonePt);
                         Real64 const mult = thisZone.Multiplier * thisZone.ListMultiplier;
                         roofArea += curArea * mult;
                         if (DetailedWWR) {
@@ -11078,6 +11080,7 @@ void WriteVeriSumTable(EnergyPlusData &state)
                     } break;
                     case SurfaceClass::Window:
                     case SurfaceClass::TDD_Dome: {
+                        auto const &thisZone = state.dataHeatBal->Zone(zonePt);
                         Real64 const mult = thisZone.Multiplier * thisZone.ListMultiplier * thisSurf.Multiplier;
                         skylightArea += curArea * mult;
                         if (DetailedWWR) {


### PR DESCRIPTION
Pull request overview
---------------------
Array index crash accidentally dropped into develop with #9958.  This fixes that crash by protecting the array lookup until it's actually needed.  FYI @jmarrec @mjwitte 

If this passes the integration debug tests, it will merge.  (There will still be one unrelated debug failure due to SSC (#9984))