### PR TITLE
Correction of Error Message in EcoRoof when User Does Not Use CTF Solution Algorithm

### DIFF
--- a/src/EnergyPlus/EcoRoofManager.cc
+++ b/src/EnergyPlus/EcoRoofManager.cc
@@ -528,6 +528,11 @@ namespace EcoRoofManager {
             ShowSevereError(state,
                             "initEcoRoofFirstTime: EcoRoof simulation but HeatBalanceAlgorithm is not ConductionTransferFunction(CTF). EcoRoof model "
                             "currently works only with CTF heat balance solution algorithm.");
+            ShowContinueError(state, format("Occurs for surface named {}", state.dataSurface->Surface(SurfNum).Name));
+            ShowContinueError(state, "Check input syntax for HeatBalanceAlgorithm, SurfaceProperty:HeatTransferAlgorithm,");
+            ShowContinueError(state, "SurfaceProperty:HeatTransferAlgorithm:MultipleSurface, and SurfaceProperty:HeatTransferAlgorithm:SurfaceList ");
+            ShowContinueError(state, "to verify that the solution method is set to CTF for the surface that is an EcoRoof.");
+            ShowFatalError(state, "initEcoRoofFirstTime: Program terminates due to preceding conditions.");
         }
 
         // ONLY READ ECOROOF PROPERTIES IN THE FIRST TIME


### PR DESCRIPTION
In order to run an EcoRoof simulation, the user must run a CTF based solution for the surface(s) that is/are green roof(s) or EcoRoof(s).  Currently, E+ provides a severe error when the user requests an EcoRoof simulation but does not use the CTF solution algorithm.  However, after an error message is produced, the simulation continues on.  The improvement here is that now E+ will fatal out.  In addition, more details are provided to the user as part of the error message that reminds the user of what syntax changes the solution procedure including for surfaces and also point to the surface that has a problem.  Unit tests also verify that the solution must be CTF or an error will be produced.

Pull request overview
---------------------

- Fixes #10871 

### Description of the purpose of this PR

This PR provides the fix and unit test to solve the defect with E+ where the solution continues when an EcoRoof is defined and the surface does NOT use the CTF solution algorithm.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [x] Perform a Code Review on GitHub
 - [x] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [x] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [x] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
