### PR TITLE
Try specifying Python executable path directly for Decent Windows

### DIFF
--- a/.decent_ci-Windows.yaml
+++ b/.decent_ci-Windows.yaml
@@ -2,5 +2,5 @@ compilers:
   - name: Visual Studio
     version: 16
     architecture: Win64
-    cmake_extra_flags: -DBUILD_FORTRAN:BOOL=ON -DBUILD_TESTING:BOOL=ON -DCOMMIT_SHA=%COMMIT_SHA% -DENABLE_GTEST_DEBUG_MODE:BOOL=OFF -DLINK_WITH_PYTHON=ON -DPYTHON_EXECUTABLE:PATH=C:/Users/elee/AppData/Local/Programs/Python/Python311/python.exe
+    cmake_extra_flags: -DBUILD_FORTRAN:BOOL=ON -DBUILD_TESTING:BOOL=ON -DCOMMIT_SHA=%COMMIT_SHA% -DENABLE_GTEST_DEBUG_MODE:BOOL=OFF -DLINK_WITH_PYTHON=ON -DPYTHON_EXECUTABLE:PATH=C:/Users/elee/AppData/Local/Programs/Python/Python311/python.exe -DPython_EXECUTABLE:PATH=C:/Users/elee/AppData/Local/Programs/Python/Python311/python.exe
     skip_regression: true

--- a/.decent_ci-Windows.yaml
+++ b/.decent_ci-Windows.yaml
@@ -2,5 +2,5 @@ compilers:
   - name: Visual Studio
     version: 16
     architecture: Win64
-    cmake_extra_flags: -DBUILD_FORTRAN:BOOL=ON -DBUILD_TESTING:BOOL=ON -DCOMMIT_SHA=%COMMIT_SHA% -DENABLE_GTEST_DEBUG_MODE:BOOL=OFF -DLINK_WITH_PYTHON=ON
+    cmake_extra_flags: -DBUILD_FORTRAN:BOOL=ON -DBUILD_TESTING:BOOL=ON -DCOMMIT_SHA=%COMMIT_SHA% -DENABLE_GTEST_DEBUG_MODE:BOOL=OFF -DLINK_WITH_PYTHON=ON -DPYTHON_EXECUTABLE:PATH=C:/Users/elee/AppData/Local/Programs/Python/Python311/python.exe
     skip_regression: true


### PR DESCRIPTION
Pull request overview
---------------------
 - Decent CI Windows machine got an update from Python 3.7 to 3.11
 - Unfortunately, Python was not placed on PATH, so CMake can't find it
 - I tried specifying Python_ROOT_DIR but it still didn't find it, however, specifying PYTHON_EXECUTABLE did find it right away, so that's what I'm trying here.

This is purely a Decent CI / Windows issue, nothing for the rest of the dev team.  If you notice odd Windows failures on your branches, just ignore and one of the next times you pull in develop it will probably be fixed.
