### PR TITLE
EnergyPlus Crash Due to Zero Input for Variable Speed Coil Total Cooling

### DIFF
--- a/doc/input-output-reference/src/overview/group-heating-and-cooling-coils.tex
+++ b/doc/input-output-reference/src/overview/group-heating-and-cooling-coils.tex
@@ -3295,7 +3295,9 @@ This numeric field defines the nominal speed level, at which the rated capacity 
 
 \paragraph{Field: Gross Rated Total Cooling Capacity at Selected Nominal Speed Level}\label{field-gross-rated-total-cooling-capacity-at-selected-nominal-speed-level}
 
-This numeric field contains the gross rated total cooling capacity at the nominal speed level. This field is autosizable. The gross rated total cooling capacity is used to determine a capacity scaling factor, as compared to the Reference Unit capacity at the nominal speed level.
+This numeric field contains the gross rated total cooling capacity at the nominal speed level. This field is autosizable. Note that if this field is set to zero rather than a positive number or autosized, the coil will be ignored and will not run.
+
+The gross rated total cooling capacity is used to determine a capacity scaling factor, as compared to the Reference Unit capacity at the nominal speed level.
 
 \begin{equation}
 {\rm{CapacityScaleFactor}} = \frac{{{\rm{Gross RatedTotalCoolingCapacity}}}}{{{\rm{ReferenceUnitCapacity}}@{\rm{NominalSpeedLevel}}}}
@@ -7521,7 +7523,9 @@ This numeric field defines the nominal speed level, at which the rated capacity,
 
 \paragraph{Field: Gross Rated Total Cooling Capacity at Selected Nominal Speed Level}\label{field-gross-rated-total-cooling-capacity-at-selected-nominal-speed-level-1}
 
-This numeric field contains the gross rated total cooling capacity at the nominal speed level. This field is autosizable. The gross rated total cooling capacity is used to determine a capacity scaling factor, as compared to the Reference Unit capacity at the nominal speed level.
+This numeric field contains the gross rated total cooling capacity at the nominal speed level. This field is autosizable. Note that if this field is set to zero rather than a positive number or autosized, the coil will be ignored and will not run.
+
+The gross rated total cooling capacity is used to determine a capacity scaling factor, as compared to the Reference Unit capacity at the nominal speed level.
 
 \begin{equation}
 CapacityScaleFactor = \frac{{GrossRatedTotalCoolingCapacity}}{{ReferenceUnitCapacity@NominalSpeedLevel}}

