### PR TITLE
Add `BufferedErrFile` env var to enable eplusout.err buffering

### DIFF
--- a/doc/module-developer/src/running-testing-energyplus-for-developers/environment-variables-to-assist-running.tex
+++ b/doc/module-developer/src/running-testing-energyplus-for-developers/environment-variables-to-assist-running.tex
@@ -138,6 +138,8 @@ Set SortIDD = yes
 
 Setting to ``yes'' (internal default is ``no'') causes the program to display some different information that could be useful to developers. In particular, this will cause the Warmup Convergence output to show the last day for each zone, each timestep. There is no Output:Diagnostics equivalent.
 
+It will also enable the automatic flushing of `eplusout.err` in Release mode (in Debug, this is enabled by default), so you can see the output the output while the program is running, and it will capture the content up to a segfault if any.
+
 \begin{lstlisting}
 Set DeveloperFlag = yes
 \end{lstlisting}

--- a/doc/module-developer/src/running-testing-energyplus-for-developers/environment-variables-to-assist-running.tex
+++ b/doc/module-developer/src/running-testing-energyplus-for-developers/environment-variables-to-assist-running.tex
@@ -138,8 +138,6 @@ Set SortIDD = yes
 
 Setting to ``yes'' (internal default is ``no'') causes the program to display some different information that could be useful to developers. In particular, this will cause the Warmup Convergence output to show the last day for each zone, each timestep. There is no Output:Diagnostics equivalent.
 
-It will also enable the automatic flushing of `eplusout.err` in Release mode (in Debug, this is enabled by default), so you can see the output the output while the program is running, and it will capture the content up to a segfault if any.
-
 \begin{lstlisting}
 Set DeveloperFlag = yes
 \end{lstlisting}
@@ -179,6 +177,16 @@ Set MinimalShadowing = yes
 \subsubsection{DisplayInputInAudit: turn on (or off) to show the input file in the audit file}\label{displayinputinaudit-turn-on-or-off-to-show-the-input-file-in-the-audit-file}
 
 Setting to ``yes'' causes the audit file to include a line-by-line echoing of the input file which may be useful for debugging purposes. For versions 8.2 and earlier, the default behavior was to include the line-by-line echoing of the input file into the audit file but it was changed to not do this by default as a way to speed up the input processing portion of executing EnergyPlus. When not set to ``yes'', the audit file contains a reference on using the DisplayInputInAudit environment variable to see the line-by-line echoing of the input file.
+
+
+\subsubsection{BufferedErrFile: Only flush err file at the end}\label{displayinputinaudit-buffered-err-file}
+
+Setting to ``yes'' will cause EnergyPlus to wait until the simulation completes to flush the eplusout.err.
+The default behavior is to enable automatic flushing so you can see the output while the program is running, and it will capture the content up to a segfault if any.
+
+\begin{lstlisting}
+Set BufferedErrFile = yes
+\end{lstlisting}
 
 \subsubsection{Caution: Environment Variables}\label{caution-environment-variables}
 

--- a/src/EnergyPlus/DataSystemVariables.cc
+++ b/src/EnergyPlus/DataSystemVariables.cc
@@ -112,6 +112,8 @@ namespace DataSystemVariables {
 
     constexpr const char *ciForceTimeStepEnvVar("CI_FORCE_TIME_STEP"); // environment var forcing 30 minute time steps on CI for efficiency
 
+    constexpr const char *cBufferedErrFileEnvVar("BufferedErrFile"); // environment var to enable buffered eplusout.err
+
     fs::path CheckForActualFilePath(EnergyPlusData &state,
                                     fs::path const &originalInputFilePath, // path (or filename only) as input for object
                                     const std::string &contextString       //
@@ -352,6 +354,11 @@ namespace DataSystemVariables {
         get_environment_variable(ciForceTimeStepEnvVar, cEnvValue);
         if (!cEnvValue.empty()) {
             state.dataSysVars->ciForceTimeStep = env_var_on(cEnvValue); // Yes or True
+        }
+
+        get_environment_variable(cBufferedErrFileEnvVar, cEnvValue);
+        if (!cEnvValue.empty()) {
+            state.dataSysVars->BufferedErrFileEnvVar = env_var_on(cEnvValue); // Yes or True
         }
     }
 

--- a/src/EnergyPlus/DataSystemVariables.hh
+++ b/src/EnergyPlus/DataSystemVariables.hh
@@ -150,6 +150,7 @@ struct SystemVarsData : BaseGlobalStruct
     int iNominalTotSurfaces = 0;
     bool Threading = false;
     bool ciForceTimeStep = false;
+    bool BufferedErrFileEnvVar = false;
 
     void init_constant_state([[maybe_unused]] EnergyPlusData &state) override
     {

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -4878,15 +4878,11 @@ int initErrorFile(EnergyPlusData &state)
         DisplayString(state, fmt::format("ERROR: Could not open file {} for output (write).", state.files.outputErrFilePath));
         return EXIT_FAILURE;
     }
-#ifndef NDEBUG
-    // Debug build: unbuffer it, flushes automatically on each output
-    state.files.err_stream->setf(std::ios::unitbuf);
-#else
-    // In release builds, only unbuffer if in developer mode
-    if (state.dataSysVars->DeveloperFlag) {
+
+    // Unless requested to be buffered: unbuffer it, flushes automatically on each output
+    if (!state.dataSysVars->BufferedErrFileEnvVar) {
         state.files.err_stream->setf(std::ios::unitbuf);
     }
-#endif
 
     return EXIT_SUCCESS;
 } // initErrorFile()

--- a/src/EnergyPlus/OutputProcessor.cc
+++ b/src/EnergyPlus/OutputProcessor.cc
@@ -4878,6 +4878,16 @@ int initErrorFile(EnergyPlusData &state)
         DisplayString(state, fmt::format("ERROR: Could not open file {} for output (write).", state.files.outputErrFilePath));
         return EXIT_FAILURE;
     }
+#ifndef NDEBUG
+    // Debug build: unbuffer it, flushes automatically on each output
+    state.files.err_stream->setf(std::ios::unitbuf);
+#else
+    // In release builds, only unbuffer if in developer mode
+    if (state.dataSysVars->DeveloperFlag) {
+        state.files.err_stream->setf(std::ios::unitbuf);
+    }
+#endif
+
     return EXIT_SUCCESS;
 } // initErrorFile()
 


### PR DESCRIPTION
Pull request overview
---------------------

### Description of the purpose of this PR

Regarding eplusout.err, I often want to see the content up to a segfault: if segfaulting, the final flush is never happening. Or just see the content while the simulation is running (slowly, in Debug).

I'd like to make it so that at least when building in Debug mode, the `err_stream` flushes on each write.

I'd personally argue that in 99.5% of cases, the amount of IO happening in `eplusout.err` is minimal and it wouldn't hurt to do it even in Release mode. Users could actually report the content up to a segfault when opening an issue, which would be useful for us. But it's not necessarily a battle I want to fight, so I took an alternative approach of doing it in Release Mode only if environment variable `DeveloperFlag=TRUE`.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
