### PR TITLE
Fix (Probable) Fan Coil Sizing Issue

### DIFF
--- a/src/EnergyPlus/FanCoilUnits.cc
+++ b/src/EnergyPlus/FanCoilUnits.cc
@@ -512,7 +512,7 @@ namespace FanCoilUnits {
                 if (!Util::SameString(fanCoil.FanType, "Fan:SystemModel")) {
                     Fans::GetFanType(state, fanCoil.FanName, fanCoil.FanType_Num, errFlag, CurrentModuleObject, fanCoil.Name);
                     // need to grab fan index here
-                    // Fans::GetFanIndex(state, fanCoil.FanName, fanCoil.FanIndex, errFlag, fanCoil.FanType);
+                    Fans::GetFanIndex(state, fanCoil.FanName, fanCoil.FanIndex, errFlag, fanCoil.FanType);
                     fanCoil.fanAvailSchIndex = Fans::GetFanAvailSchPtr(state, fanCoil.FanType, fanCoil.FanName, errFlag);
                     if (errFlag) {
                         ShowContinueError(state, format("Occurs in {} = {}", CurrentModuleObject, fanCoil.Name));

--- a/tst/EnergyPlus/unit/AirTerminalSingleDuctMixer.unit.cc
+++ b/tst/EnergyPlus/unit/AirTerminalSingleDuctMixer.unit.cc
@@ -7896,7 +7896,7 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctMixer_SimFCU_ATMInletSideTest)
     SecondaryAirMassFlowRate = state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRate - PrimaryAirMassFlowRate;
     // check results in cooling mode operation
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
-    EXPECT_NEAR(thisFanCoil.PLR, 0.76235, 0.00001); // Was 0.78843 
+    EXPECT_NEAR(thisFanCoil.PLR, 0.76235, 0.00001); // Was 0.78843
     // check mass flow rates
     EXPECT_NEAR(PrimaryAirMassFlowRate, 0.2, 0.000001);
     EXPECT_NEAR(SecondaryAirMassFlowRate, 0.350865, 0.000001);

--- a/tst/EnergyPlus/unit/AirTerminalSingleDuctMixer.unit.cc
+++ b/tst/EnergyPlus/unit/AirTerminalSingleDuctMixer.unit.cc
@@ -7896,14 +7896,14 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctMixer_SimFCU_ATMInletSideTest)
     SecondaryAirMassFlowRate = state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRate - PrimaryAirMassFlowRate;
     // check results in cooling mode operation
     EXPECT_NEAR(QZnReq, QUnitOut, 5.0);
-    EXPECT_NEAR(thisFanCoil.PLR, 0.78843, 0.00001);
+    EXPECT_NEAR(thisFanCoil.PLR, 0.76235, 0.00001); // Was 0.78843 
     // check mass flow rates
     EXPECT_NEAR(PrimaryAirMassFlowRate, 0.2, 0.000001);
-    EXPECT_NEAR(SecondaryAirMassFlowRate, 0.369714, 0.000001);
+    EXPECT_NEAR(SecondaryAirMassFlowRate, 0.350865, 0.000001);
     EXPECT_NEAR(state->dataLoopNodes->Node(thisFanCoil.AirInNode).MassFlowRate, thisFan.InletAirMassFlowRate, 0.000001);
     EXPECT_NEAR(state->dataLoopNodes->Node(thisFanCoil.ATMixerPriNode).MassFlowRate, 0.2, 0.0001);
-    EXPECT_NEAR(state->dataLoopNodes->Node(thisFanCoil.ATMixerSecNode).MassFlowRate, 0.369714, 0.000001);
-    EXPECT_NEAR(state->dataLoopNodes->Node(thisFanCoil.ATMixerOutNode).MassFlowRate, 0.569714, 0.000001);
+    EXPECT_NEAR(state->dataLoopNodes->Node(thisFanCoil.ATMixerSecNode).MassFlowRate, 0.350865, 0.000001); // Was 0.369714
+    EXPECT_NEAR(state->dataLoopNodes->Node(thisFanCoil.ATMixerOutNode).MassFlowRate, 0.550865, 0.000001); // Was 0.569714
 }
 
 TEST_F(EnergyPlusFixture, AirTerminalSingleDuctMixer_FCU_NightCycleTest)


### PR DESCRIPTION
This is a very quick one. In the process of testing a set of refactoring changes I ran into a unit test failure where the fan index was not set on an FCU until after sizing, causing the heat generated by the fan to not be  accounted. It turns out that this diff was caused by a line that was commented out, likely in error. A comment above the line confirms this suspicion. @rraustad confirms it also. The only change in this PR is to uncomment this line.