### PR TITLE
Correct Time Stamp Reported in EDD

### DIFF
--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -780,8 +780,8 @@ std::string CreateSysTimeIntervalString(EnergyPlusData &state)
     //  ActualTimeS=INT(CurrentTime)+(SysTimeElapsed+(CurrentTime - INT(CurrentTime)))
     // CR6902  ActualTimeS=INT(CurrentTime-TimeStepZone)+SysTimeElapsed
     // [DC] TODO: Improve display accuracy up to fractional seconds using hh:mm:ss.0 format
-    Real64 ActualTimeS = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + SysTimeElapsed;
-    Real64 ActualTimeE = ActualTimeS + TimeStepSys;
+    Real64 ActualTimeE = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + SysTimeElapsed;
+    Real64 ActualTimeS = ActualTimeE - TimeStepSys;
     int ActualTimeHrS = int(ActualTimeS);
     //  ActualTimeHrE=INT(ActualTimeE)
     int ActualTimeMinS = nint((ActualTimeS - ActualTimeHrS) * FracToMin);

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -780,6 +780,12 @@ std::string CreateSysTimeIntervalString(EnergyPlusData &state)
     //  ActualTimeS=INT(CurrentTime)+(SysTimeElapsed+(CurrentTime - INT(CurrentTime)))
     // CR6902  ActualTimeS=INT(CurrentTime-TimeStepZone)+SysTimeElapsed
     // [DC] TODO: Improve display accuracy up to fractional seconds using hh:mm:ss.0 format
+
+    // NOTE: SysTimeElapsed is updated at the END of the HVAC time step (loop), so it's current value is
+    //       the end of the last HVAC time step not the end of the current HVAC time step.  The other
+    //       conditions below are for when we are in the zone heat balance (SysTimeElapsed = 0) or after
+    //       we have finished the last HVAC time step.
+
     Real64 ActualTimeS;
     Real64 ActualTimeE;
     Real64 constexpr toleranceTime = 0.0001; // less than 1 second (to avoid comparisons that are not exactly identical but are essentially the same

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -780,8 +780,16 @@ std::string CreateSysTimeIntervalString(EnergyPlusData &state)
     //  ActualTimeS=INT(CurrentTime)+(SysTimeElapsed+(CurrentTime - INT(CurrentTime)))
     // CR6902  ActualTimeS=INT(CurrentTime-TimeStepZone)+SysTimeElapsed
     // [DC] TODO: Improve display accuracy up to fractional seconds using hh:mm:ss.0 format
-    Real64 ActualTimeE = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + SysTimeElapsed;
-    Real64 ActualTimeS = ActualTimeE - TimeStepSys;
+    Real64 ActualTimeS;
+    Real64 ActualTimeE;
+    Real64 constexpr toleranceTime = 0.0001; // less than 1 second (to avoid comparisons that are not exactly identical but are essentially the same
+    if ((SysTimeElapsed == 0.0) || (abs(state.dataGlobal->TimeStepZone - SysTimeElapsed) <= toleranceTime)) {
+        ActualTimeE = state.dataGlobal->CurrentTime;
+        ActualTimeS = ActualTimeE - state.dataGlobal->TimeStepZone;
+    } else {
+        ActualTimeE = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + SysTimeElapsed;
+        ActualTimeS = ActualTimeE - TimeStepSys;
+    }
     int ActualTimeHrS = int(ActualTimeS);
     //  ActualTimeHrE=INT(ActualTimeE)
     int ActualTimeMinS = nint((ActualTimeS - ActualTimeHrS) * FracToMin);

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -783,12 +783,15 @@ std::string CreateSysTimeIntervalString(EnergyPlusData &state)
     Real64 ActualTimeS;
     Real64 ActualTimeE;
     Real64 constexpr toleranceTime = 0.0001; // less than 1 second (to avoid comparisons that are not exactly identical but are essentially the same
