### PR TITLE
Correction to AirflowNetwork:Multizone:Surface Handling of People Index

### DIFF
--- a/doc/input-output-reference/src/overview/group-airflow-network.tex
+++ b/doc/input-output-reference/src/overview/group-airflow-network.tex
@@ -443,9 +443,9 @@ Let T\(_{out}\) equal the outdoor air temperature, T\(_{zone}\) equal the previo
 
 \textbf{Constant}: Whenever this object's Venting Availability Schedule allows venting, all of the zone's openable windows and doors are open, independent of indoor or outdoor conditions. Note that ``Constant'' here means that the size of each opening is fixed while venting; the air flow through each opening can, of course, vary from timestep to timestep.
 
-\textbf{ASHRAE55Adaptive}: All of the zone's operable windows and doors are opened if the operative temperature is greater than the comfort temperature (central line) calculated from the ASHRAE Standard 55-2010 adaptive comfort model and Venting Availability Schedule allows venting.
+\textbf{ASHRAE55Adaptive}: All of the zone's operable windows and doors are opened if the operative temperature is greater than the comfort temperature (central line) calculated from the ASHRAE Standard 55-2010 adaptive comfort model and Venting Availability Schedule allows venting. Note that in addition to these conditions, the zone must also be occupied for venting to take place when using this control.
 
-\textbf{CEN15251Adaptive:} All of the zone's operable windows and doors are opened if the operative temperature is greater than the comfort temperature (central line) calculated from the CEN15251 adaptive comfort model and Venting Availability Schedule allows venting.
+\textbf{CEN15251Adaptive:} All of the zone's operable windows and doors are opened if the operative temperature is greater than the comfort temperature (central line) calculated from the CEN15251 adaptive comfort model and Venting Availability Schedule allows venting. As with the ASHRAE55Adaptive venting control, the zone must also be occupied for venting to take place when using this control.
 
 \subsubsection{Field: Ventilation Control Zone Temperature Setpoint Schedule Name}\label{field-ventilation-control-zone-temperature-setpoint-schedule-name}
 

