### PR TITLE
Correction of Calculation Error when using Multiple Swimming Pools

### DIFF
--- a/doc/engineering-reference/src/simulation-models-encyclopedic-reference-003/indoor-swimming-pool.tex
+++ b/doc/engineering-reference/src/simulation-models-encyclopedic-reference-003/indoor-swimming-pool.tex
@@ -25,14 +25,14 @@ Some assumptions of the model are given below, followed by more details of indiv
 \item
   The pool is controlled to a particular temperature defined by user input.
 \item
-  Evaporation of water from the pool is added to the zone moisture balance and affects the zone humidity ratio.
+  Water that evaporates from the pool is added to the zone moisture balance and affects the zone humidity ratio.
 \item
   The pool depth is small in comparison to its surface area. Thus, heat transfer through the pool walls is neglected. This is in keeping with the standard assumption of one-dimensional heat transfer through surfaces in EnergyPlus.
 \end{itemize}
 
 \subsection{Energy Balance of Indoor Swimming Pool}\label{energy-balance-of-indoor-swimming-pool}
 
-Heat losses from indoor swimming pools occur by a variety of mechanisms. Sensible heat transfer by convection, latent heat loss associated with evaporation, and net radiative heat exchange with the surrounding occur at the pool surface. Conductive heat losses take place through the bottom of the pool. Other heat gains/losses are associated with the pool water heating system, the replacement of evaporated water with makeup water The energy balance of the indoor swimming pool estimates the heat gains/losses occurring due to:
+Heat losses from indoor swimming pools occur by a variety of mechanisms. Sensible heat transfer by convection, latent heat loss associated with evaporation, and net radiative sensible heat exchange with the surrounding occur at the pool surface. Conductive heat losses take place through the bottom of the pool. Other heat gains/losses are associated with the pool water heating system and the replacement of evaporated water with makeup water. The energy balance of the indoor swimming pool estimates the heat gains/losses occurring due to:
 
 \begin{itemize}
 \tightlist
@@ -76,11 +76,19 @@ where:
 
 \(T_a\) is the air temperature over pool (\(^{\circ}\)C).
 
-When a cover is present, the cover and the cover convection factor reduce the heat transfer coefficient proportionally. For example, if the pool is half covered and the pool cover reduces convection by 50\%, the convective heat transfer coefficient is reduced by 25\% from the value calculated using the above equation.
+When a cover is present, the cover fraction and the cover convection factor reduce the heat transfer coefficient proportionally. For example, if the pool is half covered and the pool cover reduces convection by 50\%, the convective heat transfer coefficient is reduced by 25\% from the value calculated using the above equation.
 
 \subsection{Evaporation from the pool water surface}\label{evaporation-from-the-pool-water-surface}
 
-There are 5 main variables used to calculate the evaporation rate (\(Q_{evap}\)).  Note that the units of the equation below are IP units, but this equation is used with conversion factors internally in the EnergyPlus code.
+The latent heat transfer based on the evaporation of water from the pool (\(Q_{evap}\)) is calculated using the following equation:
+
+\begin{equation}
+Q_{evap} = \dot{m}_{evap} \cdot H_{fg}(W,MAT)
+\end{equation}
+
+where \(\dot{m}_{evap}\) is the evaporation rate of the pool water and \(H_{fg}(W,MAT)\) is the heat of vaporation of water as a function of the zone humidity ratio (W) and mean air temperature (MAT).
+
+The equation used to calculate the evaporation rate (\(dot{m}_{evap}\)) is based on four variables:
 
 \begin{itemize}
 \tightlist
@@ -96,13 +104,15 @@ There are 5 main variables used to calculate the evaporation rate (\(Q_{evap}\))
   Pool water agitation and Activity Factor
 \end{itemize}
 
+The equation for the evaporation rate is:
+
 \begin{equation}
 \dot{m}_{evap} = 0.1 \cdot A \cdot AF \cdot (P_w - P_{dp})
 \end{equation}
 
 where:
 