-    if ((SysTimeElapsed == 0.0) || (abs(state.dataGlobal->TimeStepZone - SysTimeElapsed) <= toleranceTime)) {
+    if (SysTimeElapsed == 0.0) {
         ActualTimeE = state.dataGlobal->CurrentTime;
         ActualTimeS = ActualTimeE - state.dataGlobal->TimeStepZone;
-    } else {
-        ActualTimeE = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + SysTimeElapsed;
+    } else if (abs(state.dataGlobal->TimeStepZone - SysTimeElapsed) <= toleranceTime) {
+        ActualTimeE = state.dataGlobal->CurrentTime;
         ActualTimeS = ActualTimeE - TimeStepSys;
+    } else {
+        ActualTimeS = state.dataGlobal->CurrentTime - state.dataGlobal->TimeStepZone + SysTimeElapsed;
+        ActualTimeE = ActualTimeS + TimeStepSys;
     }
     int ActualTimeHrS = int(ActualTimeS);
     //  ActualTimeHrE=INT(ActualTimeE)

--- a/src/EnergyPlus/General.cc
+++ b/src/EnergyPlus/General.cc
@@ -786,7 +786,7 @@ std::string CreateSysTimeIntervalString(EnergyPlusData &state)
     if (SysTimeElapsed == 0.0) {
         ActualTimeE = state.dataGlobal->CurrentTime;
         ActualTimeS = ActualTimeE - state.dataGlobal->TimeStepZone;
-    } else if (abs(state.dataGlobal->TimeStepZone - SysTimeElapsed) <= toleranceTime) {
+    } else if (std::abs(state.dataGlobal->TimeStepZone - SysTimeElapsed) <= toleranceTime) {
         ActualTimeE = state.dataGlobal->CurrentTime;
         ActualTimeS = ActualTimeE - TimeStepSys;
     } else {

--- a/tst/EnergyPlus/unit/General.unit.cc
+++ b/tst/EnergyPlus/unit/General.unit.cc
@@ -697,4 +697,44 @@ TEST_F(EnergyPlusFixture, General_findReportPeriodIdx)
     EXPECT_FALSE(reportPeriodFlags(1));
     EXPECT_FALSE(reportPeriodFlags(2));
 }
+
+TEST_F(EnergyPlusFixture, General_CreateSysTimeIntervalString_Test)
+{
+    // Unit test created as part of fix for Issue #10801
+    auto &dHVACG = state->dataHVACGlobal;
+    auto &dGlo = state->dataGlobal;
+    std::string resultingString;
+    std::string expectedString;
+
+    // Test 1: Middle of the day/middle of zone timestep (system time step less than zone timestep)
+    dHVACG->SysTimeElapsed = 0.10;
+    dHVACG->TimeStepSys = 0.05;
+    dGlo->CurrentTime = 10.6;
+    dGlo->TimeStepZone = 0.2;
+    expectedString = "10:27 - 10:30";
+
+    resultingString = CreateSysTimeIntervalString(*state);
+    EXPECT_EQ(resultingString, expectedString);
+
+    // Test 2: Beginning of the day/hour/timestep
+    dHVACG->SysTimeElapsed = 0.10;
+    dHVACG->TimeStepSys = 0.10;
+    dGlo->CurrentTime = 0.10;
+    dGlo->TimeStepZone = 0.10;
+    expectedString = "00:00 - 00:06";
+
+    resultingString = CreateSysTimeIntervalString(*state);
+    EXPECT_EQ(resultingString, expectedString);
+
+    // Test 3: End of the day/hour/timestep
+    dHVACG->SysTimeElapsed = 0.2;
+    dHVACG->TimeStepSys = 0.2;
+    dGlo->CurrentTime = 24.0;
+    dGlo->TimeStepZone = 0.2;
+    expectedString = "23:48 - 24:00";
+
+    resultingString = CreateSysTimeIntervalString(*state);
+    EXPECT_EQ(resultingString, expectedString);
+}
+
 } // namespace EnergyPlus

--- a/tst/EnergyPlus/unit/General.unit.cc
+++ b/tst/EnergyPlus/unit/General.unit.cc
@@ -706,6 +706,11 @@ TEST_F(EnergyPlusFixture, General_CreateSysTimeIntervalString_Test)
     std::string resultingString;
     std::string expectedString;
 
+    // NOTE: SysTimeElapsed is updated at the END of the HVAC time step (loop), so it's current value is
+    //       the end of the last HVAC time step not the end of the current HVAC time step.  The other
+    //       conditions below are for when we are in the zone heat balance (SysTimeElapsed = 0) or after
+    //       we have finished the last HVAC time step.
+
     // Test 1: Middle of the day/middle of zone timestep (system time step less than zone timestep)
     dHVACG->SysTimeElapsed = 0.10;
     dHVACG->TimeStepSys = 0.05;

