### PR TITLE
Fix #10952 #10953 - Fixup tcl-tk issue on mac + add ubuntu arm64 runners

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Set up Python ${{ env.Python_REQUIRED_VERSION }}
       id: setup-python
-      uses: jmarrec/setup-python@v5
+      uses: jmarrec/setup-python@v5.4.0
       with:
         python-version: ${{ env.Python_REQUIRED_VERSION }}
 
@@ -156,7 +156,7 @@ jobs:
           path: checkout
 
       - name: Set up Python ${{ env.Python_REQUIRED_VERSION }}
-        uses: jmarrec/setup-python@v5
+        uses: actions/setup-python@v5
         id: setup-python
         with:
           python-version: ${{ env.Python_REQUIRED_VERSION }}

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Setup QtIFW 4.x
       uses: jmarrec/setup-qtifw@v1
       with:
-        qtifw-version: '4.6.1'
+        qtifw-version: '4.8.1'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -20,10 +20,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
-            pretty: "Ubuntu 22.04"
-          - os: ubuntu-24.04
-            pretty: "Ubuntu 24.04"
+        - os: ubuntu-22.04
+          pretty: "Ubuntu 22.04"
+          arch: x86_64
+          python-arch: x64
+        - os: ubuntu-24.04
+          pretty: "Ubuntu 24.04"
+          arch: x86_64
+          python-arch: x64
+        - os: ubuntu-22.04-arm
+          pretty: "Ubuntu 22.04 arm64"
+          arch: arm64
+          python-arch: arm64
+        - os: ubuntu-24.04-arm
+          pretty: "Ubuntu 24.04 arm64"
+          arch: arm64
+          python-arch: arm64
 
     permissions:
       # Needed permission to upload the release asset
@@ -72,7 +84,7 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE \
               -DLINK_WITH_PYTHON:BOOL=ON -DPYTHON_CLI:BOOL=ON \
               -DPython_REQUIRED_VERSION:STRING=${{ steps.setup-python.outputs.python-version }} \
-              -DPython_ROOT_DIR:PATH=$RUNNER_TOOL_CACHE/Python/${{ steps.setup-python.outputs.python-version }}/x64/ \
+              -DPython_ROOT_DIR:PATH=$RUNNER_TOOL_CACHE/Python/${{ steps.setup-python.outputs.python-version }}/${{ matrix.python-arch }}/ \
               -DBUILD_FORTRAN:BOOL=ON -DBUILD_PACKAGE:BOOL=ON \
               -DDOCUMENTATION_BUILD:STRING="BuildWithAll" -DTEX_INTERACTION:STRING="batchmode" -DENABLE_PCH:BOOL=OFF \
               ../
@@ -86,7 +98,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: energyplus-${{ matrix.os }}
-        path: build/EnergyPlus-*-x86_64.tar.gz
+        path: build/EnergyPlus-*-${{ matrix.arch }}.tar.gz
         if-no-files-found: error
         retention-days: 7
         overwrite: false
@@ -95,7 +107,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/EnergyPlus-*-x86_64.tar.gz
+        file: build/EnergyPlus-*-${{ matrix.arch }}.tar.gz
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
@@ -104,7 +116,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/EnergyPlus-*-x86_64.run
+        file: build/EnergyPlus-*-${{ matrix.arch }}.run
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
@@ -113,7 +125,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/EnergyPlus-*-x86_64.sh
+        file: build/EnergyPlus-*-${{ matrix.arch }}.sh
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
@@ -133,6 +145,10 @@ jobs:
             test_key: ubuntu2204
           - os: ubuntu-24.04
             test_key: ubuntu2404
+          - os: ubuntu-22.04-arm
+            test_key: ubuntu2204-arm64
+          - os: ubuntu-24.04-arm
+            test_key: ubuntu2404-arm64
 
     steps:
       - uses: actions/checkout@v4  # Still need E+ checked out to get testing scripts

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Set up Python ${{ env.Python_REQUIRED_VERSION }}
       id: setup-python
-      uses: jmarrec/setup-python@v5
+      uses: jmarrec/setup-python@v5.4.0
       with:
         python-version: ${{ env.Python_REQUIRED_VERSION }}
         # check-latest: true # Force pick up the python I built instead of the (potential) toolcache one. I could also do `rm -Rf $RUNNER_TOOL_CACHE/Python/3.12.2` before this action

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - '*'
   workflow_dispatch:
+    inputs:
+      BUILD_DOCS:
+        description: 'Whether to build docs or not as it takes 15 minutes to install MacTex'
+        required: true
+        type: boolean
+        default: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,6 +129,11 @@ jobs:
       run: |
         set -x
         brew update
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          BUILD_DOCS="${{ inputs.BUILD_DOCS }}"
+          echo "BUILD_DOCS=$BUILD_DOCS" >> $GITHUB_ENV
+        fi
+
         if [[ "$BUILD_DOCS" != "false" ]]; then
           echo "Using brew to install mactex and adding it to PATH"
           brew install --cask mactex-no-gui

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -23,14 +23,14 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        macos_dev_target: [13.0]
+        macos_dev_target: [12.1, 13.0]
         include:
-#        - macos_dev_target: 12.1
-#          os: macos-12
-#          allow_failure: false
-#          arch: x86_64
-#          python-arch: x64
-#          pretty: "Mac x64"
+        - macos_dev_target: 12.1
+          os: macos-13
+          allow_failure: false
+          arch: x86_64
+          python-arch: x64
+          pretty: "Mac x64"
         - macos_dev_target: 13.0
           os: macos-14
           allow_failure: false
