### PR TITLE
Correction to Reporting of a Conduction Finite Difference Flux Imbalance

### DIFF
--- a/src/EnergyPlus/HeatBalFiniteDiffManager.cc
+++ b/src/EnergyPlus/HeatBalFiniteDiffManager.cc
@@ -2609,6 +2609,8 @@ namespace HeatBalFiniteDiffManager {
                 interNodeFlux - sourceFlux +
                 surfaceFD.CpDelXRhoS2(node) * (surfaceFD.TDT(node) - surfaceFD.TDpriortimestep(node)) / state.dataGlobal->TimeStepZoneSec;
         }
+        if (state.dataEnvrn->IsRain)
+            state.dataHeatBalSurf->SurfOpaqOutFaceCondFlux(Surf) = -surfaceFD.QDreport(1); // Update the outside flux if it is raining
     }
 
     void adjustPropertiesForPhaseChange(EnergyPlusData &state,

--- a/tst/EnergyPlus/unit/HeatBalFiniteDiffManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalFiniteDiffManager.unit.cc
@@ -53,6 +53,7 @@
 // EnergyPlus Headers
 #include <EnergyPlus/Construction.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
+#include <EnergyPlus/DataEnvironment.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
 #include <EnergyPlus/HeatBalFiniteDiffManager.hh>
 #include <EnergyPlus/HeatBalanceManager.hh>
@@ -70,15 +71,18 @@ TEST_F(EnergyPlusFixture, HeatBalFiniteDiffManager_CalcNodeHeatFluxTest)
 {
     auto &SurfaceFD = state->dataHeatBalFiniteDiffMgr->SurfaceFD;
     int constexpr numNodes(4);
+    Real64 constexpr allowedTolerance = 0.0001;
     int nodeNum(0);
     SurfaceFD.allocate(1);
     int constexpr SurfNum(1);
-    SurfaceFD(SurfNum).QDreport.allocate(numNodes + 1);
-    SurfaceFD(SurfNum).TDpriortimestep.allocate(numNodes + 1);
-    SurfaceFD(SurfNum).TDT.allocate(numNodes + 1);
-    SurfaceFD(SurfNum).CpDelXRhoS1.allocate(numNodes + 1);
-    SurfaceFD(SurfNum).CpDelXRhoS2.allocate(numNodes + 1);
+    auto &surfFD = SurfaceFD(SurfNum);
+    surfFD.QDreport.allocate(numNodes + 1);
+    surfFD.TDpriortimestep.allocate(numNodes + 1);
+    surfFD.TDT.allocate(numNodes + 1);
+    surfFD.CpDelXRhoS1.allocate(numNodes + 1);
+    surfFD.CpDelXRhoS2.allocate(numNodes + 1);
     state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux.allocate(1);
+    state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux.allocate(1);
     state->dataGlobal->TimeStepZoneSec = 600.0;
 
     Real64 expectedResult1(0.0);
@@ -86,53 +90,71 @@ TEST_F(EnergyPlusFixture, HeatBalFiniteDiffManager_CalcNodeHeatFluxTest)
     Real64 expectedResult3(0.0);
     Real64 expectedResult4(0.0);
     Real64 expectedResult5(0.0);
+    Real64 expectedResultO(1.0);
 
     // Steady-state case
     state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum) = 100.0;
     nodeNum = 1;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 20.0;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 20.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 1000.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
+    surfFD.TDpriortimestep(nodeNum) = 20.0;
+    surfFD.TDT(nodeNum) = 20.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 1000.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
     expectedResult1 = state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum);
 
     nodeNum = 2;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 22.0;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 22.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 1000.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
+    surfFD.TDpriortimestep(nodeNum) = 22.0;
+    surfFD.TDT(nodeNum) = 22.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 1000.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
     expectedResult2 = state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum);
 
     nodeNum = 3;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 23.0;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 23.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 1000.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
+    surfFD.TDpriortimestep(nodeNum) = 23.0;
+    surfFD.TDT(nodeNum) = 23.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 1000.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
     expectedResult3 = state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum);
 
     nodeNum = 4;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 26.0;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 26.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 1000.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
