### PR TITLE
Pull the ARM build from GHA

### DIFF
--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -19,7 +19,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        macos_dev_target: [10.15, 11.6, 12.1, 13.0]
+        macos_dev_target: [10.15, 11.6, 12.1]  #, 13.0]
         include:
         - macos_dev_target: 10.15
           os: macos-11
@@ -36,11 +36,11 @@ jobs:
           allow_failure: false
           arch: x86_64
           python: 3.8
-        - macos_dev_target: 13.0
-          os: macos-14
-          allow_failure: false
-          arch: arm64
-          python: 3.12.0
+#        - macos_dev_target: 13.0
+#          os: macos-14
+#          allow_failure: false
+#          arch: arm64
+#          python: 3.12.0
     permissions:
       # Needed permission to upload the release asset
       contents: write


### PR DESCRIPTION
Pull request overview
---------------------
 - Learned a lot investigating the bump to Python 3.12 branch.  The ARM builds of Python for GHA act funny, and generally speaking Mac is not happy with things.  I'm pulling away from that effort, and instead just taking out the ARM build, so that we can keep things as they were already, with Python 3.8.  
 - We need to have a long talk about how we proceed with the Python land for the next release cycle.  Now that the API has equivalent functionality to the plugins, I would love to have talks about pulling away from the embedded interpreter dependency.  

I'll go ahead and kick off another release of this, and if happy enough, I'll merge and move on.