-\(\dot{m}_{evap}\) is the evaporation rate of pool water (lb/h)
+\(\dot{m}_{evap}\) is the evaporation rate of the pool water (lb/h)
 
 \(A\) is the surface area of pool water (ft\(^2\))
 
@@ -112,7 +122,9 @@ where:
 
 \(P_{dp}\) is the partial vapor pressure at room air dew point (in. Hg).
 
+Note that the units of the equation above are IP units.  In the EnergyPlus code, this equation uses conversion factors to maintain SI units internally.
 
+The following table provides some reference activity factors that can aide the user in determining what value(s) should be entered for this parameter in the input file.
 
 \begin{longtable}[c]{@{}ll@{}}
 \caption{Typical Activity Factor (AF) \label{table:typical-activity-factor-af}} \tabularnewline
@@ -140,19 +152,21 @@ Wave Pool, Water Slides & 1.5 – 2.0 \tabularnewline
 \bottomrule
 \end{longtable}
 
-When a cover is present, the cover and the cover evaporation factor reduce the amount of evaporation proportionally. For example, if the pool is half covered and the pool cover reduces convection by 50\%, the convective heat transfer coefficient is reduced by 25\% from the value calculated using the above equation. The value is converted to a latent gain (loss) through multiplication of the evaporation rate by the heat of vaporization of water.
+When a cover is present, the cover fraction and the cover evaporation factor reduce the amount of evaporation proportionally. For example, if the pool is half covered and the pool cover reduces convection by 50\%, the convective heat transfer coefficient is reduced by 25\% from the value calculated using the above equation. The value is converted to a latent gain (loss) through multiplication of the evaporation rate by the heat of vaporization of water.
 
 The user should be aware of two key assumptions built into the equations for calculating the evaporation from the pool.  First, when the activity factor is zero, no evaporation will take place.  Thus, activity factor is not the same thing as occupancy and should not be zero when there are no people in the pool as that will completely eliminate evaporation.  Second, when the cover evaporation factor is zero, the cover will not reduce evaporation at all.  A cover factor of 1.0 means that the cover will completely block evaporation.
 
 \subsection{Radiation exchange with the pool water surface}\label{radiation-exchange-with-the-pool-water-surface}
 
-This uses the EnergyPlus internal short- and long-wavelength radiation balances already in place. When a cover is present, it acts to reduce the amount of radiation that arrives at the pool water surface in comparison to the no cover case. Any reduction in either type of radiation is accounted for by adding a convective gain/loss to the zone air. So, in effect, the cover absorbs some radiation and then convects it to the zone air.
+The radiation exchange between the pool water surface and other surfaces and sources uses the existing EnergyPlus internal short- and long-wavelength radiation balances that are already in place within the program. When a cover is present, it acts to reduce the amount of radiation that arrives at the pool water surface in comparison to the no cover case. Any reduction in either type of radiation is accounted for by adding a convective gain/loss to the zone air. So, in effect, the cover absorbs some radiation and then convects it to the zone air.
 
 \subsection{Conduction through the bottom of the pool}\label{conduction-through-the-bottom-of-the-pool}
 
-The model ignores 2-d effects of pool walls and assume that pool depth is much less than the pool area. Conduction is calculated using the Conduction Transfer Function (CTF) equation with the outside temperature determined by the outside heat balance and the inside surface temperature calculated using the pool water heat balance that is lumped together with the inside surface heat balance.
+The model ignores 2-dimensional effects of pool walls and assume that pool depth is much less than the pool area. Conduction is calculated using the Conduction Transfer Function (CTF) equation with the outside temperature determined by the outside heat balance and the inside surface temperature calculated using the pool water heat balance that is lumped together with the inside surface heat balance.
 
 \subsection{Makeup pool water supply}\label{makeup-pool-water-supply}
+
+The energy impact of the makeup water (\(Q_{fw}\)) that is added to the pool to replace any water which evaporates is taken into account using the following equation:
 
 \begin{equation}
 Q_{fw} = \dot{m}_{fw} \cdot cw \cdot (T_p - T_{fw})
@@ -170,23 +184,25 @@ where:
 
 \subsection{Heat Gain from People}\label{heat-gain-from-people}
 