+    surfFD.TDpriortimestep(nodeNum) = 26.0;
+    surfFD.TDT(nodeNum) = 26.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 1000.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
     expectedResult4 = state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum);
 
     nodeNum = 5;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 27.0;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 27.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 1000.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
+    surfFD.TDpriortimestep(nodeNum) = 27.0;
+    surfFD.TDT(nodeNum) = 27.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 1000.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
     expectedResult5 = state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum);
 
+    state->dataEnvrn->IsRain = false;
+    state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux(SurfNum) = 77.0;
+    expectedResultO = 77.0;
+
     CalcNodeHeatFlux(*state, SurfNum, numNodes);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(1), expectedResult1, 0.0001);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(2), expectedResult2, 0.0001);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(3), expectedResult3, 0.0001);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(4), expectedResult4, 0.0001);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(5), expectedResult5, 0.0001);
+    EXPECT_NEAR(surfFD.QDreport(1), expectedResult1, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(2), expectedResult2, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(3), expectedResult3, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(4), expectedResult4, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(5), expectedResult5, allowedTolerance);
+    EXPECT_NEAR(state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux(SurfNum), expectedResultO, allowedTolerance);
+
+    state->dataEnvrn->IsRain = true;
+    state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux(SurfNum) = 77.0;
+    expectedResultO = -state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum);
+
+    CalcNodeHeatFlux(*state, SurfNum, numNodes);
+    EXPECT_NEAR(surfFD.QDreport(1), expectedResult1, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(2), expectedResult2, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(3), expectedResult3, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(4), expectedResult4, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(5), expectedResult5, allowedTolerance);
+    EXPECT_NEAR(state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux(SurfNum), expectedResultO, allowedTolerance);
 
     // Reset
-    SurfaceFD(SurfNum).QDreport = 0.0;
+    surfFD.QDreport = 0.0;
     expectedResult1 = 0.0;
     expectedResult2 = 0.0;
     expectedResult3 = 0.0;
@@ -144,50 +166,67 @@ TEST_F(EnergyPlusFixture, HeatBalFiniteDiffManager_CalcNodeHeatFluxTest)
     state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum) = -200.0;
 
     nodeNum = 5;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 27.5;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 27.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 0.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 0.0;
+    surfFD.TDpriortimestep(nodeNum) = 27.5;
+    surfFD.TDT(nodeNum) = 27.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 0.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 0.0;
     expectedResult5 = state->dataHeatBalSurf->SurfOpaqInsFaceCondFlux(SurfNum);
 
     nodeNum = 4;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 26.0;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 26.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 0.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
+    surfFD.TDpriortimestep(nodeNum) = 26.0;
+    surfFD.TDT(nodeNum) = 26.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 0.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
     expectedResult4 = expectedResult5; // r-layer with zero heat capacity, so flux passes through
 
     nodeNum = 3;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 23.0;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 23.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 1000.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
+    surfFD.TDpriortimestep(nodeNum) = 23.0;
+    surfFD.TDT(nodeNum) = 23.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 1000.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
     expectedResult3 = expectedResult4; // no change in temperature at nodes 4 and 3, so flux passes through
 
     nodeNum = 2;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 22.2;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 22.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 1000.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
-    expectedResult2 = expectedResult3 + (SurfaceFD(SurfNum).TDT(nodeNum) - SurfaceFD(SurfNum).TDpriortimestep(nodeNum)) *
-                                            SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) / state->dataGlobal->TimeStepZoneSec;
+    surfFD.TDpriortimestep(nodeNum) = 22.2;
+    surfFD.TDT(nodeNum) = 22.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 1000.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
+    expectedResult2 =
+        expectedResult3 + (surfFD.TDT(nodeNum) - surfFD.TDpriortimestep(nodeNum)) * surfFD.CpDelXRhoS2(nodeNum) / state->dataGlobal->TimeStepZoneSec;
 
     nodeNum = 1;