--- a/tst/EnergyPlus/unit/General.unit.cc
+++ b/tst/EnergyPlus/unit/General.unit.cc
@@ -711,7 +711,7 @@ TEST_F(EnergyPlusFixture, General_CreateSysTimeIntervalString_Test)
     dHVACG->TimeStepSys = 0.05;
     dGlo->CurrentTime = 10.6;
     dGlo->TimeStepZone = 0.2;
-    expectedString = "10:27 - 10:30";
+    expectedString = "10:30 - 10:33";
 
     resultingString = CreateSysTimeIntervalString(*state);
     EXPECT_EQ(resultingString, expectedString);

--- a/tst/EnergyPlus/unit/General.unit.cc
+++ b/tst/EnergyPlus/unit/General.unit.cc
@@ -735,6 +735,16 @@ TEST_F(EnergyPlusFixture, General_CreateSysTimeIntervalString_Test)
 
     resultingString = CreateSysTimeIntervalString(*state);
     EXPECT_EQ(resultingString, expectedString);
+
+    // Test 4: SysTimeElapsed zero -- before HVAC simulation sets it
+    dHVACG->SysTimeElapsed = 0.0;
+    dHVACG->TimeStepSys = 0.1;
+    dGlo->CurrentTime = 10.9;
+    dGlo->TimeStepZone = 0.1;
+    expectedString = "10:48 - 10:54";
+
+    resultingString = CreateSysTimeIntervalString(*state);
+    EXPECT_EQ(resultingString, expectedString);
 }
 
 } // namespace EnergyPlus

--- a/tst/EnergyPlus/unit/MixedAir.unit.cc
+++ b/tst/EnergyPlus/unit/MixedAir.unit.cc
@@ -6619,7 +6619,7 @@ TEST_F(EnergyPlusFixture, CO2ControlDesignOARateTest)
         "   **   ~~~   ** This may be overriding desired ventilation controls. Check inputs for Minimum Outdoor Air Flow Rate, Minimum Outdoor Air "
         "Schedule Name and Controller:MechanicalVentilation",
         "   **   ~~~   ** Minimum OA fraction = 2.9412E-003, Mech Vent OA fraction = 1.5603E-003",
-        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:00",
+        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:15",
     });
 
     EXPECT_TRUE(compare_err_stream_substring(error_string, true));

--- a/tst/EnergyPlus/unit/OutdoorAirUnit.unit.cc
+++ b/tst/EnergyPlus/unit/OutdoorAirUnit.unit.cc
@@ -376,7 +376,7 @@ TEST_F(EnergyPlusFixture, OutdoorAirUnit_AutoSize)
         "   **   ~~~   ** Air mass balance is required by other outdoor air units: Fan:ZoneExhaust, ZoneMixing, ZoneCrossMixing, or other air flow "
         "control inputs.",
         "   **   ~~~   ** The outdoor mass flow rate = 0.602 and the exhaust mass flow rate = 0.000.",
-        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:00",
+        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:15",
     });
 
     EXPECT_TRUE(compare_err_stream(error_string, true));

--- a/tst/EnergyPlus/unit/WaterThermalTanks.unit.cc
+++ b/tst/EnergyPlus/unit/WaterThermalTanks.unit.cc
@@ -3775,6 +3775,12 @@ TEST_F(EnergyPlusFixture, MixedTank_WarnPotentialFreeze)
     // zero source mass flow rate
     Tank.SourceMassFlowRate = 0.0;
 
+    // set time in simulation for time stamp in error message
+    state->dataHVACGlobal->SysTimeElapsed = 0.5;
+    state->dataHVACGlobal->TimeStepSys = 0.5;
+    state->dataGlobal->CurrentTime = 24.0;
+    state->dataGlobal->TimeStepZone = 0.5;
+
     // Calls CalcWaterThermalTankMixed
     Tank.CalcWaterThermalTank(*state);
 
@@ -3791,7 +3797,7 @@ TEST_F(EnergyPlusFixture, MixedTank_WarnPotentialFreeze)
                                                        "   **   ~~~   ** Schedule will not be validated.",
                                                        "   ** Warning ** CalcWaterThermalTankMixed: WaterHeater:Mixed = 'CHILLEDWATERTANK':  "
                                                        "Temperature of tank < 2C indicates of possibility of freeze. Tank Temperature = 1.95 C.",
-                                                       "   **   ~~~   **  Environment=, at Simulation time= 00:-1 - 00:00"});
+                                                       "   **   ~~~   **  Environment=, at Simulation time= 23:30 - 24:00"});
     EXPECT_TRUE(compare_err_stream(error_string, true));
 }
 