-The input for the swimming pool requires that the user enter the maximum number of people in the pool, a schedule modifying the maximum number of people for different pool occupancies, and a heat gain per person schedule for differing activities. These three parameters allow for the calculation of a total heat gain from people during a given time. It is assumed that all of the heat gain from people is via convection to the pool water.
+The input for the swimming pool requires that the user enter the maximum number of people in the pool, a schedule modifying the maximum number of people for different pool occupancies, and a heat gain per person schedule for differing activities. These three parameters allow for the calculation of a total heat gain from people during a given time. It is assumed that all of the heat gain from people is added to the pool water via convection.
 
 \subsection{Heat from auxiliary pool heater}\label{heat-from-auxiliary-pool-heater}
 
+The energy impact of the pool heater (\(Q_{hw}\)) on the pool water temperature is taken into account using the following equation:
+
 \begin{equation}
-Q_{fw} = \dot{m}_{hw} \cdot c_w \cdot (T_p - T_{hw})
+Q_{hw} = \dot{m}_{hw} \cdot c_w \cdot (T_p - T_{hw})
 \end{equation}
 
 where:
 
-\(m_{hw}\) = Mass flow rate (kg/s)
+\(m_{hw}\) is the mass flow rate (kg/s)
 
-\(c_w\) = Specific heat of water (J/kg-\(^{\circ}\)C)
+\(c_w\) is the specific heat of water (J/kg-\(^{\circ}\)C)
 
-\(T_p\) = Pool water temperature (\(^{\circ}\)C)
+\(T_p\) is the pool water temperature (\(^{\circ}\)C)
 
-\(T_{hw}\) = Heated water supply temperature (\(^{\circ}\)C).
+\(T_{hw}\) is the heated water supply temperature (\(^{\circ}\)C).
 
 \subsection{Pool Heating to Control the Pool Water Temperature}\label{pool-heating-to-control-the-pool-water-temperature}
 
@@ -200,7 +216,7 @@ where:
 
 \(m_w\) is the mass of pool water (kg)
 
-\(cp\) is the specific heat of water (J/kg-\(^{\circ}\)C)
+\(c_p\) is the specific heat of water (J/kg-\(^{\circ}\)C)
 
 \(\Delta t\) is the time step length (s)
 
@@ -208,9 +224,10 @@ where:
 
 \(T_{old}\) is the temperature of water at the last time step (\(^{\circ}\)C)
 
-\(m_p\) is the needed mass flow rate of water from the plant (kg/s)
+\(dot{m}_p\) is the needed mass flow rate of water from the plant (kg/s)
 
 \(T_{in}\) is the inlet water temperature from the plant (\(^{\circ}\)C).
+
 
 This equation is rearranged to solve for the needed mass flow rate of water from the plant since all of the other terms are known or given based on user input. This establishes a flow request to the plant and is capped at the maximum value defined in input by the user.
 
@@ -242,31 +259,32 @@ where:
 
 \(Q_{evap}\) is the net heat loss due to evaporation of pool water to the zone air.
 
+
 Details on each of these terms was either provided in previous parts of this section or in the standard EnergyPlus heat balance discussion elsewhere in the Engineering Reference.
 
 \subsection{Other additional information}\label{other-additional-information}
 
-The following subsections are some useful information that those wishing to model a swimming pool in EnergyPlus might find helpful. Further information can be found on-line or in reputable sources such as the ASHRAE Handbooks.
+The following subsections contain some useful information that those wishing to model a swimming pool in EnergyPlus might find helpful. Further information can be found on-line or in reputable sources such as the ASHRAE Handbooks.
 
-\subsection{Swimming Pool Flow Rate}\label{swimming-pool-flow-rate}
+\subsubsection{Swimming Pool Flow Rate}\label{swimming-pool-flow-rate}
 
 The flow rate of the circulating pump is designed to turn over (circulate) the entire volume of water in the pool in 6 to 8 hours, or 3 or 4 times in 24 hours. About 1 or 2 percent of the pumped circulation rate should be provided as continuous makeup water demand to overcome losses from evaporation, bleed-off, and spillage. To fill the pool initially, a separate quick-fill line should be provided to do the job in 8 to 16 hours; however, filling is usually done at off-peak hours. Thus, the demand flow rate need not be considered in the system demand calculations, unless it out-weighs the demand of all other demands even during the off-peak hours.
 
