### PR TITLE
Throw Fatal Error When a Required Node is Missing in HVAC Mixer and Splitter

### DIFF
--- a/src/EnergyPlus/AirLoopHVACDOAS.cc
+++ b/src/EnergyPlus/AirLoopHVACDOAS.cc
@@ -268,7 +268,7 @@ namespace AirLoopHVACDOAS {
                 }
 
                 state.dataAirLoopHVACDOAS->airloopMixer.push_back(thisMixer);
-                
+
                 if (thisMixer.numOfInletNodes < 1) { // No inlet nodes specified--this is not possible
                     ShowSevereError(state, format("{}, \"{}\" does not have any inlet nodes.", cCurrentModuleObject, thisMixer.name));
                     ShowContinueError(state, "All mixers must have at least one inlet node.");
@@ -438,7 +438,7 @@ namespace AirLoopHVACDOAS {
                 }
 
                 state.dataAirLoopHVACDOAS->airloopSplitter.push_back(thisSplitter);
-                
+
                 if (thisSplitter.numOfOutletNodes < 1) { // No outlet nodes specified--this is not possible
                     ShowSevereError(state, format("{}, \"{}\" does not have any outlet nodes.", cCurrentModuleObject, thisSplitter.name));
                     ShowContinueError(state, "All splitters must have at least one outlet node.");

--- a/src/EnergyPlus/AirLoopHVACDOAS.cc
+++ b/src/EnergyPlus/AirLoopHVACDOAS.cc
@@ -268,6 +268,12 @@ namespace AirLoopHVACDOAS {
                 }
 
                 state.dataAirLoopHVACDOAS->airloopMixer.push_back(thisMixer);
+                
+                if (thisMixer.numOfInletNodes < 1) { // No inlet nodes specified--this is not possible
+                    ShowSevereError(state, format("{}, \"{}\" does not have any inlet nodes.", cCurrentModuleObject, thisMixer.name));
+                    ShowContinueError(state, "All mixers must have at least one inlet node.");
+                    errorsFound = true;
+                }
             }
             if (errorsFound) {
                 ShowFatalError(state, "getAirLoopMixer: Previous errors cause termination.");
@@ -432,6 +438,12 @@ namespace AirLoopHVACDOAS {
                 }
 
                 state.dataAirLoopHVACDOAS->airloopSplitter.push_back(thisSplitter);
+                
+                if (thisSplitter.numOfOutletNodes < 1) { // No outlet nodes specified--this is not possible
+                    ShowSevereError(state, format("{}, \"{}\" does not have any outlet nodes.", cCurrentModuleObject, thisSplitter.name));
+                    ShowContinueError(state, "All splitters must have at least one outlet node.");
+                    errorsFound = true;
+                }
             }
             if (errorsFound) {
                 ShowFatalError(state, "getAirLoopSplitter: Previous errors cause termination.");

--- a/src/EnergyPlus/ElectricPowerServiceManager.cc
+++ b/src/EnergyPlus/ElectricPowerServiceManager.cc
@@ -4219,7 +4219,7 @@ void ElectricStorage::simulateLiIonNmcBatteryModel(EnergyPlusData &state,
     }
 
 #ifdef DEBUG_ARITHM_GCC_OR_CLANG
-    hqfeenableexcept(old_excepts);
+    feenableexcept(old_excepts);
 #endif
 
 #ifdef DEBUG_ARITHM_MSVC

--- a/src/EnergyPlus/ElectricPowerServiceManager.cc
+++ b/src/EnergyPlus/ElectricPowerServiceManager.cc
@@ -4130,7 +4130,7 @@ void ElectricStorage::simulateLiIonNmcBatteryModel(EnergyPlusData &state,
 
 // Disable floating point exceptions around SSC battery calculations, which uses quiet_NaN in particular
 #ifdef DEBUG_ARITHM_GCC_OR_CLANG
-    //int old_excepts = fegetexcept();
+    int old_excepts = fegetexcept();
     fedisableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
 #endif
 
@@ -4219,7 +4219,7 @@ void ElectricStorage::simulateLiIonNmcBatteryModel(EnergyPlusData &state,
     }
 
 #ifdef DEBUG_ARITHM_GCC_OR_CLANG
-    //hqfeenableexcept(old_excepts);
+    hqfeenableexcept(old_excepts);
 #endif
 
 #ifdef DEBUG_ARITHM_MSVC

--- a/src/EnergyPlus/ElectricPowerServiceManager.cc
+++ b/src/EnergyPlus/ElectricPowerServiceManager.cc
@@ -4130,7 +4130,7 @@ void ElectricStorage::simulateLiIonNmcBatteryModel(EnergyPlusData &state,
 
 // Disable floating point exceptions around SSC battery calculations, which uses quiet_NaN in particular
 #ifdef DEBUG_ARITHM_GCC_OR_CLANG
-    int old_excepts = fegetexcept();
+    //int old_excepts = fegetexcept();
     fedisableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
 #endif
 
@@ -4219,7 +4219,7 @@ void ElectricStorage::simulateLiIonNmcBatteryModel(EnergyPlusData &state,
     }
 
 #ifdef DEBUG_ARITHM_GCC_OR_CLANG
-    feenableexcept(old_excepts);
+    //hqfeenableexcept(old_excepts);
 #endif
 
 #ifdef DEBUG_ARITHM_MSVC

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -1061,12 +1061,6 @@ void GetOutsideAirSysInputs(EnergyPlusData &state)
                                 format("{} = \"{}\" invalid {}=\"{}\" not found.", CurrentModuleObject, AlphArray(1), cAlphaFields(2), AlphArray(2)));
                 ErrorsFound = true;
             }
-        } else {
-            if (state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, "AirLoopHVAC:DedicatedOutdoorAirSystem") == 0) {
-                ShowSevereError(state,
-                                format("{} = \"{}\" invalid {} is blank and must be entered.", CurrentModuleObject, AlphArray(1), cAlphaFields(2)));
-                ErrorsFound = true;
-            }
         }
         OASys.ControllerListNum = ListNum;
         OASys.NumSimpleControllers = NumSimpControllers;

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -1066,12 +1066,6 @@ void GetOutsideAirSysInputs(EnergyPlusData &state)
                 ShowSevereError(state,
                                 format("{} = \"{}\" invalid {} is blank and must be entered.", CurrentModuleObject, AlphArray(1), cAlphaFields(2)));
                 ErrorsFound = true;
