### PR TITLE
More IO freeze fixes.

### DIFF
--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup QtIFW 4.x
       uses: jmarrec/setup-qtifw@v1
       with:
-        qtifw-version: '4.x'
+        qtifw-version: '4.6.1'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup QtIFW 4.x
       uses: jmarrec/setup-qtifw@v1
       with:
-        qtifw-version: '4.x'
+        qtifw-version: '4.6.1'
 
     - name: Install Python dependencies
       run: |


### PR DESCRIPTION
After investigation, the Windows and Mac builds are also struggling with QtIFW 4.7, so I'm pinning those back to 4.6.1 as well.  Hopefully that will be happy.