### PR TITLE
Address 24.2 EMPD Issue

### DIFF
--- a/src/EnergyPlus/MoistureBalanceEMPDManager.cc
+++ b/src/EnergyPlus/MoistureBalanceEMPDManager.cc
@@ -249,9 +249,9 @@ void GetMoistureBalanceEMPDInput(EnergyPlusData &state)
 
         auto const &constr = state.dataConstruction->Construct(surf.Construction);
         auto const *mat = dynamic_cast<const MaterialEMPD *>(s_mat->materials(constr.LayerPoint(constr.TotLayers)));
-        assert(mat != nullptr);
+        // assert(mat != nullptr);
 
-        if (mat->mu > 0.0 && surf.Zone > 0) {
+        if (mat && mat->mu > 0.0 && surf.Zone > 0) {
             EMPDzone(surf.Zone) = true;
         } else {
             ++state.dataMoistureBalEMPD->ErrCount;


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #10777 

Most of the conversation can be found [here](https://github.com/NREL/EnergyPlus/issues/10777#issuecomment-2391655066), but basically, there was an incorrect check that let an invalid configuration pass before 24.2, accidentally segfaulted in 24.2.0, and now fails gracefully (in 24.2.1+).

I don't expect any diffs or failures, so if there are any, this won't be ready.  If it's all green, I think it's good to go.