### PR TITLE
Windows fixup for current develop

### DIFF
--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -629,7 +629,7 @@ if(WIN32 AND NOT UNIX)
 
   # ConvertInputFormat is added via add_subdirectory, and in there we set CMAKE_INSTALL_OPENMP_LIBRARIES at parent scope already
   # Otherwise, if kiva (no by default) **actually** linked to OpenMP, we need to ship the libs
-  if (NOT ${CMAKE_INSTALL_OPENMP_LIBRARIES} AND (${ENABLE_OPENMP}))
+  if ((NOT CMAKE_INSTALL_OPENMP_LIBRARIES) AND ENABLE_OPENMP)
     # Need to install vcomp140.dll or similar
     find_package(OpenMP COMPONENTS CXX)
     if(OpenMP_CXX_FOUND)

--- a/src/EnergyPlus/GroundHeatExchangers/Vertical.cc
+++ b/src/EnergyPlus/GroundHeatExchangers/Vertical.cc
@@ -525,8 +525,10 @@ void GLHEVert::calcUniformBHWallTempGFunctionsWithGHEDesigner(EnergyPlusData &st
         exePath = FileSystem::getAbsolutePath(FileSystem::getProgramPath()); // could be /path/to/energyplus(.exe) or /path/to/energyplus_tests(.exe)
         exePath = exePath.parent_path() / ("energyplus" + FileSystem::exeExtension);
     }
-    std::string const cmd = fmt::format(
-        R"("{}" {} {} "{}" "{}")", exePath.string(), "auxiliary", "ghedesigner ", ghe_designer_input_file_path, ghe_designer_output_directory);
+    std::string const cmd = fmt::format(R"("{}" auxiliary ghedesigner "{}" "{}")",
+                                        FileSystem::toString(exePath),
+                                        FileSystem::toString(ghe_designer_input_file_path),
+                                        FileSystem::toString(ghe_designer_output_directory));
     int const status = FileSystem::systemCall(cmd);
     if (status != 0) {
         ShowFatalError(state, "GHEDesigner failed to calculate G-functions.");

--- a/src/EnergyPlus/GroundHeatExchangers/Vertical.cc
+++ b/src/EnergyPlus/GroundHeatExchangers/Vertical.cc
@@ -527,8 +527,8 @@ void GLHEVert::calcUniformBHWallTempGFunctionsWithGHEDesigner(EnergyPlusData &st
     }
     std::string const cmd = fmt::format(R"("{}" auxiliary ghedesigner "{}" "{}")",
                                         FileSystem::toString(exePath),
-                                        FileSystem::toString(ghe_designer_input_file_path),
-                                        FileSystem::toString(ghe_designer_output_directory));
+                                        FileSystem::toGenericString(ghe_designer_input_file_path),
+                                        FileSystem::toGenericString(ghe_designer_output_directory));
     int const status = FileSystem::systemCall(cmd);
     if (status != 0) {
         ShowFatalError(state, "GHEDesigner failed to calculate G-functions.");

--- a/tst/EnergyPlus/unit/SolarShading.unit.cc
+++ b/tst/EnergyPlus/unit/SolarShading.unit.cc
@@ -6250,8 +6250,8 @@ TEST_F(EnergyPlusFixture, CLIPLINE_Full)
         Line line_new{}; // Only defined if visible
     };
 
-    // No need to capture the constexpr variables
-    auto testclipline = [](const TestCase &t) {
+    // No need to capture the constexpr variables (but MSVC will complain)
+    auto testclipline = [&](const TestCase &t) {
         Real64 x0 = t.line_ori.p0.x;
         Real64 y0 = t.line_ori.p0.y;
 


### PR DESCRIPTION
Pull request overview
---------------------

Fixes a number of issues after the merges of:

* #11180
     * -Wunused-lambda-capture on GCC/Clang will error if a lambda explicitly passes constexpr variables into a lambda capture (they are already in scope!) but of course MSVC isn't compliant. 
     ```
     D:\a\EnergyPlus\EnergyPlus\tst\EnergyPlus\unit\SolarShading.unit.cc(6265): error C3493:
     'minY' cannot be implicitly captured because no default capture mode has been specified
     ```
* #11152 created a couple of problems
    * The paths weren't passed properly to ghedesigner https://github.com/jmarrec/EnergyPlus/actions/runs/17477179078/job/49639778499#step:11:6043 and `integration.GSHP-GLHE-CalcGFunctions-cpg` will fail

    ```
    Starting up GHEDesigner
    <string>:4: SyntaxWarning: invalid escape sequence '\E'
    <string>:5: SyntaxWarning: invalid escape sequence '\E'
    Usage: energyplus [OPTIONS] INPUT_PATH [OUTPUT_DIRECTORY]
    Try 'energyplus --help' for help.
    Error: Invalid value for 'INPUT_PATH': Path 'D:\x07\\EnergyPlus\\EnergyPlus\testfiles\\eplus_ghedesigner_input.json' does not exist.
    ```

    * I was getting a cmake configure error locally on win10

    ```
    CMake Error at cmake/Install.cmake:632 (if):
      if given arguments:

        "NOT" "AND" "(" "OFF" ")"

      Unknown arguments specified
    Call Stack (most recent call first):
      CMakeLists.txt:430 (include)
      ```

### Description of the purpose of this PR

<!-- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
