### PR TITLE
NewFeature: Add measurement unit output for API

### DIFF
--- a/src/EnergyPlus/DataGlobalConstants.hh
+++ b/src/EnergyPlus/DataGlobalConstants.hh
@@ -363,7 +363,7 @@ namespace Constant {
         eResourceNames[(int)eFuel2eResource[(int)eFuel::Water]],
         eResourceNames[(int)eFuel2eResource[(int)eFuel::None]]};
 
-    enum class Units
+    enum class Units : signed int
     {
         Invalid = -1,
         kg_s,
@@ -473,6 +473,19 @@ namespace Constant {
         "unknown",          // unknown
         "customEMS"         // customEMS
     };
+
+    inline std::string unitToString(Units unit) {
+        switch (unit) {
+        case Units::Invalid:
+            return "invalid";
+        default:
+            if (!(0 <= (int)unit 
+                && (int)unit < (int)unitNames.size())) 
+            { return "invalid-out-of-range"; }
+            return std::string{unitNames[(unsigned int)unit]};
+        }
+        return "";
+    }
 
     constexpr std::array<std::string_view, (int)Units::Num> unitNamesUC = {
         "KG/S",             // kg_s

--- a/src/EnergyPlus/api/datatransfer.h
+++ b/src/EnergyPlus/api/datatransfer.h
@@ -89,6 +89,9 @@ struct APIDataEntry
     /// \details This is only used for actuators, and represents the control actuation.
     ///          For a node setpoint actuation, this could be either temperature or humidity, for example.
     char *type; // only used for actuators
+    /// \brief This represents the unit of measurement for this exchange point.
+    /// \details This is only used for non-plugin variables.
+    char *unit; // NOT used for plugin variables
 };
 
 /// \brief Gets available API data for the current simulation

--- a/src/EnergyPlus/api/datatransfer.py
+++ b/src/EnergyPlus/api/datatransfer.py
@@ -85,7 +85,7 @@ class DataExchange:
     """
 
     class _APIDataEntry(Structure):
-        _fields_ = [("what", c_char_p),("name", c_char_p),("key", c_char_p),("type", c_char_p),]
+        _fields_ = [("what", c_char_p),("name", c_char_p),("key", c_char_p),("type", c_char_p),("unit", c_char_p)]
 
     class APIDataExchangePoint:
         """
@@ -93,7 +93,7 @@ class DataExchange:
         class could represent output variables, output meters, actuators, and more.  The "type" member variable
         can be used to filter a specific type.
         """
-        def __init__(self, _what: str, _name: str, _key: str, _type: str):
+        def __init__(self, _what: str, _name: str, _key: str, _type: str, _unit: str):
             #: This variable will hold the basic type of API data point, in string form.
             #: This can be one of the following: "Actuator", "InternalVariable", "PluginGlobalVariable",
             #: "PluginTrendVariable", "OutputMeter", or "OutputVariable".  Once the full list of data exchange points
@@ -110,6 +110,9 @@ class DataExchange:
             #: and represents the control actuation.  For a node setpoint actuation, this could be "temperature" or
             #: "humidity", for example.
             self.type: str = _type
+            #: This represents the unit of measure for this exchange point.  
+            #: This is NOT used for plugin variables such as PluginGlobalVariable and PluginTrendVariable.
+            self.unit: str = _unit
 
     def __init__(self, api: cdll, running_as_python_plugin: bool = False):
         """
@@ -299,7 +302,9 @@ class DataExchange:
                 r[i].what.decode('utf-8'),
                 r[i].name.decode('utf-8'),
                 r[i].key.decode('utf-8'),
-                r[i].type.decode('utf-8')) for i in range(count.value)
+                r[i].type.decode('utf-8'),
+                r[i].unit.decode('utf-8'),
+            ) for i in range(count.value)
         ]
         self.api.freeAPIData(r, count)  # free the underlying C memory now that we have a Python copy
         return list_response


### PR DESCRIPTION
Pull request overview
---------------------
This PR adds units of measurement to the output of `getAPIData` (python: `get_api_data`) and `listAllAPIDataCSV` (python: `list_available_api_data_csv`) in the data transfer API. A new field named `unit` is added to the class `APIDataEntry` (python: `APIDataExchangePoint`) and a new column is added to the CSV for variables with units.

The purpose of this PR is to provide additional (and critical!) information to the API users. 
The absence of such information can have serious consequences (see https://usma.org/unit-mixups#locale-notification), including the loss of lives.

Users should NOT rely on external documents for this type of information. The API should be the authoritative single source of truth.