### PR TITLE
Correct reference entering air temperatures for the water to air heat pump dataset

### DIFF
--- a/datasets/WaterToAirHeatPumps.idf
+++ b/datasets/WaterToAirHeatPumps.idf
@@ -9,8 +9,8 @@
 !- Rated characteristics: 
 !-   * Cooling capacity: 69 kBtu/h at 86F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
 !-   * Cooling efficiency: 13.3 EER at 86F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
-!-   * Heating capacity: 92.5 kBtu/h at 68F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
-!-   * Heating efficiency: 5.0 COP at 68F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
+!-   * Heating capacity: 92.5 kBtu/h at 68F entering water temperature, and 68F/59F entering air dry-bulb and wet-bulb
+!-   * Heating efficiency: 5.0 COP at 68F entering water temperature, and 68F/59F entering air dry-bulb and wet-bulb
 
 Curve:QuadLinear,
     TCH072_WLHP_CLG_CAPFT,   !- Name
@@ -131,8 +131,8 @@ Curve:QuadLinear,
 !- Rated characteristics: 
 !-   * Cooling capacity: 77.72 kBtu/h at 59F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
 !-   * Cooling efficiency: 19.37 EER at 59F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
-!-   * Heating capacity: 73.08 kBtu/h at 50F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
-!-   * Heating efficiency: 4.3 COP at 50F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
+!-   * Heating capacity: 73.08 kBtu/h at 50F entering water temperature, and 68F/59F entering air dry-bulb and wet-bulb
+!-   * Heating efficiency: 4.3 COP at 50F entering water temperature, and 68F/59F entering air dry-bulb and wet-bulb
 
 !- Performance curve based on 15% methanol antifreeze solution
 Curve:QuadLinear,
@@ -258,8 +258,8 @@ Curve:QuadLinear,
 !- Rated characteristics: 
 !-   * Cooling capacity: 70.29 kBtu/h at 77F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
 !-   * Cooling efficiency: 14.35 EER at 77F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
-!-   * Heating capacity: 56.14 kBtu/h at 32F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
-!-   * Heating efficiency: 3.42 COP at 32F entering water temperature, and 80.6F/66.2F entering air dry-bulb and wet-bulb
+!-   * Heating capacity: 56.14 kBtu/h at 32F entering water temperature, and 68F/59F entering air dry-bulb and wet-bulb
+!-   * Heating efficiency: 3.42 COP at 32F entering water temperature, and 68F/59F entering air dry-bulb and wet-bulb
 
 !- Performance curve based on 15% methanol antifreeze solution
 Curve:QuadLinear,


### PR DESCRIPTION
Pull request overview
---------------------
 - Fix a bad copy/paste error in the `WaterToAirHeatPumps.idf` dataset

Here's screenshot from the manufacturer data used to generate the dataset:
![image](https://github.com/user-attachments/assets/63368f94-cb57-427e-a48d-72eb798c815c)
Source: https://www.climatemaster.com/download/18.274be999165850ccd5b5c48/1535543869128/lc517-climatemaster-commercial-tranquility-compact-belt-drive-tchv-series-water-source-heat-pump-submittal-set.pdf

### Pull Request Author
Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.
 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish

### Reviewer
This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