--- a/src/EnergyPlus/AirflowNetwork/include/AirflowNetwork/Solver.hpp
+++ b/src/EnergyPlus/AirflowNetwork/include/AirflowNetwork/Solver.hpp
@@ -310,6 +310,7 @@ namespace AirflowNetwork {
         void validate_distribution();
         void validate_fan_flowrate(); // Catch a fan flow rate from EPlus input file and add a flag for VAV terminal damper
         void validate_exhaust_fan_input();
+        void get_people_index(int &indexResult, int &mzZoneDataPtr, int ventCtrlNum, bool isThisSurface, int arrayIndex, bool &errorFound);
         void hybrid_ventilation_control();
         void single_sided_Cps(std::vector<std::vector<Real64>> &valsByFacade, int numWindDirs = 36);
         Real64 zone_OA_change_rate(int ZoneNum); // hybrid ventilation system controlled zone number

--- a/src/EnergyPlus/AirflowNetwork/include/AirflowNetwork/Solver.hpp
+++ b/src/EnergyPlus/AirflowNetwork/include/AirflowNetwork/Solver.hpp
@@ -310,7 +310,7 @@ namespace AirflowNetwork {
         void validate_distribution();
         void validate_fan_flowrate(); // Catch a fan flow rate from EPlus input file and add a flag for VAV terminal damper
         void validate_exhaust_fan_input();
-        void get_people_index(int &indexResult, int &mzZoneDataPtr, int ventCtrlNum, bool isThisSurface, int arrayIndex, bool &errorFound);
+        int get_people_index(int const zoneNum, int ventCtrlNum, bool &errorFound);
         void hybrid_ventilation_control();
         void single_sided_Cps(std::vector<std::vector<Real64>> &valsByFacade, int numWindDirs = 36);
         Real64 zone_OA_change_rate(int ZoneNum); // hybrid ventilation system controlled zone number

--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -11470,7 +11470,8 @@ namespace AirflowNetwork {
 
     void Solver::get_people_index(int &indexResult, int &mzZoneDataPtr, int ventCtrlNum, bool isThisSurface, int arrayIndex, bool &errorFound)
     {
-        indexResult = 0;
+        indexResult = 0;   // reset
+        mzZoneDataPtr = 0; // reset
         int zoneNum = 0;
 
         // Find the zoneNum and potentially the MultizoneZoneData index (surface only)

--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -3313,26 +3313,27 @@ namespace AirflowNetwork {
                     if (MultizoneSurfaceData(i).VentSurfCtrNum == VentControlType::ASH55 ||
                         MultizoneSurfaceData(i).VentSurfCtrNum == VentControlType::CEN15251) {
                         int zoneNum = MultizoneSurfaceData(i).NodeNums[0];
-                        if (MultizoneSurfaceData(i).RAFNflag) {
-                            zoneNum = MultizoneSurfaceData(i).ZonePtr;
-                        }
-                        if (m_state.dataSurface->Surface(MultizoneSurfaceData(i).SurfNum).Zone <= 0) {
-                            MultizoneSurfaceData(i).ZonePtr = zoneNum;
-                        }
-                        int mzPtr = 0;
-                        for (int mzIndex = 1; mzIndex <= AirflowNetworkNumOfZones; ++mzIndex) {
-                            if (zoneNum == MultizoneZoneData(mzIndex).ZoneNum) {
-                                mzPtr = mzIndex;
-                                break;
+                        if (zoneNum > 0) {
+                            int mzPtr = 0;
+                            for (int mzIndex = 1; mzIndex <= AirflowNetworkNumOfZones; ++mzIndex) {
+                                if (zoneNum == MultizoneZoneData(mzIndex).ZoneNum) {
+                                    mzPtr = mzIndex;
+                                    break;
+                                }
                             }
-                        }
-                        if (MultizoneSurfaceData(i).VentSurfCtrNum == VentControlType::ASH55) {
-                            MultizoneZoneData(mzPtr).ASH55PeopleInd =
-                                Solver::get_people_index(MultizoneZoneData(mzPtr).ZoneNum, VentControlType::ASH55, ErrorsFound);
-                        }
-                        if (MultizoneSurfaceData(i).VentSurfCtrNum == VentControlType::CEN15251) {
-                            MultizoneZoneData(mzPtr).CEN15251PeopleInd =
-                                Solver::get_people_index(MultizoneZoneData(mzPtr).ZoneNum, VentControlType::CEN15251, ErrorsFound);
+                            if (MultizoneSurfaceData(i).VentSurfCtrNum == VentControlType::ASH55) {
+                                MultizoneZoneData(mzPtr).ASH55PeopleInd =
+                                    Solver::get_people_index(MultizoneZoneData(mzPtr).ZoneNum, VentControlType::ASH55, ErrorsFound);
+                            }
+                            if (MultizoneSurfaceData(i).VentSurfCtrNum == VentControlType::CEN15251) {
+                                MultizoneZoneData(mzPtr).CEN15251PeopleInd =
+                                    Solver::get_people_index(MultizoneZoneData(mzPtr).ZoneNum, VentControlType::CEN15251, ErrorsFound);
+                            }
+                        } else {
+                            ShowSevereError(m_state,
+                                            format(RoutineName) + "No zone number was found for AFN Surface " + MultizoneSurfaceData(i).SurfName);
+                            ShowContinueError(m_state,
+                                              "Check the " + CurrentModuleObject + " and Surface objects to verify they are connected to a zone.");
                         }
                     }
                 } break;

--- a/tst/EnergyPlus/unit/AirflowNetworkComponents.unit.cc
+++ b/tst/EnergyPlus/unit/AirflowNetworkComponents.unit.cc
@@ -4490,10 +4490,7 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_get_people_indexTest)
     // Unit test added for fix to Defect #11027
     int expectedIndexResult;
     int actualIndexResult;
-    int expectedZonePtrResult;
-    int actualZonePtrResult;
     bool errFlag = false;
-    int arrayIndex;
 
     state->afn->MultizoneSurfaceData.allocate(10);
     state->afn->MultizoneZoneData.allocate(3);
@@ -4512,164 +4509,92 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_get_people_indexTest)
     state->dataHeatBal->People(3).AdaptiveASH55 = false;
     state->dataHeatBal->People(3).AdaptiveCEN15251 = false;
 
-    state->dataSurface->Surface(1).Zone = 1;
-    state->dataSurface->Surface(2).Zone = 2;
-    state->dataSurface->Surface(3).Zone = 3;
-    state->dataSurface->Surface(4).Zone = 1;
-    state->dataSurface->Surface(5).Zone = 2;
-    state->dataSurface->Surface(6).Zone = 3;
-    state->dataSurface->Surface(7).Zone = 0;
-    state->dataSurface->Surface(8).Zone = 0;
-    state->dataSurface->Surface(9).Zone = 0;
-    state->dataSurface->Surface(10).Zone = 0;
-
     state->afn->MultizoneZoneData(1).ZoneNum = 3;
     state->afn->MultizoneZoneData(2).ZoneNum = 1;
     state->afn->MultizoneZoneData(3).ZoneNum = 2;
 
-    state->afn->MultizoneSurfaceData(1).NodeNums[0] = 1;
     state->afn->MultizoneSurfaceData(1).ZonePtr = 1;
-    state->afn->MultizoneSurfaceData(1).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(1).SurfNum = 1;
-    state->afn->MultizoneSurfaceData(2).NodeNums[0] = 2;
     state->afn->MultizoneSurfaceData(2).ZonePtr = 2;
-    state->afn->MultizoneSurfaceData(2).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(2).SurfNum = 2;
-    state->afn->MultizoneSurfaceData(3).NodeNums[0] = 3;
     state->afn->MultizoneSurfaceData(3).ZonePtr = 3;
-    state->afn->MultizoneSurfaceData(3).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(3).SurfNum = 3;
-    state->afn->MultizoneSurfaceData(4).NodeNums[0] = 1;
     state->afn->MultizoneSurfaceData(4).ZonePtr = 1;
-    state->afn->MultizoneSurfaceData(4).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(4).SurfNum = 4;
-    state->afn->MultizoneSurfaceData(5).NodeNums[0] = 2;
     state->afn->MultizoneSurfaceData(5).ZonePtr = 2;
-    state->afn->MultizoneSurfaceData(5).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(5).SurfNum = 5;
-    state->afn->MultizoneSurfaceData(6).NodeNums[0] = 3;
     state->afn->MultizoneSurfaceData(6).ZonePtr = 3;
-    state->afn->MultizoneSurfaceData(6).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(6).SurfNum = 6;
-    state->afn->MultizoneSurfaceData(7).NodeNums[0] = 1;
     state->afn->MultizoneSurfaceData(7).ZonePtr = 1;
-    state->afn->MultizoneSurfaceData(7).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(7).SurfNum = 7;
-    state->afn->MultizoneSurfaceData(8).NodeNums[0] = 2;
     state->afn->MultizoneSurfaceData(8).ZonePtr = 2;
-    state->afn->MultizoneSurfaceData(8).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(8).SurfNum = 8;
-    state->afn->MultizoneSurfaceData(9).NodeNums[0] = 3;
     state->afn->MultizoneSurfaceData(9).ZonePtr = 3;
-    state->afn->MultizoneSurfaceData(9).RAFNflag = false;
-    state->afn->MultizoneSurfaceData(9).SurfNum = 9;
-    state->afn->MultizoneSurfaceData(10).NodeNums[0] = 2;
     state->afn->MultizoneSurfaceData(10).ZonePtr = 1;
-    state->afn->MultizoneSurfaceData(10).RAFNflag = true;
-    state->afn->MultizoneSurfaceData(10).SurfNum = 10;
 
     // Tests S1A/C: Surface--AFN Surface 1 (points to Zone 1 which is People 3 which does not use ASH55 or CEN15251)
-    arrayIndex = 1;
     expectedIndexResult = 0;
-    expectedZonePtrResult = 2;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, true, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneSurfaceData(1).ZonePtr, VentControlType::ASH55, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_TRUE(errFlag);
     errFlag = false; // reset
     expectedIndexResult = 0;
-    expectedZonePtrResult = 2;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, true, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneSurfaceData(1).ZonePtr, VentControlType::CEN15251, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_TRUE(errFlag);
     errFlag = false; // reset
 
     // Tests S2A/C: Surface--AFN Surface 2 (points to Zone 2 which is People 1 which uses ASH55)
-    arrayIndex = 2;
     expectedIndexResult = 1;
-    expectedZonePtrResult = 3;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, true, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneSurfaceData(2).ZonePtr, VentControlType::ASH55, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_FALSE(errFlag);
     expectedIndexResult = 0;
-    expectedZonePtrResult = 3;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, true, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneSurfaceData(2).ZonePtr, VentControlType::CEN15251, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_TRUE(errFlag);
     errFlag = false; // reset
 
-    // Tests S3A/C: Surface--AFN Surface 3 (points to Zone 3 which is People 2 which uses CEN15251)
-    arrayIndex = 3;
-    expectedIndexResult = 0;
-    expectedZonePtrResult = 1;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, true, arrayIndex, errFlag);
+    // Tests S3A/C: Surface--AFN Surface 3 (points to Zone 3 which is People 2 which uses CEN15251)    expectedIndexResult = 0;
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneSurfaceData(3).ZonePtr, VentControlType::ASH55, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_TRUE(errFlag);
     errFlag = false; // reset
     expectedIndexResult = 2;
-    expectedZonePtrResult = 1;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, true, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneSurfaceData(3).ZonePtr, VentControlType::CEN15251, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_FALSE(errFlag);
 
     // Tests S10C: Surface--AFN Surface 10 (points to Zone 2 but RAFN is set so this goes to Zone 1 which is People 3 which is rest to use CEN15251)
     state->dataHeatBal->People(3).AdaptiveCEN15251 = true;
-    arrayIndex = 10;
     expectedIndexResult = 3;
-    expectedZonePtrResult = 2;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, true, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneSurfaceData(10).ZonePtr, VentControlType::CEN15251, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_FALSE(errFlag);
     state->dataHeatBal->People(3).AdaptiveCEN15251 = false;
 
     // Tests Z1A/C: Zone--Array 1 (points to Zone 3 which is People 2 which uses CEN15251)
-    arrayIndex = 1;
     expectedIndexResult = 0;
-    expectedZonePtrResult = 1;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, false, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneZoneData(1).ZoneNum, VentControlType::ASH55, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_TRUE(errFlag);
     errFlag = false; // reset
     expectedIndexResult = 2;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, false, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneZoneData(1).ZoneNum, VentControlType::CEN15251, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_FALSE(errFlag);
 
     // Tests Z2A/C: Zone--Array 2 (points to Zone 1 which is People 3 which uses neither ASH55 nor CEN15251)
-    arrayIndex = 2;
     expectedIndexResult = 0;
-    expectedZonePtrResult = 2;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, false, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneZoneData(2).ZoneNum, VentControlType::ASH55, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_TRUE(errFlag);
     errFlag = false; // reset
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, false, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneZoneData(2).ZoneNum, VentControlType::CEN15251, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_TRUE(errFlag);
     errFlag = false; // reset
 
     // Tests Z3A/C: Zone--Array 3 (points to Zone 2 which is People 1 which uses ASH55)
-    arrayIndex = 3;
     expectedIndexResult = 1;
-    expectedZonePtrResult = 3;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, false, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneZoneData(3).ZoneNum, VentControlType::ASH55, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_FALSE(errFlag);
     expectedIndexResult = 0;
-    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, false, arrayIndex, errFlag);
+    actualIndexResult = state->afn->get_people_index(state->afn->MultizoneZoneData(3).ZoneNum, VentControlType::CEN15251, errFlag);
     EXPECT_EQ(expectedIndexResult, actualIndexResult);
-    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
     EXPECT_TRUE(errFlag);
     errFlag = false; // reset (not really necessary unless more tests are added)
 }

--- a/tst/EnergyPlus/unit/AirflowNetworkComponents.unit.cc
+++ b/tst/EnergyPlus/unit/AirflowNetworkComponents.unit.cc
@@ -4485,4 +4485,193 @@ TEST_F(EnergyPlusFixture, AirflowNetwork_TestFanModel)
     state->dataAirLoop->AirLoopAFNInfo.deallocate();
 }
 
