### PR TITLE
Correction of FEI Calculation

### DIFF
--- a/doc/engineering-reference/src/simulation-models-encyclopedic-reference-002/air-system-fans.tex
+++ b/doc/engineering-reference/src/simulation-models-encyclopedic-reference-002/air-system-fans.tex
@@ -893,7 +893,9 @@ where:
 
 \(P_0\) is 100 Pa
 
-\(\eta_0\) is 66\%.
+\(\eta_0\) is 66\% or 0.66.
+
+It should be noted that the density of air (\(\rho\)) is calculated at a reference temperature of 21\(^{\circ}\)C and a relative humidity of 50\% to represent average indoor air conditions.  The barometric pressure used to calculated the humidity ratio for this reference condition is the pressure at the elevation of the location being simulated.
 
 \emph{Reference fan transmission efficiency}
 

--- a/doc/input-output-reference/src/overview/group-user-defined-hvac-and-plant-component.tex
+++ b/doc/input-output-reference/src/overview/group-user-defined-hvac-and-plant-component.tex
@@ -310,7 +310,7 @@ This field specifies the Erl programs that are used to model the plant component
 
 This fields defines the number of different plant loop connections that the component will use. Up to four separate loops can be connected if desired. This field is required.
 
-\paragraph{Field Set: (inlet node name, outlet node name, loading mode, flow request mode, initialization program calling manager, simulation program calling manager)}\label{feildset-inlet-node-name-outlet-node-name-loading-mode-flow-request-mode-initialization-program-calling-manager-simulation-program-calling-manager.}
+\paragraph{Field Set: (inlet node name, outlet node name, loading mode, flow request mode, initialization program calling manager, simulation program calling manager)}\label{fieldset-inlet-node-name-outlet-node-name-loading-mode-flow-request-mode-initialization-program-calling-manager-simulation-program-calling-manager.}
 
 Each of the plant loop connections used is defined by a set of 6 input fields that contain and inlet node, and outlet node, a loading mode, a flow request mode, a program calling manager for setup and sizing, and a program calling manager for model calculations that should run when this loop is being simulated.
 

--- a/src/EnergyPlus/Fans.cc
+++ b/src/EnergyPlus/Fans.cc
@@ -1556,7 +1556,7 @@ void FanComponent::set_size(EnergyPlusData &state)
     OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchFanVolFlow, Name, _volFlow);
     Real64 _ratedPower = _volFlow * deltaPress / totalEff; // total fan power
     if (type != HVAC::FanType::ComponentModel) {
-        designPointFEI = FanSystem::report_fei(state, _volFlow, _ratedPower, deltaPress, state.dataEnvrn->StdRhoAir);
+        designPointFEI = FanSystem::report_fei(state, _volFlow, _ratedPower, deltaPress);
     }
     OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchFanPwr, Name, _ratedPower);
     if (_volFlow != 0.0) {
@@ -2643,8 +2643,7 @@ void FanSystem::set_size(EnergyPlusData &state)
             }
         }
     }
-    Real64 _rhoAir = Psychrometrics::PsyRhoAirFnPbTdbW(state, state.dataLoopNodes->Node(inletNodeNum).Press, inletAirTemp, inletAirHumRat);
-    designPointFEI = report_fei(state, maxAirFlowRate, designElecPower, deltaPress, _rhoAir);
+    designPointFEI = report_fei(state, maxAirFlowRate, designElecPower, deltaPress);
 
     OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchFanType, Name, HVAC::fanTypeNames[(int)type]);
     OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchFanTotEff, Name, totalEff);
@@ -2673,8 +2672,7 @@ void FanSystem::set_size(EnergyPlusData &state)
                                              airLoopNum > 0 ? state.dataAirSystemsData->PrimaryAirSystems(airLoopNum).Name : "N/A");
 }
 
