### PR TITLE
Clarify DefrostEIRTempModFac is an EIR, not an EIR modifier

### DIFF
--- a/doc/engineering-reference/src/simulation-models-encyclopedic-reference-001/coils.tex
+++ b/doc/engineering-reference/src/simulation-models-encyclopedic-reference-001/coils.tex
@@ -3547,7 +3547,7 @@ If PLF \textless{} 0.7 a warning message is issued, the program resets the PLF v
 A typical part load fraction correlation for a conventional, single-speed DX heating coil (e.g., residential heat pump) would be:  PLF = 0.85 + 0.15(PLR).
 
   \item
-The defrost energy input ratio (EIR) modifier curve (function of temperature) is a bi-quadratic curve with two independent variables: outdoor air dry-bulb temperature and the heating coil entering air wet-bulb temperature. The output of this curve is multiplied by the heating coil capacity, the fractional defrost time period and the runtime fraction of the heating coil to give the defrost power at the specific temperatures at which the coil is operating. This curve is only required when a reverse-cycle defrost strategy is specified.
+The defrost energy input ratio (EIR) curve (function of temperature) is a bi-quadratic curve with two independent variables: outdoor air dry-bulb temperature and the heating coil entering air wet-bulb temperature. The output of this curve represents the defrost power divided by the rated heating capacity (i.e., an energy input ratio, not a modifier applied to a rated EIR). It is multiplied by the heating coil capacity, the fractional defrost time period and the runtime fraction of the heating coil to give the defrost power at the specific temperatures at which the coil is operating. This curve is only required when a reverse-cycle defrost strategy is specified.
 
 \begin{equation}
 DefrostEIRTempModFac = \,a + \,b\left( {{T_{wb,i}}} \right)\,\, + \,\,c{\left( {{T_{wb,i}}} \right)^2} + \,\,d\left( {{T_{db,o}}} \right)\,\, + \,\,e{\left( {{T_{db,o}}} \right)^2} + f\left( {{T_{wb,i}}} \right)\left( {{T_{db,o}}} \right)
@@ -3666,7 +3666,7 @@ where:
 
 \({Q_{cap,defrost}}\) is the capacity of the resistive defrost heating element (W)
 
-\emph{DefrostEIRTempModFac} is the energy input ratio modifier curve applicable during defrost
+\emph{DefrostEIRTempModFac} is the defrost energy input ratio (EIR) at the specific operating temperatures. Note: despite the variable name, this value represents an EIR (defrost power / rated capacity), not a modifier applied to a rated EIR
 
 \begin{equation}
 RTF = \left( \frac{PLR}{PartLoadFrac} \right) = runtime~fraction~of~the~heating~coil
@@ -4334,7 +4334,7 @@ where:
 
 \({Q_{total,rated,n}}\) is the capacity of the resistive defrost heating element at Speed n (W)
 
-DefrostEIRTempModFac is the defrost energy input ratio (EIR) modifier curve (Ref. Coil:Heating:DX:SingleSpeed).
+DefrostEIRTempModFac is the defrost energy input ratio (EIR) curve value (Ref. Coil:Heating:DX:SingleSpeed). Note: this represents an EIR (defrost power / rated capacity), not a modifier applied to a rated EIR.
 
 T\(_{frac,defrost}\) is the fractional defrost time (Ref. Coil:Heating:DX:SingleSpeed).
 
@@ -4914,7 +4914,7 @@ If the speed reaches the highest level, the speed ratio becomes 1.0, and Speed x
 
 The defrost operation of a variable-speed DX heating coil is treated the same as the single-speed DX heating coil, except using the total heating capacity at the max speed level to replace the rated heating capacity of the single-speed DX coil, when a reverse-cycle defrost strategy is specified.
 
-We keep the defrost energy input ratio (EIR) modifier curve (function of temperature) as the single speed DX heating coil. It is a biquadratic curve with two independent variables: outdoor air dry-bulb temperature and the heating coil entering air wet-bulb temperature. The output of this curve is multiplied by the heating coil capacity, the fractional defrost time period and the runtime fraction of the heating coil to give the defrost power at the specific temperatures at which the coil is operating. This curve is only required when a reverse-cycle defrost strategy is specified.
+The defrost energy input ratio (EIR) curve (function of temperature) is the same as the single speed DX heating coil. It is a biquadratic curve with two independent variables: outdoor air dry-bulb temperature and the heating coil entering air wet-bulb temperature. The output of this curve represents the defrost power divided by the rated heating capacity (i.e., an energy input ratio, not a modifier applied to a rated EIR). It is multiplied by the heating coil capacity, the fractional defrost time period and the runtime fraction of the heating coil to give the defrost power at the specific temperatures at which the coil is operating. This curve is only required when a reverse-cycle defrost strategy is specified.
 
 \begin{equation}
 {\rm{DefrostEIRTempModFac}} = {\rm{a}} + {\rm{b*W}}{{\rm{B}}_{\rm{i}}} + {\rm{c*WB}}_{\rm{i}}^2 + {\rm{d*D}}{{\rm{B}}_{\rm{o}}} + {\rm{e*D}}{{\rm{B}}_{\rm{o}}}^2 + {\rm{f*W}}{{\rm{B}}_{\rm{i}}}{\rm{*D}}{{\rm{B}}_{\rm{o}}}


### PR DESCRIPTION
Fixes #11380

  Clarify in the Engineering Reference that DefrostEIRTempModFac represents a defrost energy input ratio (defrost power
  / rated capacity), not a modifier applied to a rated EIR. Other EIR modifier curves (e.g. EIRTempModFac) multiply
  against rated EIR, but the defrost curve multiplies against rated capacity directly. The terminology was inconsistent
  and confusing. Four locations updated in coils.tex:

  - Single-speed DX heating coil curve description
  - Single-speed defrost operation variable definition
  - Multi-speed defrost operation variable definition
  - Variable-speed defrost operation description

  No code changes — documentation only.

