### PR TITLE
A few Mac updates

### DIFF
--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -25,15 +25,19 @@ jobs:
         - macos_dev_target: 10.15
           os: macos-11
           allow_failure: false
+          arch: x86_64
         - macos_dev_target: 11.6
           os: macos-11
           allow_failure: false
+          arch: x86_64
         - macos_dev_target: 12.1
           os: macos-12
           allow_failure: false
+          arch: x86_64
         - macos_dev_target: 13.0
           os: macos-14
           allow_failure: false
+          arch: arm64
     permissions:
       # Needed permission to upload the release asset
       contents: write
@@ -111,7 +115,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/EnergyPlus-*-*.tar.gz
+        file: build/EnergyPlus-*-${{ matrix.arch }}.tar.gz
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
@@ -120,7 +124,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/EnergyPlus-*-*.dmg
+        file: build/EnergyPlus-*-${{ matrix.arch }}.dmg
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -20,7 +20,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        macos_dev_target: [10.15, 11.6, 12.1]
+        macos_dev_target: [10.15, 11.6, 12.1, 13.0]
         include:
         - macos_dev_target: 10.15
           os: macos-11
@@ -30,6 +30,9 @@ jobs:
           allow_failure: false
         - macos_dev_target: 12.1
           os: macos-12
+          allow_failure: false
+        - macos_dev_target: 13.0
+          os: macos-14
           allow_failure: false
     permissions:
       # Needed permission to upload the release asset
@@ -108,7 +111,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/EnergyPlus-*-x86_64.tar.gz
+        file: build/EnergyPlus-*-*.tar.gz
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
@@ -117,7 +120,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/EnergyPlus-*-x86_64.dmg
+        file: build/EnergyPlus-*-*.dmg
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -10,7 +10,6 @@ env:
   BUILD_TYPE: Release
   FC: gfortran-13
   SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-  Python_REQUIRED_VERSION: 3.8
 
 jobs:
   mac_release:
@@ -26,18 +25,22 @@ jobs:
           os: macos-11
           allow_failure: false
           arch: x86_64
+          python: 3.8
         - macos_dev_target: 11.6
           os: macos-11
           allow_failure: false
           arch: x86_64
+          python: 3.8
         - macos_dev_target: 12.1
           os: macos-12
           allow_failure: false
           arch: x86_64
+          python: 3.8
         - macos_dev_target: 13.0
           os: macos-14
           allow_failure: false
           arch: arm64
+          python: 3.12.0
     permissions:
       # Needed permission to upload the release asset
       contents: write
@@ -45,11 +48,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ env.Python_REQUIRED_VERSION }}
+    - name: Set up Python ${{ matrix.python }}
       id: setup-python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ env.Python_REQUIRED_VERSION }}
+        python-version: ${{ matrix.python }}
 
     - name: Setup QtIFW 4.x
       uses: jmarrec/setup-qtifw@v1

--- a/src/EnergyPlus/PlantCondLoopOperation.cc
+++ b/src/EnergyPlus/PlantCondLoopOperation.cc
@@ -412,6 +412,7 @@ void GetPlantOperationInput(EnergyPlusData &state, bool &GetInputOK)
                                                                      state.dataIPShortCut->cNumericFieldNames);
             state.dataPlnt->PlantLoop(LoopNum).NumOpSchemes = (NumAlphas - 1) / 3;
             if (state.dataPlnt->PlantLoop(LoopNum).NumOpSchemes > 0) {
+                state.dataPlnt->PlantLoop(LoopNum).OpScheme.clear();
                 state.dataPlnt->PlantLoop(LoopNum).OpScheme.allocate(state.dataPlnt->PlantLoop(LoopNum).NumOpSchemes);
                 for (Num = 1; Num <= state.dataPlnt->PlantLoop(LoopNum).NumOpSchemes; ++Num) {
                     state.dataPlnt->PlantLoop(LoopNum).OpScheme(Num).TypeOf = state.dataIPShortCut->cAlphaArgs(Num * 3 - 1);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,6 +8,7 @@ target_compile_definitions(
         INTERFACE
         JSON_USE_IMPLICIT_CONVERSIONS=1
 )
+# target_compile_options(nlohmann_json PRIVATE -Wno-deprecated-declarations)
 target_include_directories(
         nlohmann_json
         SYSTEM INTERFACE

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,7 +8,7 @@ target_compile_definitions(
         INTERFACE
         JSON_USE_IMPLICIT_CONVERSIONS=1
 )
-# target_compile_options(nlohmann_json PRIVATE -Wno-deprecated-declarations)
+target_compile_options(nlohmann_json INTERFACE -Wno-deprecated-declarations)
 target_include_directories(
         nlohmann_json
         SYSTEM INTERFACE

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,7 +8,9 @@ target_compile_definitions(
         INTERFACE
         JSON_USE_IMPLICIT_CONVERSIONS=1
 )
-target_compile_options(nlohmann_json INTERFACE -Wno-deprecated-declarations)
+if(NOT MSVC)  # This is really only needed with newer Clang, but gcc is fine with it
+  target_compile_options(nlohmann_json INTERFACE -Wno-deprecated-declarations)
+endif()
 target_include_directories(
         nlohmann_json
         SYSTEM INTERFACE


### PR DESCRIPTION
Pull request overview
---------------------
 - Attempt to add a Mac ARM build using GHA.  I'm not sure this will work, but let's see!
   - [ ] @jmarrec I forgot to make the change to put the file pattern into the matrix but I will do that before trying a release tag.
 - I tracked down the Mac test failure that persists in develop.  And that was a pain.  It got down to one line of allocate, where on Windows and Linux, and Mac Debug annoyingly, it would definitely clear the vector before reallocating.  However, on Mac release builds, it was allowing the original contents to persist, which was confusing the subsequent lines of code. All I did was explicitly clear the vector, and the test passed locally without breaking anything else.  So hopefully the test result is back to 100% on Mac now.
 - I talked with @kbenne and he offered a tip on the CMake side of things to hush up the nlohmann warnings.  As far as I can tell locally, it worked, so let's see what @nrel-bot-3 says about these changes.

I'm not sure what to label this.  If the ARM build works, then I'll say it's new feature.  If not, I think it's do-not-publish.  So that's what I'll put for now.