### PR TITLE
Improve error checking in SQLite database connection

### DIFF
--- a/src/EnergyPlus/SQLiteProcedures.cc
+++ b/src/EnergyPlus/SQLiteProcedures.cc
@@ -2632,19 +2632,27 @@ SQLiteProcedures::SQLiteProcedures(std::shared_ptr<std::ostream> const &errorStr
         // Test if we can write to the database
         // If we can't then there are probably locks on the database
         if (ok) {
-            sqlite3_open_v2(dbName.string().c_str(), &m_connection, SQLITE_OPEN_READWRITE, nullptr);
+            // sqlite3_open_v2 could return SQLITE_BUSY at this point. If so, do not proceed to sqlite3_exec.
+            rc = sqlite3_open_v2(dbName.string().c_str(), &m_connection, SQLITE_OPEN_READWRITE, nullptr);
+            if (rc) {
+                *m_errorStream << "SQLite3 message, can't get exclusive lock to open database: " << sqlite3_errmsg(m_connection) << std::endl;
+                ok = false;
+            }
+        }
+        if (ok) {
             char *zErrMsg = nullptr;
             rc = sqlite3_exec(m_connection, "CREATE TABLE Test(x INTEGER PRIMARY KEY)", nullptr, 0, &zErrMsg);
             sqlite3_close(m_connection);
             if (rc) {
-                *m_errorStream << "SQLite3 message, can't get exclusive lock on existing database: " << sqlite3_errmsg(m_connection) << std::endl;
+                *m_errorStream << "SQLite3 message, can't get exclusive lock to edit database: " << sqlite3_errmsg(m_connection) << std::endl;
                 ok = false;
             } else {
                 if (dbName != ":memory:") {
                     // Remove test db
                     rc = remove(dbName.string().c_str());
                     if (rc) {
-                        *m_errorStream << "SQLite3 message, can't remove old database: " << sqlite3_errmsg(m_connection) << std::endl;
+                        // File operation failed. SQLite connection is not in an error state.
+                        *m_errorStream << "SQLite3 message, can't remove old database." << std::endl;
                         ok = false;
                     }
                 }


### PR DESCRIPTION
Pull request overview
---------------------
 - Motivation: heard reports of SQLite fatal error messages. See  [1](https://unmethours.com/question/36452/fatal-the-sqlite-database-failed-to-open/),[2](https://discourse.ladybug.tools/t/the-sqlite-database-failed-to-open/15394),[3](https://github.com/sound-data/DEER-Prototypes-EnergyPlus/pull/31) and issue #7512.
 - Proactive effort to avoid failure modes for opening SQLite connection:
    1. Attempting to execute query after open failed. This violates documentation for [`sqlite3_exec()`](https://www.sqlite.org/c3ref/exec.html) that the connection must be valid.
    2. If deleting the test file fails, attempting to get error message when SQLite did not return an error code. In that case, the sqlite.err file would show `SQLite3 message, can't remove old database: bad parameter or other API misuse`.
- I haven't been able to reproduce the errors mentioned by other sources.

Suggested tag: Defect

### Discussion
Additional refactoring idea: currently the code creates a new empty file, writes a test table, deletes the file, then creates a new empty file again. It seems unnecessary to close the file, as this also creates another potential point of failure where some other application could lock the file after the deletion.

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