--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -11964,6 +11964,10 @@ Real64 CalcCBF(EnergyPlusData &state,
 
     auto &DXCT = state.dataHVACGlobal->DXCT;
 
+    if (AirVolFlowRate <= 0.0 || TotCap <= 0.0) { // Coil not running or has no capacity, don't calculate CBF
+        return CBF;
+    }
+
     AirMassFlowRate = AirVolFlowRate * PsyRhoAirFnPbTdbW(state, DataEnvironment::StdPressureSeaLevel, InletAirTemp, InletAirHumRat, RoutineName);
     DeltaH = TotCap / AirMassFlowRate;
     InletAirEnthalpy = PsyHFnTdbW(InletAirTemp, InletAirHumRat);

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -3998,9 +3998,7 @@ namespace VariableSpeedCoils {
             if ((state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType == DataHVACGlobals::Coil_CoolingWaterToAirHPVSEquationFit) ||
                 (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType == Coil_CoolingAirToAirVariableSpeed)) {
                 for (Mode = 1; Mode <= state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).NumOfSpeeds; ++Mode) {
-                    if (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0 &&
-                        state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal != AutoSize)
-                        break;
+                    if (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0) break;
                     // Check for zero capacity or zero max flow rate
                     if (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).MSRatedTotCap(Mode) <= 0.0) {
                         ShowSevereError(state,
@@ -5830,7 +5828,7 @@ namespace VariableSpeedCoils {
                 DefrostControl = StandardRatings::HPdefrostControl::Timed;
                 break;
             }
-            if (varSpeedCoil.RatedCapCoolTotal > 0.0 || varSpeedCoil.RatedCapCoolTotal == AutoSize) {
+            if (varSpeedCoil.RatedCapCoolTotal > 0.0) {
                 StandardRatings::CalcDXCoilStandardRating(state,
                                                           varSpeedCoil.Name,
                                                           varSpeedCoil.VarSpeedCoilType,
@@ -6111,9 +6109,7 @@ namespace VariableSpeedCoils {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = true;
         }
 
-        if (CompressorOp == CompressorOperation::Off ||
-            (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0 &&
-             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal != DataSizing::AutoSize)) {
+        if (CompressorOp == CompressorOperation::Off || state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0) {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = false;
             return;
         }
@@ -7394,9 +7390,7 @@ namespace VariableSpeedCoils {
             return;
         }
 
-        if (CompressorOp == CompressorOperation::Off ||
-            (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0 &&
-             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal != DataSizing::AutoSize)) {
+        if (CompressorOp == CompressorOperation::Off) {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = false;
             return;
         }

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -3987,10 +3987,7 @@ namespace VariableSpeedCoils {
             !state.dataVariableSpeedCoils->MyPlantScanFlag(DXCoilNum)) {
             // for each furnace, do the sizing once.
             ErrorsFound = false;
-            if (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal > 0.0 ||
-                state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal == AutoSize) {
-                SizeVarSpeedCoil(state, DXCoilNum, ErrorsFound);
-            }
+            SizeVarSpeedCoil(state, DXCoilNum, ErrorsFound);
             if (ErrorsFound) {
                 ShowFatalError(state, format("{}: Failed to size variable speed coil.", RoutineName));
             }
@@ -4001,6 +3998,9 @@ namespace VariableSpeedCoils {
             if ((state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType == DataHVACGlobals::Coil_CoolingWaterToAirHPVSEquationFit) ||
                 (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType == Coil_CoolingAirToAirVariableSpeed)) {
                 for (Mode = 1; Mode <= state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).NumOfSpeeds; ++Mode) {
+                    if (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0 &&
+                        state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal != AutoSize)
+                        break;
                     // Check for zero capacity or zero max flow rate
                     if (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).MSRatedTotCap(Mode) <= 0.0) {
                         ShowSevereError(state,
@@ -5830,28 +5830,30 @@ namespace VariableSpeedCoils {
                 DefrostControl = StandardRatings::HPdefrostControl::Timed;
                 break;
             }
-            StandardRatings::CalcDXCoilStandardRating(state,
-                                                      varSpeedCoil.Name,
-                                                      varSpeedCoil.VarSpeedCoilType,
-                                                      varSpeedCoil.VSCoilType,
-                                                      varSpeedCoil.NumOfSpeeds,
-                                                      varSpeedCoil.MSRatedTotCap,
-                                                      varSpeedCoil.MSRatedCOP,
-                                                      varSpeedCoil.MSCCapAirFFlow,
-                                                      varSpeedCoil.MSCCapFTemp,
-                                                      varSpeedCoil.MSEIRAirFFlow,
-                                                      varSpeedCoil.MSEIRFTemp,
-                                                      varSpeedCoil.PLFFPLR,
-                                                      varSpeedCoil.MSRatedAirVolFlowRate,
-                                                      varSpeedCoil.MSRatedEvaporatorFanPowerPerVolumeFlowRate2017,
-                                                      varSpeedCoil.MSRatedEvaporatorFanPowerPerVolumeFlowRate2023,
-                                                      CondenserType,
-                                                      0, // varSpeedCoil.RegionNum, // ??
-                                                      varSpeedCoil.MinOATCompressor,
-                                                      varSpeedCoil.OATempCompressorOn,
-                                                      false, // varSpeedCoil.OATempCompressorOnOffBlank, // ??
-                                                      DefrostControl,
-                                                      ObjexxFCL::Optional_bool_const());
+            if (varSpeedCoil.RatedCapCoolTotal > 0.0 || varSpeedCoil.RatedCapCoolTotal == AutoSize) {
+                StandardRatings::CalcDXCoilStandardRating(state,
+                                                          varSpeedCoil.Name,
+                                                          varSpeedCoil.VarSpeedCoilType,
+                                                          varSpeedCoil.VSCoilType,
+                                                          varSpeedCoil.NumOfSpeeds,
+                                                          varSpeedCoil.MSRatedTotCap,
+                                                          varSpeedCoil.MSRatedCOP,
+                                                          varSpeedCoil.MSCCapAirFFlow,
+                                                          varSpeedCoil.MSCCapFTemp,
+                                                          varSpeedCoil.MSEIRAirFFlow,
+                                                          varSpeedCoil.MSEIRFTemp,
+                                                          varSpeedCoil.PLFFPLR,
+                                                          varSpeedCoil.MSRatedAirVolFlowRate,
+                                                          varSpeedCoil.MSRatedEvaporatorFanPowerPerVolumeFlowRate2017,
+                                                          varSpeedCoil.MSRatedEvaporatorFanPowerPerVolumeFlowRate2023,
+                                                          CondenserType,
+                                                          0, // varSpeedCoil.RegionNum, // ??
+                                                          varSpeedCoil.MinOATCompressor,
+                                                          varSpeedCoil.OATempCompressorOn,
+                                                          false, // varSpeedCoil.OATempCompressorOnOffBlank, // ??
+                                                          DefrostControl,
+                                                          ObjexxFCL::Optional_bool_const());
+            }
             break;
         default:
             break;

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -6111,7 +6111,9 @@ namespace VariableSpeedCoils {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = true;
         }
 
-        if (CompressorOp == CompressorOperation::Off || state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0) {
+        if (CompressorOp == CompressorOperation::Off ||
+            (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0 &&
+             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal != DataSizing::AutoSize)) {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = false;
             return;
         }
@@ -7392,7 +7394,9 @@ namespace VariableSpeedCoils {
             return;
         }
 
-        if (CompressorOp == CompressorOperation::Off || state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0) {
+        if (CompressorOp == CompressorOperation::Off ||
+            (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0 &&
+             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal != DataSizing::AutoSize)) {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = false;
             return;
         }

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -189,13 +189,9 @@ namespace VariableSpeedCoils {
         if ((state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType == DataHVACGlobals::Coil_CoolingWaterToAirHPVSEquationFit) ||
             (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType == Coil_CoolingAirToAirVariableSpeed)) {
             // Cooling mode
-            if (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).coilOperationFlag) {
-                InitVarSpeedCoil(state, DXCoilNum, SensLoad, LatentLoad, CyclingScheme, OnOffAirFlowRatio, SpeedRatio, SpeedCal);
-                CalcVarSpeedCoilCooling(
-                    state, DXCoilNum, CyclingScheme, SensLoad, LatentLoad, CompressorOp, PartLoadFrac, OnOffAirFlowRatio, SpeedRatio, SpeedCal);
-            } else {
-                state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = false;
-            }
+            InitVarSpeedCoil(state, DXCoilNum, SensLoad, LatentLoad, CyclingScheme, OnOffAirFlowRatio, SpeedRatio, SpeedCal);
+            CalcVarSpeedCoilCooling(
+                state, DXCoilNum, CyclingScheme, SensLoad, LatentLoad, CompressorOp, PartLoadFrac, OnOffAirFlowRatio, SpeedRatio, SpeedCal);
             UpdateVarSpeedCoil(state, DXCoilNum);
         } else if ((state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType == DataHVACGlobals::Coil_HeatingWaterToAirHPVSEquationFit) ||
                    (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType == Coil_HeatingAirToAirVariableSpeed)) {
@@ -357,11 +353,7 @@ namespace VariableSpeedCoils {
                 DataHVACGlobals::cAllCoilTypes(state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).VSCoilType);
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).NumOfSpeeds = int(NumArray(1));
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).NormSpedLevel = int(NumArray(2));
-
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal = NumArray(3);
-            state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).coilOperationFlag =
-                setVarSpeedCoilOperationFlag(state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal);
-
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedAirVolFlowRate = NumArray(4);
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedWaterVolFlowRate = NumArray(5);
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).Twet_Rated = NumArray(6);
@@ -915,11 +907,7 @@ namespace VariableSpeedCoils {
                 DataHVACGlobals::cAllCoilTypes(Coil_CoolingAirToAirVariableSpeed);
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).NumOfSpeeds = int(NumArray(1));
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).NormSpedLevel = int(NumArray(2));
-
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal = NumArray(3);
-            state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).coilOperationFlag =
-                setVarSpeedCoilOperationFlag(state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal);
-
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedAirVolFlowRate = NumArray(4);
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).Twet_Rated = NumArray(5);
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).Gamma_Rated = NumArray(6);
@@ -3999,7 +3987,10 @@ namespace VariableSpeedCoils {
             !state.dataVariableSpeedCoils->MyPlantScanFlag(DXCoilNum)) {
             // for each furnace, do the sizing once.
             ErrorsFound = false;
-            SizeVarSpeedCoil(state, DXCoilNum, ErrorsFound);
+            if (state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal > 0.0 ||
+                state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal == AutoSize) {
+                SizeVarSpeedCoil(state, DXCoilNum, ErrorsFound);
+            }
             if (ErrorsFound) {
                 ShowFatalError(state, format("{}: Failed to size variable speed coil.", RoutineName));
             }
@@ -5986,6 +5977,7 @@ namespace VariableSpeedCoils {
             state.dataVariableSpeedCoils->CpAir_Init = PsyCpAirFnW(state.dataVariableSpeedCoils->LoadSideInletHumRat_Init);
             state.dataVariableSpeedCoils->firstTime = false;
         }
+
         state.dataVariableSpeedCoils->LoadSideInletWBTemp_Init = PsyTwbFnTdbWPb(state,
                                                                                 state.dataVariableSpeedCoils->LoadSideInletDBTemp_Init,
                                                                                 state.dataVariableSpeedCoils->LoadSideInletHumRat_Init,
@@ -6117,7 +6109,7 @@ namespace VariableSpeedCoils {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = true;
         }
 
-        if (CompressorOp == CompressorOperation::Off) {
+        if (CompressorOp == CompressorOperation::Off || state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0) {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = false;
             return;
         }
@@ -7398,7 +7390,7 @@ namespace VariableSpeedCoils {
             return;
         }
 
-        if (CompressorOp == CompressorOperation::Off) {
+        if (CompressorOp == CompressorOperation::Off || state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal <= 0.0) {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).SimFlag = false;
             return;
         }
@@ -8229,16 +8221,6 @@ namespace VariableSpeedCoils {
         return RatedSourceTemp;
     }
 
-    bool setVarSpeedCoilOperationFlag(Real64 const userSuppliedTotCoolCap)
-    {
-        // Defect Issue #10360: When user enters a zero value for the total cooling capacity of a variable speed coil,
-        // a divide by zero takes place during simulation.  The setting of the operation flag to false correctly skips
-        // the simulation of a coil with no capacity (same thing as it not being there).
-        bool opFlag = true;
-        if ((userSuppliedTotCoolCap <= 0.0) && (userSuppliedTotCoolCap != AutoSize)) opFlag = false;
-        return opFlag;
-    }
-
     void SetVarSpeedCoilData(EnergyPlusData &state,
                              int const WSHPNum,                               // Number of OA Controller
                              bool &ErrorsFound,                               // Set to true if certain errors found
@@ -8335,13 +8317,6 @@ namespace VariableSpeedCoils {
             varSpeedCoil.COP = 0.0;
             varSpeedCoil.RunFrac = 0.0;
             varSpeedCoil.PartLoadRatio = 0.0;
-
-            int inNode = varSpeedCoil.AirInletNodeNum;
-            if (inNode > 0) {
-                varSpeedCoil.InletAirDBTemp = state.dataLoopNodes->Node(inNode).Temp;
-                varSpeedCoil.InletAirHumRat = state.dataLoopNodes->Node(inNode).HumRat;
-                varSpeedCoil.InletAirEnthalpy = state.dataLoopNodes->Node(inNode).Enthalpy;
-            }
 
             varSpeedCoil.OutletAirDBTemp = varSpeedCoil.InletAirDBTemp;
             varSpeedCoil.OutletAirHumRat = varSpeedCoil.InletAirHumRat;

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -359,8 +359,8 @@ namespace VariableSpeedCoils {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).NormSpedLevel = int(NumArray(2));
 
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal = NumArray(3);
-            setVarSpeedCoilOperationFlag(state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal,
-                                         state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).coilOperationFlag);
+            state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).coilOperationFlag =
+                setVarSpeedCoilOperationFlag(state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal);
 
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedAirVolFlowRate = NumArray(4);
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedWaterVolFlowRate = NumArray(5);
@@ -917,8 +917,8 @@ namespace VariableSpeedCoils {
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).NormSpedLevel = int(NumArray(2));
 
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal = NumArray(3);
-            setVarSpeedCoilOperationFlag(state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal,
-                                         state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).coilOperationFlag);
+            state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).coilOperationFlag =
+                setVarSpeedCoilOperationFlag(state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedCapCoolTotal);
 
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).RatedAirVolFlowRate = NumArray(4);
             state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).Twet_Rated = NumArray(5);
@@ -8229,12 +8229,14 @@ namespace VariableSpeedCoils {
         return RatedSourceTemp;
     }
 
-    void setVarSpeedCoilOperationFlag(Real64 const userSuppliedTotCoolCap, bool &opFlag)
+    bool setVarSpeedCoilOperationFlag(Real64 const userSuppliedTotCoolCap)
     {
         // Defect Issue #10360: When user enters a zero value for the total cooling capacity of a variable speed coil,
         // a divide by zero takes place during simulation.  The setting of the operation flag to false correctly skips
         // the simulation of a coil with no capacity (same thing as it not being there).
+        bool opFlag = true;
         if ((userSuppliedTotCoolCap <= 0.0) && (userSuppliedTotCoolCap != AutoSize)) opFlag = false;
+        return opFlag;
     }
 
     void SetVarSpeedCoilData(EnergyPlusData &state,

--- a/src/EnergyPlus/VariableSpeedCoils.hh
+++ b/src/EnergyPlus/VariableSpeedCoils.hh
@@ -459,7 +459,7 @@ namespace VariableSpeedCoils {
 
     Real64 GetVSCoilRatedSourceTemp(EnergyPlusData &state, int const CoilIndex);
 
-    void setVarSpeedCoilOperationFlag(Real64 const userSuppliedTotCoolCap, bool &opFlag);
+    bool setVarSpeedCoilOperationFlag(Real64 const userSuppliedTotCoolCap);
 
     void SetVarSpeedCoilData(EnergyPlusData &state,
                              int const WSHPNum,                                   // Number of OA Controller

--- a/src/EnergyPlus/VariableSpeedCoils.hh
+++ b/src/EnergyPlus/VariableSpeedCoils.hh
@@ -135,6 +135,7 @@ namespace VariableSpeedCoils {
         int WaterInletNodeNum;             // Node Number of the Water Onlet
         int WaterOutletNodeNum;            // Node Number of the Water Outlet
         PlantLocation plantLoc;
+        bool coilOperationFlag; // Set to false when the RatedCapCoolTotal from user is less than or equal to zero but not AutoSize
         // set by parent object and "pushed" to this structure in SetVSWSHPData subroutine
         bool FindCompanionUpStreamCoil; // Flag to get the companion coil in Init
         bool IsDXCoilInZone;            // true means dx coil is in zone instead of outside
@@ -291,8 +292,8 @@ namespace VariableSpeedCoils {
               OutletWaterEnthalpy(0.0), Power(0.0), QLoadTotal(0.0), QSensible(0.0), QLatent(0.0), QSource(0.0), QWasteHeat(0.0), Energy(0.0),
               EnergyLoadTotal(0.0), EnergySensible(0.0), EnergyLatent(0.0), EnergySource(0.0), COP(0.0), RunFrac(0.0), PartLoadRatio(0.0),
               RatedPowerHeat(0.0), RatedCOPHeat(0.0), RatedCapCoolSens(0.0), RatedPowerCool(0.0), RatedCOPCool(0.0), AirInletNodeNum(0),
-              AirOutletNodeNum(0), WaterInletNodeNum(0), WaterOutletNodeNum(0), plantLoc{}, FindCompanionUpStreamCoil(true), IsDXCoilInZone(false),
-              CompanionCoolingCoilNum(0), CompanionHeatingCoilNum(0), FanDelayTime(0.0),
+              AirOutletNodeNum(0), WaterInletNodeNum(0), WaterOutletNodeNum(0), plantLoc{}, coilOperationFlag(true), FindCompanionUpStreamCoil(true),
+              IsDXCoilInZone(false), CompanionCoolingCoilNum(0), CompanionHeatingCoilNum(0), FanDelayTime(0.0),
               // This one calls into a std::vector, so it's 0-indexed, so we initialize it to -1
               MSHPDesignSpecIndex(-1), MSErrIndex(DataHVACGlobals::MaxSpeedLevels, 0), MSRatedPercentTotCap(DataHVACGlobals::MaxSpeedLevels, 0.0),
               MSRatedTotCap(DataHVACGlobals::MaxSpeedLevels, 0.0), MSRatedSHR(DataHVACGlobals::MaxSpeedLevels, 0.0),
@@ -457,6 +458,8 @@ namespace VariableSpeedCoils {
     );
 
     Real64 GetVSCoilRatedSourceTemp(EnergyPlusData &state, int const CoilIndex);
+
+    void setVarSpeedCoilOperationFlag(Real64 const userSuppliedTotCoolCap, bool &opFlag);
 
     void SetVarSpeedCoilData(EnergyPlusData &state,
                              int const WSHPNum,                                   // Number of OA Controller

--- a/src/EnergyPlus/VariableSpeedCoils.hh
+++ b/src/EnergyPlus/VariableSpeedCoils.hh
@@ -459,8 +459,6 @@ namespace VariableSpeedCoils {
 
     Real64 GetVSCoilRatedSourceTemp(EnergyPlusData &state, int const CoilIndex);
 
-    bool setVarSpeedCoilOperationFlag(Real64 const userSuppliedTotCoolCap);
-
     void SetVarSpeedCoilData(EnergyPlusData &state,
                              int const WSHPNum,                                   // Number of OA Controller
                              bool &ErrorsFound,                                   // Set to true if certain errors found

--- a/src/EnergyPlus/VariableSpeedCoils.hh
+++ b/src/EnergyPlus/VariableSpeedCoils.hh
@@ -135,7 +135,6 @@ namespace VariableSpeedCoils {
         int WaterInletNodeNum;             // Node Number of the Water Onlet
         int WaterOutletNodeNum;            // Node Number of the Water Outlet
         PlantLocation plantLoc;
-        bool coilOperationFlag; // Set to false when the RatedCapCoolTotal from user is less than or equal to zero but not AutoSize
         // set by parent object and "pushed" to this structure in SetVSWSHPData subroutine
         bool FindCompanionUpStreamCoil; // Flag to get the companion coil in Init
         bool IsDXCoilInZone;            // true means dx coil is in zone instead of outside
@@ -292,8 +291,8 @@ namespace VariableSpeedCoils {
               OutletWaterEnthalpy(0.0), Power(0.0), QLoadTotal(0.0), QSensible(0.0), QLatent(0.0), QSource(0.0), QWasteHeat(0.0), Energy(0.0),
               EnergyLoadTotal(0.0), EnergySensible(0.0), EnergyLatent(0.0), EnergySource(0.0), COP(0.0), RunFrac(0.0), PartLoadRatio(0.0),
               RatedPowerHeat(0.0), RatedCOPHeat(0.0), RatedCapCoolSens(0.0), RatedPowerCool(0.0), RatedCOPCool(0.0), AirInletNodeNum(0),
-              AirOutletNodeNum(0), WaterInletNodeNum(0), WaterOutletNodeNum(0), plantLoc{}, coilOperationFlag(true), FindCompanionUpStreamCoil(true),
-              IsDXCoilInZone(false), CompanionCoolingCoilNum(0), CompanionHeatingCoilNum(0), FanDelayTime(0.0),
+              AirOutletNodeNum(0), WaterInletNodeNum(0), WaterOutletNodeNum(0), plantLoc{}, FindCompanionUpStreamCoil(true), IsDXCoilInZone(false),
+              CompanionCoolingCoilNum(0), CompanionHeatingCoilNum(0), FanDelayTime(0.0),
               // This one calls into a std::vector, so it's 0-indexed, so we initialize it to -1
               MSHPDesignSpecIndex(-1), MSErrIndex(DataHVACGlobals::MaxSpeedLevels, 0), MSRatedPercentTotCap(DataHVACGlobals::MaxSpeedLevels, 0.0),
               MSRatedTotCap(DataHVACGlobals::MaxSpeedLevels, 0.0), MSRatedSHR(DataHVACGlobals::MaxSpeedLevels, 0.0),

--- a/tst/EnergyPlus/unit/DXCoils.unit.cc
+++ b/tst/EnergyPlus/unit/DXCoils.unit.cc
@@ -1998,6 +1998,7 @@ TEST_F(EnergyPlusFixture, TestReadingCoilCoolingHeatingDX)
     Real64 OnOffAirFlowRatio = 0.5;
     state->dataVariableSpeedCoils->VarSpeedCoil(VarSpeedCoilNum).AirMassFlowRate = 1.0;
     state->dataVariableSpeedCoils->VarSpeedCoil(VarSpeedCoilNum).RunFrac = 0.0;
+    state->dataVariableSpeedCoils->VarSpeedCoil(VarSpeedCoilNum).RatedCapCoolTotal = 100.0;
     // power = 26 + 2x
     VariableSpeedCoils::CalcVarSpeedCoilCooling(*state,
                                                 VarSpeedCoilNum,

--- a/tst/EnergyPlus/unit/VariableSpeedCoils.unit.cc
+++ b/tst/EnergyPlus/unit/VariableSpeedCoils.unit.cc
@@ -6963,4 +6963,30 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_Coil_Defrost_Power_Fix_Test)
     EXPECT_NEAR(state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).DefrostPower, 0.0, 1e-3);
 }
 
+TEST_F(EnergyPlusFixture, setVarSpeedCoilOperationFlagTest)
+{
+    Real64 userVarSpeedCoilCoolCap;
+    bool functionResult;
+
+    // Case 1: coil capacity is positive-->result is true
+    userVarSpeedCoilCoolCap = 12345.6789;
+    functionResult = VariableSpeedCoils::setVarSpeedCoilOperationFlag(userVarSpeedCoilCoolCap);
+    EXPECT_TRUE(functionResult);
+
+    // Case 2: coil capacity is autosized-->result is true
+    userVarSpeedCoilCoolCap = DataSizing::AutoSize;
+    functionResult = VariableSpeedCoils::setVarSpeedCoilOperationFlag(userVarSpeedCoilCoolCap);
+    EXPECT_TRUE(functionResult);
+
+    // Case 3: coil capacity is zero-->result is false
+    userVarSpeedCoilCoolCap = 0.0;
+    functionResult = VariableSpeedCoils::setVarSpeedCoilOperationFlag(userVarSpeedCoilCoolCap);
+    EXPECT_FALSE(functionResult);
+
+    // Case 4: coil capacity is negative but not AutoSize-->result is false
+    userVarSpeedCoilCoolCap = -123.456;
+    functionResult = VariableSpeedCoils::setVarSpeedCoilOperationFlag(userVarSpeedCoilCoolCap);
+    EXPECT_FALSE(functionResult);
+}
+
 } // namespace EnergyPlus

--- a/tst/EnergyPlus/unit/VariableSpeedCoils.unit.cc
+++ b/tst/EnergyPlus/unit/VariableSpeedCoils.unit.cc
@@ -6963,4 +6963,160 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_Coil_Defrost_Power_Fix_Test)
     EXPECT_NEAR(state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).DefrostPower, 0.0, 1e-3);
 }
 
+TEST_F(EnergyPlusFixture, VariableSpeedCoils_ZeroRatedCoolingCapacity_Test)
+{
+    // Code borrowed/modified from another test (VariableSpeedCoils_ContFanCycCoil_Test) above
+    std::string const idf_objects = delimited_string({
+        "  Coil:Cooling:DX:VariableSpeed,",
+        "    VS DXCOIL,               !- Name",
+        "    VS DXCOIL_CoolCNode,     !- Air Inlet Node Name",
+        "    VS DXCOIL_HeatCNode,     !- Air Outlet Node Name",
+        "    5,                       !- Number of Speeds {dimensionless}",
+        "    5,                       !- Nominal Speed Level {dimensionless}",
+        "    0.0,                     !- Rated Total Cooling Capacity At Selected Nominal Speed Level {w}",
+        "    5.00,                    !- Rated Volumetric Air Flow Rate At Selected Nominal Speed Level {m3/s}",
+        "    0,                       !- Nominal Time for Condensate to Begin Leaving the Coil {s}",
+        "    0,                       !- Initial Moisture Evaporation Rate Divided by Steady-State AC Latent Capacity {dimensionless}",
+        "    ,                        !- Maximum Cycling Rate",
+        "    ,                        !- Latent Capacity Time Constant",
+        "    ,                        !- Fan Delay Time",
+        "    PLF Curve,               !- Energy Part Load Fraction Curve Name",
+        "    ,                        !- Condenser Air Inlet Node Name",
+        "    AirCooled,               !- Condenser Type",
+        "    ,                        !- Evaporative Condenser Pump Rated Power Consumption {W}",
+        "    ,                        !- Crankcase Heater Capacity {W}",
+        "    ,                        !- Crankcase Heater Capacity Function of Temperature Curve Name",
+        "    10,                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}",
+        "    ,                        !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}",
+        "    ,                        !- Supply Water Storage Tank Name",
+        "    ,                        !- Condensate Collection Water Storage Tank Name",
+        "    ,                        !- Basin Heater Capacity {W/K}",
+        "    2,                       !- Basin Heater Setpoint Temperature {C}",
+        "    ,                        !- Basin Heater Operating Schedule Name",
+        "    33000.0,                 !- Speed 1 Reference Unit Total Cooling Capacity At Rated Conditions {w}",
+        "    0.70,                    !- Speed 1 Reference Unit Sensible Heat Ratio At Rated Conditions {dimensionless}",
+        "    4.34,                    !- Speed 1 Reference Unit COP At Rated Conditions {dimensionless}",
+        "    1.40,                    !- Speed 1 Reference Unit Air Flow Rate At Rated Conditions {m3/s}",
+        "    773.3,                   !- Speed 1 2017 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    934.4,                   !- Speed 1 2023 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    4.03,                    !- Speed 1 Reference Unit Condenser Flow Rate at Rated Conditions {m3/s}",
+        "    ,                        !- Speed 1 Reference Unit Pad Effectiveness of Evap Precooling at Rated Conditions {dimensionless}",
+        "    CapacityCurve,           !- Speed 1 Total Cooling Capacity Function of Temperature Curve Name",
+        "    CAPFF Curve,             !- Speed 1 Total Cooling Capacity Function of Air Flow Fraction Curve Name",
+        "    PowerCurve,              !- Speed 1 Energy Input Ratio Function of Temperature Curve Name",
+        "    EIRFF Curve,             !- Speed 1 Energy Input Ratio Function of Air Flow Fraction Curve Name",
+        "    35000.0,                 !- Speed 2 Reference Unit Total Cooling Capacity At Rated Conditions {w}",
+        "    0.78,                    !- Speed 2 Reference Unit Sensible Heat Ratio At Rated Conditions {dimensionless}",
+        "    4.54,                    !- Speed 2 Reference Unit COP At Rated Conditions {dimensionless}",
+        "    1.90,                    !- Speed 2 Reference Unit Air Flow Rate At Rated Conditions {m3/s}",
+        "    773.3,                   !- Speed 2 2017 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    934.4,                   !- Speed 2 2023 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    5.47,                    !- Speed 2 Reference Unit Condenser Flow Rate at Rated Conditions {m3/s}",
+        "    ,                        !- Speed 2 Reference Unit Pad Effectiveness of Evap Precooling at Rated Conditions {dimensionless}",
+        "    CapacityCurve,           !- Speed 2 Total Cooling Capacity Function of Temperature Curve Name",
+        "    CAPFF Curve,             !- Speed 2 Total Cooling Capacity Function of Air Flow Fraction Curve Name",
+        "    PowerCurve,              !- Speed 2 Energy Input Ratio Function of Temperature Curve Name",
+        "    EIRFF Curve,             !- Speed 2 Energy Input Ratio Function of Air Flow Fraction Curve Name",
+        "    70000.0,                 !- Speed 3 Reference Unit Total Cooling Capacity At Rated Conditions {w}",
+        "    0.70,                    !- Speed 3 Reference Unit Sensible Heat Ratio At Rated Conditions {dimensionless}",
+        "    4.20,                    !- Speed 3 Reference Unit COP At Rated Conditions {dimensionless}",
+        "    2.89,                    !- Speed 3 Reference Unit Air Flow Rate At Rated Conditions {m3/s}",
+        "    773.3,                   !- Speed 3 2017 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    934.4,                   !- Speed 3 2023 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    8.26,                    !- Speed 3 Reference Unit Condenser Flow Rate at Rated Conditions {m3/s}",
+        "    ,                        !- Speed 3 Reference Unit Pad Effectiveness of Evap Precooling at Rated Conditions {dimensionless}",
+        "    CapacityCurve,           !- Speed 3 Total Cooling Capacity Function of Temperature Curve Name",
+        "    CAPFF Curve,             !- Speed 3 Total Cooling Capacity Function of Air Flow Fraction Curve Name",
+        "    PowerCurve,              !- Speed 3 Energy Input Ratio Function of Temperature Curve Name",
+        "    EIRFF Curve,             !- Speed 3 Energy Input Ratio Function of Air Flow Fraction Curve Name",
+        "    120000.0,                !- Speed 4 Reference Unit Total Cooling Capacity At Rated Conditions {w}",
+        "    0.62,                    !- Speed 4 Reference Unit Sensible Heat Ratio At Rated Conditions {dimensionless}",
+        "    3.47,                    !- Speed 4 Reference Unit COP At Rated Conditions {dimensionless}",
+        "    3.56,                    !- Speed 4 Reference Unit Air Flow Rate At Rated Conditions {m3/s}",
+        "    773.3,                   !- Speed 4 2017 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    934.4,                   !- Speed 4 2023 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    10.25,                   !- Speed 4 Reference Unit Condenser Flow Rate at Rated Conditions {m3/s}",
+        "    ,                        !- Speed 4 Reference Unit Pad Effectiveness of Evap Precooling at Rated Conditions {dimensionless}",
+        "    CapacityCurve,           !- Speed 4 Total Cooling Capacity Function of Temperature Curve Name",
+        "    CAPFF Curve,             !- Speed 4 Total Cooling Capacity Function of Air Flow Fraction Curve Name",
+        "    PowerCurve,              !- Speed 4 Energy Input Ratio Function of Temperature Curve Name",
+        "    EIRFF Curve,             !- Speed 4 Energy Input Ratio Function of Air Flow Fraction Curve Name",
+        "    140000.0,                !- Speed 5 Reference Unit Total Cooling Capacity At Rated Conditions {w}",
+        "    0.69,                    !- Speed 5 Reference Unit Sensible Heat Ratio At Rated Conditions {dimensionless}",
+        "    3.84,                    !- Speed 5 Reference Unit COP At Rated Conditions {dimensionless}",
+        "    5.68,                    !- Speed 5 Reference Unit Air Flow Rate At Rated Conditions {m3/s}",
+        "    773.3,                   !- Speed 5 2017 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    934.4,                   !- Speed 5 2023 Rated Evaporator Fan Power Per Volume Flow Rate",
+        "    16.36,                   !- Speed 5 Reference Unit Condenser Flow Rate at Rated Conditions {m3/s}",
+        "    ,                        !- Speed 5 Reference Unit Pad Effectiveness of Evap Precooling at Rated Conditions {dimensionless}",
+        "    CapacityCurve,           !- Speed 5 Total Cooling Capacity Function of Temperature Curve Name",
+        "    CAPFF Curve,             !- Speed 5 Total Cooling Capacity Function of Air Flow Fraction Curve Name",
+        "    PowerCurve,              !- Speed 5 Energy Input Ratio Function of Temperature Curve Name",
+        "    EIRFF Curve;             !- Speed 5 Energy Input Ratio Function of Air Flow Fraction Curve Name",
+
+        "Curve:Biquadratic,",
+        "    CapacityCurve, 1, 0, 0, 0, 0, 0, 10, 25.5, 7.2, 48.8, , , Temperature, Temperature, Dimensionless;",
+        "Curve:Biquadratic,",
+        "    PowerCurve, 1, 0, 0, 0, 0, 0, 10, 25.5, 7.2, 48.8, , , Temperature, Temperature, Dimensionless;",
+        "Curve:Cubic,",
+        "    CAPFF Curve, 1, 0, 0, 0, 0, 1, , , Dimensionless, Dimensionless;",
+        "Curve:Cubic,",
+        "    EIRFF Curve, 1, 0, 0, 0, 0, 1, , , Dimensionless, Dimensionless;",
+        "Curve:Quadratic,",
+        "    PLF Curve, 0.85, 0.8333, 0.0, 0.0, 0.3, 0.85, 1.0, Dimensionless, Dimensionless;",
+
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+    // get coil inputs
+    VariableSpeedCoils::GetVarSpeedCoilInput(*state);
+    // Setting predefined tables is needed though
+    OutputReportPredefined::SetPredefinedTables(*state);
+    // Set up some environmental parameters
+    state->dataEnvrn->OutDryBulbTemp = 5.0;
+    state->dataEnvrn->OutHumRat = 0.0009;
+    state->dataEnvrn->OutBaroPress = 99000.0;
+    state->dataEnvrn->OutWetBulbTemp =
+        Psychrometrics::PsyTwbFnTdbWPb(*state, state->dataEnvrn->OutDryBulbTemp, state->dataEnvrn->OutHumRat, state->dataEnvrn->OutBaroPress);
+    state->dataEnvrn->WindSpeed = 5.0;
+    state->dataEnvrn->WindDir = 270.0;
+    state->dataEnvrn->StdRhoAir = 1.1;
+    // set coil parameters
+    int const CyclingScheme = DataHVACGlobals::ContFanCycCoil;
+    int DXCoilNum = 1;
+    DataHVACGlobals::CompressorOperation CompressorOp = DataHVACGlobals::CompressorOperation::Off;
+    int constexpr SpeedCal = 1;
+    Real64 SensLoad = 0.0;
+    Real64 LatentLoad = 0.0;
+    Real64 PartLoadFrac = 0.0;
+    Real64 OnOffAirFlowRatio = 1.0;
+    Real64 SpeedRatio = 0.0;
+
+    // run coil init
+    VariableSpeedCoils::InitVarSpeedCoil(*state, DXCoilNum, SensLoad, LatentLoad, CyclingScheme, OnOffAirFlowRatio, SpeedRatio, SpeedCal);
+    // set coil inlet condition
+    state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).InletAirDBTemp = 24.0;
+    state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).InletAirHumRat = 0.009;
+    state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).InletAirEnthalpy = Psychrometrics::PsyHFnTdbW(24.0, 0.009);
+    // test 1: compressor is On, PLR > 0, but RatedCapCoolTotal
+    CompressorOp = DataHVACGlobals::CompressorOperation::On;
+    PartLoadFrac = 1.0;
+    // set coil inlet air flow rate to speed 1
+    state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).AirMassFlowRate =
+        state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).MSRatedAirMassFlowRate(1) * 0.1;
+    state->dataVariableSpeedCoils->LoadSideMassFlowRate = state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).AirMassFlowRate;
+    state->dataLoopNodes->Node(state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).AirInletNodeNum).MassFlowRate =
+        state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).AirMassFlowRate;
+    VariableSpeedCoils::CalcVarSpeedCoilCooling(
+        *state, DXCoilNum, CyclingScheme, SensLoad, LatentLoad, CompressorOp, PartLoadFrac, OnOffAirFlowRatio, SpeedRatio, SpeedCal);
+    VariableSpeedCoils::UpdateVarSpeedCoil(*state, DXCoilNum);
+    // check coil outlet and inlet air conditions match
+    EXPECT_EQ(state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).OutletAirDBTemp,
+              state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).InletAirDBTemp);
+    EXPECT_EQ(state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).OutletAirHumRat,
+              state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).InletAirHumRat);
+    EXPECT_EQ(state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).OutletAirEnthalpy,
+              state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).InletAirEnthalpy);
+}
+
 } // namespace EnergyPlus

