### PR TITLE
Allow ConvertInputFormat to run with missing building and geometry

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -168,7 +168,7 @@ jobs:
 
     - name: Install Regression Tool
       if: always() && matrix.run_regressions && steps.branch_build.outcome != 'failure'  # always run this step as long as we actually built
-      run: pip install energyplus-regressions>=2.1.1  # could rely on the requirements.txt file maybe
+      run: pip install energyplus-regressions>=2.1.2
 
     - name: Run Regressions
       if: always() && matrix.run_regressions && steps.branch_build.outcome != 'failure'  # always run this step as long as we actually built

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 # requirements for building an EnergyPlus wheel
 wheel
 
-# requirements for the CI regression testing scripts
-energyplus-regressions>=2.1.1

--- a/src/ConvertInputFormat/main.cpp
+++ b/src/ConvertInputFormat/main.cpp
@@ -255,12 +255,18 @@ bool processErrors(std::unique_ptr<IdfParser> const &idf_parser, std::unique_ptr
         displayMessage(warning);
     }
     for (auto const &error : validation_errors) {
-        if (isDDY) {
-            if ((error.find("Missing required property 'Building'") != std::string::npos) ||
-                (error.find("Missing required property 'GlobalGeometryRules'") != std::string::npos)) {
+        bool const missing_building = error.find("Missing required property 'Building'") != std::string::npos;
+        bool const missing_geometry = error.find("Missing required property 'GlobalGeometryRules'") != std::string::npos;
+        // if we encountered one of the expected missing building/geometry errors, we should handle them special
+        if (missing_building || missing_geometry) {
+            if (isDDY) { // for DDY files just ignore it completely
                 continue;
             }
+            // for other IDFs, go ahead and emit a message, but don't trigger a failure
+            displayMessage(error);
+            continue;
         }
+        // and if it wasn't a missing building or missing geometry error, we will emit that as a proper error and fail
         hasValidationErrors = true;
         displayMessage(error);
     }

--- a/tst/EnergyPlus/unit/FluidCoolers.unit.cc
+++ b/tst/EnergyPlus/unit/FluidCoolers.unit.cc
@@ -365,7 +365,7 @@ TEST_F(EnergyPlusFixture, FluidCooler_SizeWhenPlantSizingIndexIsZero)
     state->dataPlnt->PlantLoop.allocate(FluidCoolerNum);
     state->dataPlnt->PlantLoop(1).FluidName = "WATER";
     state->dataPlnt->PlantLoop(1).glycol = Fluid::GetWater(*state);
-    state->dataFluidCoolers->SimpleFluidCooler.allocate(FluidCoolerNum);
+    // state->dataFluidCoolers->SimpleFluidCooler.allocate(FluidCoolerNum);
     state->dataFluidCoolers->SimpleFluidCooler(FluidCoolerNum).plantLoc.loopNum = 1;
     state->dataPlnt->PlantLoop(1).PlantSizNum = 0;
 


### PR DESCRIPTION
Fixes #10925 

A user trying to convert the datasets to epjson ran into an error.  The convert input format tool required a building and geometry.  For DDY files, the tool is able to detect the extension and ignore the missing building and geometry.  So I took that logic and ran with it here.

The tool still emits the message, but allows the conversion to report a successful exit code -- if those are the only errors encountered.  Since we can't easily differentiate between any user IDF, and an IDF that just happens to be in a folder called datasets/, I think this might be the best alternative.  Again, if it is any other error type, it will fail as expected.  I am open to suggestion, but it's a starting point anyway.

And a quick rider: this also points to an updated regression tool which fixes a link/path issue on table diff summaries.

And a second rider: @mjwitte noted that a test was failing in a debug build.  Allocate was being called and wiping out an array after get input had already set it up.  The allocate was removed to fix the test.