### PR TITLE
Protect for table lookup zero divisor

### DIFF
--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -2494,6 +2494,11 @@ namespace Curve {
 
                 if (normalizeMethod != NM_NONE && fields.count("normalization_divisor")) {
                     normalizationDivisor = fields.at("normalization_divisor").get<Real64>();
+                    if (fabs(normalizationDivisor) < std::numeric_limits<Real64>::min()) {
+                        ShowSevereError(
+                            state, format("Table:Lookup named \"{}\": Normalization divisor entered as zero, which is invalid", thisCurve->Name));
+                        ErrorsFound = true;
+                    }
                 }
 
                 std::vector<double> lookupValues;

--- a/src/EnergyPlus/CurveManager.cc
+++ b/src/EnergyPlus/CurveManager.cc
@@ -2494,7 +2494,7 @@ namespace Curve {
 
                 if (normalizeMethod != NM_NONE && fields.count("normalization_divisor")) {
                     normalizationDivisor = fields.at("normalization_divisor").get<Real64>();
-                    if (fabs(normalizationDivisor) < std::numeric_limits<Real64>::min()) {
+                    if (std::abs(normalizationDivisor) < std::numeric_limits<Real64>::min()) {
                         ShowSevereError(
                             state, format("Table:Lookup named \"{}\": Normalization divisor entered as zero, which is invalid", thisCurve->Name));
                         ErrorsFound = true;

--- a/tst/EnergyPlus/unit/CurveManager.unit.cc
+++ b/tst/EnergyPlus/unit/CurveManager.unit.cc
@@ -476,6 +476,53 @@ TEST_F(EnergyPlusFixture, DivisorNormalizationDivisorOnly)
     }
 }
 
+TEST_F(EnergyPlusFixture, DivisorNormalizationDivisorOnlyButItIsZero)
+{
+    std::string const idf_objects = delimited_string({"Table:Lookup,",
+                                                      "y_values,                              !- Name",
+                                                      "y_values_list,                         !- Independent Variable List Name",
+                                                      "DivisorOnly,                           !- Normalization Method",
+                                                      "0.0,                                   !- Normalization Divisor",
+                                                      "2.0,                                   !- Minimum Output",
+                                                      "21.0,                                  !- Maximum Output",
+                                                      "Dimensionless,                         !- Output Unit Type",
+                                                      ",                                      !- External File Name",
+                                                      ",                                      !- External File Column Number",
+                                                      ",                                      !- External File Starting Row Number",
+                                                      "2.0,                                   !- Value 1",
+                                                      "4.0;                                   !- Value 2",
+
+                                                      "Table:IndependentVariableList,",
+                                                      "y_values_list,                         !- Name",
+                                                      "x_values_1;                            !- Independent Variable Name 1",
+
+                                                      "Table:IndependentVariable,",
+                                                      "x_values_1,                            !- Name",
+                                                      ",                                      !- Interpolation Method",
+                                                      ",                                      !- Extrapolation Method",
+                                                      ",                                      !- Minimum value",
+                                                      ",                                      !- Maximum value",
+                                                      ",                                      !- Normalization Reference Value",
+                                                      "Dimensionless                          !- Output Unit Type",
+                                                      ",                                      !- External File Name",
+                                                      ",                                      !- External File Column Number",
+                                                      ",                                      !- External File Starting Row Number",
+                                                      ",",
+                                                      "2.0,                                   !- Value 1",
+                                                      "3.0;                                   !- Value 3"});
+
+    ASSERT_TRUE(process_idf(idf_objects));
+    EXPECT_EQ(0, state->dataCurveManager->NumCurves);
+
+    Curve::GetCurveInput(*state);
+    state->dataCurveManager->GetCurvesInputFlag = false;
+    ASSERT_EQ(1, state->dataCurveManager->NumCurves);
+
+    auto const x = Curve::CurveValue(*state, 1, 1.0);
+    bool isValid = (!std::isinf(x)) && (!std::isnan(x));
+    ASSERT_TRUE(isValid);
+}
+
 TEST_F(EnergyPlusFixture, DivisorNormalizationAutomaticWithDivisor)
 {
     //    /*

--- a/tst/EnergyPlus/unit/CurveManager.unit.cc
+++ b/tst/EnergyPlus/unit/CurveManager.unit.cc
@@ -515,7 +515,7 @@ TEST_F(EnergyPlusFixture, DivisorNormalizationDivisorOnlyButItIsZero)
     EXPECT_EQ(0, state->dataCurveManager->NumCurves);
 
     EXPECT_THROW(Curve::GetCurveInput(*state), std::runtime_error);
-    EXPECT_TRUE(this->err_stream->str().find("Normalization divisor entered as zero") != std::string::npos);
+    EXPECT_TRUE(this->compare_err_stream_substring("Normalization divisor entered as zero"));
 }
 
 TEST_F(EnergyPlusFixture, DivisorNormalizationAutomaticWithDivisor)

--- a/tst/EnergyPlus/unit/CurveManager.unit.cc
+++ b/tst/EnergyPlus/unit/CurveManager.unit.cc
@@ -514,13 +514,8 @@ TEST_F(EnergyPlusFixture, DivisorNormalizationDivisorOnlyButItIsZero)
     ASSERT_TRUE(process_idf(idf_objects));
     EXPECT_EQ(0, state->dataCurveManager->NumCurves);
 
-    Curve::GetCurveInput(*state);
-    state->dataCurveManager->GetCurvesInputFlag = false;
-    ASSERT_EQ(1, state->dataCurveManager->NumCurves);
-
-    auto const x = Curve::CurveValue(*state, 1, 1.0);
-    bool isValid = (!std::isinf(x)) && (!std::isnan(x));
-    ASSERT_TRUE(isValid);
+    EXPECT_THROW(Curve::GetCurveInput(*state), std::runtime_error);
+    EXPECT_TRUE(this->err_stream->str().find("Normalization divisor entered as zero") != std::string::npos);
 }
 
 TEST_F(EnergyPlusFixture, DivisorNormalizationAutomaticWithDivisor)

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
@@ -202,6 +202,15 @@ bool EnergyPlusFixture::compare_err_stream(std::string const &expected_string, b
     return are_equal;
 }
 
+bool EnergyPlusFixture::compare_err_stream_substring(std::string const &search_string, bool reset_stream)
+{
+    auto const stream_str = this->err_stream->str();
+    bool const found = stream_str.find("Normalization divisor entered as zero") != std::string::npos;
+    EXPECT_TRUE(found);
+    if (reset_stream) this->err_stream->str(std::string());
+    return found;
+}
+
 bool EnergyPlusFixture::compare_cout_stream(std::string const &expected_string, bool reset_stream)
 {
     auto const stream_str = this->m_cout_buffer->str();

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.hh
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.hh
@@ -197,6 +197,13 @@ protected:
     // Will return true if string matches the stream and false if it does not
     bool compare_err_stream(std::string const &expected_string, bool reset_stream = true);
 
+    // Check if ERR stream contains a substring. The default is to reset the ERR stream after every call.
+    // It is easier to test successive functions if the ERR stream is 'empty' before the next call.
+    // This calls EXPECT_* within the function as well as returns a boolean so you can call [ASSERT/EXPECT]_[TRUE/FALSE] depending
+    // if it makes sense for the unit test to continue after returning from function.
+    // Will return true if string is found in the stream and false if it is not
+    bool compare_err_stream_substring(std::string const &search_string, bool reset_stream = true);
+
     // Compare an expected string against the COUT stream. The default is to reset the COUT stream after every call.
     // It is easier to test successive functions if the COUT stream is 'empty' before the next call.
     // This calls EXPECT_* within the function as well as returns a boolean so you can call [ASSERT/EXPECT]_[TRUE/FALSE] depending
@@ -298,14 +305,13 @@ private:
     //    static bool process_idd(std::string const &idd, bool &errors_found);
 
     // Note that these are non-owning raw pointers. The `state` object owns the underlying streams.
+    std::ostringstream *err_stream;
+
     std::unique_ptr<std::ostringstream> m_cout_buffer;
     std::unique_ptr<std::ostringstream> m_cerr_buffer;
     std::unique_ptr<std::ostringstream> m_delightin_stream;
     std::unique_ptr<RedirectCout> m_redirect_cout;
     std::unique_ptr<RedirectCerr> m_redirect_cerr;
-
-protected:
-    std::ostringstream *err_stream;
 };
 
 } // namespace EnergyPlus

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.hh
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.hh
@@ -292,19 +292,20 @@ private:
     // This function should be called by process_idf() so unit tests can take advantage of caching
     // To test this function use InputProcessorFixture
     // This calls EXPECT_* within the function as well as returns a boolean so you can call [ASSERT/EXPECT]_[TRUE/FALSE] depending
-    // if it makes sense for the unit test to continue after retrning from function.
+    // if it makes sense for the unit test to continue after returning from function.
     // Will return false if no errors found and true if errors found
 
     //    static bool process_idd(std::string const &idd, bool &errors_found);
 
     // Note that these are non-owning raw pointers. The `state` object owns the underlying streams.
-    std::ostringstream *err_stream;
-
     std::unique_ptr<std::ostringstream> m_cout_buffer;
     std::unique_ptr<std::ostringstream> m_cerr_buffer;
     std::unique_ptr<std::ostringstream> m_delightin_stream;
     std::unique_ptr<RedirectCout> m_redirect_cout;
     std::unique_ptr<RedirectCerr> m_redirect_cerr;
+
+protected:
+    std::ostringstream *err_stream;
 };
 
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #10464 

The actual problem wasn't in the load calculations, it was a NaN being propagated after a divide by zero.  In the table lookup objects. users can enter a normalization divisor value, and a zero value was allowed to pass through without being checked.  This resulted in a NaN value coming out of the curve evaluation, which was immediately causing problems in other parts of the code.

I added a trap for zero value on the normalization divisor and we now issue a severe error.  I added a unit test that ensures the zero value is caught properly.