-Real64 FanSystem::report_fei(
-    EnergyPlusData &state, Real64 const _designFlowRate, Real64 const _designElecPower, Real64 const _designDeltaPress, Real64 _inletRhoAir)
+Real64 FanSystem::report_fei(EnergyPlusData &state, Real64 const _designFlowRate, Real64 const _designElecPower, Real64 const _designDeltaPress)
 {
     // PURPOSE OF THIS SUBROUTINE:
     // Calculate the Fan Energy Index
@@ -2683,9 +2681,14 @@ Real64 FanSystem::report_fei(
     // ANSI/AMCA Standard 207-17: Fan System Efficiency and Fan System Input Power Calculation, 2017.
     // AANSI / AMCA Standard 208 - 18: Calculation of the Fan Energy Index, 2018.
 
-    assert(state.dataEnvrn->StdRhoAir > 0.0);
+    Real64 constexpr rhoAirStd = 1.2;   // Value from the above referenced standard
+    Real64 constexpr tempAirFan = 21.0; // Standard fan inlet temperature in Celsius
+    Real64 constexpr hrAirFan = 0.5;    // Standard fan inlet humidity ratio (50%)
+    Real64 _wAirFan = Psychrometrics::PsyWFnTdbRhPb(state, tempAirFan, hrAirFan, state.dataEnvrn->StdBaroPress);
+    Real64 _rhoAirFan = Psychrometrics::PsyRhoAirFnPbTdbW(state, state.dataEnvrn->StdBaroPress, tempAirFan, _wAirFan);
+
     // Calculate reference fan shaft power
-    Real64 _refFanShaftPower = (_designFlowRate + 0.118) * (_designDeltaPress + 100 * _inletRhoAir / state.dataEnvrn->StdRhoAir) / (1000 * 0.66);
+    Real64 _refFanShaftPower = (_designFlowRate + 0.118) * (_designDeltaPress + 100 * _rhoAirFan / rhoAirStd) / (1000 * 0.66);
 
     // Calculate reference reference fan transmission efficiency
     Real64 _refFanTransEff = 0.96 * pow((_refFanShaftPower / (_refFanShaftPower + 1.64)), 0.05);

--- a/src/EnergyPlus/Fans.hh
+++ b/src/EnergyPlus/Fans.hh
@@ -394,8 +394,7 @@ namespace Fans {
         bool isSecondaryDriver = false; // true if this fan is used to augment flow and may pass air when off.
 
         // FEI
-        static Real64 report_fei(
-            EnergyPlusData &state, Real64 const designFlowRate, Real64 const designElecPower, Real64 const designDeltaPress, Real64 inletRhoAir);
+        static Real64 report_fei(EnergyPlusData &state, Real64 const designFlowRate, Real64 const designElecPower, Real64 const designDeltaPress);
 
         void init(EnergyPlusData &state);
 

--- a/tst/EnergyPlus/unit/Fans.unit.cc
+++ b/tst/EnergyPlus/unit/Fans.unit.cc
@@ -90,7 +90,7 @@ TEST_F(EnergyPlusFixture, Fans_FanSizing)
     fan1->set_size(*state);
     EXPECT_DOUBLE_EQ(1.00635, fan1->maxAirFlowRate);
     state->dataSize->DataNonZoneNonAirloopValue = 0.0;
-    EXPECT_NEAR(1.0371, fan1->designPointFEI, 0.0001);
+    EXPECT_NEAR(1.0352, fan1->designPointFEI, 0.0001);
 }
 
 TEST_F(EnergyPlusFixture, Fans_ConstantVolume_EMSPressureRiseResetTest)

--- a/tst/EnergyPlus/unit/HVACFan.unit.cc
+++ b/tst/EnergyPlus/unit/HVACFan.unit.cc
@@ -484,9 +484,79 @@ TEST_F(EnergyPlusFixture, SystemFanObj_TwoSpeedFanPowerCalc4)
 TEST_F(EnergyPlusFixture, SystemFanObj_FanEnergyIndex)
 {
     // this unit test checks the functions calculating FEI
-    state->dataEnvrn->StdRhoAir = 1.2;
-    Real64 testFEI = Fans::FanSystem::report_fei(*state, 1.0, 1000.0, 100.0, 1.2);
-    EXPECT_NEAR(testFEI, 0.4917, 0.001);
+    // expanded for test of correction to defect #10509
+    Real64 designFlow;
+    Real64 designPower;
+    Real64 designDeltaP;
+    Real64 testFEI;
+    Real64 expectedAnswer;
+    Real64 constexpr allowedTolerance = 0.001;
+
+    // Test 1: (already existing) normal operation of function
+    designFlow = 1.0;
+    designPower = 1000.0;
+    designDeltaP = 100.0;
+    expectedAnswer = 0.4892;
+    testFEI = Fans::FanSystem::report_fei(*state, designFlow, designPower, designDeltaP);
+    EXPECT_NEAR(testFEI, expectedAnswer, allowedTolerance);
+
+    // Test 2a: Zero power-->should result in zero result
+    designFlow = 1.0;
+    designPower = 0.0;
+    designDeltaP = 100.0;
+    expectedAnswer = 0.0;
+    testFEI = Fans::FanSystem::report_fei(*state, designFlow, designPower, designDeltaP);
+    EXPECT_NEAR(testFEI, expectedAnswer, allowedTolerance);
+
+    // Test 2b: Negative power-->should also result in zero result
+    designFlow = 1.0;
+    designPower = -1000.0;
+    designDeltaP = 100.0;
+    expectedAnswer = 0.0;
+    testFEI = Fans::FanSystem::report_fei(*state, designFlow, designPower, designDeltaP);
+    EXPECT_NEAR(testFEI, expectedAnswer, allowedTolerance);
+
+    // Test 3: Lower design power-->higher FEI
+    designFlow = 1.0;
+    designPower = 500.0;
+    designDeltaP = 100.0;
+    expectedAnswer = 0.9784;
+    testFEI = Fans::FanSystem::report_fei(*state, designFlow, designPower, designDeltaP);
+    EXPECT_NEAR(testFEI, expectedAnswer, allowedTolerance);
+
+    // Test 4: Lower flow rate-->lower FEI
+    designFlow = 0.5;
+    designPower = 1000.0;
+    designDeltaP = 100.0;
+    expectedAnswer = 0.2990;
+    testFEI = Fans::FanSystem::report_fei(*state, designFlow, designPower, designDeltaP);
+    EXPECT_NEAR(testFEI, expectedAnswer, allowedTolerance);
+
+    // Test 5: Lower pressure differential-->lower FEI
+    designFlow = 1.0;
+    designPower = 1000.0;
+    designDeltaP = 50.0;
+    expectedAnswer = 0.3833;
+    testFEI = Fans::FanSystem::report_fei(*state, designFlow, designPower, designDeltaP);
+    EXPECT_NEAR(testFEI, expectedAnswer, allowedTolerance);
+
+    // Test 6: Test at altitude (roughly Denver at a pressure of 82 kPa)-->slightly lower FEI if power stays the same
+    state->dataEnvrn->StdBaroPress = 82000.0;
+    designFlow = 1.0;
+    designPower = 1000.0;
+    designDeltaP = 100.0;
+    expectedAnswer = 0.4491;
+    testFEI = Fans::FanSystem::report_fei(*state, designFlow, designPower, designDeltaP);
+    EXPECT_NEAR(testFEI, expectedAnswer, allowedTolerance);
+
+    // Test 7: High values to trigger high motor efficiency limit
+    state->dataEnvrn->StdBaroPress = 82000.0;
+    designFlow = 100.0;
+    designPower = 5000000.0;
+    designDeltaP = 10000.0;
+    expectedAnswer = 0.3311;
+    testFEI = Fans::FanSystem::report_fei(*state, designFlow, designPower, designDeltaP);
+    EXPECT_NEAR(testFEI, expectedAnswer, allowedTolerance);
 }
 
 TEST_F(EnergyPlusFixture, SystemFanObj_DiscreteMode_noPowerFFlowCurve)


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #10509 
 - It was identified that there was an issue with the fan FEI calculation where it was not using the correct density values for a density ratio of design conditions to assumed conditions at sea level.  In the ANSI/AMCA Standard 207-17, the value for density at sea level is defined as 1.2 kg/m^3.  This was implemented along with changes to the design conditions density which is now assumed to be 21C, 50% RH at the elevation of the location.  The function that was used to do the FEI calculation was modified to conform to the standard with these assumptions.  Existing unit tests were updated to accommodate this change and an existing unit test was significantly expanded to more fully test the FEI calculation function.  Minor edits (additions) were made to the Engineering Reference in the section that docments the FEI calculation.  There are a number of differences in the output.  These are all changes to the report table that shows the FEI result.  Since the FEI calculation has changed, this was in line with expectations.

**NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE**

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