-\subsection{Comfort and Health}\label{comfort-and-health}
+\subsubsection{Comfort and Health}\label{comfort-and-health}
 
-Indoor pools are normally maintained between 50 and 60\% RH for two reasons:
+Zones with indoor swimming pools are normally maintained between 50 and 60\% RH for two reasons:
 
 \begin{itemize}
 \tightlist
 \item
-  Swimmers leaving the water feel chilly at lower relative humidity due to evaporation off the body
+  Swimmers leaving the water may feel thermally cool at lower relative humidity due to incrased evaporation off of the body at lower relative humidity levels.
 \item
-  It is considerably more expensive (and unnecessary) to maintain 40\% RH instead of 50\% RH
+  It is considerably more expensive (and unnecessary) to maintain 40\% RH instead of 50\% RH.
 \end{itemize}
 
-\subsection{Air Delivery Rates (Indoor Pool)}\label{air-delivery-rates-indoor-pool}
+\subsubsection{Air Delivery Rates (Indoor Pool)}\label{air-delivery-rates-indoor-pool}
 
-Most codes require a minimum of 6 ACH, except where mechanical cooling is used. This rate may prove inadequate for some occupancy and use. Where mechanical dehumidification is provided, air delivery rates should be established to maintain appropriate conditions of temperature and humidity. The following rates are typically desired:
+Most codes require a minimum of 6 ACH for air circulation, except where mechanical cooling is used. This rate may prove inadequate for some occupancy and use. Where mechanical dehumidification is provided, air delivery rates should be established to maintain appropriate conditions of temperature and humidity. The following rates are typically desired:
 
 \begin{itemize}
 \tightlist
@@ -278,7 +296,9 @@ Most codes require a minimum of 6 ACH, except where mechanical cooling is used. 
   Therapeutic pools, 4 \textasciitilde{} 6 ACH
 \end{itemize}
 
+\subsubsection{Indoor Pool Recommended Air and Water Temperatures}\label{indoor-pool-recommended-air-and-water-temperatures}
 
+The following table provides a starting point for determining the appropriate zone air and pool water temperatures one might expect in a zone that contains an indoor swimming pool.  As with any building parameter, users should determine these based on best practices and their own experience and set the appropriate parameters in their input files accordingly.
 
 \begin{longtable}[c]{@{}lll@{}}
 \caption{Typical Swimming Pool Design Conditions \label{table:typical-swimming-pool-design-conditions}} \tabularnewline

--- a/doc/input-output-reference/src/overview/group-internal-gains-people-lights-other.tex
+++ b/doc/input-output-reference/src/overview/group-internal-gains-people-lights-other.tex
@@ -3212,7 +3212,7 @@ There are a variety of rules that limit the application of indoor swimming pools
   \item The pool cannot utilize movable insulation or have a heat source or sink associated with it (something used to model low temperature radiant systems).
 \end{itemize}
 
-The following information is useful for defining and modeling an indoor pool in EnergyPlus. For more information on the algorithm used for this model or details on some of the input parameters, please reference the indoor pool section of the EnergyPlus Engineering Reference document.
+The following information is useful for defining and modeling an indoor pool in EnergyPlus. For more information on the algorithm used for this model or details on some of the input parameters, please reference the Indoor Swimming Pool section of the EnergyPlus Engineering Reference document.
 
 \subsubsection{Inputs}\label{inputs-7-012}
 
@@ -3230,11 +3230,11 @@ This field is the average depth of the pool in meters. If the pool has variable 
 
 \paragraph{Field: Activity Factor Schedule Name}\label{field-activity-factor-schedule-name}
 
