### PR TITLE
Update windows doc action miktex version

### DIFF
--- a/.github/workflows/documentation-windows.yml
+++ b/.github/workflows/documentation-windows.yml
@@ -28,8 +28,8 @@ jobs:
         set -x
         echo "Downloading MiKTeX CLI installer"
         # We download from a specific miror already # TODO: Should store this setup package somewhere ourselves
-        curl -L -O https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/miktexsetup-5.2.0%2Bb8f430f-x64.zip
-        unzip miktexsetup-5.2.0%2Bb8f430f-x64.zip
+        curl -L -O https://ctan.math.illinois.edu/systems/win32/miktex/setup/windows-x64/miktexsetup-5.5.0%2B1763023-x64.zip
+        unzip miktexsetup-5.5.0%2B1763023-x64.zip
 
         echo "Setting up the local package directory via download"
         ./miktexsetup_standalone --verbose \


### PR DESCRIPTION
MikTeX was updated in the windows-release GitHub action workflow, but I forgot to update this one as well.  This just bumps the MikTeX version so it builds.  I don't anticipate sneaking this ahead of v23.2.0 as it's not needed.