### PR TITLE
Run and Cache Regressions on Develop And reuse in PR workflows

### DIFF
--- a/.github/actions/configure-and-build/action.yml
+++ b/.github/actions/configure-and-build/action.yml
@@ -1,0 +1,120 @@
+name: "CMake Configure and Build"
+description: "Run CMake Configure and Build the targets"
+
+inputs:
+  build-directory:
+    description: "the E+ working directory, top level of the repo"
+  nproc:
+    required: true
+  minimal-targets:
+    description: "If true will build only energyplus and a couple of fortran ones, just enough to run reg tests"
+    type: boolean
+    default: false
+  python-version:
+    required: true
+  python-root-dir:
+    required: true
+  enable-pch:
+    description: "Turn on ENABLE_PCH to have pre-compiled headers. Pass ON or OFF"
+    default: "OFF"
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Configure CMake And Build on Windows
+    if: runner.os == 'Windows'
+    working-directory: ${{ inputs.build-directory }}
+    shell: pwsh
+    run: |
+      $ErrorActionPreference = 'stop'
+      $PSNativeCommandUseErrorActionPreference = $true
+
+      function Begin-Group {
+          param([string]$Title)
+          Write-Output "::group::`e[93m$Title`e[0m"
+      }
+
+      switch ($env:PROCESSOR_ARCHITECTURE) {
+        "AMD64" { $target_arch = "x64" }
+        "ARM64" { $target_arch = "arm64" }
+        default { throw "Unknown architecture: $env:PROCESSOR_ARCHITECTURE" }
+      }
+
+      Begin-Group "Entering a VS Dev Shell"
+      Import-Module "$env:MSVC_DIR\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+      Enter-VsDevShell -VsInstallPath "$env:MSVC_DIR" -SkipAutomaticLocation -devCmdArguments "-arch=$target_arch"
+      Write-Output "::endgroup::"
+
+      Begin-Group "CMake configure"
+      cmake `
+        -G Ninja `
+        -DENABLE_PCH:BOOL=${{ inputs.enable-pch }} `
+        -DCMAKE_BUILD_TYPE:STRING=Release `
+        -DLINK_WITH_PYTHON:BOOL=ON `
+        -DPYTHON_CLI:BOOL=ON `
+        -DPython_REQUIRED_VERSION:STRING=${{ inputs.python-version }} `
+        -DPython_ROOT_DIR:PATH=${{ inputs.python-root-dir }} `
+        -DBUILD_TESTING:BOOL=ON `
+        -DBUILD_FORTRAN:BOOL=ON `
+        -DBUILD_PACKAGE:BOOL=OFF `
+        -DDOCUMENTATION_BUILD:STRING=DoNotBuild `
+        -DENABLE_OPENMP:BOOL=OFF `
+        ../
+      Write-Output "::endgroup::"
+
+      if ("${{ inputs.minimal-targets }}" -eq "true") {
+          Begin-Group "Building only energyplus and fortran targets"
+          ninja energyplus ExpandObjects_build ReadVars_build Slab_build Basement_build AppGPostProcess_build ParametricPreprocessor_build
+          Write-Output "::endgroup::"
+      }
+      else {
+          Begin-Group "Building full energyplus"
+          ninja
+          Write-Output "::endgroup::"
+      }
+
+      Begin-Group "Showing CCache Stats"
+      try { ccache --show-stats -vv } catch { ccache --show-stats }
+      ccache --zero-stats
+      ccache -p
+      Write-Output "::endgroup::"
+
+  - name: Configure CMake And Build on Unix
+    if: runner.os != 'Windows'
+    working-directory: ${{ inputs.build-directory }}
+    shell: bash
+    run: |
+      begin_group() { echo -e "::group::\033[93m$1\033[0m"; }
+
+      begin_group "CMake configure"
+      cmake \
+        -G Ninja \
+        -DENABLE_PCH:BOOL=${{ inputs.enable-pch }} \
+        -DCMAKE_BUILD_TYPE:STRING=Release \
+        -DLINK_WITH_PYTHON:BOOL=ON \
+        -DPYTHON_CLI:BOOL=ON \
+        -DPython_REQUIRED_VERSION:STRING=${{ inputs.python-version }} \
+        -DPython_ROOT_DIR:PATH=${{ inputs.python-root-dir }} \
+        -DBUILD_TESTING:BOOL=ON \
+        -DBUILD_FORTRAN:BOOL=ON \
+        -DBUILD_PACKAGE:BOOL=OFF \
+        -DDOCUMENTATION_BUILD:STRING=DoNotBuild \
+        -DENABLE_OPENMP:BOOL=OFF \
+        ../
+
+      if [ "${{ inputs.minimal-targets }}" == "true" ]; then
+        begin_group "Builing only energyplus and fortran targets"
+        ninja energyplus ExpandObjects ReadVarsESO Slab Basement AppGPostProcess ParametricPreprocessor
+        echo "::endgroup::"
+      else
+        begin_group "Builing full energyplus"
+        ninja
+        echo "::endgroup::"
+      fi;
+
+      begin_group "Showing CCache Stats"
+      ccache --show-stats -vv || ccache --show-stats || true
+      ccache --zero-stats
+      ccache -p
+      echo "::endgroup::"

--- a/.github/actions/setup-runner/action.yml
+++ b/.github/actions/setup-runner/action.yml
@@ -1,0 +1,114 @@
+name: "Setup Runner"
+description: "Setup Python, System Dependencies and configure CCache"
+
+inputs:
+  python-version:
+    required: true
+  python-arch:
+    required: true
+
+outputs:
+  nproc:
+    description: "The number of processors"
+    value: ${{ steps.install-deps.outputs.nproc }}
+  python-root-dir:
+    description: "The Python_ROOT_DIR"
+    value: ${{ steps.install-deps.outputs.python-root-dir }}
+  ccache-dir:
+    description: "The ccache directory"
+    value: ${{ steps.install-deps.outputs.ccache-dir }}
+  compiler-id:
+    description: "The computer compiler id to use as a caching key"
+    value: ${{ steps.install-deps.outputs.compiler-id }}
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Set up Python ${{ inputs.python-version }}
+    id: setup-python
+    uses: actions/setup-python@v5
+    with:
+      python-version: ${{ inputs.python-version }}
+      architecture: ${{ inputs.python-arch }}
+
+  - name: Install Dependencies
+    id: install-deps
+    shell: bash
+    run: |
+      echo "Configuring"
+      begin_group() { echo -e "::group::\033[93m$1\033[0m"; }
+
+      begin_group "Figure out NPROC"
+      NPROC=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
+      echo "There are $NPROC threads available"
+      echo "NPROC=$NPROC" >> $GITHUB_ENV
+      echo "nproc=$NPROC" >> $GITHUB_OUTPUT
+      echo "::endgroup::"
+
+      if [ "$RUNNER_OS" == "Windows" ]; then
+        DIR_SEP="\\"
+      else
+        DIR_SEP="/"
+      fi
+      echo "DIR_SEP=$DIR_SEP" >> $GITHUB_ENV
+
+      begin_group "Install system dependencies such as ninja and ccache"
+      CCACHE_DIR="${{ github.workspace }}${DIR_SEP}.ccache"
+      echo "CCACHE_DIR=$CCACHE_DIR"
+      echo "CCACHE_DIR=$CCACHE_DIR" >> $GITHUB_ENV
+      echo "ccache-dir=$CCACHE_DIR" >> $GITHUB_OUTPUT
+
+      if [ "$RUNNER_OS" == "Linux" ]; then
+        echo "FC=gfortran-13" >> $GITHUB_ENV
+        sudo apt-get -qq update
+        sudo apt-get -qq install -y libxkbcommon-x11-0 xorg-dev libgl1-mesa-dev ccache
+
+        COMPILER="gcc-$(gcc -dumpversion)"
+      elif [ "$RUNNER_OS" == "Windows" ]; then
+        choco install ninja ccache
+
+        # C:\Program Files\Microsoft Visual Studio\2022\Enterprise
+        MSVC_DIR=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -latest -property installationPath)
+        echo "Latest MSVC_DIR is: $MSVC_DIR"
+        echo "MSVC_DIR=$MSVC_DIR" >> $GITHUB_ENV
+        # add folder containing vcvarsall.bat
+        echo "$MSVC_DIR\VC\Auxiliary\Build" >> $GITHUB_PATH
+        # msvc-17.14
+        # COMPILER="msvc-$(vswhere -products '*' -requires Microsoft.Component.MSBuild -latest -property installationVersion | cut -d'.' -f 1,2)"
+        # msvc-2022
+        COMPILER="msvc-$(vswhere -products '*' -requires Microsoft.Component.MSBuild -latest -property catalog_productLineVersion)"
+      elif [ "$RUNNER_OS" == "macOS" ]; then
+        brew update
+        brew install tcl-tk
+        brew reinstall gcc@13
+        echo "FC=$(brew --prefix gcc@13)/bin/gfortran-13" >> $GITHUB_ENV
+        echo "MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos_dev_target }}" >> $GITHUB_ENV
+
+        brew install ccache
+        ccache --set-config=compiler_check=content # darwin only
+        # clang-19
+        COMPILER="clang-$(clang -dumpversion | cut -d'.' -f 1)"
+      fi;
+
+      echo "COMPILER=$COMPILER" >> $GITHUB_ENV
+      echo "compiler-id=$COMPILER" >> $GITHUB_OUTPUT
+
+      # Setup ccache, common
+      ccache --set-config=cache_dir=$CCACHE_DIR
+      ccache --set-config=max_size=500M
+      ccache --set-config=compression=true
+      ccache --set-config=sloppiness=pch_defines,time_macros
+      ccache --set-config=base_dir="${{ github.workspace }}"
+
+      echo "::endgroup::"
+
+      begin_group "App Python_ROOT_DIR env variable"
+      Python_ROOT_DIR="$RUNNER_TOOL_CACHE/Python/${{ steps.setup-python.outputs.python-version }}/${{ inputs.python-arch }}"
+      echo "Python_ROOT_DIR=$Python_ROOT_DIR" >> $GITHUB_ENV
+      echo "python-root-dir=$Python_ROOT_DIR" >> $GITHUB_OUTPUT
+      echo "::endgroup::"
+
+      begin_group "Install python dependencies"
+      pip install pytest lxml tzdata
+      echo "::endgroup::"

--- a/.github/workflows/clean_cache.yml
+++ b/.github/workflows/clean_cache.yml
@@ -1,0 +1,29 @@
+name: Cleanup github runner caches on closed pull requests
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/run_and_cache_regressions_develop.yml
+++ b/.github/workflows/run_and_cache_regressions_develop.yml
@@ -1,0 +1,130 @@
+name: Build, Run and Cache Develop Regressions
+
+on:
+  push:
+    branches: [ develop ]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  FC: gfortran-13
+
+jobs:
+  build_and_test:
+    name: Testing on ${{ matrix.pretty }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: macos-14
+          macos_dev_target: 13.0
+          arch: arm64
+          python-arch: arm64
+          pretty: "Mac arm64"
+          python-version: 3.12.3  # 3.12.2 not available on Ubuntu 24 GHA
+        - os: ubuntu-24.04
+          arch: x86_64
+          python-arch: x64
+          pretty: "Ubuntu 24.04"
+          python-version: 3.12.3  # 3.12.2 not available on Ubuntu 24 GHA
+        - os: windows-2022
+          arch: x86_64
+          python-arch: x64
+          pretty: "Windows x64"
+          python-version: 3.12.3  # 3.12.2 not available on Ubuntu 24 GHA
+        - os: ubuntu-24.04-arm
+          arch: arm64
+          python-arch: arm64
+          pretty: "Ubuntu 24.04 arm64"
+          python-version: 3.12.3  # 3.12.2 not available on Ubuntu 24 GHA
+        - os: windows-11-arm
+          arch: arm64
+          python-arch: arm64
+          pretty: "Windows arm64"
+          python-version: 3.12.10
+
+    steps:
+
+    - uses: actions/checkout@v5
+
+    - name: Setup System
+      id: setup-runner
+      uses: ./.github/actions/setup-runner
+      with:
+        python-version: ${{ matrix.python-version }}
+        python-arch: ${{ matrix.python-arch }}
+
+    - name: Get Current SHA
+      shell: bash
+      run: |
+        echo "Figuring out the develop GIT SHA"
+        CURRENT_SHA=$(git rev-parse --short=10 HEAD)
+        echo "Develop GIT SHA is '${CURRENT_SHA}'"
+        echo "CURRENT_SHA=$CURRENT_SHA" >> $GITHUB_ENV
+
+    - name: Cache CCACHE
+      uses: actions/cache@v4
+      id: cacheccache
+      with:
+        path: |
+          ${{ steps.setup-runner.outputs.ccache-dir }}
+        key: ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-${{ env.CURRENT_SHA }}
+        restore-keys: |
+          ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-
+          ccache-${{ matrix.os }}-
+
+    - name: Did restoring the CCache-cache work? Yes
+      # If the SDK wasn't found in the cache
+      if: steps.cacheccache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        ccache --show-stats -vv || ccache --show-stats
+        ccache --zero-stats
+        ccache -p
+
+    - name: Create Build Directory
+      shell: bash
+      run: |
+        cmake -E make_directory ./build/
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          # The MACOSX_DEPLOYMENT_TARGET environment variable sets the default value for the CMAKE_OSX_DEPLOYMENT_TARGET variable.
+          echo MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos_dev_target }} >> $GITHUB_ENV
+        fi;
+
+    - name: Install problem matcher
+      shell: bash
+      run: echo "::add-matcher::./.github/workflows/cpp-problem-matcher.json"
+
+    - name: Configure and Build
+      uses: ./.github/actions/configure-and-build
+      with:
+        enable-pch: OFF
+        minimal-targets: false
+        build-directory: ./build
+        nproc: ${{ steps.setup-runner.outputs.nproc }}
+        python-version: ${{ matrix.python-version }}
+        python-root-dir: ${{ steps.setup-runner.outputs.python-root-dir }}
+
+    - name: Remove problem matcher
+      shell: bash
+      run: echo "::remove-matcher owner=gcc-problem-matcher::"
+
+    - name: Run Tests
+      working-directory: ./build
+      shell: bash
+      run: |
+        if ctest -j ${{ env.NPROC }}; then
+          echo "All tests passed"
+        else
+          echo "Re-running failed tests..."
+          ctest --rerun-failed --output-on-failure
+        fi;
+        mv testfiles testfiles-develop
+
+    - uses: actions/cache/save@v4
+      with:
+        path: |
+          ./build/testfiles-develop
+        key: baselineregression-${{ matrix.os }}-${{ env.CURRENT_SHA }}

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches: [ develop ]
 
-defaults:
-  run:
-    shell: bash
-
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FC: gfortran-13
@@ -27,142 +23,157 @@ jobs:
           macos_dev_target: 13.0
           arch: arm64
           python-arch: arm64
-          generator: "Unix Makefiles"
-          nproc: 3
           run_regressions: true
           pretty: "Mac arm64"
-#        - os: ubuntu-24.04
-#          arch: x86_64
-#          python-arch: x64
-#          generator: "Unix Makefiles"
-#          nproc: 4
-#          run_regressions: false
-#          pretty: "Ubuntu 24.04"
-#        - os: windows-2022
-#          arch: x86_64
-#          python-arch: x64
-#          generator: "Visual Studio 17 2022"
-#          nproc: 4
-#          run_regressions: false
-#          pretty: "Windows x64"
+        - os: ubuntu-24.04
+          arch: x86_64
+          python-arch: x64
+          run_regressions: true
+          pretty: "Ubuntu 24.04"
+        - os: windows-2022
+          arch: x86_64
+          python-arch: x64
+          run_regressions: true
+          pretty: "Windows x64"
 
     steps:
 
-    - name: Set up Python ${{ env.Python_REQUIRED_VERSION }}
-      id: setup-python
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+
+    - name: Setup System
+      id: setup-runner
+      uses: ./.github/actions/setup-runner
       with:
         python-version: ${{ env.Python_REQUIRED_VERSION }}
+        python-arch: ${{ matrix.python-arch }}
 
-    - name: Install Dependencies for Mac  # gcc13 reinstall may not be needed
-      if: runner.os == 'macOS'
+    - name: Get Develop and Branch Git SHA
+      shell: bash
       run: |
-        brew update
-        brew install tcl-tk
-        brew reinstall gcc@13
-        echo "FC=$(brew --prefix gcc@13)/bin/gfortran-13" >> $GITHUB_ENV
-        echo MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos_dev_target }} >> $GITHUB_ENV
-        pip install pytest lxml
+        echo "Figuring out the develop GIT SHA"
+        # github.event.pull_request.base.sha points to develop at the time the PR was created, not the current one
+        DEVELOP_SHA=$(git ls-remote https://github.com/$GITHUB_REPOSITORY.git develop | cut -f1 | cut -c1-10)
+        echo "Develop GIT SHA is '${DEVELOP_SHA}'"
+        echo "DEVELOP_SHA=$DEVELOP_SHA" >> $GITHUB_ENV
 
-    - name: Install Dependencies for Linux
-      if: runner.os == 'Linux'
+        CURRENT_HEAD_SHA=${{ github.event.pull_request.head.sha }}
+        echo "Current Branch HEAD SHA is '${CURRENT_HEAD_SHA}'"
+        echo "CURRENT_HEAD_SHA=$DEVELOP_SHA" >> $GITHUB_ENV
+
+        echo "Current merge commit SHA is '${GITHUB_SHA}'"
+        echo "::endgroup::"
+        # We default to using PCH, in case we don't find the baseline reg tests,
+        # since it speeds up the build significantly and we'll build TWICE
+        echo "ENABLE_PCH=ON" >> $GITHUB_ENV
+
+    - name: Baseline Regression Testing caching
+      uses: actions/cache@v4
+      id: cachebaselineregression
+      with:
+        path: |
+          ./build/testfiles-develop
+        key: baselineregression-${{ matrix.os }}-${{ env.DEVELOP_SHA }}
+
+    - name: Did restoring the Baseline Regression Tests work? Yes
+      if: steps.cachebaselineregression.outputs.cache-hit == 'true'
+      shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install libxkbcommon-x11-0 xorg-dev libgl1-mesa-dev
-        if [[ "${{ matrix.os }}" == "ubuntu-24.04" ]]; then
-          # https://github.com/actions/runner-images/issues/10025
-          echo "FC=gfortran-13" >> $GITHUB_ENV
-        fi
-        pip install pytest lxml
+        echo "Found the regression tests!"
+        # We turn off the PCH in that case, since that's how develop builds it
+        echo "ENABLE_PCH=OFF" >> $GITHUB_ENV
 
-    # BUILD AND TEST INTEGRATION FILES ON THE BASELINE BRANCH
+    - name: Cache CCACHE
+      uses: actions/cache@v4
+      id: cacheccache
+      with:
+        path: |
+          ${{ steps.setup-runner.outputs.ccache-dir }}
+        key: ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-${{ github.head_ref }}-pch=${{ env.ENABLE_PCH }}
+        restore-keys: |
+          ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-${{ github.head_ref }}
+          ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-${{ env.DEVELOP_SHA }}
+          ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-
+          ccache-${{ matrix.os }}-
 
+    - name: Did restoring the CCache-cache work? Yes
+      # If the SDK wasn't found in the cache
+      if: steps.cacheccache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        ccache --show-stats -vv || ccache --show-stats
+        ccache --zero-stats
+        ccache -p
+
+    - name: Create Build Directory
+      shell: bash
+      run: |
+        cmake -E make_directory ./build/
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          # The MACOSX_DEPLOYMENT_TARGET environment variable sets the default value for the CMAKE_OSX_DEPLOYMENT_TARGET variable.
+          echo MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos_dev_target }} >> $GITHUB_ENV
+        fi;
+
+    # Checkout baseline, overrides the branch basically
     - name: Baseline Checkout
-      if: matrix.run_regressions
+      if: matrix.run_regressions && steps.cachebaselineregression.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
       with:
         ref: develop
-        path: baseline
+        clean: false # Do NOT wipe the build/ and .ccache folder (`git clean -ffdx && git reset --hard HEAD`)
 
-    - name: Baseline Create Build Directory
-      if: matrix.run_regressions
-      run: cmake -E make_directory ./baseline/build/
-
-    - name: Baseline Configure CMake
-      if: matrix.run_regressions
-      working-directory: ./baseline/build
-      run: >
-        cmake
-        -G "${{ matrix.generator }}"
-        -DCMAKE_BUILD_TYPE:STRING=Release
-        -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${{ matrix.macos_dev_target }}
-        -DLINK_WITH_PYTHON:BOOL=ON
-        -DPYTHON_CLI:BOOL=ON
-        -DPython_REQUIRED_VERSION:STRING=${{ steps.setup-python.outputs.python-version }}
-        -DPython_ROOT_DIR:PATH=$RUNNER_TOOL_CACHE/Python/${{ steps.setup-python.outputs.python-version }}/${{ matrix.python-arch }}/
-        -DBUILD_TESTING:BOOL=ON
-        -DBUILD_FORTRAN:BOOL=ON
-        -DBUILD_PACKAGE:BOOL=OFF
-        -DDOCUMENTATION_BUILD:STRING=DoNotBuild
-        -DENABLE_OPENMP:BOOL=OFF
-        ../
-
-    # During baseline builds, just build specific target list so that we don't waste time building the unit test binary
-
-    - name: Baseline Build on Windows
-      if: matrix.run_regressions && runner.os == 'Windows'
-      working-directory: ./baseline/build
-      run: cmake --build . -j ${{ matrix.nproc }} --config Release --target energyplus ExpandObjects_build ReadVars_build Slab_build Basement_build AppGPostProcess_build ParametricPreprocessor_build
-
-    - name: Baseline Build on Mac/Linux
-      if: matrix.run_regressions && runner.os != 'Windows'
-      working-directory: ./baseline/build
-      run: cmake --build . -j ${{ matrix.nproc }} --target energyplus ExpandObjects ReadVarsESO Slab Basement AppGPostProcess ParametricPreprocessor
+    - name: Baseline Configure and Build
+      if: matrix.run_regressions && steps.cachebaselineregression.outputs.cache-hit != 'true'
+      uses: ./.github/actions/configure-and-build
+      with:
+        enable-pch: ${{ env.ENABLE_PCH }} # this is 'ON' in this case
+        minimal-targets: true
+        build-directory: ./build
+        nproc: ${{ steps.setup-runner.outputs.nproc }}
+        python-version: ${{ env.Python_REQUIRED_VERSION }}
+        python-root-dir: ${{ steps.setup-runner.outputs.python-root-dir }}
 
     - name: Baseline Test
-      if: matrix.run_regressions
-      working-directory: ./baseline/build
-      run: ctest -C Release -R integration -j ${{ matrix.nproc }}  # TODO: Speed up basement so we don't have to skip it.
+      if: matrix.run_regressions && steps.cachebaselineregression.outputs.cache-hit != 'true'
+      working-directory: ./build
+      shell: bash
+      run: |
+        ctest -R integration -j ${{ env.NPROC }} --ouput-on-failure
 
-    # BUILD AND TEST EVERYTHING ON THE CURRENT BRANCH
-
-    - name: Branch Checkout
+    - name: Checkout Branch again
+      if: matrix.run_regressions && steps.cachebaselineregression.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
       with:
-        path: branch
+        clean: false # Do NOT wipe the build/ and .ccache folder (`git clean -ffdx && git reset --hard HEAD`)
 
-    - name: Branch Create Build Directory
-      run: cmake -E make_directory ./branch/build/
+    - name: Install problem matcher
+      shell: bash
+      run: echo "::add-matcher::./.github/workflows/cpp-problem-matcher.json"
 
-    - name: Branch Configure CMake
-      working-directory: ./branch/build
-      run: >
-        cmake
-        -G "${{ matrix.generator }}"
-        -DCMAKE_BUILD_TYPE:STRING=Release
-        -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${{ matrix.macos_dev_target }}
-        -DLINK_WITH_PYTHON:BOOL=ON
-        -DPYTHON_CLI:BOOL=ON
-        -DPython_REQUIRED_VERSION:STRING=${{ steps.setup-python.outputs.python-version }}
-        -DPython_ROOT_DIR:PATH=$RUNNER_TOOL_CACHE/Python/${{ steps.setup-python.outputs.python-version }}/${{ matrix.python-arch }}/
-        -DBUILD_TESTING:BOOL=ON
-        -DBUILD_FORTRAN:BOOL=ON
-        -DBUILD_PACKAGE:BOOL=OFF
-        -DDOCUMENTATION_BUILD:STRING=DoNotBuild
-        -DENABLE_OPENMP:BOOL=OFF
-        ../
-
-    - name: Branch Build
+    - name: Configure and Build
       id: branch_build
-      working-directory: ./branch/build
-      run: |
-        echo "::add-matcher::./branch/.github/workflows/cpp-problem-matcher.json"
-        cmake --build . -j ${{ matrix.nproc }} --config Release
-        echo "::remove-matcher owner=gcc-problem-matcher::"
+      uses: ./.github/actions/configure-and-build
+      with:
+        enable-pch: ${{ env.ENABLE_PCH }}
+        minimal-targets: false
+        build-directory: ./build
+        nproc: ${{ steps.setup-runner.outputs.nproc }}
+        python-version: ${{ env.Python_REQUIRED_VERSION }}
+        python-root-dir: ${{ steps.setup-runner.outputs.python-root-dir }}
 
-    - name: Branch Test
-      working-directory: ./branch/build
-      run: ctest -C Release -j ${{ matrix.nproc }}
+    - name: Remove problem matcher
+      shell: bash
+      run: echo "::remove-matcher owner=gcc-problem-matcher::"
+
+    - name: Run Tests
+      working-directory: ./build
+      shell: bash
+      run: |
+        if ctest -j ${{ env.NPROC }}; then
+          echo "All tests passed"
+        else
+          echo "Re-running failed tests..."
+          ctest --rerun-failed --output-on-failure
+        fi;
 
     - name: Install Regression Tool
       if: always() && matrix.run_regressions && steps.branch_build.outcome != 'failure'  # always run this step as long as we actually built
@@ -173,7 +184,7 @@ jobs:
       id: regressions
       # steps.regressions.conclusion is always "success", but if no regressions, steps.regressions.outcome is "success"
       continue-on-error: true
-      run: python ./branch/scripts/dev/gha_regressions.py ./baseline/build/testfiles ./branch/build/testfiles/ ./regressions
+      run: python ./scripts/dev/gha_regressions.py ./build/testfiles-develop ./build/testfiles ./regressions
 
     - uses: actions/upload-artifact@v4
       id: upload_regressions
@@ -185,7 +196,7 @@ jobs:
     - name: Generate Regression Summary GitHub Script
       if: always() && matrix.run_regressions && steps.regressions.outcome == 'failure'
       run: >
-        python ./branch/scripts/dev/build_regression_summary.py
+        python ./scripts/dev/build_regression_summary.py
         ${{ github.workspace }}/regressions/summary.md
         ${{ github.workspace }}/regressions/summary.js
         ${{ matrix.os }}

--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 project(miniziplib C)
 
+include(../../cmake/TargetArch.cmake)
+target_architecture(TARGET_ARCH)
+
 include(CheckTypeSize)
 include(CheckFunctionExists)
 include(CheckIncludeFile)
@@ -145,7 +148,11 @@ add_library(miniziplib STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HD
 
 if( MSVC )
   if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-    set_target_properties(miniziplib PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+    if(TARGET_ARCH MATCHES "arm64")
+      set_target_properties(miniziplib PROPERTIES STATIC_LIBRARY_FLAGS "/machine:arm64")
+    else()
+      set_target_properties(miniziplib PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+    endif()
   else()
     set_target_properties(miniziplib PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x86")
   endif()


### PR DESCRIPTION
Pull request overview
---------------------

This pull requests enables caching both CCache and regression results from develop.

What does this mean in practice?

A PR workflow with a minimal change (touching a few lines in Boilers.cc) will run under 6 minutes versus about 52 minutes

### Description of the purpose of this PR

60+ commits (probably close to a 100 in reality since I squashed and force pushed a bunch) were eventually squashed into one. Some details can be found on my fork at https://github.com/jmarrec/EnergyPlus/compare/develop_cache_details...jmarrec:EnergyPlus:cache_regression_details?expand=1

This PR does several things, some of which can be turned off:

* It uses the Ninja generator on all platforms to maximize the speed
* It installs and configures CCache + it CACHES on Github (actions/cache) to speed up incremental builds
* It creates two in-repo composite actions
     * `setup-runner`: takes care of installing the system dependencies such as ninja and ccache, and configuring ccache, (and figuring out nproc)
     * `configure-and-build`: takes care of calling CMake Configure with the appropriate options regardless of whether we use windows or Unix, then buildings with ninja (with minimal targets for integration only or the full thing, based on a boolean)
* It Creates a workflow that runs on develop that will pick up an existing ccache, build E+, then run the tests. The integration tests results are **cached**
* it heavily modifies the test_pull_request.yml workflow so that:
     * It picks up the cached develop regression tests based on the develop SHA (and platform + compiler ID I'm computing) at the time of the workflow run
     * **ONLY** In the event of a race condition (develop workflow didn't have time to finish before the pr workflow runs) will it build the baseline first and then run the integration tests (the alternative would be to just fail the workflow, and we reboot it later)
     * Otherwise, if the cached regression results from develop are found, develop branch is not even built
     * The PR checkout is built (reusing a CCache cache from the branch if any, otherwise it falls back to the latest develop CCache) and integration tests will run.
     * Rest is business as usual: analyze the regressions and produce a summary etc
* I currently enabled probably too many platforms for the develop workflow
     * I added an arm64 ubuntu 24.04, which happens to fail on 1ZoneUncontrolledUTF8 btw
     * I added a windows-11-arm (WoA) runner, made a couple of tweaks for minizip build options so it'd work
     * (The idea was to ensure that the shared composite actions were doing the RIGHT thing in all cases, future proofing)
* I added a workflow that will cleanup any branch specific cache after the pull_request in question is merged (or the branch is deleted)

#### What testing has been conducted?

Well, I've done a LOT of runs on my fork.


* Example workflow where a PR is opened and develop regression results are already cached: https://github.com/jmarrec/EnergyPlus/actions/runs/17404299581/job/49404555111
     * When the corresponding PR was closed: https://github.com/jmarrec/EnergyPlus/pull/12
     * the cache cleaning workflow did run, and it did clean up the branch specific caches https://github.com/jmarrec/EnergyPlus/actions/runs/17404517494 
* Example workflow with a race condition, when the PR is opened and the develop regression results aren't cached yet: https://github.com/jmarrec/EnergyPlus/actions/runs/17458297978/job/49576780306
    *  It detects that it cannot find the cached regressions
    * It EXPLICITLY builds develop first, then branch, then correctly run regressions

After squashing all these commits, here is a run after I did `gh cache delete --all` so there are zero ccaches to be found:

* https://github.com/jmarrec/EnergyPlus/actions/runs/17474863331



#### Some caveat on precompiled headers:

* I disabled PCH because I couldn't really make it work properly with ccache **on mac arm64**. mac, well, clang to be precise, is notoriously harder to configure ccache with PCH enabled. But mac arm64 was the first platform I tested it on, since it's what's the current test_pull_request workflow uses. I've briefly tried re-enabling it on ubuntu arm64, but I already spent too much time working on this

Future investigations into re-enabling PCH should start with this

* https://ccache.dev/manual/latest.html#_precompiled_headers
    * I already tweaked the slopiness, but I haven't tried the compiler flags 
* https://discourse.cmake.org/t/ccache-clang-and-fno-pch-timestamp/7253



### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