@@ -268,13 +268,13 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        macos_dev_target: [ 13.0]
+        macos_dev_target: [12.1, 13.0]
         include:
-          #- macos_dev_target: 12.1
-          #  os: macos-12
-          #  arch: x86_64
-          #  python-arch: x64
-          #  test_key: mac12
+          - macos_dev_target: 12.1
+            os: macos-13
+            arch: x86_64
+            python-arch: x64
+            test_key: mac12
           - macos_dev_target: 13.0
             os: macos-14
             arch: arm64

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Setup QtIFW 4.x
       uses: jmarrec/setup-qtifw@v1
       with:
-        qtifw-version: '4.6.1'
+        qtifw-version: '4.8.1'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ env.Python_REQUIRED_VERSION }}
-      uses: jmarrec/setup-python@v5
+      uses: jmarrec/setup-python@v5.4.0
       id: setup-python
       with:
         python-version: ${{ env.Python_REQUIRED_VERSION }}

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 env:
   CMAKE_Fortran_COMPILER: "/c/msys64/mingw64/bin/x86_64-w64-mingw32-gfortran.exe"

--- a/cmake/PythonFixUpTclTk.py
+++ b/cmake/PythonFixUpTclTk.py
@@ -63,9 +63,9 @@ import os
 import stat
 
 
-def locate_tk_so(_python_dir: Path) -> Path:
-    print(f"Searching for _tkinter so in {_python_dir}")
-    sos = list(_python_dir.glob("lib-dynload/_tkinter*.so"))
+def locate_tk_so(python_dir: Path) -> Path:
+    print(f"Searching for _tkinter so in {python_dir}")
+    sos = list(python_dir.glob("lib-dynload/_tkinter*.so"))
     assert len(sos) == 1, "Unable to locate _tkinter so"
     return sos[0]
 
@@ -140,9 +140,6 @@ if __name__ == "__main__":
         )
         # Change the id that's the first line of the otool -L in this case and it's confusing
         subprocess.check_output(["install_name_tool", "-id", str(new_tcl_tk_so.name), str(new_tcl_tk_so)])
-
-    # as a very quick test, I wonder what happens if we just let it continue without this dep...I'll force fail the workflow as a reminder
-    sys.exit(0)
 
     if any_missing:
         sys.exit(1)

--- a/cmake/PythonFixUpTclTk.py
+++ b/cmake/PythonFixUpTclTk.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
             assert new_tcl_tk_so.is_file(), f"{new_tcl_tk_so} missing when the tkinter so is already adjusted. Wipe the dir"
             print("Already fixed up the libtcl and libtk, nothing to do here")
             continue
-        if not tcl_tk_so.exists():
+        elif not str(tcl_tk_so).startswith('@') and not tcl_tk_so.exists():
             print(f"Hmmm... could not find the dependency shared object at {tcl_tk_so}; script will continue but fail")
             any_missing = True
             continue

--- a/scripts/package_tests/runner.py
+++ b/scripts/package_tests/runner.py
@@ -89,6 +89,12 @@ CONFIGURATIONS = {
     'ubuntu2404': {
         'os': OS.Linux, 'bitness': 'x64', 'asset_pattern': 'Linux-Ubuntu24.04-x86_64.tar.gz', 'os_version': '24.04'
     },
+    'ubuntu2204-arm64': {
+        'os': OS.Linux, 'bitness': 'arm64', 'asset_pattern': 'Linux-Ubuntu22.04-arm64.tar.gz', 'os_version': '22.04'
+    },
+    'ubuntu2404-arm64': {
+        'os': OS.Linux, 'bitness': 'arm64', 'asset_pattern': 'Linux-Ubuntu24.04-arm64.tar.gz', 'os_version': '24.04'
+    },
     'mac11': {
         'os': OS.Mac, 'bitness': 'x64', 'asset_pattern': 'Darwin-macOS11.6-x86_64.tar.gz', 'os_version': '11.6'
     },


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #10952 
- Fixes #10953

### Description of the purpose of this PR

* I updated by jmarrec/python-versions repo
    * rebased onto main
    * adding runners for the new ubuntu-2x.04-arm GHA hosted runners that are now in public preview
    * couple of tweaks to make the mac python be built specifically against `brew --prefix tcl-tk@8` (important the `@8` here),  
        * On mac, homebrew uses tcl-tk 9 now, which is NOT backward compat
        * The old python binaries were linking to `brew --prefix tcl-tk`, which used to be tcl tk 8.6, but now is 9. So it goes awfully.
        * The GHA team "fixed" it by adding a force symlink from brew --prefix tcl-tk@8 to /usr/local/lib/libtcl8.6.dylib. On mac arm64, brew --prefix is NOT /usr/local, but /opt/homebrew, so it can't work for us
            * https://github.com/actions/runner-images/issues/11074 
     *  https://github.com/jmarrec/python-versions/releases/tag/3.12.2-13521204118
     * https://github.com/jmarrec/python-versions/pull/4
* In jmarrec/setup-python  (the action), I created a tag v5.4.0 that points to that new release of python 3.12.2. I might update v5 tag to point to that v5.4.0, but haven't done it yet
* Added ubuntu 22.04 and 24.04 arm64 runners
* I had to update my jmarrec/setup-qtifw action to handle the arm64 lin,ux dependencies that were missing
     * https://github.com/jmarrec/setup-qtifw/releases/tag/v1.3.0 
* Reverted some of the shenanigans @Myoldmopar had to do to release IOFreeze


Test release on my fork at https://github.com/jmarrec/EnergyPlus/releases/tag/v25.1.0-IOFreeze-Ubuntu-arm64-macfixup

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
