### PR TITLE
fix #6163: BCVTB doc swaps NAME/TYPE mapping for Output:Variable

### DIFF
--- a/doc/external-interfaces-application-guide/src/external-interface-s/bcvtb-examples.tex
+++ b/doc/external-interfaces-application-guide/src/external-interface-s/bcvtb-examples.tex
@@ -107,7 +107,7 @@ where NAME needs to be the EnergyPlus actuator name. For ExternalInterface:Varia
 
 where NAME needs to be the EnergyPlus Energy Runtime Language (Erl) variable name.
 
-The external interface can also read data from any Output:Variable and EnergyManagementSystem:OutputVariable. For these objects, set the ``source'' attribute to ``EnergyPlus,'' because they are computed by EnergyPlus. The read an Output:Variable, use
+The external interface can also read data from any Output:Variable and EnergyManagementSystem:OutputVariable. For these objects, set the ``source'' attribute to ``EnergyPlus,'' because they are computed by EnergyPlus. To read an Output:Variable, use
 
 ~ \textless{}variable source = ``EnergyPlus''\textgreater{}
 
@@ -115,7 +115,7 @@ The external interface can also read data from any Output:Variable and EnergyMan
 
 ~ \textless{}/variable\textgreater{}
 
-where NAME needs to be the EnergyPlus ``Variable Name'' (such as ZONE/SYS AIR TEMP) and TYPE needs to be the EnergyPlus ``Key Value'' (such as ZONE ONE). To read an EnergyManagementSystem:OutputVariable, use
+where NAME needs to be the EnergyPlus ``Key Value'' (such as ZONE ONE) and TYPE needs to be the EnergyPlus ``Variable Name'' (such as Zone Air Temperature). To read an EnergyManagementSystem:OutputVariable, use
 
 \textless{}variable source = ``EnergyPlus''\textgreater{}
 


### PR DESCRIPTION
## Summary

Fixes #6163. In `doc/external-interfaces-application-guide/src/external-interface-s/bcvtb-examples.tex:118`, the prose description of the BCVTB `variables.cfg` XML for reading an Output:Variable had `NAME` and `TYPE` swapped.

After fix:
> where NAME needs to be the EnergyPlus "Key Value" (such as ZONE ONE) and TYPE needs to be the EnergyPlus "Variable Name" (such as Zone Air Temperature).

also:
- Typo on L110: `"The read an Output:Variable"` → `"To read an Output:Variable"`.
- Modernized stale example `ZONE/SYS AIR TEMP` → `Zone Air Temperature` (matches in-file L245).

## Evidence

**Code** (authoritative — all local refs):
- `third_party/BCVTB/utilXml.c:179,190` — XML `name` attr parsed into `outputVarsName`; `type` attr into `outputVarsType`.
- `src/EnergyPlus/ExternalInterface.cc:441-443, 506-507` — after parse: `xmlStrOutTyp` (← XML `name`) → `varKeys`; `xmlStrOut` (← XML `type`) → `varNames`.
- `src/EnergyPlus/ExternalInterface.cc:2291,2299` (`GetReportVariableKey`) — `VarNames` passed to `GetVariableKeyCountandType` (= E+ Variable Name); `varKeys` matched against `keyNames` (= E+ Key Value).
- Conclusion: XML `name` → E+ Key Value; XML `type` → E+ Variable Name. Pre-fix doc had it backwards.

**Doc self-contradiction** (same file):
- L118 (pre-fix, wrong): `NAME=Variable Name, TYPE=Key Value`.
- L126 (already correct, EMS subcase): "the attribute 'type' must be set to the EMS variable name."

**Doc example blocks already demonstrate correct mapping:**
- L242: `name="ENVIRONMENT" type="SITE OUTDOOR AIR DRYBULB TEMPERATURE"` — ENVIRONMENT is the key; SITE… is the variable name.
- L245: `name="ZSF1" type="ZONE AIR TEMPERATURE"` — zone name is the key.

**Sibling FMU doc** (`fmu-examples.tex:154-155`): `ZONE ONE` labeled "EnergyPlus Key Value"; `Zone Mean Air Temperature` labeled "EnergyPlus Variable Name". Post-fix BCVTB prose uses the same terminology and ordering convention.

## Test plan

- [ ] CI `build_documentation.yml` builds `ExternalInterfacesApplicationGuide.pdf` without LaTeX errors.
- [ ] Visual diff of rendered PDF §"XML Syntax" shows corrected prose at the Output:Variable description.

No code, IDD, or test changes. Docs-only. No changelog.