-            } else {
-                ShowWarningError(state,
-                                 format("{} = \"{}\": blank {} must be used with AirLoopHVAC:DedicatedOutdoorAirSystem.",
-                                        CurrentModuleObject,
-                                        AlphArray(1),
-                                        cAlphaFields(2)));
             }
         }
         OASys.ControllerListNum = ListNum;

--- a/tst/EnergyPlus/unit/AirLoopHVACDOAS.unit.cc
+++ b/tst/EnergyPlus/unit/AirLoopHVACDOAS.unit.cc
@@ -11691,4 +11691,71 @@ TEST_F(EnergyPlusFixture, AirLoopHVACDOAS_TestFanDrawThroughPlacement)
     EXPECT_EQ(thisAirLoopDOASObjec.m_CompPointerAirLoopMixer->InletNodeNum[0], 18);
 }
 
+TEST_F(EnergyPlusFixture, AirLoopHVACDOAS_TestMixerSplitterMissingNodes)
+{
+    // Test of Fix for Defect #10815
+    std::string const idf_objects = delimited_string({
+        " AirLoopHVAC:Mixer,",
+        "  DOAS loop Mixer Correct,         !- Name",
+        "  MixerOutletNode1,         !- Outlet Node Name",
+        "  MixerInletNode1;  !- Inlet 1 Node Name",
+
+        " AirLoopHVAC:Mixer,",
+        "  DOAS loop Mixer Wrong,         !- Name",
+        "  MixerOutletNode2         !- Outlet Node Name",
+        "  MixerInletNode2;  !- Inlet 1 Node Name",
+
+        " AirLoopHVAC:Splitter,",
+        "  DOAS loop Splitter Correct,      !- Name",
+        "  SplitterInletNode1,       !- Inlet Node Name",
+        "  SplitterOutletNode1;  !- Outlet 1 Node Name",
+
+        " AirLoopHVAC:Splitter,",
+        "  DOAS loop Splitter Wrong,      !- Name",
+        "  SplitterInletNode2       !- Inlet Node Name",
+        "  SplitterOutletNode2;  !- Outlet 1 Node Name",
+
+        " NodeList,",
+        "  All The Nodes,  !- Name",
+        "  MixerInletNode1,  !- Node 1 Name",
+        "  MixerInletNode2,  !- Node 2 Name",
+        "  MixerOutletNode1,  !- Node 3 Name",
+        "  MixerOutletNode2,  !- Node 4 Name",
+        "  SplitterInletNode1,  !- Node 1 Name",
+        "  SplitterInletNode2,  !- Node 2 Name",
+        "  SplitterOutletNode1,  !- Node 3 Name",
+        "  SplitterOutletNode2;  !- Node 4 Name",
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+
+    state->init_state(*state);
+
+    // Test 1: Mixer Test--first one is correct, second one generates the severe/fatal that was added as part of this fix
+    ASSERT_THROW(AirLoopHVACDOAS::AirLoopMixer::getAirLoopMixer(*state), std::runtime_error);
+
+    std::string const error_stringMix = delimited_string({
+        "   ** Severe  ** AirLoopHVAC:Mixer, \"DOAS LOOP MIXER WRONG\" does not have any inlet nodes.",
+        "   **   ~~~   ** All mixers must have at least one inlet node.",
+        "   **  Fatal  ** getAirLoopMixer: Previous errors cause termination.",
+        "   ...Summary of Errors that led to program termination:",
+        "   ..... Reference severe error count=1",
+        "   ..... Last severe error=AirLoopHVAC:Mixer, \"DOAS LOOP MIXER WRONG\" does not have any inlet nodes.",
+    });
+    EXPECT_TRUE(compare_err_stream(error_stringMix, true));
+
+    // Test 2: Splitter Test--first one is correct, second one generates the severe/fatal that was added as part of this fix
+    ASSERT_THROW(AirLoopHVACDOAS::AirLoopSplitter::getAirLoopSplitter(*state), std::runtime_error);
+
+    std::string const error_stringSplit = delimited_string({
+        "   ** Severe  ** AirLoopHVAC:Splitter, \"DOAS LOOP SPLITTER WRONG\" does not have any outlet nodes.",
+        "   **   ~~~   ** All splitters must have at least one outlet node.",
+        "   **  Fatal  ** getAirLoopSplitter: Previous errors cause termination.",
+        "   ...Summary of Errors that led to program termination:",
+        "   ..... Reference severe error count=2",
+        "   ..... Last severe error=AirLoopHVAC:Splitter, \"DOAS LOOP SPLITTER WRONG\" does not have any outlet nodes.",
+    });
+    EXPECT_TRUE(compare_err_stream(error_stringSplit, true));
+}
+
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #10815 

### Description of the purpose of this PR

In an IDF created by a user, there was a comma missing after the outlet node of an AirLoopHVAC:Mixer.  When this was parsed, it meant that the first and only inlet node was not read in.  This led to a hard crash of EnergyPlus.  This PR fixes the problem so that when no inlet nodes are detected the program produces a severe/fatal with error messages that point to the location of the issue.  A similar fix was made to the AirLoopHVAC:Splitter to avoid potential issues with that device.  Both were tested with EnergyPlus and produce the severe/fatal when an IDF has a missing comma after the single required outlet (Mixer) or inlet (Splitter) node.  A unit test testing the new code is also included.

### Pull Request Author

 - [X ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [x] Perform a Code Review on GitHub
 - [x] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [x] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [x] CI status: all green or justified
 - [x] Check that performance is not impacted (CI Linux results include performance check)
 - [x] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
