### PR TITLE
Correction of Error in Xing Ground Temperature Model Get Input

### DIFF
--- a/src/EnergyPlus/GroundTemperatureModeling/XingGroundTemperatureModel.cc
+++ b/src/EnergyPlus/GroundTemperatureModeling/XingGroundTemperatureModel.cc
@@ -85,6 +85,9 @@ namespace GroundTemp {
         std::string_view const cCurrentModuleObject = GroundTemp::modelTypeNamesUC[(int)modelType];
         const int numCurrModels = state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, cCurrentModuleObject);
 
+        thisModel->modelType = modelType;
+        thisModel->Name = objectName;
+
         for (int modelNum = 1; modelNum <= numCurrModels; ++modelNum) {
 
             state.dataInputProcessing->inputProcessor->getObjectItem(state,
@@ -96,11 +99,8 @@ namespace GroundTemp {
                                                                      NumNums,
                                                                      IOStat);
 
-            if (objectName == state.dataIPShortCut->cAlphaArgs(1)) {
-                // Read input into object here
-
-                thisModel->Name = state.dataIPShortCut->cAlphaArgs(1);
-                thisModel->modelType = modelType;
+            if (thisModel->Name == state.dataIPShortCut->cAlphaArgs(1)) {
+                // Read remaining input into object here
                 thisModel->groundThermalDiffusivity = state.dataIPShortCut->rNumericArgs(1) /
                                                       (state.dataIPShortCut->rNumericArgs(2) * state.dataIPShortCut->rNumericArgs(3)) *
                                                       Constant::rSecsInDay;

--- a/tst/EnergyPlus/unit/XingGroundTemperatureModel.unit.cc
+++ b/tst/EnergyPlus/unit/XingGroundTemperatureModel.unit.cc
@@ -89,3 +89,45 @@ TEST_F(EnergyPlusFixture, XingGroundTempsModelTest)
 
     EXPECT_NEAR(11.1, thisModel->getGroundTempAtTimeInMonths(*state, 100.0, 1), 0.1); // January--deep
 }
+
+TEST_F(EnergyPlusFixture, XingGroundTempsGetInputTest)
+{
+    Real64 constexpr closeEnough = 0.00001;
+
+    std::string const idf_objects = delimited_string({
+        "Site:GroundTemperature:Undisturbed:Xing,",
+        "    Test1,   !- Name of object",
+        "    1.0,     !- Soil Thermal Conductivity {W/m-K}",
+        "    1000.0,  !- Soil Density {kg/m3}",
+        "    2500,    !- Soil Specific Heat {J/kg-K}",
+        "    10.0,    !- Average Soil Surface Temperature {C}",
+        "    12.0,    !- Soil Surface Temperature Amplitude 1 {deltaC}",
+        "    1.0,     !- Soil Surface Temperature Amplitude 2 {deltaC}",
+        "    25,      !- Phase Shift of Temperature Amplitude 1 {days}",
+        "    30;      !- Phase Shift of Temperature Amplitude 2 {days}",
+        "",
+        "Site:GroundTemperature:Undisturbed:Xing,",
+        "    Test2,   !- Name of object",
+        "    2.0,     !- Soil Thermal Conductivity {W/m-K}",
+        "    1200,    !- Soil Density {kg/m3}",
+        "    2400,    !- Soil Specific Heat {J/kg-K}",
+        "    11.1,    !- Average Soil Surface Temperature {C}",
+        "    22.2,    !- Soil Surface Temperature Amplitude 1 {deltaC}",
+        "    2.5,     !- Soil Surface Temperature Amplitude 2 {deltaC}",
+        "    20,      !- Phase Shift of Temperature Amplitude 1 {days}",
+        "    40;      !- Phase Shift of Temperature Amplitude 2 {days}",
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+
+    // Tests to verify fix for Defect #10981 (overwrote the name of the object which resulted in a fatal error
+    // Test 1: First object instance--make sure name and model type are read in correctly
+    auto *thisModel1 = GroundTemp::GetGroundTempModelAndInit(*state, GroundTemp::ModelType::Xing, "TEST1");
+    EXPECT_EQ(thisModel1->Name, "TEST1");
+    EXPECT_EQ(thisModel1->modelType, GroundTemp::ModelType::Xing);
+
+    // Test 2: Second object instance--another test to make sure name and model type are read in correctly
+    auto *thisModel2 = GroundTemp::GetGroundTempModelAndInit(*state, GroundTemp::ModelType::Xing, "TEST2");
+    EXPECT_EQ(thisModel2->Name, "TEST2");
+    EXPECT_EQ(thisModel2->modelType, GroundTemp::ModelType::Xing);
+}


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #10981

For some reason, when the get input routine for the Xing model was executed, the variable objectName was being overwritten and turned into a blank field when GetObjectItem was called.  The solution was to follow the method used by another ground temperature get routines which included moving the assignments for the base class to before the call to GetObjectItem.  The unit test shows that the name and model type are preserved and no fatal error happens.  Testing with the user example file no longer crashes but successfully completes.

### Description of the purpose of this PR

This PR fixes the issue (user file now runs successfully) and includes a unit test.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