-This field references a schedule that contains values for pool activity. This parameter can be varied using the schedule named here, and it has an impact on the amount of evaporation that will take place from the pool to the surrounding zone air. For example values of the activity factor and what impact it will have on the evaporation of water from the pool, please refer to the Indoor Swimming Pool section of the EnergyPlus Engineering Reference document. If left blank, the activity factor will be assumed to be unity. Note that the activity factor should not be set equal to an occupancy schedule since an activity factor of zero means that no evaporation will take place from the pool.
+This field references a schedule that contains values for pool activity. This parameter can be varied using the schedule named here, and it has an impact on the amount of evaporation that will take place from the pool to the surrounding zone air. For example values of the activity factor and what impact it will have on the evaporation of water from the pool, please refer to the Indoor Swimming Pool section of the EnergyPlus Engineering Reference document. If left blank, the activity factor will be assumed to be unity. Note that the activity factor schedule should not be set equal to an occupancy schedule since an activity factor of zero means that no evaporation will take place from the pool.
 
 \paragraph{Field: Make-up Water Supply Schedule Name}\label{field-make-up-water-supply-schedule-name}
 
-The scheduled named by this field establishes a cold water temperature {[}C{]} for the water that replaces the water which is lost from the pool due to evaporation. If blank, water temperatures are calculated by the \hyperref[sitewatermainstemperature]{Site:WaterMainsTemperature} object. This field (even if blank) overrides the Cold Water Supply Temperature Schedule in all of the listed \hyperref[wateruseequipment]{WaterUse:Equipment} objects.
+The schedule named by this field establishes a cold water temperature {[}C{]} for the water that replaces the water which is lost from the pool due to evaporation. If blank, water temperatures are calculated by the \hyperref[sitewatermainstemperature]{Site:WaterMainsTemperature} object. This field (even if blank) overrides the Cold Water Supply Temperature Schedule in all of the listed \hyperref[wateruseequipment]{WaterUse:Equipment} objects.
 
 \paragraph{Field: Cover Schedule Name}\label{field-cover-schedule-name}
 
@@ -3258,19 +3258,19 @@ This input field can optionally be used to modify the pool long-wavelength radia
 
 \paragraph{Field: Pool Water Inlet Node}\label{field-pool-water-inlet-node}
 
-This input is the name of the node on the demand side of a plant loop that leads into the pool. From the standpoint of an EnergyPlus input file, the pool sits on a plant demand loop, and the pump and heater reside on the plant supply loop. The pool heater and pump must be defined by other existing EnergyPlus input.
+This input is the name of the node on the demand side of a plant loop that leads into the pool. From the standpoint of an EnergyPlus input file, the pool is placed on a plant demand loop, and the pump and heater reside on the plant supply loop. The pool heater and pump must be defined by other existing EnergyPlus input.
 
 \paragraph{Field: Pool Water Outlet Node}\label{field-pool-water-outlet-node}
 
-This input is the name of the node on the demand side of a plant loop that leads out of the pool. From the standpoint of an EnergyPlus input file, the pool sits on a plant demand loop, and the pump and heater reside on the plant supply loop. The pool heater and pump must be defined by other existing EnergyPlus input.
+This input is the name of the node on the demand side of a plant loop that leads out of the pool. From the standpoint of an EnergyPlus input file, the pool is placed on a plant demand loop, and the pump and heater reside on the plant supply loop. The pool heater and pump must be defined by other existing EnergyPlus input.
 
 \paragraph{Field: Pool Water Maximum Flow Rate}\label{field-pool-water-maximum-flow-rate}
 
-This input is the maximum water volumetric flow rate in m3/s going between the pool and the water heating equipment. This along with the pool setpoint temperature and the heating plant equipment outlet temperature will establish the maximum heat addition to the pool. This flow rate to the pool will be varied in an attempt to reach the desired pool water setpoint temperature (see Setpoint Temperature Schedule below).
+This input is the maximum water volumetric flow rate in m\(^{3}\)/s going between the pool and the water heating equipment. This along with the pool setpoint temperature and the heating plant equipment outlet temperature will establish the maximum heat addition to the pool. This flow rate to the pool will be varied in an attempt to reach the desired pool water setpoint temperature (see Setpoint Temperature Schedule below).
 
 \paragraph{Field: Pool Miscellaneous Equipment Power}\label{field-pool-miscellaneous-equipment-power}
 
