### PR TITLE
Fix missing zone volume in Engineering Reference C_z definition

### DIFF
--- a/doc/engineering-reference/src/integrated-solution-manager/basis-for-the-zone-and-air-system-integration.tex
+++ b/doc/engineering-reference/src/integrated-solution-manager/basis-for-the-zone-and-air-system-integration.tex
@@ -21,7 +21,9 @@ where:
 
 ${C_z}\frac{dT_z}{dt} =$ energy stored in zone air
 
-C\(_{z}\) = $\rho$\(_{air}\)C\(_{p}\)C\(_{T}\)
+C\(_{z}\) = $V_{z}$$\rho$\(_{air}\)C\(_{p}\)C\(_{T}\)
+
+\(V_{z}\) = zone air volume
 
 $\rho$\(_{air}\) = zone air density
 


### PR DESCRIPTION
Fixes #11418

  Add missing zone volume (V_z) term to Engineering Reference Equation 2.1 definition of C_z.

  The definition was ρ_air × C_p × C_T (units: J/°C·m³). Correct definition is V_z × ρ_air × C_p × C_T (units: J/°C),
  matching the code in ZoneTempPredictorCorrector.cc.

  Documentation-only change — no code or simulation impact.

 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions


### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
