### PR TITLE
Protect a few Plugin tests with LINK_WITH_PYTHON

### DIFF
--- a/src/EnergyPlus/CMakeLists.txt
+++ b/src/EnergyPlus/CMakeLists.txt
@@ -1111,16 +1111,17 @@ if(BUILD_TESTING)
   set(PY_FILE "${EXAMPLES_FILES_DIR}/${TEST_CASE}.py")
   configure_file(${PY_FILE} "${INPUT_TEST_DIR}/${TEST_CASE}.py" COPYONLY)
 
-  add_test(NAME energyplus.TestNonASCIIDirsAndFiles.PythonPlugin.FromWithin
-    COMMAND  energyplus -D -d "${CLI_TEST_DIR}/PythonPlugin.FromWithin/out-${NON_ASCII_DIRNAME}" ${TEST_CASE}.idf
-    WORKING_DIRECTORY  "${CLI_TEST_DIR}/${NON_ASCII_DIRNAME}"
-  )
+  if(LINK_WITH_PYTHON)
+    add_test(NAME energyplus.TestNonASCIIDirsAndFiles.PythonPlugin.FromWithin
+      COMMAND  energyplus -D -d "${CLI_TEST_DIR}/PythonPlugin.FromWithin/out-${NON_ASCII_DIRNAME}" ${TEST_CASE}.idf
+      WORKING_DIRECTORY  "${CLI_TEST_DIR}/${NON_ASCII_DIRNAME}"
+    )
 
-  add_test(NAME energyplus.TestNonASCIIDirsAndFiles.PythonPlugin.FromOutside
-    COMMAND  energyplus -D -d "${CLI_TEST_DIR}/PythonPlugin.FromOutside/out-${NON_ASCII_DIRNAME}" ${NON_ASCII_DIRNAME}/${TEST_CASE}.idf
-    WORKING_DIRECTORY  "${CLI_TEST_DIR}"
-  )
-
+    add_test(NAME energyplus.TestNonASCIIDirsAndFiles.PythonPlugin.FromOutside
+      COMMAND  energyplus -D -d "${CLI_TEST_DIR}/PythonPlugin.FromOutside/out-${NON_ASCII_DIRNAME}" ${NON_ASCII_DIRNAME}/${TEST_CASE}.idf
+      WORKING_DIRECTORY  "${CLI_TEST_DIR}"
+    )
+  endif()
 endif()
 
 if(UNIX AND NOT APPLE)


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #10356 

When I build develop with LINK_WITH_PYTHON=OFF, it still attempts to run these two tests, and they fail.  With this change, these tests are only included if LINK_WITH_PYTHON=ON, and everything is happy.

@jmarrec if you want to give this a 5 second look over, that would be great, but it's pretty clear that it should go in.