### PR TITLE
assertion failure in VRF low load calculation solving for Te

### DIFF
--- a/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
+++ b/src/EnergyPlus/HVACVariableRefrigerantFlow.cc
@@ -13965,10 +13965,18 @@ void VRFCondenserEquipment::VRFOU_CalcCompC(EnergyPlusData &state,
                     ShowContinueErrorTimeStamp(state, "");
                     ShowContinueError(state, format("  Iteration limit [{}] exceeded in calculating OU evaporating temperature", MaxIter));
                 } else if (SolFla == -2) {
-                    // demand < capacity at both endpoints of the Te range, assuming f(x) is roughly monotonic than this is the low load case
-                    assert(f(T_suction) < 0);
-                    // TeTol is added to prevent the final updated Te to go out of bounds
-                    SmallLoadTe = 6 + TeTol; // MinOutdoorUnitTe; //SmallLoadTe( Te'_new ) is constant during iterations
+                    if (f(T_suction) < 0) {
+                        // demand < capacity at both endpoints of the Te range, assuming f(x) is roughly monotonic than this is the low load case
+                        // TeTol is added to prevent the final updated Te to go out of bounds
+                        SmallLoadTe = 6 + TeTol; // MinOutdoorUnitTe; //SmallLoadTe( Te'_new ) is constant during iterations
+                    } else {
+                        // demand > capacity at both endpoints of the Te range, take the end point x where f(x) is closer to zero
+                        if (f(MinOutdoorUnitTe) > f(T_suction)) { // f(T_suction > 0, not equal as SolFla will not be -2
+                            SmallLoadTe = T_suction;
+                        } else {
+                            SmallLoadTe = MinOutdoorUnitTe;
+                        }
+                    }
                 }
 
                 // Get an updated Te corresponding to the updated Te'


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes the assertion failure

The issue of assertion failure here https://github.com/NREL/EnergyPlus/blob/92df2f38cc3c4094086806b9724ae5b1e19e144e/src/EnergyPlus/HVACVariableRefrigerantFlow.cc#L13969
This might arise from the recent update in the refrigerant flow rate lower bound. Refrigerant flow rate is related to the `C_cap_operation` calculation, see PR #10752. 

This assertion should be a if statement as there could be two different cases where `SolFla = -2`: 1) f(xmin) < 0 and f(xmax) < 0, 2) f(xmin) > 0 and f(xmax) > 0. This PR adds handling of case 2): if argmin(f(xmin), f(xmax)), i.e. take the x value with f(x) closer to 0. The handling of case 1) is inherited from before.

<!-- NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE -->

### Description of the purpose of this PR

<!-- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
