### PR TITLE
Fix #10197 - Spurious unit test failure in CommandLineInterfaceFixture

### DIFF
--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -291,4 +291,7 @@ set(test_src
     CommandLineInterface.unit.cc
     main.cc
 )
+# For CommandLineInterface.unit.cc, make an in.idf / in.epw in the test directory so we can test the legacy CLI (applies to CTest which sets the current directory to this one)
+configure_file("${PROJECT_SOURCE_DIR}/weather/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw" "in.epw" COPYONLY)
+configure_file("Resources/UnitaryHybridUnitTest_DOSA.idf" "in.idf" COPYONLY)
 create_test_targets(energyplusapi "${test_src}" "${test_dependencies}" True)

--- a/tst/EnergyPlus/unit/CMakeLists.txt
+++ b/tst/EnergyPlus/unit/CMakeLists.txt
@@ -292,6 +292,6 @@ set(test_src
     main.cc
 )
 # For CommandLineInterface.unit.cc, make an in.idf / in.epw in the test directory so we can test the legacy CLI (applies to CTest which sets the current directory to this one)
-configure_file("${PROJECT_SOURCE_DIR}/weather/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw" "in.epw" COPYONLY)
-configure_file("Resources/UnitaryHybridUnitTest_DOSA.idf" "in.idf" COPYONLY)
+configure_file("${PROJECT_SOURCE_DIR}/weather/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw" "${CMAKE_CURRENT_BINARY_DIR}/in.epw" COPYONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Resources/UnitaryHybridUnitTest_DOSA.idf" "${CMAKE_CURRENT_BINARY_DIR}/in.idf" COPYONLY)
 create_test_targets(energyplusapi "${test_src}" "${test_dependencies}" True)

--- a/tst/EnergyPlus/unit/CommandLineInterface.unit.cc
+++ b/tst/EnergyPlus/unit/CommandLineInterface.unit.cc
@@ -102,12 +102,24 @@ protected:
     {
         EnergyPlusFixture::SetUpTestCase();
 
-        // For the "legacy" mode, we need in.idf / in.epw in the current directory
-        auto inputFilePath = configured_source_directory() / "tst/EnergyPlus/unit/Resources/UnitaryHybridUnitTest_DOSA.idf";
-        fs::copy_file(inputFilePath, FileSystem::getAbsolutePath("in.idf"), fs::copy_options::skip_existing);
+        // For the "legacy" mode, we need *any* in.idf / in.epw in the current directory
+        // This is done via cmake for the CTest case at least, but if you run the energyplusapi_tests exe directly, the current directory isn't
+        // necessarily the <build>/tst/unit/EnergyPlus one, so we do it here anyways
+        {
+            auto destPath = FileSystem::getAbsolutePath("in.idf");
+            if (!fs::is_regular_file(destPath)) {
+                auto inputFilePath = configured_source_directory() / "tst/EnergyPlus/unit/Resources/UnitaryHybridUnitTest_DOSA.idf";
+                fs::copy_file(inputFilePath, destPath, fs::copy_options::skip_existing);
+            }
+        }
 
-        auto inputWeatherFilePath = configured_source_directory() / "weather/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw";
-        fs::copy_file(inputWeatherFilePath, FileSystem::getAbsolutePath("in.epw"), fs::copy_options::skip_existing);
+        {
+            auto destPath = FileSystem::getAbsolutePath("in.epw");
+            if (!fs::is_regular_file(destPath)) {
+                auto inputWeatherFilePath = configured_source_directory() / "weather/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw";
+                fs::copy_file(inputWeatherFilePath, destPath, fs::copy_options::skip_existing);
+            }
+        }
     }
 
     void SetUp() override

--- a/tst/EnergyPlus/unit/WeatherManager.unit.cc
+++ b/tst/EnergyPlus/unit/WeatherManager.unit.cc
@@ -1913,7 +1913,7 @@ TEST_F(EnergyPlusFixture, WeatherRunPeriod_WeatherFile_Missing)
 
     // We don't have an EPW
     state->dataWeatherManager->WeatherFileExists = false;
-    state->files.inputWeatherFilePath.filePath = "in.epw";
+    state->files.inputWeatherFilePath.filePath = "doesntnotexist.epw";
 
     state->dataGlobal->BeginSimFlag = false;
     state->dataGlobal->NumOfTimeStepInHour = 4;


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #10197 


### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
