### PR TITLE
#11123 - Document that api_data_fully_ready is probably not need for Construction actuators

### DIFF
--- a/src/EnergyPlus/api/datatransfer.h
+++ b/src/EnergyPlus/api/datatransfer.h
@@ -109,6 +109,9 @@ ENERGYPLUSLIB_API char *listAllAPIDataCSV(EnergyPlusState state);
 ///          Do not call for variable, meter, actuator, or any other internal exchange data prior to this returning true.
 /// \param[in] state An active EnergyPlusState instance created with `stateNew`.
 /// \return Returns 1 (true) once the data is ready, otherwise returns 0 (false).
+/// \remark  Note that in the case of Surface actuators for "Construction State" and for a call to \link getConstructionHandle \endlink,
+///          this is not required to be true, as construction data is generally available earlier in the simulation process.
+///          Bypassing this check will allow affecting the Sizing calculations.
 ENERGYPLUSLIB_API int apiDataFullyReady(EnergyPlusState state);
 /// \brief Provides a user-facing check on the API error flag
 /// \details Some API functions return a value of 0, which could potentially indicate an error, or an actual 0 value.

--- a/src/EnergyPlus/api/datatransfer.py
+++ b/src/EnergyPlus/api/datatransfer.py
@@ -110,7 +110,7 @@ class DataExchange:
             #: and represents the control actuation.  For a node setpoint actuation, this could be "temperature" or
             #: "humidity", for example.
             self.type: str = _type
-            #: This represents the unit of measure for this exchange point.  
+            #: This represents the unit of measure for this exchange point.
             #: This is NOT used for plugin variables such as PluginGlobalVariable and PluginTrendVariable.
             self.unit: str = _unit
 
@@ -330,11 +330,17 @@ class DataExchange:
 
     def api_data_fully_ready(self, state: c_void_p) -> bool:
         """
-        Check whether the data exchange API is ready.
-        Handles to variables, actuators, and other data are not reliably defined prior to this being true.
+        Check whether the data exchange API is fully ready.
+        Handles to variables, actuators, and other data are not guaranteed to be defined prior to this being true.
+        Up until this point some output vars, meters, actuators, etc., may not have been registered yet.
 
-        :param state: An active EnergyPlus "state" that is returned from a call to `api.state_manager.new_state()`.
+        :param state: An active EnergyPlus "state" that is returned from a call to :func:`api.state_manager.new_state() <state.StateManager.new_state>`.
         :return: Returns a boolean value to indicate whether variables, actuators, and other data are ready for access.
+
+        .. note::
+            In the case of Surface actuators for "Construction State" and for a call to :func:`get_construction_handle`,
+            this is not required to be true, as construction data is generally available earlier in the simulation process.
+            Bypassing this check will allow affecting the Sizing calculations.
         """
         if self.api.apiDataFullyReady(state) == 1:
             return True


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11123
- Document that api_data_fully_ready is probably not need for Construction actuators

### Description of the purpose of this PR

This comes after a long investigation. You can find a notebook that demonstrates the investigation at https://github.com/NREL/EnergyPlusDevSupport/blob/master/DefectFiles/11000s/11123/11123_Reproducer.ipynb (Public Gist version [here](https://gist.github.com/jmarrec/5fd26911e5c321befe738541db3fcc61))

I took 5ZoneAirCooled.idf and added another construction => `base.idf`.

Then I made several variations that use a ConstructionIndexVariable with a Surface "Construction State Actuator", and changes the construction for all windows on `BeginTimestepBeforePredictor`, like the original defect file.

* An EMS version
* An API version
* A Python Plugin Version
    * And one that sets "Run During Warmup" to false

The python_plugin.py goes somethng like

```python
    def on_begin_timestep_before_predictor(self, state) -> int:
        if not self.api.exchange.api_data_fully_ready(state):
            return 0

        # Get handles if needed

        # actuate
```

I was getting different total site energy, and could see that the Zone Sizing in eplusout.eio was different.

And then I realized, via a debugger, that the issue was that `api.exchange.api_data_fully_ready` is set MUCH later, so that Zone Sizing happens with the construction switch for the EMS case but not the PythonPlugin/API Version

