### PR TITLE
Rollback Test PR Workflow to Before #11506

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -23,30 +23,22 @@ jobs:
           macos_dev_target: 14.0
           arch: arm64
           python-arch: arm64
-          enable_pch: ON
           run_regressions: true
           pretty: "Mac arm64"
         - os: ubuntu-24.04
           arch: x86_64
           python-arch: x64
-          enable_pch: ON
           run_regressions: true
           pretty: "Ubuntu 24.04"
         - os: windows-2022
           arch: x86_64
           python-arch: x64
-          enable_pch: OFF
           run_regressions: false
           pretty: "Windows x64"
 
     steps:
 
-    - name: Checkout PR head
-      uses: actions/checkout@v6
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
+    - uses: actions/checkout@v6
 
     - name: Setup System
       id: setup-runner
@@ -58,26 +50,21 @@ jobs:
     - name: Get Develop and Branch Git SHA
       shell: bash
       run: |
-        echo "Figuring out the develop GIT SHA already merged into the PR branch"
-        BASE_BRANCH="${{ github.base_ref }}"
-        if git remote get-url upstream >/dev/null 2>&1; then
-          git remote set-url upstream "https://github.com/$GITHUB_REPOSITORY.git"
-        else
-          git remote add upstream "https://github.com/$GITHUB_REPOSITORY.git"
-        fi
-        git fetch --no-tags upstream "refs/heads/${BASE_BRANCH}:refs/remotes/upstream/${BASE_BRANCH}"
-        DEVELOP_SHA=$(git merge-base HEAD "upstream/${BASE_BRANCH}")
-        echo "Develop GIT SHA merged into this branch is '${DEVELOP_SHA}'"
+        echo "Figuring out the develop GIT SHA"
+        # github.event.pull_request.base.sha points to develop at the time the PR was created, not the current one
+        DEVELOP_SHA=$(git ls-remote https://github.com/$GITHUB_REPOSITORY.git develop | cut -f1 | cut -c1-10)
+        echo "Develop GIT SHA is '${DEVELOP_SHA}'"
         echo "DEVELOP_SHA=$DEVELOP_SHA" >> $GITHUB_ENV
 
         CURRENT_HEAD_SHA=${{ github.event.pull_request.head.sha }}
         echo "Current Branch HEAD SHA is '${CURRENT_HEAD_SHA}'"
-        echo "CURRENT_HEAD_SHA=$CURRENT_HEAD_SHA" >> $GITHUB_ENV
+        echo "CURRENT_HEAD_SHA=$DEVELOP_SHA" >> $GITHUB_ENV
 
-        echo "GitHub synthetic merge commit SHA is '${GITHUB_SHA}'"
+        echo "Current merge commit SHA is '${GITHUB_SHA}'"
         echo "::endgroup::"
-        # Default PCH behavior is per-platform, then regression-cache hits may override it.
-        echo "ENABLE_PCH=${{ matrix.enable_pch }}" >> $GITHUB_ENV
+        # We default to using PCH, in case we don't find the baseline reg tests,
+        # since it speeds up the build significantly and we'll build TWICE
+        echo "ENABLE_PCH=ON" >> $GITHUB_ENV
 
     - name: Baseline Regression Testing caching
       uses: actions/cache@v5
@@ -105,6 +92,8 @@ jobs:
         restore-keys: |
           ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-${{ github.head_ref }}
           ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-${{ env.DEVELOP_SHA }}
+          ccache-${{ matrix.os }}-${{ steps.setup-runner.outputs.compiler-id }}-
+          ccache-${{ matrix.os }}-
 
     - name: Did restoring the CCache-cache work?
       shell: bash
@@ -151,8 +140,7 @@ jobs:
       if: matrix.run_regressions && steps.cachebaselineregression.outputs.cache-hit != 'true'
       uses: actions/checkout@v6
       with:
-        repository: ${{ github.repository }}
-        ref: ${{ env.DEVELOP_SHA }}
+        ref: develop
         clean: false # Do NOT wipe the build/ and .ccache folder (`git clean -ffdx && git reset --hard HEAD`)
 
     - name: Baseline Configure and Build
@@ -196,8 +184,6 @@ jobs:
       if: matrix.run_regressions && steps.cachebaselineregression.outputs.cache-hit != 'true'
       uses: actions/checkout@v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ env.CURRENT_HEAD_SHA }}
         clean: false # Do NOT wipe the build/ and .ccache folder (`git clean -ffdx && git reset --hard HEAD`)
 
     - name: Install problem matcher


### PR DESCRIPTION
Pull request overview
---------------------

- Rollback the test pull request workflow to before #11506.

### Description of the purpose of this PR

Due to my misunderstanding of the previous workflow, I'm rolling back #11506. [This block](https://github.com/NatLabRockies/EnergyPlus/blob/6940d9bb3b24a6c5ddfec1c4ecfe749909a87ad2/.github/workflows/test_pull_requests.yml#L3-L5) ensures that the workflow only runs on PRs submitted to be merged to `develop`. The nuanced behavior that I did not understand is that when this happens, GitHub creates a temporary, behind the scenes "synthetic" merge commit, which is the product of the `develop` branch at its _current_ state and the feature branch. `develop` ___is not___ picked at its most recent intersection with your branch (i.e. the latest point at which someone has merged `develop` into the feature branch manually). 

The advantage of this is that even if your branch is behind `develop` locally, GitHub will merge them together, and (\*should) give you the current status of regressions ran against your branch and current develop.

\* There have been instances of where this has failed, due to currently unknown reasons, including [here](https://github.com/NatLabRockies/EnergyPlus/pull/11482#issuecomment-4206690847). I'm attaching the log of that run here for archiving purposes.

[2026-04-07T20:46:30.3111801Z.log](https://github.com/user-attachments/files/26637518/2026-04-07T20.46.30.3111801Z.log)

Unfortunately, the only suggestion I currently have when this happens is to trigger a rerun of the workflow. If things like this keep happening, we'll dig back in and investigate further. 

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
