### PR TITLE
Fix Meter:Custom with mix of valid and invalid names

### DIFF
--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -803,7 +803,7 @@ namespace OutputProcessor {
 
                     // Has to be a summed variable
                     if (srcDDVar->storeType != StoreType::Sum) {
-                        ShowWarningCustomMessage(state,
+                        ShowWarningCustomMessage(state, // Is clang-format formatting things like this? This is gross.
                                                  eoh,
                                                  format(R"(Meter:Custom="{}", variable not summed variable {}="{}".)",
                                                         ipsc->cAlphaArgs(1),
@@ -867,8 +867,7 @@ namespace OutputProcessor {
                                             ipsc->cAlphaFieldNames(fldIndex + 1),
                                             ipsc->cAlphaArgs(fldIndex + 1)));
                     ShowContinueError(state, "...will not be shown with the Meter results.");
-                    foundBadSrc = true;
-                    break;
+                    // Not setting the foundBadSrc flag here.
                 }
 
             } // for (fldIndex)


### PR DESCRIPTION
[PR #10384](https://github.com/NREL/EnergyPlus/pull/10384) changed the behavior of `Meter:Custom` so that meter creation fails if one of the component variables or meters is missing. According to [issue #10771](https://github.com/NREL/EnergyPlus/issues/10771), the desired behavior is to create the custom meter but ignore the missing component variable or meter. This behavior was restored.