-    SurfaceFD(SurfNum).TDpriortimestep(nodeNum) = 20.1;
-    SurfaceFD(SurfNum).TDT(nodeNum) = 20.0;
-    SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum) = 1000.0;
-    SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) = 2000.0;
-    expectedResult1 = expectedResult2 + (SurfaceFD(SurfNum).TDT(nodeNum + 1) - SurfaceFD(SurfNum).TDpriortimestep(nodeNum + 1)) *
-                                            SurfaceFD(SurfNum).CpDelXRhoS1(nodeNum + 1) / state->dataGlobal->TimeStepZoneSec;
-    expectedResult1 = expectedResult1 + (SurfaceFD(SurfNum).TDT(nodeNum) - SurfaceFD(SurfNum).TDpriortimestep(nodeNum)) *
-                                            SurfaceFD(SurfNum).CpDelXRhoS2(nodeNum) / state->dataGlobal->TimeStepZoneSec;
+    surfFD.TDpriortimestep(nodeNum) = 20.1;
+    surfFD.TDT(nodeNum) = 20.0;
+    surfFD.CpDelXRhoS1(nodeNum) = 1000.0;
+    surfFD.CpDelXRhoS2(nodeNum) = 2000.0;
+    expectedResult1 = expectedResult2 + (surfFD.TDT(nodeNum + 1) - surfFD.TDpriortimestep(nodeNum + 1)) * surfFD.CpDelXRhoS1(nodeNum + 1) /
+                                            state->dataGlobal->TimeStepZoneSec;
+    expectedResult1 =
+        expectedResult1 + (surfFD.TDT(nodeNum) - surfFD.TDpriortimestep(nodeNum)) * surfFD.CpDelXRhoS2(nodeNum) / state->dataGlobal->TimeStepZoneSec;
+
+    state->dataEnvrn->IsRain = false;
+    state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux(SurfNum) = 123.0;
+    expectedResultO = 123.0;
 
     CalcNodeHeatFlux(*state, SurfNum, numNodes);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(1), expectedResult1, 0.0001);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(2), expectedResult2, 0.0001);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(3), expectedResult3, 0.0001);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(4), expectedResult4, 0.0001);
-    EXPECT_NEAR(SurfaceFD(SurfNum).QDreport(5), expectedResult5, 0.0001);
+    EXPECT_NEAR(surfFD.QDreport(1), expectedResult1, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(2), expectedResult2, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(3), expectedResult3, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(4), expectedResult4, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(5), expectedResult5, allowedTolerance);
+    EXPECT_NEAR(state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux(SurfNum), expectedResultO, allowedTolerance);
+
+    state->dataEnvrn->IsRain = true;
+    state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux(SurfNum) = 123.0;
+    expectedResultO = -expectedResult1;
+
+    CalcNodeHeatFlux(*state, SurfNum, numNodes);
+    EXPECT_NEAR(surfFD.QDreport(1), expectedResult1, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(2), expectedResult2, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(3), expectedResult3, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(4), expectedResult4, allowedTolerance);
+    EXPECT_NEAR(surfFD.QDreport(5), expectedResult5, allowedTolerance);
+    EXPECT_NEAR(state->dataHeatBalSurf->SurfOpaqOutFaceCondFlux(SurfNum), expectedResultO, allowedTolerance);
 }
 
 TEST_F(EnergyPlusFixture, HeatBalFiniteDiffManager_adjustPropertiesForPhaseChange)


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #8234 
 - A user reported that when summing the inside and outside flux for an exterior surface over a multi-year simulation was resulting in a cumulative sum that drifted away from zero, indicating that the surface was storing energy over time.  The problem was noted in the CondFD solution but not the CTF method.  Based on a comparison of both the CondFD and the CTF solution, it was identified that the outside surface flux was wrong.  After testing and comparing the outside face surface flux and the outside node flux, two output variables that should be very close, it was seen that the two variables were almost always identical except when the IsRain flag was true when the two were vastly different.  The variable that was causing the imbalance was not being set properly due to a different solution path when the IsRain flag was set to true.  This was the cause of the flux inconsistencies.  The fix corrects this problem and the long term summation of the inside and outside flux now balance like the CTF method.  An existing unit test was expanded to include cases that specifically exercise this correction.


**NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE**

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
