### PR TITLE
Add a workflow for self-hosted runners

### DIFF
--- a/.github/workflows/self_hosted_build_and_test.yml
+++ b/.github/workflows/self_hosted_build_and_test.yml
@@ -1,0 +1,41 @@
+name: Self-Hosted Build and Test
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to test (leave empty for current ref)"
+        required: false
+        default: ""
+
+jobs:
+  build_and_test:
+    name: Build and Test (Ubuntu matrix)
+    strategy:
+      matrix:
+        runner:
+          - [self-hosted, linux, x64, ubuntu-22.04]
+          - [self-hosted, linux, x64, ubuntu-24.04]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout EnergyPlus
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -G "Unix Makefiles"
+          -DCMAKE_BUILD_TYPE=Release
+          -DBUILD_TESTING=ON
+          -DBUILD_PACKAGE=OFF
+          -DDOCUMENTATION_BUILD=DoNotBuild
+
+      - name: Build
+        run: cmake --build build -j "$(nproc)"
+
+      - name: Run tests
+        run: ctest --test-dir build -j "$(nproc)"


### PR DESCRIPTION
This new workflow will utilize Ubuntu 22.04 and 24.04 self hosted runners to build and test EnergyPlus. Currently the trigger is a commit to the develop branch or a manual action. We can expand from here, by adding additional workflow for various tasks we might want (such as packaging) and for additional triggers (such as PRs). A pattern is established that allows for additional build types such as Windows to be added to the workflow's build matrix.