https://github.com/NREL/EnergyPlus/blob/446b7cfdc8ad348d40a86c8e6530763d230913e1/src/EnergyPlus/SimulationManager.cc#L343

The EMS goes:

```
Initializing Surfaces
Initializing Outdoor environment for Surfaces
Setting up Surface Reporting Variables
Initializing Temperature and Flux Histories
Initializing Window Shading
Computing Interior Absorption Factors
Computing Interior Diffuse Solar Absorption Factors
Initializing Solar Heat Gains
Initializing Internal Heat Gains
Initializing Interior Solar Distribution
Initializing Interior Convection Coefficients
Gathering Information for Predefined Reporting
Completed Initializing Surface Heat Balance
Calculate Outside Surface Heat Balance
Calculate Inside Surface Heat Balance
Calculate Air Heat Balance
Initializing HVAC
Process 1672468 stopped
* thread #1, name = 'energyplus', stop reason = breakpoint 2.1
    frame #0: 0x00007ffff3bac59e libenergyplusapi.so.25.2.0`EnergyPlus::HeatBalanceSurfaceManager::InitEMSControlledConstructions(state=0x00007fffffffa800) at HeatBalanceSurfaceManager.cc:4686:29
   4683	    state.dataGlobal->AnyConstrOverridesInModel = false;
   4684	    for (int SurfNum = 1; SurfNum <= state.dataSurface->TotSurfaces; ++SurfNum) {
   4685	        if (state.dataSurface->SurfEMSConstructionOverrideON(SurfNum)) {
-> 4686	            state.dataGlobal->AnyConstrOverridesInModel = true;
   4687	            break;
   4688	        }
   4689	    }
```

The PythonPlugin goes

```
[...]
Initializing HVAC
Warming up
Warming up
Warming up
Warming up
Warming up
Warming up
Performing Zone Sizing Simulation for Load Component Report
...for Sizing Period: #1 CHICAGO_IL_USA ANNUAL HEATING 99% DESIGN CONDITIONS DB
Warming up
Warming up
Warming up
Warming up
Warming up
Warming up
Performing Zone Sizing Simulation for Load Component Report
...for Sizing Period: #2 CHICAGO_IL_USA ANNUAL COOLING 1% DESIGN CONDITIONS DB/MCWB
Re-zeroing zone sizing arrays
Warming up
Warming up
Warming up
Warming up
Warming up
Warming up
Performing Zone Sizing Simulation
...for Sizing Period: #1 CHICAGO_IL_USA ANNUAL HEATING 99% DESIGN CONDITIONS DB
Warming up
Warming up
Warming up
Warming up
Warming up
Warming up
Performing Zone Sizing Simulation
...for Sizing Period: #2 CHICAGO_IL_USA ANNUAL COOLING 1% DESIGN CONDITIONS DB/MCWB
Calculating System sizing
...for Sizing Period: #1 CHICAGO_IL_USA ANNUAL HEATING 99% DESIGN CONDITIONS DB
Calculating System sizing
...for Sizing Period: #2 CHICAGO_IL_USA ANNUAL COOLING 1% DESIGN CONDITIONS DB/MCWB
Adjusting Air System Sizing
Adjusting Standard 62.1 Ventilation Sizing
Initializing Simulation
Reporting Surfaces
Beginning Primary Simulation
Initializing New Environment Parameters
Warming up {1}
['DB-1', 'DF-1', 'WB-1', 'WF-1', 'WL-1', 'WR-1']
actuating
Process 1672717 stopped
* thread #1, name = 'energyplus', stop reason = breakpoint 1.1
    frame #0: 0x00007ffff3bac59e libenergyplusapi.so.25.2.0`EnergyPlus::HeatBalanceSurfaceManager::InitEMSControlledConstructions(state=0x00007fffffffa800) at HeatBalanceSurfaceManager.cc:4686:29
   4683	    state.dataGlobal->AnyConstrOverridesInModel = false;
   4684	    for (int SurfNum = 1; SurfNum <= state.dataSurface->TotSurfaces; ++SurfNum) {
   4685	        if (state.dataSurface->SurfEMSConstructionOverrideON(SurfNum)) {
-> 4686	            state.dataGlobal->AnyConstrOverridesInModel = true;
   4687	            break;
   4688	        }
   4689	    }
```
### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
