### PR TITLE
Fix #11181 - Wrong Sunlit fractions for Detached Shading Surfaces when Sun is Down

### DIFF
--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -4918,78 +4918,73 @@ void CalcPerSolarBeam(EnergyPlusData &state,
 
     // Initialize some values for the appropriate period
     if (!state.dataSysVars->DetailedSolarTimestepIntegration) {
-        for (int zoneNum = 1; zoneNum <= state.dataGlobal->NumOfZones; ++zoneNum) {
-            for (int spaceNum : state.dataHeatBal->Zone(zoneNum).spaceIndexes) {
-                auto &thisSpace = state.dataHeatBal->space(spaceNum);
-                int firstSurf = thisSpace.OpaqOrIntMassSurfaceFirst;
-                int lastSurf = thisSpace.OpaqOrIntMassSurfaceLast;
-                for (int surfNum = firstSurf; surfNum <= lastSurf; ++surfNum) {
-                    s_surf->SurfOpaqAO(surfNum) = 0.0;
-                }
-                firstSurf = thisSpace.HTSurfaceFirst;
-                lastSurf = thisSpace.HTSurfaceLast;
-                for (int surfNum = firstSurf; surfNum <= lastSurf; ++surfNum) {
-                    state.dataSolarShading->SurfSunCosTheta(surfNum) = 0.0;
-                }
-                for (int hour = 1; hour <= 24; ++hour) {
-                    for (int surfNum = firstSurf; surfNum <= lastSurf; ++surfNum) {
-                        state.dataHeatBal->SurfSunlitFracHR(hour, surfNum) = 0.0;
-                        state.dataHeatBal->SurfCosIncAngHR(hour, surfNum) = 0.0;
-                    }
-                }
-                for (int hour = 1; hour <= 24; ++hour) {
-                    for (int timestep = 1; timestep <= state.dataGlobal->TimeStepsInHour; ++timestep) {
-                        for (int surfNum = firstSurf; surfNum <= lastSurf; ++surfNum) {
-                            state.dataHeatBal->SurfSunlitFrac(hour, timestep, surfNum) = 0.0;
-                            state.dataHeatBal->SurfCosIncAng(hour, timestep, surfNum) = 0.0;
-                            state.dataHeatBal->SurfSunlitFracWithoutReveal(hour, timestep, surfNum) = 0.0;
-                        }
-                    }
-                }
-                for (int hour = 1; hour <= 24; ++hour) {
-                    for (int timestep = 1; timestep <= state.dataGlobal->TimeStepsInHour; ++timestep) {
-                        for (int backSurfNum = 1; backSurfNum <= state.dataBSDFWindow->MaxBkSurf; ++backSurfNum) {
-                            for (int surfNum = firstSurf; surfNum <= lastSurf; ++surfNum) {
-                                state.dataHeatBal->SurfWinBackSurfaces(hour, timestep, backSurfNum, surfNum) = 0.0;
-                                state.dataHeatBal->SurfWinOverlapAreas(hour, timestep, backSurfNum, surfNum) = 0.0;
-                            }
-                        }
-                    } // for (timestep)
-                } // for (hour)
-            } // for (spaceNum)
-        } // for (zoneNum)
 
-        for (auto &e : s_surf->SurfaceWindow) {
-            std::fill(e.OutProjSLFracMult.begin(), e.OutProjSLFracMult.end(), 1.0);
-            std::fill(e.InOutProjSLFracMult.begin(), e.InOutProjSLFracMult.end(), 1.0);
+        // Array1D and 1D-ish
+        for (int surfNum = 1; surfNum <= state.dataSurface->TotSurfaces; ++surfNum) {
+            s_surf->SurfOpaqAO(surfNum) = 0.0;
+            state.dataSolarShading->SurfSunCosTheta(surfNum) = 0.0;
+
+            for (int hour = 1; hour <= 24; ++hour) {
+                s_surf->SurfaceWindow(surfNum).OutProjSLFracMult[hour] = 1.0;
+                s_surf->SurfaceWindow(surfNum).InOutProjSLFracMult[hour] = 1.0;
+            }
         }
-    } else {
-        for (int zoneNum = 1; zoneNum <= state.dataGlobal->NumOfZones; ++zoneNum) {
-            for (int spaceNum : state.dataHeatBal->Zone(zoneNum).spaceIndexes) {
-                auto &thisSpace = state.dataHeatBal->space(spaceNum);
-                int const firstSurf = thisSpace.HTSurfaceFirst;
-                int const lastSurf = thisSpace.HTSurfaceLast;
-                for (int surfNum = firstSurf; surfNum <= lastSurf; ++surfNum) {
-                    state.dataSolarShading->SurfSunCosTheta(surfNum) = 0.0;
-                    s_surf->SurfOpaqAO(surfNum) = 0.0;
-                    state.dataHeatBal->SurfSunlitFrac(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, surfNum) = 0.0;
-                    state.dataHeatBal->SurfSunlitFracWithoutReveal(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, surfNum) = 0.0;
-                    state.dataHeatBal->SurfSunlitFracHR(state.dataGlobal->HourOfDay, surfNum) = 0.0;
-                    state.dataHeatBal->SurfCosIncAngHR(state.dataGlobal->HourOfDay, surfNum) = 0.0;
-                    state.dataHeatBal->SurfCosIncAng(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, surfNum) = 0.0;
+
+        // Array2D
+        for (int hour = 1; hour <= 24; ++hour) {
+            for (int surfNum = 1; surfNum <= state.dataSurface->TotSurfaces; ++surfNum) {
+                state.dataHeatBal->SurfSunlitFracHR(hour, surfNum) = 0.0;
+                state.dataHeatBal->SurfCosIncAngHR(hour, surfNum) = 0.0;
+            }
+        }
+
+        // Array3D
+        for (int hour = 1; hour <= 24; ++hour) {
+            for (int timestep = 1; timestep <= state.dataGlobal->TimeStepsInHour; ++timestep) {
+                for (int surfNum = 1; surfNum <= state.dataSurface->TotSurfaces; ++surfNum) {
+                    state.dataHeatBal->SurfSunlitFrac(hour, timestep, surfNum) = 0.0;
+                    state.dataHeatBal->SurfCosIncAng(hour, timestep, surfNum) = 0.0;
+                    state.dataHeatBal->SurfSunlitFracWithoutReveal(hour, timestep, surfNum) = 0.0;
                 }
+            }
+        }
+
+        // Array4D
+        for (int hour = 1; hour <= 24; ++hour) {
+            for (int timestep = 1; timestep <= state.dataGlobal->TimeStepsInHour; ++timestep) {
                 for (int backSurfNum = 1; backSurfNum <= state.dataBSDFWindow->MaxBkSurf; ++backSurfNum) {
-                    for (int surfNum = firstSurf; surfNum <= lastSurf; ++surfNum) {
-                        state.dataHeatBal->SurfWinBackSurfaces(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, backSurfNum, surfNum) = 0;
-                        state.dataHeatBal->SurfWinOverlapAreas(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, backSurfNum, surfNum) = 0.0;
+                    for (int surfNum = 1; surfNum <= state.dataSurface->TotSurfaces; ++surfNum) {
+                        state.dataHeatBal->SurfWinBackSurfaces(hour, timestep, backSurfNum, surfNum) = 0.0;
+                        state.dataHeatBal->SurfWinOverlapAreas(hour, timestep, backSurfNum, surfNum) = 0.0;
                     }
                 }
             }
         }
 
-        for (int SurfNum = 1; SurfNum <= s_surf->TotSurfaces; ++SurfNum) {
-            s_surf->SurfaceWindow(SurfNum).OutProjSLFracMult[state.dataGlobal->HourOfDay] = 1.0;
-            s_surf->SurfaceWindow(SurfNum).InOutProjSLFracMult[state.dataGlobal->HourOfDay] = 1.0;
+    } else {
+        for (int surfNum = 1; surfNum <= state.dataSurface->TotSurfaces; ++surfNum) {
+            state.dataSolarShading->SurfSunCosTheta(surfNum) = 0.0;
+            s_surf->SurfOpaqAO(surfNum) = 0.0;
+
+            s_surf->SurfaceWindow(surfNum).OutProjSLFracMult[state.dataGlobal->HourOfDay] = 1.0;
+            s_surf->SurfaceWindow(surfNum).InOutProjSLFracMult[state.dataGlobal->HourOfDay] = 1.0;
+
+            // Array2D
+            state.dataHeatBal->SurfSunlitFracHR(state.dataGlobal->HourOfDay, surfNum) = 0.0;
+            state.dataHeatBal->SurfCosIncAngHR(state.dataGlobal->HourOfDay, surfNum) = 0.0;
+
+            // Array3D
+            state.dataHeatBal->SurfSunlitFrac(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, surfNum) = 0.0;
+            state.dataHeatBal->SurfSunlitFracWithoutReveal(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, surfNum) = 0.0;
+            state.dataHeatBal->SurfCosIncAng(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, surfNum) = 0.0;
+        }
+
+        // Array4D
+        for (int backSurfNum = 1; backSurfNum <= state.dataBSDFWindow->MaxBkSurf; ++backSurfNum) {
+            for (int surfNum = 1; surfNum <= state.dataSurface->TotSurfaces; ++surfNum) {
+                state.dataHeatBal->SurfWinBackSurfaces(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, backSurfNum, surfNum) = 0;
+                state.dataHeatBal->SurfWinOverlapAreas(state.dataGlobal->HourOfDay, state.dataGlobal->TimeStep, backSurfNum, surfNum) = 0.0;
+            }
         }
     }
 

--- a/tst/EnergyPlus/unit/SolarShading.unit.cc
+++ b/tst/EnergyPlus/unit/SolarShading.unit.cc
@@ -4144,6 +4144,8 @@ TEST_F(EnergyPlusFixture, ShadowCalculation_CSV)
     state->dataSurface->Surface(2).Class = DataSurfaces::SurfaceClass::Wall;
     state->dataSurface->Surface(2).Construction = 1;
 
+    state->dataSurface->SurfaceWindow.allocate(state->dataSurface->TotSurfaces);
+
     state->files.shade.open_as_stringstream();
 
     HeatBalanceManager::OpenShadingFile(*state);

--- a/tst/EnergyPlus/unit/SolarShading.unit.cc
+++ b/tst/EnergyPlus/unit/SolarShading.unit.cc
@@ -173,6 +173,218 @@ TEST_F(EnergyPlusFixture, SolarShadingTest_CalcPerSolarBeamTest)
     state->dataHeatBal->SurfWinOverlapAreas.deallocate();
 }
 
+TEST_F(EnergyPlusFixture, SolarShadingTest_CalcPerSolarBeamTestResetsFrac)
+{
+    // Test for #11181 - Test inits for integrated and non-integrated shading calcs, including for DETACHED shading surfaces
+    // We are going to mimic the case where we have two surfaces:
+    // 1) A surface part a zone
+    // 2) A detached or building shading surface, not part of any zone
+    //
+    // We also assume we are in a case where we're starting a new environment, and the SurfSunlitFrac is already filled with numbers
+    // The issue with #11181 was that the arrays were NOT being cleared for the detached shading surfaces, so the previous values were retained when
+    // the Sun was down, because FigureSolarBeamAtTimestep returns early in that case
+
+    state->dataGlobal->TimeStepsInHour = 4;
+    state->dataGlobal->TimeStepZone = 1.0 / state->dataGlobal->TimeStepsInHour;
+
+    // Mimic December 1 in Chicago
+    state->dataEnvrn->DayOfYear = 335;
+    state->dataEnvrn->Month = 12;
+    state->dataEnvrn->DayOfMonth = 1;
+    state->dataGlobal->TimeStep = 1;
+
+    Real64 AvgSinSolarDeclin = 0.0;
+    Real64 AvgEqOfTime = 0.0;                                                        // Average value of Equation of Time for period
+    SolarShading::SUN3(state->dataEnvrn->DayOfYear, AvgSinSolarDeclin, AvgEqOfTime); // Average value of Sine of Solar Declination for period
+    Real64 const AvgCosSolarDeclin = std::sqrt(1.0 - pow_2(AvgSinSolarDeclin));      // Average value of Cosine of Solar Declination for period
+
+    EXPECT_NEAR(0.18712816682814074, AvgEqOfTime, 0.0000000000000001);
+    EXPECT_NEAR(-0.36958738195178753, AvgSinSolarDeclin, 0.0000000000000001);
+    EXPECT_NEAR(0.92919597884516458, AvgCosSolarDeclin, 0.0000000000000001);
+
+    state->dataEnvrn->Latitude = 41.98;
+    state->dataEnvrn->Longitude = -87.92;
+    state->dataEnvrn->SinLatitude = std::sin(Constant::DegToRad * state->dataEnvrn->Latitude);
+    state->dataEnvrn->CosLatitude = std::cos(Constant::DegToRad * state->dataEnvrn->Latitude);
+    state->dataEnvrn->TimeZoneNumber = -6.0;
+    state->dataEnvrn->TimeZoneMeridian = state->dataEnvrn->TimeZoneNumber * 15.0; // -90.0
+
+    state->dataSurface->TotSurfaces = 2;
+    state->dataBSDFWindow->MaxBkSurf = 2;
+    int constexpr zoneSurfaceIndex = 1;
+    int constexpr shadingSurfaceIndex = 2;
+
+    state->dataSurface->Surface.allocate(state->dataSurface->TotSurfaces);
+    state->dataSurface->SurfaceWindow.allocate(state->dataSurface->TotSurfaces);
+    EnergyPlus::SurfaceGeometry::AllocateSurfaceWindows(*state, state->dataSurface->TotSurfaces);
+
+    state->dataGlobal->NumOfZones = 1;
+    state->dataHeatBal->Zone.allocate(state->dataGlobal->NumOfZones);
+    auto &thisZone = state->dataHeatBal->Zone(1);
+    thisZone.Name = "ZONE 1";
+    thisZone.spaceIndexes.emplace_back(1);
+    state->dataHeatBal->space.allocate(1);
+    auto &thisSpace = state->dataHeatBal->space(1);
+    thisSpace.HTSurfaceFirst = zoneSurfaceIndex;
+    thisSpace.HTSurfaceLast = zoneSurfaceIndex;
+
+    auto &zoneSurface = state->dataSurface->Surface(zoneSurfaceIndex);
+    zoneSurface.Name = "ROOF";
+    zoneSurface.Class = DataSurfaces::SurfaceClass::Wall;
+    zoneSurface.Zone = 1;
+    zoneSurface.spaceNum = 1;
+    zoneSurface.BaseSurf = zoneSurfaceIndex;
+    zoneSurface.HeatTransSurf = true;
+    zoneSurface.ExtSolar = true;
+    zoneSurface.OutNormVec = {0.0, 0.0, 1.0};
+    zoneSurface.Sides = 4;
+    zoneSurface.Vertex.allocate(zoneSurface.Sides);
+    zoneSurface.Vertex(1) = {10.0, 0.0, 4.0};
+    zoneSurface.Vertex(2) = {10.0, 10.0, 4.0};
+    zoneSurface.Vertex(3) = {0.0, 10.0, 4.0};
+    zoneSurface.Vertex(4) = {0.0, 0.0, 4.0};
+    zoneSurface.Area = 100.0;
+    zoneSurface.NetAreaShadowCalc = 100.0;
+
+    auto &shadingSurface = state->dataSurface->Surface(shadingSurfaceIndex);
+    shadingSurface.Name = "SHADING";
+    shadingSurface.Class = DataSurfaces::SurfaceClass::Detached_B;
+    shadingSurface.HeatTransSurf = false;
+    shadingSurface.ExtSolar = true;
+    shadingSurface.IsShadowing = true;
+    shadingSurface.OutNormVec = {0.0, 0.0, 1.0};
+    shadingSurface.Sides = 4;
+    shadingSurface.Vertex.allocate(shadingSurface.Sides);
+    shadingSurface.Vertex(1) = {110.0, 0.0, 4.0};
+    shadingSurface.Vertex(2) = {110.0, 10.0, 4.0};
+    shadingSurface.Vertex(3) = {100.0, 10.0, 4.0};
+    shadingSurface.Vertex(4) = {100.0, 0.0, 4.0};
+    shadingSurface.Area = 100.0;
+    shadingSurface.NetAreaShadowCalc = 100.0;
+
+    Window::initWindowModel(*state);
+    SolarShading::AllocateModuleArrays(*state);
+
+    // Prefill with some values
+    state->dataHeatBal->SurfSunlitFrac = 0.5;
+    state->dataHeatBal->SurfSunlitFracHR = 0.5;
+    // Test non-integrated option first, CalcPerSolarBeam should set OutProjSLFracMult and InOutProjSLFracMult to 1.0 for all hours
+    for (int SurfNum = 1; SurfNum <= state->dataSurface->TotSurfaces; ++SurfNum) {
+        for (int Hour = 1; Hour <= Constant::iHoursInDay; ++Hour) {
+            state->dataSurface->SurfaceWindow(SurfNum).OutProjSLFracMult[Hour] = 999.0;
+            state->dataSurface->SurfaceWindow(SurfNum).InOutProjSLFracMult[Hour] = 888.0;
+        }
+    }
+
+    SolarShading::DetermineShadowingCombinations(*state);
+
+    state->dataSysVars->DetailedSolarTimestepIntegration = false;
+    CalcPerSolarBeam(*state, AvgEqOfTime, AvgSinSolarDeclin, AvgCosSolarDeclin);
+
+    int constexpr sunRiseHour = 8;
+    int constexpr sunRiseTimeStep = 1;
+    int constexpr sunSetHour = 17;
+    int constexpr sunSetTimeStep = 1;
+
+    auto isSunUp = [=](int hour, int timestep) {
+        if ((hour < sunRiseHour || (hour == sunRiseHour && timestep < sunRiseTimeStep))) {
+            return false;
+        }
+        if (hour > sunSetHour || (hour == sunSetHour && timestep > sunSetTimeStep)) {
+            return false;
+        }
+
+        return true;
+    };
+
+    // Ensure we have sun is Up working properly
+    for (int hour = 1; hour <= Constant::iHoursInDay; ++hour) {
+        for (int timestep = 1; timestep <= state->dataGlobal->TimeStepsInHour; ++timestep) {
+            if (isSunUp(hour, timestep)) {
+                EXPECT_GT(state->dataBSDFWindow->SUNCOSTS(timestep, hour).z, 0.0);
+            } else {
+                EXPECT_LT(state->dataBSDFWindow->SUNCOSTS(timestep, hour).z, 0.0);
+            }
+        }
+    }
+
+    // Check that the fraction Sunlit is properly set to 1.0 when the sun is Up and ZERO otherwis: it does NOT remember previously set values
+    for (int surfNum = 1; surfNum <= state->dataSurface->TotSurfaces; ++surfNum) {
+        SCOPED_TRACE(fmt::format("Surface {}='{}'", surfNum, state->dataSurface->Surface(surfNum).Name));
+        for (int hour = 1; hour <= Constant::iHoursInDay; ++hour) {
+            SCOPED_TRACE(fmt::format("Hour={}", hour));
+            if (isSunUp(hour, state->dataGlobal->TimeStepsInHour)) {
+                EXPECT_DOUBLE_EQ(1.0, state->dataHeatBal->SurfSunlitFracHR(hour, surfNum)) << "Failed when Sun is Up";
+            } else {
+                EXPECT_DOUBLE_EQ(0.0, state->dataHeatBal->SurfSunlitFracHR(hour, surfNum)) << "Failed when Sun is Down";
+            }
+            for (int timestep = 1; timestep <= state->dataGlobal->TimeStepsInHour; ++timestep) {
+                SCOPED_TRACE(fmt::format("Timestep={}", timestep));
+                if (isSunUp(hour, timestep)) {
+                    EXPECT_DOUBLE_EQ(1.0, state->dataHeatBal->SurfSunlitFrac(hour, timestep, surfNum)) << "Failed when Sun is Up";
+                } else {
+                    EXPECT_DOUBLE_EQ(0.0, state->dataHeatBal->SurfSunlitFrac(hour, timestep, surfNum)) << "Failed when Sun is Down";
+                }
+            }
+
+            EXPECT_EQ(1.0, state->dataSurface->SurfaceWindow(surfNum).OutProjSLFracMult[hour]);
+            EXPECT_EQ(1.0, state->dataSurface->SurfaceWindow(surfNum).InOutProjSLFracMult[hour]);
+        }
+    }
+
+    // Test integrated option, CalcPerSolarBeam should set OutProjSLFracMult and InOutProjSLFracMult to 1.0 only for the specified hour
+    // Re-initialize to new values
+    for (int surfNum = 1; surfNum <= state->dataSurface->TotSurfaces; ++surfNum) {
+        for (int hour = 1; hour <= Constant::iHoursInDay; ++hour) {
+            state->dataSurface->SurfaceWindow(surfNum).OutProjSLFracMult[hour] = 555.0;
+            state->dataSurface->SurfaceWindow(surfNum).InOutProjSLFracMult[hour] = 444.0;
+        }
+    }
+    state->dataHeatBal->SurfSunlitFrac = 0.5;
+    state->dataHeatBal->SurfSunlitFracHR = 0.5;
+
+    state->dataSysVars->DetailedSolarTimestepIntegration = true;
+    state->dataGlobal->HourOfDay = 23;
+    state->dataGlobal->TimeStep = 3;
+    CalcPerSolarBeam(*state, AvgEqOfTime, AvgSinSolarDeclin, AvgCosSolarDeclin);
+
+    for (int surfNum = 1; surfNum <= state->dataSurface->TotSurfaces; ++surfNum) {
+        SCOPED_TRACE(fmt::format("Surface {}='{}'", surfNum, state->dataSurface->Surface(surfNum).Name));
+        for (int hour = 1; hour <= Constant::iHoursInDay; ++hour) {
+            SCOPED_TRACE(fmt::format("Hour={}", hour));
+            if (hour == state->dataGlobal->HourOfDay) {
+                EXPECT_EQ(1.0, state->dataSurface->SurfaceWindow(surfNum).OutProjSLFracMult[hour]);
+                EXPECT_EQ(1.0, state->dataSurface->SurfaceWindow(surfNum).InOutProjSLFracMult[hour]);
+                EXPECT_DOUBLE_EQ(0.0, state->dataHeatBal->SurfSunlitFracHR(hour, surfNum));
+            } else {
+                EXPECT_EQ(555.0, state->dataSurface->SurfaceWindow(surfNum).OutProjSLFracMult[hour]);
+                EXPECT_EQ(444.0, state->dataSurface->SurfaceWindow(surfNum).InOutProjSLFracMult[hour]);
+                EXPECT_DOUBLE_EQ(0.5, state->dataHeatBal->SurfSunlitFracHR(hour, surfNum));
+            }
+            for (int timestep = 1; timestep <= state->dataGlobal->TimeStepsInHour; ++timestep) {
+                SCOPED_TRACE(fmt::format("Timestep={}", timestep));
+                if (hour == state->dataGlobal->HourOfDay && timestep == state->dataGlobal->TimeStep) {
+                    EXPECT_DOUBLE_EQ(0.0, state->dataHeatBal->SurfSunlitFrac(hour, timestep, surfNum));
+                } else {
+                    EXPECT_DOUBLE_EQ(0.5, state->dataHeatBal->SurfSunlitFrac(hour, timestep, surfNum));
+                }
+            }
+        }
+    }
+
+    // Clean up (Why is this needed?!)
+    state->dataSurface->SurfaceWindow.deallocate();
+    state->dataHeatBal->SurfSunlitFracHR.deallocate();
+    state->dataHeatBal->SurfSunlitFrac.deallocate();
+    state->dataHeatBal->SurfSunlitFracWithoutReveal.deallocate();
+    state->dataSolarShading->SurfSunCosTheta.deallocate();
+    state->dataHeatBal->SurfCosIncAngHR.deallocate();
+    state->dataHeatBal->SurfCosIncAng.deallocate();
+    state->dataSurface->SurfOpaqAO.deallocate();
+    state->dataHeatBal->SurfWinBackSurfaces.deallocate();
+    state->dataHeatBal->SurfWinOverlapAreas.deallocate();
+}
+
 TEST_F(EnergyPlusFixture, SolarShadingTest_SurfaceScheduledSolarInc)
 {
     int SurfSolIncPtr;


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #11181 

Some solar shading arrays are not cleared.



### Description of the purpose of this PR

The issue with #11181 was that the arrays were NOT being cleared for the detached shading surfaces, so the previous values were retained when the Sun was down, because FigureSolarBeamAtTimestep returns early in that case

Original regression appeared in v9.6.0, and is due to https://github.com/NREL/EnergyPlus/pull/8820
Specifically the commit, the change in SolarShading.cc https://github.com/NREL/EnergyPlus/commit/c10a756a4fe766999e79518aac927105853c67f7#diff-18fbb8a5b1334b62513de2441bdb4bb4ef1fbe5fbec24d5dd0effcd019dfc33dR4795

Before, the ObjexxFCL assignment was used to reset everything this commit changed the initialization to explicit loop variables, BUT it does it only for heat transfer surfaces linked to a zone/space, and no longer does it for detached shading surfaces.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [x] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [x] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [x] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [x] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [x] If structural output changes, add to output rules file and add OutputChange label
 - [x] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
