### PR TITLE
Addition of Error Messages for Cases where Simulation Control Do HVAC is Set to Yes but No Plant:Sizing Objects Present

### DIFF
--- a/doc/input-output-reference/src/overview/group-simulation-parameters.tex
+++ b/doc/input-output-reference/src/overview/group-simulation-parameters.tex
@@ -809,7 +809,7 @@ Input is Yes or No. The default is Yes. Yes implies the simulation will be run o
 
 \paragraph{Field: Do HVAC Sizing Simulation for Sizing Periods}\label{field-do-hvac-sizing-simulation-for-sizing-periods}
 
-This field is optional. It can be used to enable certain advanced sizing calculations that rely on simulating the sizing periods to collect information. This is currently only applicable when sizing plant loops using the sizing option called Coincident.
+This field is optional. It can be used to enable certain advanced sizing calculations that rely on simulating the sizing periods to collect information. This is currently only applicable when sizing plant loops using the sizing option called Coincident. Note that if the input file specifies ''Yes'' for both this field and the Do Plant Sizing field above that the user must also enter at least one \hyperref[sizingplant]{Sizing:Plant} object.
 
 \paragraph{Field: Maximum Number of HVAC Sizing Simulation Passes}\label{field-maximum-number-of-hvac-sizing-simulation-passes}
 

--- a/src/EnergyPlus/SimulationManager.cc
+++ b/src/EnergyPlus/SimulationManager.cc
@@ -1131,6 +1131,32 @@ namespace SimulationManager {
             if (NumAlpha > 5) {
                 if (Alphas(6) == "YES") {
                     state.dataGlobal->DoHVACSizingSimulation = true;
+                    if (!state.dataGlobal->DoPlantSizing) { // if not doing plant sizing, cannot do HVAC sizing simulation
+                        state.dataGlobal->DoHVACSizingSimulation = false;
+
+                        ShowWarningError(
+                            state, "GetProjectData: Mismatch in the Sizing Flags Do HVAC Sizing and Do Plant Sizing in SimulationControl object");
+                        ShowContinueError(state, "...The Do HVAC Sizing Simulation for Sizing Periods flag is YES, but the Do Plant Sizing");
+                        ShowContinueError(state, "...Calculation flag is NO.  This is not allowed.  Either set the Do HVAC Sizing Simulation");
+                        ShowContinueError(state, "...for Sizing Periods flag to NO or set the Do Plant Sizing Calculation to YES and add the");
+                        ShowContinueError(state, "...appropriate Sizing:Plant object(s) to the input file.  The simulation continues with");
+                        ShowContinueError(state, "...the Do HVAC Sizing flag reset to NO.");
+                    } else {
+                        std::string spObject = "Sizing:Plant";
+                        int NumPltSizInput = state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, spObject);
+                        if (NumPltSizInput == 0 && state.dataGlobal->DoHVACSizingSimulation && state.dataGlobal->DoPlantSizing) {
+                            ShowSevereError(
+                                state,
+                                format(
+                                    "GetProjectData: No {} object entered when the Do HVAC Sizing Simulation and Do Plant Sizing are both YES in the "
+                                    "SimulationControl object.",
+                                    spObject));
+                            ShowContinueError(state, format("...When these input flags are both yes, a {} object is required.", spObject));
+                            ShowContinueError(state, format("...Either add one or more appropriate {} objects to the input file", spObject));
+                            ShowContinueError(state, "...or change both the Do HVAC Sizing Simulation and Do Plant Sizing are both YES. ");
+                            ErrorsFound = true;
+                        }
+                    }
                 }
             }
         }

--- a/testfiles/5ZoneIceStorage.idf
+++ b/testfiles/5ZoneIceStorage.idf
@@ -217,7 +217,7 @@
   SimulationControl,
     Yes,                     !- Do Zone Sizing Calculation
     Yes,                     !- Do System Sizing Calculation
-    No,                      !- Do Plant Sizing Calculation
+    Yes,                     !- Do Plant Sizing Calculation
     No,                      !- Run Simulation for Sizing Periods
     Yes,                     !- Run Simulation for Weather File Run Periods
     YES,                     !- Do HVAC Sizing Simulation for Sizing Periods

--- a/tst/EnergyPlus/unit/SimulationManager.unit.cc
+++ b/tst/EnergyPlus/unit/SimulationManager.unit.cc
@@ -489,9 +489,9 @@ TEST_F(EnergyPlusFixture, SimulationManager_HVACSizingSimulationChoiceTest)
     EXPECT_TRUE(process_idf(idf_objects));
     state->init_state(*state);
 
-    EXPECT_TRUE(state->dataGlobal->DoHVACSizingSimulation);
+    EXPECT_FALSE(state->dataGlobal->DoHVACSizingSimulation); // flag gets reset because Do Plant is NO
     // get a default value
-    EXPECT_EQ(state->dataGlobal->HVACSizingSimMaxIterations, 1);
+    EXPECT_EQ(state->dataGlobal->HVACSizingSimMaxIterations, 0); // this is no longer set because
 }
 
 TEST_F(EnergyPlusFixture, Test_SimulationControl_ZeroSimulation)
@@ -582,4 +582,26 @@ TEST_F(EnergyPlusFixture, SimulationManager_ReportLoopConnectionsTest)
     });
 
     EXPECT_TRUE(compare_err_stream(error_string, true));
+}
+
+TEST_F(EnergyPlusFixture, SimulationManager_PlantSizingInputTest)
+{
+    // Unit Test for Defect #10797: Check for Bad Input (avoid a hard crash)
+    std::string const idf_objects = delimited_string({
+        "SimulationControl,",
+        "  No,                       !- Do Zone Sizing Calculation",
+        "  No,                       !- Do System Sizing Calculation",
+        "  Yes,                      !- Do Plant Sizing Calculation",
+        "  No,                       !- Run Simulation for Sizing Periods",
+        "  No,                       !- Run Simulation for Weather File Run Periods",
+        "  Yes,                      !- Do HVAC Sizing Simulation for Sizing Periods",
+        "  2;                        !- Maximum Number of HVAC Sizing Simulation Passes",
+    });
+
+    EXPECT_TRUE(process_idf(idf_objects));
+
+    EXPECT_THROW(SimulationManager::GetProjectData(*state), std::runtime_error);
+
+    EXPECT_TRUE(compare_err_stream_substring(
+        "GetProjectData: No Sizing:Plant object entered when the Do HVAC Sizing Simulation and Do Plant Sizing are both YES", true));
 }


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #10797 

### Description of the purpose of this PR

It was noticed that when in the SimulationControl object that a user says "Yes" for the Do HVAC Sizing Simulation for Sizing Periods field without having any Sizing:Plant objects in the input that a hard crash results which is undesirable.

Now, when the user sets this field to "Yes" without any Sizing:Plant objects, one of two things happen.  If the Do Plant Sizing Calculation field is set to "No", this overrides the user input for Do HVAC Sizing Simulation for Sizing Periods field and a warning error is produced.  If the Do Plant Sizing Calculation field is set to "Yes", EnergyPlus will produce a severe/error warning stating that at least one Sizing:Plant object must be entered or these fields should both be set to "No".

A new unit test verifying the correct severe/fatal error is being produced under the correct conditions (both "Yes" and no Sizing:Plant objects).  In addition, the description of the Do HVAC Sizing Simulation for Sizing Periods field was enhanced in the Input Output Reference so that it is clear what is required of the user.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
