### PR TITLE
Water Use Equipment Shows Volumetric Flow Mismatch with Node Data

### DIFF
--- a/src/EnergyPlus/WaterUse.hh
+++ b/src/EnergyPlus/WaterUse.hh
@@ -255,7 +255,7 @@ struct WaterUseData : BaseGlobalStruct
     bool getWaterUseInputFlag = true;
     bool calcRhoH2O = true;
     bool MyEnvrnFlagLocal = true;
-    Real64 rhoH2OStd;
+    Real64 rhoH2OStd = 1000.0;
     Array1D_bool CheckEquipName;
     EPVector<WaterUse::WaterEquipmentType> WaterEquipment;
     EPVector<WaterUse::WaterConnectionsType> WaterConnections;

--- a/src/EnergyPlus/WaterUse.hh
+++ b/src/EnergyPlus/WaterUse.hh
@@ -243,6 +243,8 @@ namespace WaterUse {
 
     void CalcWaterUseZoneGains(EnergyPlusData &state);
 
+    Real64 calcH2ODensity(EnergyPlusData &state);
+
 } // namespace WaterUse
 
 struct WaterUseData : BaseGlobalStruct
@@ -251,7 +253,9 @@ struct WaterUseData : BaseGlobalStruct
     int numWaterEquipment = 0;
     int numWaterConnections = 0;
     bool getWaterUseInputFlag = true;
+    bool calcRhoH2O = true;
     bool MyEnvrnFlagLocal = true;
+    Real64 rhoH2OStd;
     Array1D_bool CheckEquipName;
     EPVector<WaterUse::WaterEquipmentType> WaterEquipment;
     EPVector<WaterUse::WaterConnectionsType> WaterConnections;