-This input defines the power consumption rate of miscellaneous equipment such as the filtering and chlorination technology associated with the pool. The units for this input are in power consumption per flow rate of water through the pool from the heater or W/(m3/s). This field will be multiplied by the flow rate of water through the pool to determine the power consumption of this equipment. Any heat generated by this equipment is assumed to have no effect on the pool water itself.
+This input defines the power consumption rate of miscellaneous equipment such as the filtering and chlorination technology associated with the pool. The units for this input are in power consumption per flow rate of water through the pool from the heater or W/(m\(^{3}\)/s). This field will be multiplied by the flow rate of water through the pool to determine the power consumption of this equipment. Any heat generated by this equipment is assumed to have no effect on the pool water itself.
 
 \paragraph{Field: Setpoint Temperature Schedule}\label{field-setpoint-temperature-schedule}
 
@@ -3363,11 +3363,11 @@ SwimmingPool:Indoor,
   HVAC, Average, Indoor Pool Current Cover LW Radiation Factor {[]}
 \end{itemize}
 
-\paragraph{Indoor Pool Makeup Water Rate {[}m3/s{]}}\label{indoor-pool-makeup-water-rate-m3s}
+\paragraph{Indoor Pool Makeup Water Rate {[}m\(^{3}\)/s{]}}\label{indoor-pool-makeup-water-rate-m3s}
 
 The water consumption rate for the makeup water of indoor swimming pool.
 
-\paragraph{Indoor Pool Makeup Water Volume {[}m3{]}}\label{indoor-pool-makeup-water-volume-m3}
+\paragraph{Indoor Pool Makeup Water Volume {[}m\(^{3}\){]}}\label{indoor-pool-makeup-water-volume-m3}
 
 The water consumption for the makeup water of indoor swimming pool.
 

--- a/src/EnergyPlus/SwimmingPool.cc
+++ b/src/EnergyPlus/SwimmingPool.cc
@@ -1056,23 +1056,22 @@ void UpdatePoolSourceValAvg(EnergyPlusData &state, bool &SwimmingPoolOn) // .TRU
     // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
     SwimmingPoolOn = false;
 
-    // If this was never allocated, then there are no radiant systems in this input file (just RETURN)
+    // If this was never allocated, then there are no swimming pools in this input file (just RETURN)
     for (int PoolNum = 1; PoolNum <= state.dataSwimmingPools->NumSwimmingPools; ++PoolNum) {
         if (!allocated(state.dataSwimmingPools->Pool(PoolNum).QPoolSrcAvg)) return;
 
-        // If it was allocated, then we have to check to see if this was running at all
+        // If it was allocated, then we have to check to see if this pool was running at all.  If so, update pool terms also.
         for (int SurfNum = 1; SurfNum <= state.dataSurface->TotSurfaces; ++SurfNum) {
             if (state.dataSwimmingPools->Pool(PoolNum).QPoolSrcAvg(SurfNum) != 0.0) {
                 SwimmingPoolOn = true;
+                state.dataHeatBalFanSys->QPoolSurfNumerator(SurfNum) = state.dataSwimmingPools->Pool(PoolNum).QPoolSrcAvg(SurfNum);
+                state.dataHeatBalFanSys->PoolHeatTransCoefs(SurfNum) = state.dataSwimmingPools->Pool(PoolNum).HeatTransCoefsAvg(SurfNum);
                 break; // DO loop
             }
         }
-
-        state.dataHeatBalFanSys->QPoolSurfNumerator = state.dataSwimmingPools->Pool(PoolNum).QPoolSrcAvg;
-        state.dataHeatBalFanSys->PoolHeatTransCoefs = state.dataSwimmingPools->Pool(PoolNum).HeatTransCoefsAvg;
     }
 
