### PR TITLE
Disable ffp-contract on GCC too for arm64 GCC

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -122,6 +122,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" O
     target_compile_options(project_warnings INTERFACE -Wno-stringop-overflow)
     # for RelWithDebInfo builds, lets turn OFF NDEBUG, which will re-enable assert statements
     target_compile_options(project_options INTERFACE $<$<CONFIG:RelWithDebInfo>:-UNDEBUG>)
+    target_compile_options(project_fp_options INTERFACE -ffp-contract=off) # Disable fused-floating point operations (default is fast)
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
       # Suppress unused-but-set warnings until more serious ones are addressed
@@ -129,7 +130,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" O
     endif()
     target_compile_options(project_warnings INTERFACE -Wno-vexing-parse)
     target_compile_options(project_warnings INTERFACE -Wno-invalid-source-encoding)
-    target_compile_options(project_fp_options INTERFACE -ffp-contract=off)
+    target_compile_options(project_fp_options INTERFACE -ffp-contract=off) # Disable fused-floating point operations (default is on)
   endif()
 
   set(need_arithm_debug_genex "$<OR:$<BOOL:${FORCE_DEBUG_ARITHM_GCC_OR_CLANG}>,$<CONFIG:Debug>>")


### PR DESCRIPTION
Pull request overview
---------------------

Disable ffp-contract on GCC too for arm64 GCC

OpenStudio SDK has a test that was failing because of that. The SQL values are slightly different.

GCC defaults `-ffp-contract=fast`, which enables FMA on native archs that support it, arm64 is such. (clang does `-ffp-contract=on` default)

```
  172: [ RUN      ] SqlFileFixture.AnnualTotalCosts
  172: /home/root/OpenStudio/src/utilities/sql/Test/SqlFile_GTest.cpp:364: Failure
  172: The difference between ep_2520.annualTotalUtilityCost and sqlFile2.annualTotalUtilityCost().get() is 1191.5300000011921, which exceeds 0.03, where
  172: ep_2520.annualTotalUtilityCost evaluates to 191876887.69,
  172: sqlFile2.annualTotalUtilityCost().get() evaluates to 191875696.16, and
  172: 0.03 evaluates to 0.029999999999999999.
  172:
  172: /home/root/OpenStudio/src/utilities/sql/Test/SqlFile_GTest.cpp:367: Failure
  172: Expected equality of these values:
  172:   ep_2520.annualTotalCost_Electricity
  172:     Which is: 27893.060000000001
  172:   sqlFile2.annualTotalCost(FuelType::Electricity).get()
  172:     Which is: 27893.029999999999
  172:
  172: /home/root/OpenStudio/src/utilities/sql/Test/SqlFile_GTest.cpp:368: Failure
  172: Expected equality of these values:
  172:   ep_2520.annualTotalCost_Gas
  172:     Which is: 407.55000000000001
  172:   sqlFile2.annualTotalCost(FuelType::Gas).get()
  172:     Which is: 407.54000000000002
  172:
  172: /home/root/OpenStudio/src/utilities/sql/Test/SqlFile_GTest.cpp:371: Failure
  172: The difference between ep_2520.annualTotalCost_Water and sqlFile2.annualTotalCost(FuelType::Water).get() is 8.5100000002421439, which exceeds 0.03, where
  172: ep_2520.annualTotalCost_Water evaluates to 3328949.3599999999,
  172: sqlFile2.annualTotalCost(FuelType::Water).get() evaluates to 3328957.8700000001, and
  172: 0.03 evaluates to 0.029999999999999999.
  172:
  172: /home/root/OpenStudio/src/utilities/sql/Test/SqlFile_GTest.cpp:372: Failure
  172: Expected equality of these values:
  172:   ep_2520.annualTotalCost_FuelOil_1
  172:     Which is: 188518500
  172:   sqlFile2.annualTotalCost(FuelType::FuelOil_1).get()
  172:     Which is: 188517300
  172:
  172: [  FAILED  ] SqlFileFixture.AnnualTotalCosts (35 ms)
```

### Description of the purpose of this PR

<!-- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
