### PR TITLE
Remove 'cooling' from ASHRAE205 coils.

### DIFF
--- a/doc/input-output-reference/src/overview/group-coil-cooling-dx.tex
+++ b/doc/input-output-reference/src/overview/group-coil-cooling-dx.tex
@@ -6,7 +6,7 @@ This coil input structure is meant to supplant the coil objects from previous En
 \def\labelenumi{\arabic{enumi}.}
 \item Coil:Cooling:DX - Defines where the coil's evaporator and condenser sections are connected to the HVAC system through node connections to air loops or zones (if condenser section rejects heat to a zone), as well as the coil's availability.
 
-\item Coil:Cooling:DX:CurveFit:Performance or Coil:Cooling:DX:ASHRAE205:Performance - Defines how the coil operates over a range of operating conditions.
+\item Coil:Cooling:DX:CurveFit:Performance or Coil:DX:ASHRAE205:Performance - Defines how the coil operates over a range of operating conditions.
 
 \item Coil:Cooling:DX:CurveFit:OperatingMode (CurveFit only) - Defines the rated coil characteristics (capacity, evaporator section air flow rate, etc.) and capacity control method for a given operating mode. Operating modes are generally used to describe humidity control strategies for DX cooling coil arrangements that enable enhanced dehumidification.
 
@@ -54,7 +54,7 @@ The name of the HVAC system node to which the condenser of the DX cooling coil s
 
 \paragraph{Field: Performance Object Name}\label{field-performance-object-name-6-001}
 
-The name of the Coil:Cooling:DX:CurveFit:Performance or Coil:Cooling:DX:ASHRAE205:Performance object that defines this coil's performance specifications.
+The name of the Coil:Cooling:DX:CurveFit:Performance or Coil:DX:ASHRAE205:Performance object that defines this coil's performance specifications.
 
 \paragraph{Field: Condensate Collection Water Storage Tank Name}
 
@@ -64,7 +64,7 @@ This field is optional. It is used to describe where condensate from the coil is
 
 This field is optional. It is used to describe where the coil obtains water used for evaporative cooling of its condenser. If blank or omitted, then the unit will obtain water directly from the mains. If the name of a WaterUse:Storage object is used here, then the unit will obtain its water from that tank. If a tank is specified, the unit will attempt to obtain all the water it uses from the tank. However, if the tank cannot provide all the water the condenser needs, then the unit will still operate and obtain the rest of the water it needs from the mains (referred to as StarvedWater).
 
-\subsection{Coil:Cooling:DX:ASHRAE205:Performance}\label{coilcoolingdxashrae205performance}
+\subsection{Coil:DX:ASHRAE205:Performance}\label{coildxashrae205performance}
 
 This object defines basic unit control and ASHRAE205 representation file for one Coil:Cooling:DX object.
 


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11382 

### Description of the purpose of this PR

The Coil representation in ASHRAE Standard 205 is agnostic of whether a coil is used for heating or cooling. Therefore, although other EnergyPlus Coil objects are under an umbrella of either Coil:Cooling:DX or Coil:Heating:DX, the ASHRAE205 coils will be labeled consistently in both the IDD and documentation as simply Coil:DX.


### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