-    // For interzone surfaces, modQPoolSrcAvg was only updated for the "active" side.  The active side
+    // For interzone surfaces, QPoolSrcAvg was only updated for the "active" side.  The active side
     // would have a non-zero value at this point.  If the numbers differ, then we have to manually update.
     for (int SurfNum = 1; SurfNum <= state.dataSurface->TotSurfaces; ++SurfNum) {
         if (state.dataSurface->Surface(SurfNum).ExtBoundCond > 0 && state.dataSurface->Surface(SurfNum).ExtBoundCond != SurfNum) {

--- a/tst/EnergyPlus/unit/SwimmingPool.unit.cc
+++ b/tst/EnergyPlus/unit/SwimmingPool.unit.cc
@@ -55,11 +55,11 @@
 #include <EnergyPlus/Construction.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataHeatBalFanSys.hh>
 #include <EnergyPlus/DataSizing.hh>
 #include <EnergyPlus/DataSurfaces.hh>
 #include <EnergyPlus/Plant/DataPlant.hh>
 #include <EnergyPlus/SwimmingPool.hh>
-#include <EnergyPlus/DataHeatBalFanSys.hh>
 
 using namespace EnergyPlus;
 using namespace EnergyPlus::SwimmingPool;
@@ -361,7 +361,7 @@ TEST_F(EnergyPlusFixture, SwimmingPool_MultiplePoolUpdatePoolSourceValAvgTest)
     // Test of UpdatePoolSourceValAvg for Multiple Swimming Pools (Fix for Defect #9797)
     // The specification of multiple pools in single input file led to weird results and
     // was traced back to improper assignment statements in UpdatePoolSourceValAvg.
-    
+
     auto &PoolData = state->dataSwimmingPools;
     auto &SurfData = state->dataSurface;
     auto &HBFanData = state->dataHeatBalFanSys;
@@ -378,15 +378,15 @@ TEST_F(EnergyPlusFixture, SwimmingPool_MultiplePoolUpdatePoolSourceValAvgTest)
         PoolData->Pool(poolNum).QPoolSrcAvg.allocate(SurfData->TotSurfaces);
         PoolData->Pool(poolNum).HeatTransCoefsAvg.allocate(SurfData->TotSurfaces);
     }
-    
+
     Real64 noResult = -9999.0;
     HBFanData->QPoolSurfNumerator.allocate(SurfData->TotSurfaces);
     HBFanData->QPoolSurfNumerator = noResult;
     HBFanData->PoolHeatTransCoefs.allocate(SurfData->TotSurfaces);
     HBFanData->PoolHeatTransCoefs = noResult;
-    
-    for (int surfNum= 1; surfNum <= SurfData->TotSurfaces; ++surfNum) {
-        SurfData->Surface(surfNum).ExtBoundCond = 0;    // All connected to exterior
+
+    for (int surfNum = 1; surfNum <= SurfData->TotSurfaces; ++surfNum) {
+        SurfData->Surface(surfNum).ExtBoundCond = 0; // All connected to exterior
     }
 
     // Test 1: both pools off
@@ -394,17 +394,17 @@ TEST_F(EnergyPlusFixture, SwimmingPool_MultiplePoolUpdatePoolSourceValAvgTest)
     Pool1Data.HeatTransCoefsAvg = 0.0;
     Pool2Data.QPoolSrcAvg = 0.0;
     Pool2Data.HeatTransCoefsAvg = 0.0;
-    
+
     // Call subroutine
     bool poolOnFlag = false;
-    UpdatePoolSourceValAvg(*state,poolOnFlag);
-    
+    UpdatePoolSourceValAvg(*state, poolOnFlag);
+
     // Test data transfer
     EXPECT_FALSE(poolOnFlag);
-    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(1),noResult,closeEnough);
-    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(2),noResult,closeEnough);
-    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(1),noResult,closeEnough);
-    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(2),noResult,closeEnough);
+    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(1), noResult, closeEnough);
+    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(2), noResult, closeEnough);
+    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(1), noResult, closeEnough);
+    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(2), noResult, closeEnough);
 
     // Test 2a: pool 1 on, pool 2 off
     Pool1Data.QPoolSrcAvg(1) = 100.0;
@@ -416,14 +416,14 @@ TEST_F(EnergyPlusFixture, SwimmingPool_MultiplePoolUpdatePoolSourceValAvgTest)
 
     // Call subroutine
     poolOnFlag = false;