--- a/tst/EnergyPlus/unit/VariableSpeedCoils.unit.cc
+++ b/tst/EnergyPlus/unit/VariableSpeedCoils.unit.cc
@@ -6963,30 +6963,4 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_Coil_Defrost_Power_Fix_Test)
     EXPECT_NEAR(state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).DefrostPower, 0.0, 1e-3);
 }
 
-TEST_F(EnergyPlusFixture, setVarSpeedCoilOperationFlagTest)
-{
-    Real64 userVarSpeedCoilCoolCap;
-    bool functionResult;
-
-    // Case 1: coil capacity is positive-->result is true
-    userVarSpeedCoilCoolCap = 12345.6789;
-    functionResult = VariableSpeedCoils::setVarSpeedCoilOperationFlag(userVarSpeedCoilCoolCap);
-    EXPECT_TRUE(functionResult);
-
-    // Case 2: coil capacity is autosized-->result is true
-    userVarSpeedCoilCoolCap = DataSizing::AutoSize;
-    functionResult = VariableSpeedCoils::setVarSpeedCoilOperationFlag(userVarSpeedCoilCoolCap);
-    EXPECT_TRUE(functionResult);
-
-    // Case 3: coil capacity is zero-->result is false
-    userVarSpeedCoilCoolCap = 0.0;
-    functionResult = VariableSpeedCoils::setVarSpeedCoilOperationFlag(userVarSpeedCoilCoolCap);
-    EXPECT_FALSE(functionResult);
-
-    // Case 4: coil capacity is negative but not AutoSize-->result is false
-    userVarSpeedCoilCoolCap = -123.456;
-    functionResult = VariableSpeedCoils::setVarSpeedCoilOperationFlag(userVarSpeedCoilCoolCap);
-    EXPECT_FALSE(functionResult);
-}
-
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #10386 
 - This is the second attempt to fix this problem.  In a nutshell, when the user specifies a variable speed DX cooling coil but sets the capacity to zero, the simulation enters an infinite loop with temperatures that go to NaN but doesn't trigger a program crash.  When the user enters an actual value for the capacity or sets the input to autosize, E+ runs to completion successfully.  The initial solution was to reset the capacity of the highest speed of the coil.  This resolved the fix.  However, the reviewers felt that the preferred solution was to simply ignore the coil when the user sets the capacity to zero since this is an easy way to simply remove it from an input file.  Due to the fact that the previous solution had some other unrelated code changes, it was decided to make a clean branch and start over so that the fix/solution is much clearer.  The old pull request (PR#10410: https://github.com/NREL/EnergyPlus/pull/10410) has been closed out and replaced by this one.  The new solution does in fact cause the DX variable speed coil to do nothing when the user sets the capacity to zero.  The program now runs to completion and it was verified that the coil does nothing (conditions at the inlet and outlet node are always the same).  When the coil has a positive capacity or the capacity is autosized, the coil operates as intended.  This pull request includes the code fix, a new unit test, and minor documentation edits to note how a zero capacity is interpreted by E+.

**NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE**

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