@@ -3886,6 +3892,12 @@ TEST_F(EnergyPlusFixture, StratifiedTank_WarnPotentialFreeze)
     // zero source mass flow rate
     Tank.SourceMassFlowRate = 0.0;
 
+    // set time in simulation for time stamp in error message
+    state->dataHVACGlobal->SysTimeElapsed = 0.1;
+    state->dataHVACGlobal->TimeStepSys = 0.1;
+    state->dataGlobal->CurrentTime = 0.1;
+    state->dataGlobal->TimeStepZone = 0.1;
+
     // Calls CalcWaterThermalTankStratified
     Tank.CalcWaterThermalTank(*state);
 
@@ -3907,7 +3919,7 @@ TEST_F(EnergyPlusFixture, StratifiedTank_WarnPotentialFreeze)
                           "   **   ~~~   ** Schedule will not be validated.",
                           "   ** Warning ** CalcWaterThermalTankStratified: WaterHeater:Stratified = 'STRATIFIED CHILLEDWATERTANK':  Temperature of "
                           "tank < 2C indicates of possibility of freeze. Tank Temperature = 1.75 C.",
-                          "   **   ~~~   **  Environment=, at Simulation time= 00:-1 - 00:00"});
+                          "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:06"});
     EXPECT_TRUE(compare_err_stream(error_string, true));
 }
 

--- a/tst/EnergyPlus/unit/WaterUse.unit.cc
+++ b/tst/EnergyPlus/unit/WaterUse.unit.cc
@@ -451,7 +451,7 @@ TEST_F(EnergyPlusFixture, WaterUse_WaterTempWarnings)
     std::string const error_string1 = delimited_string({
         "   ** Warning ** CalcEquipmentFlowRates: \"CORE_ZN WATER EQUIPMENT\" - Hot water temperature is less than the cold water temperature by "
         "(5.00 C)",
-        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:00",
+        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:15",
         "   **   ~~~   ** ...hot water temperature        = 10.00 C",
         "   **   ~~~   ** ...cold water temperature       = 15.00 C",
         "   **   ~~~   ** ...Hot water temperature should be greater than or equal to the cold water temperature. Verify temperature setpoints and "
@@ -478,7 +478,7 @@ TEST_F(EnergyPlusFixture, WaterUse_WaterTempWarnings)
     std::string const error_string2 = delimited_string({
         "   ** Warning ** CalcEquipmentFlowRates: \"CORE_ZN WATER EQUIPMENT\" - Target water temperature is greater than the hot water temperature "
         "by (6.70 C)",
-        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:00",
+        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:15",
         "   **   ~~~   ** ...target water temperature     = 50.00 C",
         "   **   ~~~   ** ...hot water temperature        = 43.30 C",
         "   **   ~~~   ** ...Target water temperature should be less than or equal to the hot water temperature. Verify temperature setpoints and "
@@ -496,7 +496,7 @@ TEST_F(EnergyPlusFixture, WaterUse_WaterTempWarnings)
     std::string const error_string3 = delimited_string({
         "   ** Warning ** CalcEquipmentFlowRates: \"CORE_ZN WATER EQUIPMENT\" - Target water temperature is less than the cold water temperature "
         "by (15.00 C)",
-        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:00",
+        "   **   ~~~   **  Environment=, at Simulation time= 00:00 - 00:15",
         "   **   ~~~   ** ...target water temperature     = 0.00 C",
         "   **   ~~~   ** ...cold water temperature       = 15.00 C",
         "   **   ~~~   ** ...Target water temperature should be greater than or equal to the cold water temperature. Verify temperature setpoints "


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #10801 

### Description of the purpose of this PR

It was noted that the time stamp reported in a user input file was shifted by one time stamp in the EDD.  The first time of the day was tagged as "00:10 - 00:20" and the last time step as "24:00-24:10".  The logic being used for the time stamp flag was found to be wrong and corrected so that the time stamps in the resulting EDD from the user input file starts each day with "00:00 - 00:10" and ends with "23:50 - 24:00" as expected.  This time stamp was also being used by various error messages --these are also now correct.  A new unit test to verify the correction was added and two existing unit tests were modified to reflect this change.  The only differences in output would be in either the EDD which includes the time stamp as output or ERR files that contain error messages that include the timestamp as part of the output.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