-    UpdatePoolSourceValAvg(*state,poolOnFlag);
-    
+    UpdatePoolSourceValAvg(*state, poolOnFlag);
+
     // Test data transfer
     EXPECT_TRUE(poolOnFlag);
-    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(1),Pool1Data.QPoolSrcAvg(1),closeEnough);
-    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(2),noResult,closeEnough);
-    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(1),Pool1Data.HeatTransCoefsAvg(1),closeEnough);
-    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(2),noResult,closeEnough);
+    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(1), Pool1Data.QPoolSrcAvg(1), closeEnough);
+    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(2), noResult, closeEnough);
+    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(1), Pool1Data.HeatTransCoefsAvg(1), closeEnough);
+    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(2), noResult, closeEnough);
 
     // Test 2b: pool 1 off, pool 2 on
     Pool1Data.QPoolSrcAvg(1) = 0.0;
@@ -435,14 +435,14 @@ TEST_F(EnergyPlusFixture, SwimmingPool_MultiplePoolUpdatePoolSourceValAvgTest)
 
     // Call subroutine
     poolOnFlag = false;
-    UpdatePoolSourceValAvg(*state,poolOnFlag);
-    
+    UpdatePoolSourceValAvg(*state, poolOnFlag);
+
     // Test data transfer
     EXPECT_TRUE(poolOnFlag);
-    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(1),noResult,closeEnough);
-    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(2),Pool2Data.QPoolSrcAvg(2),closeEnough);
-    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(1),noResult,closeEnough);
-    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(2),Pool2Data.HeatTransCoefsAvg(2),closeEnough);
+    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(1), noResult, closeEnough);
+    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(2), Pool2Data.QPoolSrcAvg(2), closeEnough);
+    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(1), noResult, closeEnough);
+    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(2), Pool2Data.HeatTransCoefsAvg(2), closeEnough);
 
     // Test 3: both pools on
     Pool1Data.QPoolSrcAvg(1) = 100.0;
@@ -454,13 +454,12 @@ TEST_F(EnergyPlusFixture, SwimmingPool_MultiplePoolUpdatePoolSourceValAvgTest)
 
     // Call subroutine
     poolOnFlag = false;
-    UpdatePoolSourceValAvg(*state,poolOnFlag);
-    
+    UpdatePoolSourceValAvg(*state, poolOnFlag);
+
     // Test data transfer
     EXPECT_TRUE(poolOnFlag);
-    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(1),Pool1Data.QPoolSrcAvg(1),closeEnough);
-    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(2),Pool2Data.QPoolSrcAvg(2),closeEnough);
-    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(1),Pool1Data.HeatTransCoefsAvg(1),closeEnough);
-    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(2),Pool2Data.HeatTransCoefsAvg(2),closeEnough);
-
+    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(1), Pool1Data.QPoolSrcAvg(1), closeEnough);
+    EXPECT_NEAR(HBFanData->QPoolSurfNumerator(2), Pool2Data.QPoolSrcAvg(2), closeEnough);
+    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(1), Pool1Data.HeatTransCoefsAvg(1), closeEnough);
+    EXPECT_NEAR(HBFanData->PoolHeatTransCoefs(2), Pool2Data.HeatTransCoefsAvg(2), closeEnough);
 }


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #9797 
 - When using more than one swimming pool, a user noticed that the first swimming pool would not arrive at the desired setpoint while the second pool entered would.  This was noticed when the pools were in the same zone and even when they were in separate zones.  In the original defect description for #9797, the user provided both the input files and a graph of what was being seen.  The erroneous results were confirmed with the latest version of EnergyPlus.  After investigation of the problem, it was determined that there was a bug in the way that the two variables were being averaged over the zone time step and then assigned to other variables.  This was corrected, an the results after the fix was made show that the pool temperature was going to the setpoint temperature as expected (see #9797 conversation for graphs of pre- and post-fix results).  This work included both a unit test to verify the fix as well as a thorough review (edits and additions) of both the Input Output Reference and the Engineering Reference sections for the indoor swimming pool.

**NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE**

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [X] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [X] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
