### PR TITLE
Fix #11026 - Bad thermostat control type value results in crash due to null schedule pointer

### DIFF
--- a/src/EnergyPlus/DataHVACGlobals.hh
+++ b/src/EnergyPlus/DataHVACGlobals.hh
@@ -120,7 +120,7 @@ namespace HVAC {
         Num
     };
 
-    static constexpr std::array<SetptType, (int)SetptType::Num> setptTypes = {
+    static constexpr std::array<SetptType, 4> controlledSetptTypes = {
         SetptType::SingleHeat, SetptType::SingleCool, SetptType::SingleHeatCool, SetptType::DualHeatCool};
 
     static constexpr std::array<std::string_view, (int)SetptType::Num> setptTypeNames = {

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -719,7 +719,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
 
             if (!setpt.isUsed) {
                 // Catch early issues
-                if (tempZone.setptTypeSched->hasVal(state, (int)setptType)) {
+                if (setptType != HVAC::SetptType::Uncontrolled && tempZone.setptTypeSched->hasVal(state, (int)setptType)) {
                     ShowSevereError(state, format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
                     ShowContinueError(
                         state,

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -673,7 +673,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
     for (TempControlledZoneNum = 1; TempControlledZoneNum <= state.dataZoneCtrls->NumTempControlledZones; ++TempControlledZoneNum) {
         auto &tempZone = state.dataZoneCtrls->TempControlledZone(TempControlledZoneNum);
 
-        for (HVAC::SetptType setptType : HVAC::setptTypes) {
+        for (HVAC::SetptType setptType : HVAC::controlledSetptTypes) {
             auto &setpt = tempZone.setpts[(int)setptType];
             if (!setpt.isUsed) {
                 continue;
@@ -714,12 +714,12 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
             CTSchedMapToControlledZone(TempControlledZoneNum) = tempZone.setptTypeSched->Num;
         }
 
-        for (HVAC::SetptType setptType : HVAC::setptTypes) {
+        for (HVAC::SetptType setptType : HVAC::controlledSetptTypes) {
             auto const &setpt = tempZone.setpts[(int)setptType];
 
             if (!setpt.isUsed) {
                 // Catch early issues
-                if (setptType != HVAC::SetptType::Uncontrolled && tempZone.setptTypeSched->hasVal(state, (int)setptType)) {
+                if (tempZone.setptTypeSched->hasVal(state, (int)setptType)) {
                     ShowSevereError(state, format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
                     ShowContinueError(
                         state,
@@ -767,7 +767,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
             continue; // error caught elsewhere -- would just be confusing here
         }
 
-        for (HVAC::SetptType setptType : HVAC::setptTypes) {
+        for (HVAC::SetptType setptType : HVAC::controlledSetptTypes) {
             if (TStatControlTypes(TempControlledZoneNum).MustHave[(int)setptType] &&
                 TStatControlTypes(TempControlledZoneNum).DidHave[(int)setptType]) {
                 continue;
@@ -1318,7 +1318,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
 
         auto &comfortZone = state.dataZoneCtrls->ComfortControlledZone(ComfortControlledZoneNum);
 
-        for (HVAC::SetptType setptType : HVAC::setptTypes) {
+        for (HVAC::SetptType setptType : HVAC::controlledSetptTypes) {
             auto &setpt = comfortZone.setpts[(int)setptType];
             if (!setpt.isUsed) {
                 continue;
@@ -1361,7 +1361,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
             CCmSchedMapToControlledZone(ComfortControlledZoneNum) = comfortZone.setptTypeSched->Num;
         }
 
-        for (HVAC::SetptType setptType : HVAC::setptTypes) {
+        for (HVAC::SetptType setptType : HVAC::controlledSetptTypes) {
             auto const &setpt = comfortZone.setpts[(int)setptType];
             if (!setpt.isUsed) {
                 continue;
@@ -1405,7 +1405,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
             continue;
         }
 
-        for (HVAC::SetptType setptType : HVAC::setptTypes) {
+        for (HVAC::SetptType setptType : HVAC::controlledSetptTypes) {
             if (TComfortControlTypes(ComfortControlledZoneNum).MustHave[(int)setptType] &&
                 TComfortControlTypes(ComfortControlledZoneNum).DidHave[(int)setptType]) {
                 continue;
@@ -6638,7 +6638,7 @@ void FillPredefinedTableOnThermostatSchedules(EnergyPlusData &state)
 
         std::vector<ControlTypeInfo> infos;
         infos.resize((int)HVAC::SetptType::Num);
-        for (HVAC::SetptType setptType : HVAC::setptTypes) {
+        for (HVAC::SetptType setptType : HVAC::controlledSetptTypes) {
             auto &setpt = tcz.setpts[(int)setptType];
 
             auto &info = infos[(int)setptType];

--- a/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
@@ -1150,7 +1150,18 @@ TEST_F(EnergyPlusFixture, ZoneTempPredictorCorrector_WrongControlTypeSchedule)
     ASSERT_FALSE(ErrorsFound);
 
     EXPECT_THROW(GetZoneAirSetPoints(*state), EnergyPlus::FatalError);
-    std::string const error_string = delimited_string({""});
+    std::string const error_string = delimited_string({
+        "   ** Severe  ** Control Type Schedule=SINGLE HEATING CONTROL TYPE SCHED",
+        "   **   ~~~   ** ..specifies 1 (ThermostatSetpoint:SingleHeating) as the control type. Not valid for this zone.",
+        "   **   ~~~   ** ..reference ZoneControl:Thermostat=ZONE1 THERMOSTAT",
+        "   **   ~~~   ** ..reference ZONE=ZONE1",
+        "   ** Severe  ** GetStagedDualSetpoint: Errors with invalid names in ZoneControl:Thermostat:StagedDualSetpoint objects.",
+        "   **   ~~~   ** ...These will not be read in.  Other errors may occur.",
+        "   **  Fatal  ** Errors getting Zone Control input data.  Preceding condition(s) cause termination.",
+        "   ...Summary of Errors that led to program termination:",
+        "   ..... Reference severe error count=2",
+        "   ..... Last severe error=GetStagedDualSetpoint: Errors with invalid names in ZoneControl:Thermostat:StagedDualSetpoint objects.",
+    });
     EXPECT_TRUE(compare_err_stream(error_string, true));
     // Avoid calling InitZoneAirSetPoints(*state); but still initialize needed arrays
     state->dataHeatBalFanSys->TempControlType.allocate(1);

--- a/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
@@ -1298,6 +1298,7 @@ TEST_F(EnergyPlusFixture, SetPointWithCutoutDeltaT_test)
     auto *coolSetptSched = Sched::AddScheduleConstant(*state, "COOL SETPT-1");
 
     state->dataZoneCtrls->TempControlledZone(1).setpts[(int)HVAC::SetptType::SingleHeat].heatSetptSched = heatSetptSched;
+    state->dataZoneCtrls->TempControlledZone(1).setpts[(int)HVAC::SetptType::SingleHeat].isUsed = true;
     state->dataZoneTempPredictorCorrector->tempSetptScheds[(int)HVAC::SetptType::SingleHeat].allocate(1);
     state->dataZoneTempPredictorCorrector->tempSetptScheds[(int)HVAC::SetptType::SingleHeat](1).heatSched = heatSetptSched;
     heatSetptSched->currentVal = 22.0;
@@ -1431,6 +1432,7 @@ TEST_F(EnergyPlusFixture, TempAtPrevTimeStepWithCutoutDeltaT_test)
     state->dataHeatBalFanSys->TempControlType.allocate(1);
     state->dataHeatBalFanSys->TempControlTypeRpt.allocate(1);
     state->dataZoneCtrls->TempControlledZone(1).setpts[(int)HVAC::SetptType::SingleHeat].heatSetptSched = heatSetptSched;
+    state->dataZoneCtrls->TempControlledZone(1).setpts[(int)HVAC::SetptType::SingleHeat].isUsed = true;
     state->dataZoneTempPredictorCorrector->tempSetptScheds[(int)HVAC::SetptType::SingleHeat].allocate(1);
     state->dataZoneTempPredictorCorrector->tempSetptScheds[(int)HVAC::SetptType::SingleHeat](1).heatSched = heatSetptSched;
     heatSetptSched->currentVal = 22.0;

--- a/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
+++ b/tst/EnergyPlus/unit/ZoneTempPredictorCorrector.unit.cc
@@ -1163,12 +1163,6 @@ TEST_F(EnergyPlusFixture, ZoneTempPredictorCorrector_WrongControlTypeSchedule)
         "   ..... Last severe error=GetStagedDualSetpoint: Errors with invalid names in ZoneControl:Thermostat:StagedDualSetpoint objects.",
     });
     EXPECT_TRUE(compare_err_stream(error_string, true));
-    // Avoid calling InitZoneAirSetPoints(*state); but still initialize needed arrays
-    state->dataHeatBalFanSys->TempControlType.allocate(1);
-    state->dataHeatBalFanSys->TempControlTypeRpt.allocate(1);
-    state->dataHeatBalFanSys->zoneTstatSetpts.allocate(1);
-
-    CalcZoneAirTempSetPoints(*state);
 }
 
 TEST_F(EnergyPlusFixture, temperatureAndCountInSch_test)


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11026

### Description of the purpose of this PR

This PR reverts to the 24.2.0 functionality which catches these errors during the GetInput (GetZoneAirSetPoints).

* Related #10848 

The Defect file, when run with this PR will no longer segfault, but will Fatal out as expected, as was done in 24.2.0

```
   ** Warning ** processZoneEquipmentInput: ZoneHVAC:EquipmentList = LIVING_EQUIPMENT
   **   ~~~   ** ...zero assigned to Zone Equipment Heating or No-Load Sequence=1, apparent gap in sequence assignments in this equipment list.
   ** Severe  ** Control Type Schedule=ALWAYS_ON
   **   ~~~   ** ..specifies 1 (ThermostatSetpoint:SingleHeating) as the control type. Not valid for this zone.
   **   ~~~   ** ..reference ZoneControl:Thermostat=THERMOSTAT_LIVING
   **   ~~~   ** ..reference ZONE=LIVING
   ** Severe  ** GetStagedDualSetpoint: Errors with invalid names in ZoneControl:Thermostat:StagedDualSetpoint objects.
   **   ~~~   ** ...These will not be read in.  Other errors may occur.
   **  Fatal  ** Errors getting Zone Control input data.  Preceding condition(s) cause termination.
```

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [x] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [x] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [x] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [x] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [x] If structural output changes, add to output rules file and add OutputChange label
 - [x] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
