### PR TITLE
Use LaTeX labels to reference figures in epw-csv-format-in-out.tex

### DIFF
--- a/doc/auxiliary-programs/src/weather-converter-program/epw-csv-format-in-out.tex
+++ b/doc/auxiliary-programs/src/weather-converter-program/epw-csv-format-in-out.tex
@@ -98,7 +98,7 @@ Each data item field obeys the same ``missing'' and other content rules as shown
 \caption{EnergyPlus EPW CSV file (spreadsheet view) \protect \label{fig:energyplus-epw-csv-file-spreadsheet-view}}
 \end{figure}
 
-The figure above shows how the EnergyPlus EPW CSV file (initial header records) looks when opened in a spreadsheet. Each header record is shown in bold with data following the headers..
+Figure \ref{fig:energyplus-epw-csv-file-spreadsheet-view} shows how the EnergyPlus EPW CSV file (initial header records) looks when opened in a spreadsheet. Each header record is shown in bold with data following the headers..
 
 \begin{figure}[hbtp] % fig 18
 \centering
@@ -106,4 +106,4 @@ The figure above shows how the EnergyPlus EPW CSV file (initial header records) 
 \caption{EnergyPlus EPW CSV Data Records (spreadsheet view) \protect \label{fig:energyplus-epw-csv-data-records-spreadsheet}}
 \end{figure}
 
-The above figure shows how the data periods header record and the individual data records look when opened in a spread sheet. Again, the headers are shown in bold. Note that there are two header records for the data records - one with short names - one with longer more descriptive names.
+Figure \ref{fig:energyplus-epw-csv-data-records-spreadsheet} shows how the data periods header record and the individual data records look when opened in a spread sheet. Again, the headers are shown in bold. Note that there are two header records for the data records - one with short names - one with longer more descriptive names.


### PR DESCRIPTION
Use LaTeX labels to reference figures.
In the current documentation figures are referred to with "above figure" while they are in the next pages