+TEST_F(EnergyPlusFixture, AirflowNetwork_get_people_indexTest)
+{
+    // Unit test added for fix to Defect #11027
+    int expectedIndexResult;
+    int actualIndexResult;
+    int expectedZonePtrResult;
+    int actualZonePtrResult;
+    bool errFlag = false;
+    int arrayIndex;
+
+    state->afn->MultizoneSurfaceData.allocate(10);
+    state->afn->MultizoneZoneData.allocate(3);
+    state->dataHeatBal->TotPeople = 3;
+    state->dataHeatBal->People.allocate(state->dataHeatBal->TotPeople);
+    state->dataSurface->Surface.allocate(10);
+    state->afn->AirflowNetworkNumOfZones = 3;
+
+    state->dataHeatBal->People(1).ZonePtr = 2;
+    state->dataHeatBal->People(1).AdaptiveASH55 = true;
+    state->dataHeatBal->People(1).AdaptiveCEN15251 = false;
+    state->dataHeatBal->People(2).ZonePtr = 3;
+    state->dataHeatBal->People(2).AdaptiveASH55 = false;
+    state->dataHeatBal->People(2).AdaptiveCEN15251 = true;
+    state->dataHeatBal->People(3).ZonePtr = 1;
+    state->dataHeatBal->People(3).AdaptiveASH55 = false;
+    state->dataHeatBal->People(3).AdaptiveCEN15251 = false;
+
+    state->dataSurface->Surface(1).Zone = 1;
+    state->dataSurface->Surface(2).Zone = 2;
+    state->dataSurface->Surface(3).Zone = 3;
+    state->dataSurface->Surface(4).Zone = 1;
+    state->dataSurface->Surface(5).Zone = 2;
+    state->dataSurface->Surface(6).Zone = 3;
+    state->dataSurface->Surface(7).Zone = 0;
+    state->dataSurface->Surface(8).Zone = 0;
+    state->dataSurface->Surface(9).Zone = 0;
+    state->dataSurface->Surface(10).Zone = 0;
+
+    state->afn->MultizoneZoneData(1).ZoneNum = 3;
+    state->afn->MultizoneZoneData(2).ZoneNum = 1;
+    state->afn->MultizoneZoneData(3).ZoneNum = 2;
+
+    state->afn->MultizoneSurfaceData(1).NodeNums[0] = 1;
+    state->afn->MultizoneSurfaceData(1).ZonePtr = 1;
+    state->afn->MultizoneSurfaceData(1).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(1).SurfNum = 1;
+    state->afn->MultizoneSurfaceData(2).NodeNums[0] = 2;
+    state->afn->MultizoneSurfaceData(2).ZonePtr = 2;
+    state->afn->MultizoneSurfaceData(2).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(2).SurfNum = 2;
+    state->afn->MultizoneSurfaceData(3).NodeNums[0] = 3;
+    state->afn->MultizoneSurfaceData(3).ZonePtr = 3;
+    state->afn->MultizoneSurfaceData(3).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(3).SurfNum = 3;
+    state->afn->MultizoneSurfaceData(4).NodeNums[0] = 1;
+    state->afn->MultizoneSurfaceData(4).ZonePtr = 1;
+    state->afn->MultizoneSurfaceData(4).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(4).SurfNum = 4;
+    state->afn->MultizoneSurfaceData(5).NodeNums[0] = 2;
+    state->afn->MultizoneSurfaceData(5).ZonePtr = 2;
+    state->afn->MultizoneSurfaceData(5).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(5).SurfNum = 5;
+    state->afn->MultizoneSurfaceData(6).NodeNums[0] = 3;
+    state->afn->MultizoneSurfaceData(6).ZonePtr = 3;
+    state->afn->MultizoneSurfaceData(6).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(6).SurfNum = 6;
+    state->afn->MultizoneSurfaceData(7).NodeNums[0] = 1;
+    state->afn->MultizoneSurfaceData(7).ZonePtr = 1;
+    state->afn->MultizoneSurfaceData(7).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(7).SurfNum = 7;
+    state->afn->MultizoneSurfaceData(8).NodeNums[0] = 2;
+    state->afn->MultizoneSurfaceData(8).ZonePtr = 2;
+    state->afn->MultizoneSurfaceData(8).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(8).SurfNum = 8;
+    state->afn->MultizoneSurfaceData(9).NodeNums[0] = 3;
+    state->afn->MultizoneSurfaceData(9).ZonePtr = 3;
+    state->afn->MultizoneSurfaceData(9).RAFNflag = false;
+    state->afn->MultizoneSurfaceData(9).SurfNum = 9;
+    state->afn->MultizoneSurfaceData(10).NodeNums[0] = 2;
+    state->afn->MultizoneSurfaceData(10).ZonePtr = 1;
+    state->afn->MultizoneSurfaceData(10).RAFNflag = true;
+    state->afn->MultizoneSurfaceData(10).SurfNum = 10;
+
+    // Tests S1A/C: Surface--AFN Surface 1 (points to Zone 1 which is People 3 which does not use ASH55 or CEN15251)
+    arrayIndex = 1;
+    expectedIndexResult = 0;
+    expectedZonePtrResult = 2;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, true, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_TRUE(errFlag);
+    errFlag = false; // reset
+    expectedIndexResult = 0;
+    expectedZonePtrResult = 2;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, true, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_TRUE(errFlag);
+    errFlag = false; // reset
+
+    // Tests S2A/C: Surface--AFN Surface 2 (points to Zone 2 which is People 1 which uses ASH55)
+    arrayIndex = 2;
+    expectedIndexResult = 1;
+    expectedZonePtrResult = 3;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, true, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_FALSE(errFlag);
+    expectedIndexResult = 0;
+    expectedZonePtrResult = 3;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, true, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_TRUE(errFlag);
+    errFlag = false; // reset
+
+    // Tests S3A/C: Surface--AFN Surface 3 (points to Zone 3 which is People 2 which uses CEN15251)
+    arrayIndex = 3;
+    expectedIndexResult = 0;
+    expectedZonePtrResult = 1;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, true, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_TRUE(errFlag);
+    errFlag = false; // reset
+    expectedIndexResult = 2;
+    expectedZonePtrResult = 1;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, true, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_FALSE(errFlag);
+
+    // Tests S10C: Surface--AFN Surface 10 (points to Zone 2 but RAFN is set so this goes to Zone 1 which is People 3 which is rest to use CEN15251)
+    state->dataHeatBal->People(3).AdaptiveCEN15251 = true;
+    arrayIndex = 10;
+    expectedIndexResult = 3;
+    expectedZonePtrResult = 2;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, true, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_FALSE(errFlag);
+    state->dataHeatBal->People(3).AdaptiveCEN15251 = false;
+
+    // Tests Z1A/C: Zone--Array 1 (points to Zone 3 which is People 2 which uses CEN15251)
+    arrayIndex = 1;
+    expectedIndexResult = 0;
+    expectedZonePtrResult = 1;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, false, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_TRUE(errFlag);
+    errFlag = false; // reset
+    expectedIndexResult = 2;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, false, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_FALSE(errFlag);
+
+    // Tests Z2A/C: Zone--Array 2 (points to Zone 1 which is People 3 which uses neither ASH55 nor CEN15251)
+    arrayIndex = 2;
+    expectedIndexResult = 0;
+    expectedZonePtrResult = 2;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, false, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_TRUE(errFlag);
+    errFlag = false; // reset
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, false, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_TRUE(errFlag);
+    errFlag = false; // reset
+
+    // Tests Z3A/C: Zone--Array 3 (points to Zone 2 which is People 1 which uses ASH55)
+    arrayIndex = 3;
+    expectedIndexResult = 1;
+    expectedZonePtrResult = 3;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::ASH55, false, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_FALSE(errFlag);
+    expectedIndexResult = 0;
+    state->afn->get_people_index(actualIndexResult, actualZonePtrResult, VentControlType::CEN15251, false, arrayIndex, errFlag);
+    EXPECT_EQ(expectedIndexResult, actualIndexResult);
+    EXPECT_EQ(expectedZonePtrResult, actualZonePtrResult);
+    EXPECT_TRUE(errFlag);
+    errFlag = false; // reset (not really necessary unless more tests are added)
+}
+
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11027 

### Description of the purpose of this PR

For situations where a user specified AirflowNetwork:Multizone:Surface objects with CEN15251 (or ASH55) venting controls but the AirflowNetwork:Multizone:Zone object used some other venting control, no link was made to the correct people statement.  As a result, no venting was ever done for this situation which was incorrect.  Now, the code links up the proper zone and then links up to the correct People statement and venting occurs as specified by the user via a new subroutine which handles both ASH55 and CEN15251 for both the :Surface and :Zone objects.  Two IDFs were included with the defect.  One did not work because it met the condition shown above.  The second had the :Zone object set to CEN15251 which then did allow venting.  There were clear differences in the outputs.  After the fix, both files produce exactly the same results as expected and these match the results of the second input file with :Zone set to CEN15251.  No differences were noted in the ci results as anticipated.  A minor documentation edit and a unit test are included.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [x] Perform a Code Review on GitHub
 - [x] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [x] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [x] CI status: all green or justified
 - [x] Check that performance is not impacted (CI Linux results include performance check)
 - [x] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