--- a/src/EnergyPlus/WaterUse.hh
+++ b/src/EnergyPlus/WaterUse.hh
@@ -153,7 +153,6 @@ namespace WaterUse {
     {
         std::string Name;        // Name of DHW
         bool Init = true;        // Flag for initialization:  TRUE means do the init
-        bool InitSizing = true;  // Flag for initialization of plant sizing
         bool StandAlone = false; // Flag for operation with no plant connections
         int InletNode = 0;       // Hot water demand node
         int OutletNode = 0;      // Cold water supply node
@@ -168,7 +167,6 @@ namespace WaterUse {
         Real64 Effectiveness = 0.0;
         Real64 RecoveryRate = 0.0;
         Real64 RecoveryEnergy = 0.0;
-        Real64 MainsMassFlowRate = 0.0; // Mass flow rate (kg/s)
         Real64 TankMassFlowRate = 0.0;  // Mass flow rate (kg/s)
         Real64 ColdMassFlowRate = 0.0;  // Mass flow rate (kg/s)  cold = mains + tank
         Real64 HotMassFlowRate = 0.0;   // Mass flow rate (kg/s)
@@ -176,7 +174,6 @@ namespace WaterUse {
         Real64 DrainMassFlowRate = 0.0;
         Real64 RecoveryMassFlowRate = 0.0;
         Real64 PeakVolFlowRate = 0.0;  // Volumetric flow rate, also water consumption rate (m3/s)
-        Real64 MainsVolFlowRate = 0.0; // Volumetric flow rate, also water consumption rate (m3/s)
         Real64 TankVolFlowRate = 0.0;  // Volumetric flow rate, also water consumption rate (m3/s)
         Real64 ColdVolFlowRate = 0.0;  // Volumetric flow rate, also water consumption rate (m3/s)
         Real64 HotVolFlowRate = 0.0;   // Volumetric flow rate, also water consumption rate (m3/s)
@@ -185,7 +182,6 @@ namespace WaterUse {
         Real64 PeakMassFlowRate = 0.0; // Peak Mass flow rate for MassFlowRateMax
         int ColdTempSchedule = 0;      // Index for schedule object
         int HotTempSchedule = 0;       // Index for schedule object
-        Real64 MainsTemp = 0.0;        // Cold supply water temperature (C)
         Real64 TankTemp = 0.0;         // Cold supply water temperature (C)
         Real64 ColdSupplyTemp = 0.0;   // cold from mains, schedule, or tank, depending
         Real64 ColdTemp = 0.0;         // Cold supply water temperature (C)  actual cold (could be reheated)
@@ -195,7 +191,6 @@ namespace WaterUse {
         Real64 ReturnTemp = 0.0;
         Real64 WasteTemp = 0.0;
         Real64 TempError = 0.0;
-        Real64 MainsVolume = 0.0; // Water consumption (m3)
         Real64 TankVolume = 0.0;  // Water consumption (m3)
         Real64 ColdVolume = 0.0;  // Water consumption (m3)
         Real64 HotVolume = 0.0;   // Water consumption (m3)

--- a/tst/EnergyPlus/unit/WaterUse.unit.cc
+++ b/tst/EnergyPlus/unit/WaterUse.unit.cc
@@ -1265,3 +1265,30 @@ TEST_F(EnergyPlusFixture, WaterUse_Default_Target_Temperature_Test2)
 
     EXPECT_NEAR(thisWaterEquipment.ColdMassFlowRate + thisWaterEquipment.HotMassFlowRate, thisWaterEquipment.TotalMassFlowRate, 1e-8);
 }
+
+TEST_F(EnergyPlusFixture, WaterUse_calcH2ODensity_Test)
+{
+    Real64 functionResult;
+    Real64 expectedResult;
+    Real64 allowedTolerance = 0.001;
+
+    // Test 1: Set the flag to false means don't recalculate.  This means it wasn't set so this should be the default value.
+    state->dataWaterUse->calcRhoH2O = false;
+    expectedResult = 1000.0;
+    functionResult = calcH2ODensity(*state);
+    EXPECT_NEAR(functionResult, expectedResult, allowedTolerance);
+    EXPECT_FALSE(state->dataWaterUse->calcRhoH2O);
+
+    // Test 2: Now set the flag to true so that an actual value is calculated and flag should come back false.
+    state->dataWaterUse->calcRhoH2O = true;
+    expectedResult = 999.898;
+    functionResult = calcH2ODensity(*state);
+    EXPECT_NEAR(functionResult, expectedResult, allowedTolerance);
+    EXPECT_FALSE(state->dataWaterUse->calcRhoH2O);
+
+    // Test 2: Now the flag is still false.  The actual value should have been preserved and returned; flag should come back false.
+    expectedResult = 999.898;
+    functionResult = calcH2ODensity(*state);
+    EXPECT_NEAR(functionResult, expectedResult, allowedTolerance);
+    EXPECT_FALSE(state->dataWaterUse->calcRhoH2O);
+}


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #10443 
 - A user noticed when comparing the volumetric flow rate of the water use component output with the node data at the inlet and outlet of that component that there was a mismatch in the flow rates.  This was eventually traced back to the fact that on the plant loop the density was being calculated using the fluid property routines (table look-up) while the water use equipment component was calling the water density in the psychrometric routines (equation).  Even though the two were using the same standard temperature, it was resulting in two different densities which led to the difference in volumetric flow rate (at the standard temperature).  This was corrected by using the fluid property routines throughout the water use equipment module.  While correcting the problem, the code was also made more efficient.  In the past, the code calculated this standard density EVERY TIME the calculation was called even though the standard temperature never changes.  Now, the code not only uses the fluid property routine but it also only calls this once per water use equipment and then stores that data to be reused in all subsequent steps of the simulation.  Overall, this should make the code much more efficient and avoid costly unneeded calls to the fluid property routines.  A unit test verifies the new function which controls when to calculate the water density.  Testing with the user input file that led to this defect now shows agreement between the node and component data as it should.  Due to the use of a different density function in the water use module, there are expected differences in the program output.  These differences are not very large and happen only for files that have a water use component in the idf.

**NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE**

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
