### PR TITLE
Remove fmt: convert I* files to std::format (part 4)

### DIFF
--- a/src/EnergyPlus/ICEngineElectricGenerator.cc
+++ b/src/EnergyPlus/ICEngineElectricGenerator.cc
@@ -47,6 +47,7 @@
 
 // C++ Headers
 #include <cmath>
+#include <format>
 
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array.functions.hh>
@@ -104,8 +105,8 @@ namespace ICEngineElectricGenerator {
         }
         // If we didn't find it, fatal
         ShowFatalError(state,
-                       EnergyPlus::format("LocalICEngineGeneratorFactory: Error getting inputs for internal combustion engine generator named: {}",
-                                          objectName)); // LCOV_EXCL_LINE
+                       std::format("LocalICEngineGeneratorFactory: Error getting inputs for internal combustion engine generator named: {}",
+                                   objectName)); // LCOV_EXCL_LINE
         // Shut up the compiler
         return nullptr; // LCOV_EXCL_LINE
     }
@@ -138,7 +139,7 @@ namespace ICEngineElectricGenerator {
             state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, s_ipsc->cCurrentModuleObject);
 
         if (state.dataICEngElectGen->NumICEngineGenerators <= 0) {
-            ShowSevereError(state, EnergyPlus::format("No {} equipment specified in input file", s_ipsc->cCurrentModuleObject));
+            ShowSevereError(state, std::format("No {} equipment specified in input file", s_ipsc->cCurrentModuleObject));
             ErrorsFound = true;
         }
 
@@ -168,8 +169,8 @@ namespace ICEngineElectricGenerator {
 
             iceGen.RatedPowerOutput = NumArray(1);
             if (NumArray(1) == 0.0) {
-                ShowSevereError(state, EnergyPlus::format("Invalid {}={:.2R}", s_ipsc->cNumericFieldNames(1), NumArray(1)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", s_ipsc->cCurrentModuleObject, AlphArray(1)));
+                ShowSevereError(state, std::format("Invalid {}={:.2f}", s_ipsc->cNumericFieldNames(1), NumArray(1)));
+                ShowContinueError(state, std::format("Entered in {}={}", s_ipsc->cCurrentModuleObject, AlphArray(1)));
                 ErrorsFound = true;
             }
 
@@ -230,11 +231,10 @@ namespace ICEngineElectricGenerator {
             } else {
                 Real64 xValue = iceGen.ExhaustTempCurve->value(state, 1.0);
                 if (xValue < ReferenceTemp) {
-                    ShowSevereError(state,
-                                    EnergyPlus::format("GetICEngineGeneratorInput: {} output has very low value.", s_ipsc->cAlphaFieldNames(7)));
-                    ShowContinueError(state, EnergyPlus::format("...curve generates [{:.3R} C] at PLR=1.0", xValue));
-                    ShowContinueError(
-                        state, EnergyPlus::format("...this is less than the Reference Temperature [{:.2R} C] and may cause errors.", ReferenceTemp));
+                    ShowSevereError(state, std::format("GetICEngineGeneratorInput: {} output has very low value.", s_ipsc->cAlphaFieldNames(7)));
+                    ShowContinueError(state, std::format("...curve generates [{:.3f} C] at PLR=1.0", xValue));
+                    ShowContinueError(state,
+                                      std::format("...this is less than the Reference Temperature [{:.2f} C] and may cause errors.", ReferenceTemp));
                 }
             }
 
@@ -257,8 +257,8 @@ namespace ICEngineElectricGenerator {
                                                                      Node::CompFluidStream::Primary,
                                                                      Node::ObjectIsNotParent);
                 if (iceGen.HeatRecInletNodeNum == 0) {
-                    ShowSevereError(state, EnergyPlus::format("Invalid {}={}", s_ipsc->cAlphaFieldNames(8), AlphArray(8)));
-                    ShowContinueError(state, EnergyPlus::format("Entered in {}={}", s_ipsc->cCurrentModuleObject, AlphArray(1)));
+                    ShowSevereError(state, std::format("Invalid {}={}", s_ipsc->cAlphaFieldNames(8), AlphArray(8)));
+                    ShowContinueError(state, std::format("Entered in {}={}", s_ipsc->cCurrentModuleObject, AlphArray(1)));
                     ErrorsFound = true;
                 }
                 iceGen.HeatRecOutletNodeNum = Node::GetOnlySingleNode(state,
@@ -271,8 +271,8 @@ namespace ICEngineElectricGenerator {
                                                                       Node::CompFluidStream::Primary,
                                                                       Node::ObjectIsNotParent);
                 if (iceGen.HeatRecOutletNodeNum == 0) {
-                    ShowSevereError(state, EnergyPlus::format("Invalid {}={}", s_ipsc->cAlphaFieldNames(9), AlphArray(9)));
-                    ShowContinueError(state, EnergyPlus::format("Entered in {}={}", s_ipsc->cCurrentModuleObject, AlphArray(1)));
+                    ShowSevereError(state, std::format("Invalid {}={}", s_ipsc->cAlphaFieldNames(9), AlphArray(9)));
+                    ShowContinueError(state, std::format("Entered in {}={}", s_ipsc->cCurrentModuleObject, AlphArray(1)));
                     ErrorsFound = true;
                 }
                 Node::TestCompSet(state, s_ipsc->cCurrentModuleObject, AlphArray(1), AlphArray(8), AlphArray(9), "Heat Recovery Nodes");
@@ -283,9 +283,9 @@ namespace ICEngineElectricGenerator {
                 iceGen.HeatRecOutletNodeNum = 0;
                 if (!s_ipsc->lAlphaFieldBlanks(8) || !s_ipsc->lAlphaFieldBlanks(9)) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("Since Design Heat Flow Rate = 0.0, Heat Recovery inactive for {}={}",
-                                                        s_ipsc->cCurrentModuleObject,
-                                                        AlphArray(1)));
+                                     std::format("Since Design Heat Flow Rate = 0.0, Heat Recovery inactive for {}={}",
+                                                 s_ipsc->cCurrentModuleObject,
+                                                 AlphArray(1)));
                     ShowContinueError(state, "However, Node names were specified for Heat Recovery inlet or outlet nodes");
                 }
             }
@@ -293,8 +293,8 @@ namespace ICEngineElectricGenerator {
             // Validate fuel type input
             iceGen.FuelType = static_cast<Constant::eFuel>(getEnumValue(Constant::eFuelNamesUC, AlphArray(10)));
             if (iceGen.FuelType == Constant::eFuel::Invalid) {
-                ShowSevereError(state, EnergyPlus::format("Invalid {}={}", s_ipsc->cAlphaFieldNames(10), AlphArray(10)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", s_ipsc->cCurrentModuleObject, AlphArray(1)));
+                ShowSevereError(state, std::format("Invalid {}={}", s_ipsc->cAlphaFieldNames(10), AlphArray(10)));
+                ShowContinueError(state, std::format("Entered in {}={}", s_ipsc->cCurrentModuleObject, AlphArray(1)));
                 ErrorsFound = true;
             }
 
@@ -302,7 +302,7 @@ namespace ICEngineElectricGenerator {
         }
 
         if (ErrorsFound) {
-            ShowFatalError(state, EnergyPlus::format("Errors found in processing input for {}", s_ipsc->cCurrentModuleObject));
+            ShowFatalError(state, std::format("Errors found in processing input for {}", s_ipsc->cCurrentModuleObject));
         }
     }
 
@@ -329,7 +329,7 @@ namespace ICEngineElectricGenerator {
                             OutputProcessor::EndUseCat::Cogeneration);
 
         SetupOutputVariable(state,
-                            EnergyPlus::format("Generator {} Rate", sFuelType),
+                            std::format("Generator {} Rate", sFuelType),
                             Constant::Units::W,
                             this->FuelEnergyUseRate,
                             OutputProcessor::TimeStepType::System,
@@ -337,7 +337,7 @@ namespace ICEngineElectricGenerator {
                             this->Name);
 
         SetupOutputVariable(state,
-                            EnergyPlus::format("Generator {} Energy", sFuelType),
+                            std::format("Generator {} Energy", sFuelType),
                             Constant::Units::J,
                             this->FuelEnergy,
                             OutputProcessor::TimeStepType::System,
@@ -365,7 +365,7 @@ namespace ICEngineElectricGenerator {
                             this->Name);
 
         SetupOutputVariable(state,
-                            EnergyPlus::format("Generator {} Mass Flow Rate", sFuelType),
+                            std::format("Generator {} Mass Flow Rate", sFuelType),
                             Constant::Units::kg_s,
                             this->FuelMdot,
                             OutputProcessor::TimeStepType::System,
@@ -649,11 +649,10 @@ namespace ICEngineElectricGenerator {
                 QExhaustRec = max(ExhaustGasFlow * ExhaustCP * (exhaustTemp - exhaustStackTemp), 0.0);
             } else {
                 if (this->ErrExhaustTempIndex == 0) {
-                    ShowWarningMessage(state,
-                                       EnergyPlus::format("CalcICEngineGeneratorModel: {}=\"{}\" low Exhaust Temperature from Curve Value",
-                                                          this->TypeOf,
-                                                          this->Name));
-                    ShowContinueError(state, EnergyPlus::format("...curve generated temperature=[{:.3R} C], PLR=[{:.3R}].", exhaustTemp, PLR));
+                    ShowWarningMessage(
+                        state,
+                        std::format("CalcICEngineGeneratorModel: {}=\"{}\" low Exhaust Temperature from Curve Value", this->TypeOf, this->Name));
+                    ShowContinueError(state, std::format("...curve generated temperature=[{:.3f} C], PLR=[{:.3f}].", exhaustTemp, PLR));
                     ShowContinueError(state, "...simulation will continue with exhaust heat reclaim set to 0.");
                 }
                 ShowRecurringWarningErrorAtEnd(state,

--- a/src/EnergyPlus/IceThermalStorage.cc
+++ b/src/EnergyPlus/IceThermalStorage.cc
@@ -136,8 +136,7 @@ namespace IceThermalStorage {
         }
         // If we didn't find it, fatal
         ShowFatalError(
-            state,
-            EnergyPlus::format("LocalSimpleIceStorageFactory: Error getting inputs for simple ice storage named: {}", objectName)); // LCOV_EXCL_LINE
+            state, std::format("LocalSimpleIceStorageFactory: Error getting inputs for simple ice storage named: {}", objectName)); // LCOV_EXCL_LINE
         // Shut up the compiler
         return nullptr; // LCOV_EXCL_LINE
     }
@@ -158,8 +157,8 @@ namespace IceThermalStorage {
         }
         // If we didn't find it, fatal
         ShowFatalError(state,
-                       EnergyPlus::format("LocalDetailedIceStorageFactory: Error getting inputs for detailed ice storage named: {}",
-                                          objectName)); // LCOV_EXCL_LINE
+                       std::format("LocalDetailedIceStorageFactory: Error getting inputs for detailed ice storage named: {}",
+                                   objectName)); // LCOV_EXCL_LINE
         // Shut up the compiler
         return nullptr; // LCOV_EXCL_LINE
     }
@@ -514,7 +513,7 @@ namespace IceThermalStorage {
                         ++this->ChargeIterErrors;
                         if (this->ChargeIterErrors <= 25) {
                             ShowWarningError(state, "Detailed Ice Storage model exceeded its internal charging maximum iteration limit");
-                            ShowContinueError(state, EnergyPlus::format("Detailed Ice Storage System Name = {}", this->Name));
+                            ShowContinueError(state, std::format("Detailed Ice Storage System Name = {}", this->Name));
                             ShowContinueErrorTimeStamp(state, "");
                         } else {
                             ShowRecurringWarningErrorAtEnd(state,
@@ -648,7 +647,7 @@ namespace IceThermalStorage {
                         ++this->DischargeIterErrors;
                         if (this->DischargeIterErrors <= 25) {
                             ShowWarningError(state, "Detailed Ice Storage model exceeded its internal discharging maximum iteration limit");
-                            ShowContinueError(state, EnergyPlus::format("Detailed Ice Storage System Name = {}", this->Name));
+                            ShowContinueError(state, std::format("Detailed Ice Storage System Name = {}", this->Name));
                             ShowContinueErrorTimeStamp(state, "");
                         } else {
                             ShowRecurringWarningErrorAtEnd(state,
@@ -743,14 +742,14 @@ namespace IceThermalStorage {
             if (state.dataIceThermalStorage->ThermalStorageSizing(sizingNum).onPeakEnd <=
                 state.dataIceThermalStorage->ThermalStorageSizing(sizingNum).onPeakStart) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{}{}=\"{}\"",
-                                                   routineName,
-                                                   state.dataIPShortCut->cCurrentModuleObject,
-                                                   state.dataIceThermalStorage->ThermalStorageSizing(sizingNum).name));
+                                std::format("{}{}=\"{}\"",
+                                            routineName,
+                                            state.dataIPShortCut->cCurrentModuleObject,
+                                            state.dataIceThermalStorage->ThermalStorageSizing(sizingNum).name));
                 ShowContinueError(state,
-                                  EnergyPlus::format("Invalid start {} and end times {}. End time must be greater than start time.",
-                                                     state.dataIceThermalStorage->ThermalStorageSizing(sizingNum).onPeakStart,
-                                                     state.dataIceThermalStorage->ThermalStorageSizing(sizingNum).onPeakEnd));
+                                  std::format("Invalid start {} and end times {}. End time must be greater than start time.",
+                                              state.dataIceThermalStorage->ThermalStorageSizing(sizingNum).onPeakStart,
+                                              state.dataIceThermalStorage->ThermalStorageSizing(sizingNum).onPeakEnd));
             }
         }
 
@@ -789,9 +788,9 @@ namespace IceThermalStorage {
             } else if (Util::SameString(state.dataIceThermalStorage->SimpleIceStorage(iceNum).ITSType, "IceOnCoilExternal")) {
                 state.dataIceThermalStorage->SimpleIceStorage(iceNum).ITSType_Num = ITSType::IceOnCoilExternal;
             } else {
-                ShowSevereError(state, EnergyPlus::format("{}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
-                ShowContinueError(
-                    state, EnergyPlus::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(2), state.dataIPShortCut->cAlphaArgs(2)));
+                ShowSevereError(state, std::format("{}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowContinueError(state,
+                                  std::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(2), state.dataIPShortCut->cAlphaArgs(2)));
                 ErrorsFound = true;
             }
 
@@ -800,10 +799,9 @@ namespace IceThermalStorage {
             if (state.dataIPShortCut->rNumericArgs(1) == DataSizing::AutoSize) {
                 state.dataIceThermalStorage->SimpleIceStorage(iceNum).NomCapacityWasAutoSized = true;
             } else if (state.dataIPShortCut->rNumericArgs(1) == 0.0) {
-                ShowSevereError(state, EnergyPlus::format("{}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("{}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.2R}", state.dataIPShortCut->cNumericFieldNames(1), state.dataIPShortCut->rNumericArgs(1)));
+                    state, std::format("Invalid {}={:.2f}", state.dataIPShortCut->cNumericFieldNames(1), state.dataIPShortCut->rNumericArgs(1)));
                 ErrorsFound = true;
             }
 
@@ -843,14 +841,13 @@ namespace IceThermalStorage {
                 state.dataIPShortCut->cAlphaArgs(5), state.dataIceThermalStorage->ThermalStorageSizing, &ThermalStorageSizingData::name);
             if (state.dataIceThermalStorage->SimpleIceStorage(iceNum).TESSizingIndex == 0 &&
                 state.dataIceThermalStorage->SimpleIceStorage(iceNum).NomCapacityWasAutoSized) {
-                ShowSevereError(state,
-                                EnergyPlus::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(5), state.dataIPShortCut->cAlphaArgs(5)));
-                ShowContinueError(
-                    state, EnergyPlus::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(5), state.dataIPShortCut->cAlphaArgs(5)));
                 ShowContinueError(state,
-                                  EnergyPlus::format("Input field {} must be entered when input field {} is autosized",
-                                                     state.dataIPShortCut->cAlphaFieldNames(5),
-                                                     state.dataIPShortCut->cNumericFieldNames(1)));
+                                  std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowContinueError(state,
+                                  std::format("Input field {} must be entered when input field {} is autosized",
+                                              state.dataIPShortCut->cAlphaFieldNames(5),
+                                              state.dataIPShortCut->cNumericFieldNames(1)));
                 ErrorsFound = true;
             }
 
@@ -869,7 +866,7 @@ namespace IceThermalStorage {
         } // IceNum
 
         if (ErrorsFound) {
-            ShowFatalError(state, EnergyPlus::format("Errors found in processing input for {}", state.dataIPShortCut->cCurrentModuleObject));
+            ShowFatalError(state, std::format("Errors found in processing input for {}", state.dataIPShortCut->cCurrentModuleObject));
         }
 
         ErrorsFound = false; // Always need to reset this since there are multiple types of ice storage systems
@@ -922,11 +919,10 @@ namespace IceThermalStorage {
             if (state.dataIPShortCut->rNumericArgs(1) == DataSizing::AutoSize) {
                 state.dataIceThermalStorage->DetailedIceStorage(iceNum).NomCapacityWasAutoSized = true;
             } else if (state.dataIPShortCut->rNumericArgs(1) <= 0.0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.2R}", state.dataIPShortCut->cNumericFieldNames(1), state.dataIPShortCut->rNumericArgs(1)));
-                ShowContinueError(
-                    state, EnergyPlus::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.2f}", state.dataIPShortCut->cNumericFieldNames(1), state.dataIPShortCut->rNumericArgs(1)));
+                ShowContinueError(state,
+                                  std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ErrorsFound = true;
             }
 
@@ -967,20 +963,19 @@ namespace IceThermalStorage {
             state.dataIceThermalStorage->DetailedIceStorage(iceNum).DischargeCurveNum =
                 Curve::GetCurveIndex(state, state.dataIPShortCut->cAlphaArgs(6));
             if (state.dataIceThermalStorage->DetailedIceStorage(iceNum).DischargeCurveNum <= 0) {
-                ShowSevereError(state,
-                                EnergyPlus::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(6), state.dataIPShortCut->cAlphaArgs(6)));
-                ShowContinueError(
-                    state, EnergyPlus::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(6), state.dataIPShortCut->cAlphaArgs(6)));
+                ShowContinueError(state,
+                                  std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ErrorsFound = true;
             }
 
             int dischargeCurveDim =
                 state.dataCurveManager->curves(state.dataIceThermalStorage->DetailedIceStorage(iceNum).DischargeCurveNum)->numDims;
             if (dischargeCurveDim != 2) {
-                ShowSevereError(
-                    state, EnergyPlus::format("{}: Discharge curve must have 2 independent variables", state.dataIPShortCut->cCurrentModuleObject));
-                ShowContinueError(
-                    state, EnergyPlus::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state,
+                                std::format("{}: Discharge curve must have 2 independent variables", state.dataIPShortCut->cCurrentModuleObject));
+                ShowContinueError(state,
+                                  std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state,
                                   std::format("{} does not have 2 independent variables and thus cannot be used for detailed ice storage",
                                               state.dataIPShortCut->cAlphaArgs(6)));
@@ -1066,9 +1061,8 @@ namespace IceThermalStorage {
             state.dataIceThermalStorage->DetailedIceStorage(iceNum).CurveFitTimeStep = state.dataIPShortCut->rNumericArgs(2);
             if ((state.dataIceThermalStorage->DetailedIceStorage(iceNum).CurveFitTimeStep <= 0.0) ||
                 (state.dataIceThermalStorage->DetailedIceStorage(iceNum).CurveFitTimeStep > 1.0)) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.3R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.3f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
                 ShowContinueError(state,
                                   std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(
@@ -1114,9 +1108,8 @@ namespace IceThermalStorage {
 
             if ((state.dataIceThermalStorage->DetailedIceStorage(iceNum).DischargeParaElecLoad < 0.0) ||
                 (state.dataIceThermalStorage->DetailedIceStorage(iceNum).DischargeParaElecLoad > 1.0)) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.3R}", state.dataIPShortCut->cNumericFieldNames(3), state.dataIPShortCut->rNumericArgs(3)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.3f}", state.dataIPShortCut->cNumericFieldNames(3), state.dataIPShortCut->rNumericArgs(3)));
                 ShowContinueError(state,
                                   std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Value is either less than/equal to zero or greater than 1");
@@ -1125,9 +1118,8 @@ namespace IceThermalStorage {
 
             if ((state.dataIceThermalStorage->DetailedIceStorage(iceNum).ChargeParaElecLoad < 0.0) ||
                 (state.dataIceThermalStorage->DetailedIceStorage(iceNum).ChargeParaElecLoad > 1.0)) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.3R}", state.dataIPShortCut->cNumericFieldNames(4), state.dataIPShortCut->rNumericArgs(4)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.3f}", state.dataIPShortCut->cNumericFieldNames(4), state.dataIPShortCut->rNumericArgs(4)));
                 ShowContinueError(state,
                                   std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Value is either less than/equal to zero or greater than 1");
@@ -1136,9 +1128,8 @@ namespace IceThermalStorage {
 
             if ((state.dataIceThermalStorage->DetailedIceStorage(iceNum).TankLossCoeff < 0.0) ||
                 (state.dataIceThermalStorage->DetailedIceStorage(iceNum).TankLossCoeff > 0.1)) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.3R}", state.dataIPShortCut->cNumericFieldNames(5), state.dataIPShortCut->rNumericArgs(5)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.3f}", state.dataIPShortCut->cNumericFieldNames(5), state.dataIPShortCut->rNumericArgs(5)));
                 ShowContinueError(state,
                                   std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Value is either less than/equal to zero or greater than 0.1 (10%)");
@@ -1147,10 +1138,9 @@ namespace IceThermalStorage {
 
             if ((state.dataIceThermalStorage->DetailedIceStorage(iceNum).FreezingTemp < -10.0) ||
                 (state.dataIceThermalStorage->DetailedIceStorage(iceNum).FreezingTemp > 10.0)) {
-                ShowWarningError(state,
-                                 EnergyPlus::format("Potentially invalid {}={:.3R}",
-                                                    state.dataIPShortCut->cNumericFieldNames(6),
-                                                    state.dataIPShortCut->rNumericArgs(6)));
+                ShowWarningError(
+                    state,
+                    std::format("Potentially invalid {}={:.3f}", state.dataIPShortCut->cNumericFieldNames(6), state.dataIPShortCut->rNumericArgs(6)));
                 ShowContinueError(state,
                                   std::format("Entered in {}={}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Value is either less than -10.0C or greater than 10.0C");

--- a/src/EnergyPlus/InternalHeatGains.cc
+++ b/src/EnergyPlus/InternalHeatGains.cc
@@ -272,15 +272,15 @@ namespace InternalHeatGains {
         int IOStat;
 
         // Formats
-        static constexpr std::string_view Format_720(" Zone Internal Gains Nominal, {},{:.2R},{:.1R},");
-        static constexpr std::string_view Format_722(" {} Internal Gains Nominal, {},{},{},{:.2R},{:.1R},");
+        static constexpr std::string_view Format_720(" Zone Internal Gains Nominal, {},{:.2f},{:.1f},");
+        static constexpr std::string_view Format_722(" {} Internal Gains Nominal, {},{},{},{:.2f},{:.1f},");
         static constexpr std::string_view Format_723(
             "! <{} Internal Gains Nominal>,Name,Schedule Name,Zone Name,Zone Floor Area {{m2}},# Zone Occupants,{}");
         static constexpr std::string_view Format_724(" {}, {}\n");
 
         auto print_and_divide_if_greater_than_zero = [&](const Real64 numerator, const Real64 denominator) {
             if (denominator > 0.0) {
-                print(state.files.eio, "{:.3R},", numerator / denominator);
+                print(state.files.eio, "{:.3f},", numerator / denominator);
             } else {
                 print(state.files.eio, "N/A,");
             }
@@ -447,12 +447,12 @@ namespace InternalHeatGains {
                     if (Item1 == 1) {
                         if (thisPeople.FractionConvected < 0.0) {
                             ShowSevereError(state,
-                                            EnergyPlus::format("{}{}=\"{}\", {} < 0.0, value ={:.2R}",
-                                                               RoutineName,
-                                                               peopleModuleObject,
-                                                               IHGAlphas(1),
-                                                               IHGNumericFieldNames(4),
-                                                               IHGNumbers(4)));
+                                            std::format("{}{}=\"{}\", {} < 0.0, value ={:.2f}",
+                                                        RoutineName,
+                                                        peopleModuleObject,
+                                                        IHGAlphas(1),
+                                                        IHGNumericFieldNames(4),
+                                                        IHGNumbers(4)));
                             ErrorsFound = true;
                         }
                     }
@@ -483,12 +483,12 @@ namespace InternalHeatGains {
 
                     if (thisPeople.CO2RateFactor < 0.0) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}{}=\"{}\", {} < 0.0, value ={:.2R}",
-                                                           RoutineName,
-                                                           peopleModuleObject,
-                                                           IHGAlphas(1),
-                                                           IHGNumericFieldNames(6),
-                                                           IHGNumbers(6)));
+                                        std::format("{}{}=\"{}\", {} < 0.0, value ={:.2f}",
+                                                    RoutineName,
+                                                    peopleModuleObject,
+                                                    IHGAlphas(1),
+                                                    IHGNumericFieldNames(6),
+                                                    IHGNumbers(6)));
                         ErrorsFound = true;
                     }
 
@@ -546,12 +546,11 @@ namespace InternalHeatGains {
                             NoTCModelSelectedWithSchedules =
                                 CheckThermalComfortSchedules(IHGAlphaFieldBlanks(9), IHGAlphaFieldBlanks(12), IHGAlphaFieldBlanks(13));
                             if (NoTCModelSelectedWithSchedules) {
-                                ShowWarningError(
-                                    state,
-                                    EnergyPlus::format("{}{}=\"{}\" has comfort related schedules but no thermal comfort model selected.",
-                                                       RoutineName,
-                                                       peopleModuleObject,
-                                                       IHGAlphas(1)));
+                                ShowWarningError(state,
+                                                 std::format("{}{}=\"{}\" has comfort related schedules but no thermal comfort model selected.",
+                                                             RoutineName,
+                                                             peopleModuleObject,
+                                                             IHGAlphas(1)));
                                 ShowContinueError(state,
                                                   "If schedules are specified for air velocity, clothing insulation, and/or work efficiency but no "
                                                   "thermal comfort");
@@ -635,13 +634,13 @@ namespace InternalHeatGains {
                                 if (thisPeople.SurfacePtr == 0 && ModelWithAdditionalInputs) {
                                     if (Item1 == 1) {
                                         ShowSevereError(state,
-                                                        EnergyPlus::format("{}{}=\"{}\", {}={} invalid Surface Name={}",
-                                                                           RoutineName,
-                                                                           peopleModuleObject,
-                                                                           IHGAlphas(1),
-                                                                           IHGAlphaFieldNames(7),
-                                                                           IHGAlphas(7),
-                                                                           IHGAlphas(8)));
+                                                        std::format("{}{}=\"{}\", {}={} invalid Surface Name={}",
+                                                                    RoutineName,
+                                                                    peopleModuleObject,
+                                                                    IHGAlphas(1),
+                                                                    IHGAlphaFieldNames(7),
+                                                                    IHGAlphas(7),
+                                                                    IHGAlphas(8)));
                                         ErrorsFound = true;
                                     }
                                 } else {
@@ -649,17 +648,17 @@ namespace InternalHeatGains {
                                     int const thisPeopleRadEnclNum = state.dataHeatBal->space(thisPeople.spaceIndex).radiantEnclosureNum;
                                     if (surfRadEnclNum != thisPeopleRadEnclNum && ModelWithAdditionalInputs) {
                                         ShowSevereError(state,
-                                                        EnergyPlus::format("{}{}=\"{}\", Surface referenced in {}={} in different enclosure.",
-                                                                           RoutineName,
-                                                                           peopleModuleObject,
-                                                                           IHGAlphas(1),
-                                                                           IHGAlphaFieldNames(7),
-                                                                           IHGAlphas(7)));
+                                                        std::format("{}{}=\"{}\", Surface referenced in {}={} in different enclosure.",
+                                                                    RoutineName,
+                                                                    peopleModuleObject,
+                                                                    IHGAlphas(1),
+                                                                    IHGAlphaFieldNames(7),
+                                                                    IHGAlphas(7)));
                                         ShowContinueError(state,
-                                                          EnergyPlus::format("Surface is in Enclosure={} and {} is in Enclosure={}",
-                                                                             state.dataViewFactor->EnclRadInfo(surfRadEnclNum).Name,
-                                                                             peopleModuleObject,
-                                                                             state.dataViewFactor->EnclRadInfo(thisPeopleRadEnclNum).Name));
+                                                          std::format("Surface is in Enclosure={} and {} is in Enclosure={}",
+                                                                      state.dataViewFactor->EnclRadInfo(surfRadEnclNum).Name,
+                                                                      peopleModuleObject,
+                                                                      state.dataViewFactor->EnclRadInfo(thisPeopleRadEnclNum).Name));
                                         ErrorsFound = true;
                                     }
                                 }
@@ -672,12 +671,12 @@ namespace InternalHeatGains {
                             default: { // An invalid keyword was entered--warn but ignore
                                 if (Item1 == 1 && ModelWithAdditionalInputs) {
                                     ShowWarningError(state,
-                                                     EnergyPlus::format("{}{}=\"{}\", invalid {}={}",
-                                                                        RoutineName,
-                                                                        peopleModuleObject,
-                                                                        IHGAlphas(1),
-                                                                        IHGAlphaFieldNames(7),
-                                                                        IHGAlphas(7)));
+                                                     std::format("{}{}=\"{}\", invalid {}={}",
+                                                                 RoutineName,
+                                                                 peopleModuleObject,
+                                                                 IHGAlphas(1),
+                                                                 IHGAlphaFieldNames(7),
+                                                                 IHGAlphas(7)));
                                     ShowContinueError(state, "...Valid values are \"EnclosureAveraged\", \"SurfaceWeighted\", \"AngleFactor\".");
                                 }
                             } break;
@@ -856,17 +855,15 @@ namespace InternalHeatGains {
                     if (state.dataHeatBal->Zone(Loop).FloorArea > 0.0 &&
                         state.dataHeatBal->Zone(Loop).FloorArea / state.dataHeatBal->Zone(Loop).TotOccupants < 0.1) {
                         ShowWarningError(
-                            state,
-                            EnergyPlus::format("{}Zone=\"{}\" occupant density is extremely high.", RoutineName, state.dataHeatBal->Zone(Loop).Name));
+                            state, std::format("{}Zone=\"{}\" occupant density is extremely high.", RoutineName, state.dataHeatBal->Zone(Loop).Name));
                         if (state.dataHeatBal->Zone(Loop).FloorArea > 0.0) {
-                            ShowContinueError(
-                                state,
-                                EnergyPlus::format("Occupant Density=[{:.0R}] person/m2.",
-                                                   state.dataHeatBal->Zone(Loop).TotOccupants / state.dataHeatBal->Zone(Loop).FloorArea));
+                            ShowContinueError(state,
+                                              std::format("Occupant Density=[{:.0f}] person/m2.",
+                                                          state.dataHeatBal->Zone(Loop).TotOccupants / state.dataHeatBal->Zone(Loop).FloorArea));
                         }
                         ShowContinueError(state,
-                                          EnergyPlus::format("Occupant Density=[{:.3R}] m2/person. Problems in Temperature Out of Bounds may result.",
-                                                             state.dataHeatBal->Zone(Loop).FloorArea / state.dataHeatBal->Zone(Loop).TotOccupants));
+                                          std::format("Occupant Density=[{:.3f}] m2/person. Problems in Temperature Out of Bounds may result.",
+                                                      state.dataHeatBal->Zone(Loop).FloorArea / state.dataHeatBal->Zone(Loop).TotOccupants));
                     }
                     Real64 maxOccupLoad = 0.0;
                     int OptionNum = 0;
@@ -883,22 +880,21 @@ namespace InternalHeatGains {
                     if (maxOccupLoad > state.dataHeatBal->Zone(Loop).TotOccupants) {
                         if (state.dataHeatBal->Zone(Loop).FloorArea > 0.0 && state.dataHeatBal->Zone(Loop).FloorArea / maxOccupLoad < 0.1) {
                             ShowWarningError(state,
-                                             EnergyPlus::format("{}Zone=\"{}\" occupant density at a maximum schedule value is extremely high.",
-                                                                RoutineName,
-                                                                state.dataHeatBal->Zone(Loop).Name));
+                                             std::format("{}Zone=\"{}\" occupant density at a maximum schedule value is extremely high.",
+                                                         RoutineName,
+                                                         state.dataHeatBal->Zone(Loop).Name));
                             if (state.dataHeatBal->Zone(Loop).FloorArea > 0.0) {
-                                ShowContinueError(state,
-                                                  EnergyPlus::format("Occupant Density=[{:.0R}] person/m2.",
-                                                                     maxOccupLoad / state.dataHeatBal->Zone(Loop).FloorArea));
+                                ShowContinueError(
+                                    state,
+                                    std::format("Occupant Density=[{:.0f}] person/m2.", maxOccupLoad / state.dataHeatBal->Zone(Loop).FloorArea));
                             }
-                            ShowContinueError(
-                                state,
-                                EnergyPlus::format("Occupant Density=[{:.3R}] m2/person. Problems in Temperature Out of Bounds may result.",
-                                                   state.dataHeatBal->Zone(Loop).FloorArea / maxOccupLoad));
                             ShowContinueError(state,
-                                              EnergyPlus::format("Check values in People={}, Number of People Schedule={}",
-                                                                 state.dataHeatBal->People(OptionNum).Name,
-                                                                 state.dataHeatBal->People(OptionNum).sched->getCurrentVal()));
+                                              std::format("Occupant Density=[{:.3f}] m2/person. Problems in Temperature Out of Bounds may result.",
+                                                          state.dataHeatBal->Zone(Loop).FloorArea / maxOccupLoad));
+                            ShowContinueError(state,
+                                              std::format("Check values in People={}, Number of People Schedule={}",
+                                                          state.dataHeatBal->People(OptionNum).Name,
+                                                          state.dataHeatBal->People(OptionNum).sched->getCurrentVal()));
                         }
                     }
                 }
@@ -1015,8 +1011,8 @@ namespace InternalHeatGains {
                     }
                     if (thisLights.FractionConvected < 0.0) {
                         if (Item1 == 1) {
-                            ShowSevereError(
-                                state, EnergyPlus::format("{}{}=\"{}\", Sum of Fractions > 1.0", RoutineName, lightsModuleObject, thisLights.Name));
+                            ShowSevereError(state,
+                                            std::format("{}{}=\"{}\", Sum of Fractions > 1.0", RoutineName, lightsModuleObject, thisLights.Name));
                             ErrorsFound = true;
                         }
                     }
@@ -1042,12 +1038,12 @@ namespace InternalHeatGains {
                     } else if (IHGAlphas(6) != "YES" && IHGAlphas(6) != "NO") {
                         if (Item1 == 1) {
                             ShowWarningError(state,
-                                             EnergyPlus::format("{}{}=\"{}\", invalid {}, value  ={}",
-                                                                RoutineName,
-                                                                lightsModuleObject,
-                                                                thisLightsInput.Name,
-                                                                IHGAlphaFieldNames(6),
-                                                                IHGAlphas(6)));
+                                             std::format("{}{}=\"{}\", invalid {}, value  ={}",
+                                                         RoutineName,
+                                                         lightsModuleObject,
+                                                         thisLightsInput.Name,
+                                                         IHGAlphaFieldNames(6),
+                                                         IHGAlphas(6)));
                             ShowContinueError(state, ".. Return Air Fraction from Plenum will NOT be calculated.");
                         }
                         thisLights.FractionReturnAirIsCalculated = false;
@@ -1061,11 +1057,11 @@ namespace InternalHeatGains {
                     if (!IHGAlphaFieldBlanks(7)) {
                         if (thisLightsInput.ZoneListActive) {
                             ShowSevereError(state,
-                                            EnergyPlus::format("{}{}=\"{}\": {} must be blank when using a ZoneList.",
-                                                               RoutineName,
-                                                               lightsModuleObject,
-                                                               thisLightsInput.Name,
-                                                               IHGAlphaFieldNames(7)));
+                                            std::format("{}{}=\"{}\": {} must be blank when using a ZoneList.",
+                                                        RoutineName,
+                                                        lightsModuleObject,
+                                                        thisLightsInput.Name,
+                                                        IHGAlphaFieldNames(7)));
                             ErrorsFound = true;
                         } else {
                             thisLights.RetNodeName = IHGAlphas(7);
@@ -1078,7 +1074,7 @@ namespace InternalHeatGains {
                     if ((thisLights.ZoneReturnNum == 0) && (thisLights.FractionReturnAir > 0.0) && (!IHGAlphaFieldBlanks(7))) {
                         ShowSevereError(
                             state,
-                            EnergyPlus::format(
+                            std::format(
                                 "{}{}=\"{}\", invalid {} ={}", RoutineName, lightsModuleObject, IHGAlphas(1), IHGAlphaFieldNames(7), IHGAlphas(7)));
                         ShowContinueError(state, "No matching Zone Return Air Node found.");
                         ErrorsFound = true;
@@ -1088,11 +1084,11 @@ namespace InternalHeatGains {
                     if (!IHGAlphaFieldBlanks(8)) {
                         if (thisLightsInput.ZoneListActive) {
                             ShowSevereError(state,
-                                            EnergyPlus::format("{}{}=\"{}\": {} must be blank when using a ZoneList.",
-                                                               RoutineName,
-                                                               lightsModuleObject,
-                                                               thisLightsInput.Name,
-                                                               IHGAlphaFieldNames(8)));
+                                            std::format("{}{}=\"{}\": {} must be blank when using a ZoneList.",
+                                                        RoutineName,
+                                                        lightsModuleObject,
+                                                        thisLightsInput.Name,
+                                                        IHGAlphaFieldNames(8)));
                             ErrorsFound = true;
                         } else {
                             bool exhaustNodeError = false;
@@ -1111,12 +1107,12 @@ namespace InternalHeatGains {
                             }
                             if (exhaustNodeError) {
                                 ShowSevereError(state,
-                                                EnergyPlus::format("{}{}=\"{}\", invalid {} = {}",
-                                                                   RoutineName,
-                                                                   lightsModuleObject,
-                                                                   IHGAlphas(1),
-                                                                   IHGAlphaFieldNames(8),
-                                                                   IHGAlphas(8)));
+                                                std::format("{}{}=\"{}\", invalid {} = {}",
+                                                            RoutineName,
+                                                            lightsModuleObject,
+                                                            IHGAlphas(1),
+                                                            IHGAlphaFieldNames(8),
+                                                            IHGAlphas(8)));
                                 ShowContinueError(state, "No matching Zone Exhaust Air Node found.");
                                 ErrorsFound = true;
                             } else {
@@ -1126,12 +1122,12 @@ namespace InternalHeatGains {
                                     CheckSharedExhaustFlag = true;
                                 } else {
                                     ShowSevereError(state,
-                                                    EnergyPlus::format("{}{}=\"{}\", {} ={} is not used",
-                                                                       RoutineName,
-                                                                       lightsModuleObject,
-                                                                       IHGAlphas(1),
-                                                                       IHGAlphaFieldNames(8),
-                                                                       IHGAlphas(8)));
+                                                    std::format("{}{}=\"{}\", {} ={} is not used",
+                                                                RoutineName,
+                                                                lightsModuleObject,
+                                                                IHGAlphas(1),
+                                                                IHGAlphaFieldNames(8),
+                                                                IHGAlphas(8)));
                                     ShowContinueError(
                                         state, "No matching Zone Return Air Node found. The Exhaust Node requires Return Node to work together");
                                     ErrorsFound = true;
@@ -1235,14 +1231,14 @@ namespace InternalHeatGains {
                         if (ReturnNum == state.dataHeatBal->Lights(Loop1).ZoneReturnNum &&
                             ExhaustNodeNum != state.dataHeatBal->Lights(Loop1).ZoneExhaustNodeNum) {
                             ShowSevereError(state,
-                                            EnergyPlus::format("{}{}: Duplicated Return Air Node = {} is found, ",
-                                                               RoutineName,
-                                                               lightsModuleObject,
-                                                               state.dataHeatBal->Lights(Loop1).RetNodeName));
+                                            std::format("{}{}: Duplicated Return Air Node = {} is found, ",
+                                                        RoutineName,
+                                                        lightsModuleObject,
+                                                        state.dataHeatBal->Lights(Loop1).RetNodeName));
                             ShowContinueError(state,
-                                              EnergyPlus::format(" in both Lights objects = {} and {}.",
-                                                                 state.dataHeatBal->Lights(Loop).Name,
-                                                                 state.dataHeatBal->Lights(Loop1).Name));
+                                              std::format(" in both Lights objects = {} and {}.",
+                                                          state.dataHeatBal->Lights(Loop).Name,
+                                                          state.dataHeatBal->Lights(Loop1).Name));
                             ErrorsFound = true;
                             ReturnNodeShared(Loop1) = true;
                         }
@@ -1351,8 +1347,8 @@ namespace InternalHeatGains {
                         thisZoneElectric.FractionConvected = 0.0;
                     }
                     if (thisZoneElectric.FractionConvected < 0.0) {
-                        ShowSevereError(
-                            state, EnergyPlus::format("{}{}=\"{}\", Sum of Fractions > 1.0", RoutineName, elecEqModuleObject, thisElecEqInput.Name));
+                        ShowSevereError(state,
+                                        std::format("{}{}=\"{}\", Sum of Fractions > 1.0", RoutineName, elecEqModuleObject, thisElecEqInput.Name));
                         ErrorsFound = true;
                     }
 
@@ -1473,22 +1469,22 @@ namespace InternalHeatGains {
                     }
                     if (thisZoneGas.CO2RateFactor < 0.0) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}{}=\"{}\", {} < 0.0, value ={:.2R}",
-                                                           RoutineName,
-                                                           gasEqModuleObject,
-                                                           thisGasEqInput.Name,
-                                                           IHGNumericFieldNames(7),
-                                                           IHGNumbers(7)));
+                                        std::format("{}{}=\"{}\", {} < 0.0, value ={:.2f}",
+                                                    RoutineName,
+                                                    gasEqModuleObject,
+                                                    thisGasEqInput.Name,
+                                                    IHGNumericFieldNames(7),
+                                                    IHGNumbers(7)));
                         ErrorsFound = true;
                     }
                     if (thisZoneGas.CO2RateFactor > 4.0e-7) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}{}=\"{}\", {} > 4.0E-7, value ={:.2R}",
-                                                           RoutineName,
-                                                           gasEqModuleObject,
-                                                           thisGasEqInput.Name,
-                                                           IHGNumericFieldNames(7),
-                                                           IHGNumbers(7)));
+                                        std::format("{}{}=\"{}\", {} > 4.0E-7, value ={:.2f}",
+                                                    RoutineName,
+                                                    gasEqModuleObject,
+                                                    thisGasEqInput.Name,
+                                                    IHGNumericFieldNames(7),
+                                                    IHGNumbers(7)));
                         ErrorsFound = true;
                     }
                     // FractionConvected is a calculated field
@@ -1935,22 +1931,22 @@ namespace InternalHeatGains {
                     }
                     if (thisZoneOthEq.CO2RateFactor < 0.0) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}{}=\"{}\", {} < 0.0, value ={:.2R}",
-                                                           RoutineName,
-                                                           othEqModuleObject,
-                                                           thisOthEqInput.Name,
-                                                           IHGNumericFieldNames(7),
-                                                           IHGNumbers(7)));
+                                        std::format("{}{}=\"{}\", {} < 0.0, value ={:.2f}",
+                                                    RoutineName,
+                                                    othEqModuleObject,
+                                                    thisOthEqInput.Name,
+                                                    IHGNumericFieldNames(7),
+                                                    IHGNumbers(7)));
                         ErrorsFound = true;
                     }
                     if (thisZoneOthEq.CO2RateFactor > 4.0e-7) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}{}=\"{}\", {} > 4.0E-7, value ={:.2R}",
-                                                           RoutineName,
-                                                           othEqModuleObject,
-                                                           thisOthEqInput.Name,
-                                                           IHGNumericFieldNames(7),
-                                                           IHGNumbers(7)));
+                                        std::format("{}{}=\"{}\", {} > 4.0E-7, value ={:.2f}",
+                                                    RoutineName,
+                                                    othEqModuleObject,
+                                                    thisOthEqInput.Name,
+                                                    IHGNumericFieldNames(7),
+                                                    IHGNumbers(7)));
                         ErrorsFound = true;
                     }
 
@@ -2134,12 +2130,12 @@ namespace InternalHeatGains {
                                         }
                                     } else {
                                         ShowSevereError(state,
-                                                        EnergyPlus::format("{}{}=\"{}\", invalid {}, value  [<0.0]={:.3R}",
-                                                                           RoutineName,
-                                                                           itEqModuleObject,
-                                                                           IHGAlphas(1),
-                                                                           IHGNumericFieldNames(3),
-                                                                           IHGNumbers(3)));
+                                                        std::format("{}{}=\"{}\", invalid {}, value  [<0.0]={:.3f}",
+                                                                    RoutineName,
+                                                                    itEqModuleObject,
+                                                                    IHGAlphas(1),
+                                                                    IHGNumericFieldNames(3),
+                                                                    IHGNumbers(3)));
                                         ErrorsFound = true;
                                     }
                                 }
@@ -2689,14 +2685,14 @@ namespace InternalHeatGains {
             if (zone.FloorArea > 0.0) {
                 print(state.files.eio, Format_720, zone.Name, zone.FloorArea, zone.TotOccupants);
                 print_and_divide_if_greater_than_zero(zone.FloorArea, zone.TotOccupants);
-                print(state.files.eio, "{:.3R},", zone.TotOccupants / zone.FloorArea);
-                print(state.files.eio, "{:.3R},", LightTot / zone.FloorArea);
-                print(state.files.eio, "{:.3R},", ElecTot / zone.FloorArea);
-                print(state.files.eio, "{:.3R},", GasTot / zone.FloorArea);
-                print(state.files.eio, "{:.3R},", OthTot / zone.FloorArea);
-                print(state.files.eio, "{:.3R},", HWETot / zone.FloorArea);
-                print(state.files.eio, "{:.3R},", StmTot / zone.FloorArea);
-                print(state.files.eio, "{:.3R},{}\n", zone.InternalHeatGains / zone.FloorArea, BBHeatInd);
+                print(state.files.eio, "{:.3f},", zone.TotOccupants / zone.FloorArea);
+                print(state.files.eio, "{:.3f},", LightTot / zone.FloorArea);
+                print(state.files.eio, "{:.3f},", ElecTot / zone.FloorArea);
+                print(state.files.eio, "{:.3f},", GasTot / zone.FloorArea);
+                print(state.files.eio, "{:.3f},", OthTot / zone.FloorArea);
+                print(state.files.eio, "{:.3f},", HWETot / zone.FloorArea);
+                print(state.files.eio, "{:.3f},", StmTot / zone.FloorArea);
+                print(state.files.eio, "{:.3f},{}\n", zone.InternalHeatGains / zone.FloorArea, BBHeatInd);
             } else {
                 print(state.files.eio, Format_720, zone.Name, zone.FloorArea, zone.TotOccupants);
                 print(state.files.eio, "0.0,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A,{}\n", BBHeatInd);
@@ -2735,7 +2731,7 @@ namespace InternalHeatGains {
             auto const &zone = state.dataHeatBal->Zone(people.ZonePtr);
 
             print(state.files.eio, Format_722, "People", people.Name, people.sched->Name, zone.Name, zone.FloorArea, zone.TotOccupants);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople);
 
             print_and_divide_if_greater_than_zero(people.NumberOfPeople, zone.FloorArea);
 
@@ -2745,41 +2741,41 @@ namespace InternalHeatGains {
                 print(state.files.eio, "N/A,");
             }
 
-            print(state.files.eio, "{:.3R},", people.FractionRadiant);
-            print(state.files.eio, "{:.3R},", people.FractionConvected);
+            print(state.files.eio, "{:.3f},", people.FractionRadiant);
+            print(state.files.eio, "{:.3f},", people.FractionConvected);
             if (people.UserSpecSensFrac == Constant::AutoCalculate) {
                 print(state.files.eio, "AutoCalculate,");
             } else {
-                print(state.files.eio, "{:.3R},", people.UserSpecSensFrac);
+                print(state.files.eio, "{:.3f},", people.UserSpecSensFrac);
             }
             print(state.files.eio, "{},", people.activityLevelSched->Name);
 
             print(state.files.eio, "{},", yesNoNames[(int)people.Show55Warning]);
-            print(state.files.eio, "{:.4R},", people.CO2RateFactor);
-            print(state.files.eio, "{:.1R},", people.NomMinNumberPeople);
-            print(state.files.eio, "{:.1R},", people.NomMaxNumberPeople);
+            print(state.files.eio, "{:.4E},", people.CO2RateFactor);
+            print(state.files.eio, "{:.1f},", people.NomMinNumberPeople);
+            print(state.files.eio, "{:.1f},", people.NomMaxNumberPeople);
 
             Real64 SchMin, SchMax;
 
             // weekdays
             std::tie(SchMin, SchMax) = people.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::Weekday);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople * SchMin);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople * SchMax);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople * SchMin);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople * SchMax);
 
             // weekends/holidays
             std::tie(SchMin, SchMax) = people.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WeekEndHoliday);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople * SchMin);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople * SchMax);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople * SchMin);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople * SchMax);
 
             // summer design days
             std::tie(SchMin, SchMax) = people.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::SummerDesignDay);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople * SchMin);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople * SchMax);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople * SchMin);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople * SchMax);
 
             // winter design days
             std::tie(SchMin, SchMax) = people.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WinterDesignDay);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople * SchMin);
-            print(state.files.eio, "{:.1R},", people.NumberOfPeople * SchMax);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople * SchMin);
+            print(state.files.eio, "{:.1f},", people.NumberOfPeople * SchMax);
 
             if (people.Fanger || people.Pierce || people.KSU || people.CoolingEffectASH55 || people.AnkleDraftASH55) {
 
@@ -2839,42 +2835,42 @@ namespace InternalHeatGains {
 
             print(state.files.eio, Format_722, "Lights", lights.Name, lights.sched->Name, zone.Name, zone.FloorArea, zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", lights.DesignLevel);
+            print(state.files.eio, "{:.3f},", lights.DesignLevel);
 
             print_and_divide_if_greater_than_zero(lights.DesignLevel, zone.FloorArea);
             print_and_divide_if_greater_than_zero(lights.DesignLevel, zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", lights.FractionReturnAir);
-            print(state.files.eio, "{:.3R},", lights.FractionRadiant);
-            print(state.files.eio, "{:.3R},", lights.FractionShortWave);
-            print(state.files.eio, "{:.3R},", lights.FractionConvected);
-            print(state.files.eio, "{:.3R},", lights.FractionReplaceable);
+            print(state.files.eio, "{:.3f},", lights.FractionReturnAir);
+            print(state.files.eio, "{:.3f},", lights.FractionRadiant);
+            print(state.files.eio, "{:.3f},", lights.FractionShortWave);
+            print(state.files.eio, "{:.3f},", lights.FractionConvected);
+            print(state.files.eio, "{:.3f},", lights.FractionReplaceable);
             print(state.files.eio, "{},", lights.EndUseSubcategory);
-            print(state.files.eio, "{:.3R},", lights.NomMinDesignLevel);
-            print(state.files.eio, "{:.3R},", lights.NomMaxDesignLevel);
+            print(state.files.eio, "{:.3f},", lights.NomMinDesignLevel);
+            print(state.files.eio, "{:.3f},", lights.NomMaxDesignLevel);
 
             auto &light = state.dataHeatBal->Lights(Loop);
 
             Real64 SchMin, SchMax;
             // weekdays
             std::tie(SchMin, SchMax) = light.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::Weekday);
-            print(state.files.eio, "{:.3R},", light.DesignLevel * SchMin);
-            print(state.files.eio, "{:.1R},", light.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", light.DesignLevel * SchMin);
+            print(state.files.eio, "{:.1f},", light.DesignLevel * SchMax);
 
             // weekends/holidays
             std::tie(SchMin, SchMax) = light.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WeekEndHoliday);
-            print(state.files.eio, "{:.3R},", light.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", light.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", light.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", light.DesignLevel * SchMax);
 
             // summer design days
             std::tie(SchMin, SchMax) = light.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::SummerDesignDay);
-            print(state.files.eio, "{:.3R},", light.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", light.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", light.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", light.DesignLevel * SchMax);
 
             // winter design days
             std::tie(SchMin, SchMax) = light.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WinterDesignDay);
-            print(state.files.eio, "{:.3R},", light.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R}\n", light.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", light.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f}\n", light.DesignLevel * SchMax);
         }
 
         for (int Loop = 1; Loop <= state.dataHeatBal->TotElecEquip; ++Loop) {
@@ -2901,40 +2897,40 @@ namespace InternalHeatGains {
             auto &zone = state.dataHeatBal->Zone(elecEq.ZonePtr);
 
             print(state.files.eio, Format_722, "ElectricEquipment", elecEq.Name, elecEq.sched->Name, zone.Name, zone.FloorArea, zone.TotOccupants);
-            print(state.files.eio, "{:.3R},", elecEq.DesignLevel);
+            print(state.files.eio, "{:.3f},", elecEq.DesignLevel);
 
             print_and_divide_if_greater_than_zero(elecEq.DesignLevel, zone.FloorArea);
             print_and_divide_if_greater_than_zero(elecEq.DesignLevel, zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", elecEq.FractionLatent);
-            print(state.files.eio, "{:.3R},", elecEq.FractionRadiant);
-            print(state.files.eio, "{:.3R},", elecEq.FractionLost);
-            print(state.files.eio, "{:.3R},", elecEq.FractionConvected);
+            print(state.files.eio, "{:.3f},", elecEq.FractionLatent);
+            print(state.files.eio, "{:.3f},", elecEq.FractionRadiant);
+            print(state.files.eio, "{:.3f},", elecEq.FractionLost);
+            print(state.files.eio, "{:.3f},", elecEq.FractionConvected);
             print(state.files.eio, "{},", elecEq.EndUseSubcategory);
-            print(state.files.eio, "{:.3R},", elecEq.NomMinDesignLevel);
-            print(state.files.eio, "{:.3R},", elecEq.NomMaxDesignLevel);
+            print(state.files.eio, "{:.3f},", elecEq.NomMinDesignLevel);
+            print(state.files.eio, "{:.3f},", elecEq.NomMaxDesignLevel);
 
             Real64 SchMin, SchMax;
 
             // weekdays
             std::tie(SchMin, SchMax) = elecEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::Weekday);
-            print(state.files.eio, "{:.3R},", elecEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", elecEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", elecEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", elecEq.DesignLevel * SchMax);
 
             // weekends/holidays
             std::tie(SchMin, SchMax) = elecEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WeekEndHoliday);
-            print(state.files.eio, "{:.3R},", elecEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", elecEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", elecEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", elecEq.DesignLevel * SchMax);
 
             // summer design days
             std::tie(SchMin, SchMax) = elecEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::SummerDesignDay);
-            print(state.files.eio, "{:.3R},", elecEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", elecEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", elecEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", elecEq.DesignLevel * SchMax);
 
             // winter design days
             std::tie(SchMin, SchMax) = elecEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WinterDesignDay);
-            print(state.files.eio, "{:.3R},", elecEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R}\n", elecEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", elecEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f}\n", elecEq.DesignLevel * SchMax);
         }
 
         for (int Loop = 1; Loop <= state.dataHeatBal->TotGasEquip; ++Loop) {
@@ -2961,39 +2957,39 @@ namespace InternalHeatGains {
             auto &zone = state.dataHeatBal->Zone(gasEq.ZonePtr);
 
             print(state.files.eio, Format_722, "GasEquipment", gasEq.Name, gasEq.sched->Name, zone.Name, zone.FloorArea, zone.TotOccupants);
-            print(state.files.eio, "{:.3R},", gasEq.DesignLevel);
+            print(state.files.eio, "{:.3f},", gasEq.DesignLevel);
 
             print_and_divide_if_greater_than_zero(gasEq.DesignLevel, zone.FloorArea);
             print_and_divide_if_greater_than_zero(gasEq.DesignLevel, zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", gasEq.FractionLatent);
-            print(state.files.eio, "{:.3R},", gasEq.FractionRadiant);
-            print(state.files.eio, "{:.3R},", gasEq.FractionLost);
-            print(state.files.eio, "{:.3R},", gasEq.FractionConvected);
+            print(state.files.eio, "{:.3f},", gasEq.FractionLatent);
+            print(state.files.eio, "{:.3f},", gasEq.FractionRadiant);
+            print(state.files.eio, "{:.3f},", gasEq.FractionLost);
+            print(state.files.eio, "{:.3f},", gasEq.FractionConvected);
             print(state.files.eio, "{},", gasEq.EndUseSubcategory);
-            print(state.files.eio, "{:.3R},", gasEq.NomMinDesignLevel);
-            print(state.files.eio, "{:.3R},", gasEq.NomMaxDesignLevel);
+            print(state.files.eio, "{:.3f},", gasEq.NomMinDesignLevel);
+            print(state.files.eio, "{:.3f},", gasEq.NomMaxDesignLevel);
 
             Real64 SchMin, SchMax;
             // weekdays
             std::tie(SchMin, SchMax) = gasEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::Weekday);
-            print(state.files.eio, "{:.3R},", gasEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", gasEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", gasEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", gasEq.DesignLevel * SchMax);
 
             // weekends/holidays
             std::tie(SchMin, SchMax) = gasEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WeekEndHoliday);
-            print(state.files.eio, "{:.3R},", gasEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", gasEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", gasEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", gasEq.DesignLevel * SchMax);
 
             // summer design days
             std::tie(SchMin, SchMax) = gasEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::SummerDesignDay);
-            print(state.files.eio, "{:.3R},", gasEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", gasEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", gasEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", gasEq.DesignLevel * SchMax);
 
             // winter design days
             std::tie(SchMin, SchMax) = gasEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WinterDesignDay);
-            print(state.files.eio, "{:.3R},", gasEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R}\n", gasEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", gasEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f}\n", gasEq.DesignLevel * SchMax);
         }
 
         for (int Loop = 1; Loop <= state.dataHeatBal->TotHWEquip; ++Loop) {
@@ -3028,39 +3024,39 @@ namespace InternalHeatGains {
                   zone.FloorArea,
                   zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", hotWaterEq.DesignLevel);
+            print(state.files.eio, "{:.3f},", hotWaterEq.DesignLevel);
 
             print_and_divide_if_greater_than_zero(hotWaterEq.DesignLevel, zone.FloorArea);
             print_and_divide_if_greater_than_zero(hotWaterEq.DesignLevel, zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", hotWaterEq.FractionLatent);
-            print(state.files.eio, "{:.3R},", hotWaterEq.FractionRadiant);
-            print(state.files.eio, "{:.3R},", hotWaterEq.FractionLost);
-            print(state.files.eio, "{:.3R},", hotWaterEq.FractionConvected);
+            print(state.files.eio, "{:.3f},", hotWaterEq.FractionLatent);
+            print(state.files.eio, "{:.3f},", hotWaterEq.FractionRadiant);
+            print(state.files.eio, "{:.3f},", hotWaterEq.FractionLost);
+            print(state.files.eio, "{:.3f},", hotWaterEq.FractionConvected);
             print(state.files.eio, "{},", hotWaterEq.EndUseSubcategory);
-            print(state.files.eio, "{:.3R},", hotWaterEq.NomMinDesignLevel);
-            print(state.files.eio, "{:.3R},", hotWaterEq.NomMaxDesignLevel);
+            print(state.files.eio, "{:.3f},", hotWaterEq.NomMinDesignLevel);
+            print(state.files.eio, "{:.3f},", hotWaterEq.NomMaxDesignLevel);
 
             Real64 SchMin, SchMax;
             // weekdays
             std::tie(SchMin, SchMax) = hotWaterEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::Weekday);
-            print(state.files.eio, "{:.3R},", hotWaterEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", hotWaterEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", hotWaterEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", hotWaterEq.DesignLevel * SchMax);
 
             // weekends/holidays
             std::tie(SchMin, SchMax) = hotWaterEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WeekEndHoliday);
-            print(state.files.eio, "{:.3R},", hotWaterEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", hotWaterEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", hotWaterEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", hotWaterEq.DesignLevel * SchMax);
 
             // summer design days
             std::tie(SchMin, SchMax) = hotWaterEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::SummerDesignDay);
-            print(state.files.eio, "{:.3R},", hotWaterEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", hotWaterEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", hotWaterEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", hotWaterEq.DesignLevel * SchMax);
 
             // winter design days
             std::tie(SchMin, SchMax) = hotWaterEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WinterDesignDay);
-            print(state.files.eio, "{:.3R},", hotWaterEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R}\n", hotWaterEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", hotWaterEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f}\n", hotWaterEq.DesignLevel * SchMax);
         }
 
         for (int Loop = 1; Loop <= state.dataHeatBal->TotStmEquip; ++Loop) {
@@ -3087,39 +3083,39 @@ namespace InternalHeatGains {
             auto &zone = state.dataHeatBal->Zone(steamEq.ZonePtr);
 
             print(state.files.eio, Format_722, "SteamEquipment", steamEq.Name, steamEq.sched->Name, zone.Name, zone.FloorArea, zone.TotOccupants);
-            print(state.files.eio, "{:.3R},", steamEq.DesignLevel);
+            print(state.files.eio, "{:.3f},", steamEq.DesignLevel);
 
             print_and_divide_if_greater_than_zero(steamEq.DesignLevel, zone.FloorArea);
             print_and_divide_if_greater_than_zero(steamEq.DesignLevel, zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", steamEq.FractionLatent);
-            print(state.files.eio, "{:.3R},", steamEq.FractionRadiant);
-            print(state.files.eio, "{:.3R},", steamEq.FractionLost);
-            print(state.files.eio, "{:.3R},", steamEq.FractionConvected);
+            print(state.files.eio, "{:.3f},", steamEq.FractionLatent);
+            print(state.files.eio, "{:.3f},", steamEq.FractionRadiant);
+            print(state.files.eio, "{:.3f},", steamEq.FractionLost);
+            print(state.files.eio, "{:.3f},", steamEq.FractionConvected);
             print(state.files.eio, "{},", steamEq.EndUseSubcategory);
-            print(state.files.eio, "{:.3R},", steamEq.NomMinDesignLevel);
-            print(state.files.eio, "{:.3R},", steamEq.NomMaxDesignLevel);
+            print(state.files.eio, "{:.3f},", steamEq.NomMinDesignLevel);
+            print(state.files.eio, "{:.3f},", steamEq.NomMaxDesignLevel);
 
             Real64 SchMin, SchMax;
             // weekdays
             std::tie(SchMin, SchMax) = steamEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::Weekday);
-            print(state.files.eio, "{:.3R},", steamEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", steamEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", steamEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", steamEq.DesignLevel * SchMax);
 
             // weekends/holidays
             std::tie(SchMin, SchMax) = steamEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WeekEndHoliday);
-            print(state.files.eio, "{:.3R},", steamEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", steamEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", steamEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", steamEq.DesignLevel * SchMax);
 
             // summer design days
             std::tie(SchMin, SchMax) = steamEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::SummerDesignDay);
-            print(state.files.eio, "{:.3R},", steamEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", steamEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", steamEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", steamEq.DesignLevel * SchMax);
 
             // winter design days
             std::tie(SchMin, SchMax) = steamEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WinterDesignDay);
-            print(state.files.eio, "{:.3R},", steamEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R}\n", steamEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", steamEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f}\n", steamEq.DesignLevel * SchMax);
         }
 
         for (int Loop = 1; Loop <= state.dataHeatBal->TotOthEquip; ++Loop) {
@@ -3146,39 +3142,39 @@ namespace InternalHeatGains {
             auto const &zone = state.dataHeatBal->Zone(otherEq.ZonePtr);
 
             print(state.files.eio, Format_722, "OtherEquipment", otherEq.Name, otherEq.sched->Name, zone.Name, zone.FloorArea, zone.TotOccupants);
-            print(state.files.eio, "{:.3R},", otherEq.DesignLevel);
+            print(state.files.eio, "{:.3f},", otherEq.DesignLevel);
 
             print_and_divide_if_greater_than_zero(otherEq.DesignLevel, zone.FloorArea);
             print_and_divide_if_greater_than_zero(otherEq.DesignLevel, zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", otherEq.FractionLatent);
-            print(state.files.eio, "{:.3R},", otherEq.FractionRadiant);
-            print(state.files.eio, "{:.3R},", otherEq.FractionLost);
-            print(state.files.eio, "{:.3R},", otherEq.FractionConvected);
-            print(state.files.eio, "{:.3R},", otherEq.NomMinDesignLevel);
-            print(state.files.eio, "{:.3R},", otherEq.NomMaxDesignLevel);
+            print(state.files.eio, "{:.3f},", otherEq.FractionLatent);
+            print(state.files.eio, "{:.3f},", otherEq.FractionRadiant);
+            print(state.files.eio, "{:.3f},", otherEq.FractionLost);
+            print(state.files.eio, "{:.3f},", otherEq.FractionConvected);
+            print(state.files.eio, "{:.3f},", otherEq.NomMinDesignLevel);
+            print(state.files.eio, "{:.3f},", otherEq.NomMaxDesignLevel);
 
             Real64 SchMin, SchMax;
 
             // weekdays
             std::tie(SchMin, SchMax) = otherEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::Weekday);
-            print(state.files.eio, "{:.3R},", otherEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", otherEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", otherEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", otherEq.DesignLevel * SchMax);
 
             // weekends/holidays
             std::tie(SchMin, SchMax) = otherEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WeekEndHoliday);
-            print(state.files.eio, "{:.3R},", otherEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", otherEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", otherEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", otherEq.DesignLevel * SchMax);
 
             // summer design days
             std::tie(SchMin, SchMax) = otherEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::SummerDesignDay);
-            print(state.files.eio, "{:.3R},", otherEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R},", otherEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", otherEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f},", otherEq.DesignLevel * SchMax);
 
             // winter design days
             std::tie(SchMin, SchMax) = otherEq.sched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WinterDesignDay);
-            print(state.files.eio, "{:.3R},", otherEq.DesignLevel * SchMin);
-            print(state.files.eio, "{:.3R}\n", otherEq.DesignLevel * SchMax);
+            print(state.files.eio, "{:.3f},", otherEq.DesignLevel * SchMin);
+            print(state.files.eio, "{:.3f}\n", otherEq.DesignLevel * SchMax);
         }
 
         for (int Loop = 1; Loop <= state.dataHeatBal->TotITEquip; ++Loop) {
@@ -3214,7 +3210,7 @@ namespace InternalHeatGains {
                   zone.FloorArea,
                   zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower);
 
             print_and_divide_if_greater_than_zero(itEq.DesignTotalPower, zone.FloorArea);
             print_and_divide_if_greater_than_zero(itEq.DesignTotalPower, zone.TotOccupants);
@@ -3225,31 +3221,31 @@ namespace InternalHeatGains {
             print(state.files.eio, "{},", itEq.EndUseSubcategoryCPU);
             print(state.files.eio, "{},", itEq.EndUseSubcategoryFan);
             print(state.files.eio, "{},", itEq.EndUseSubcategoryUPS);
-            print(state.files.eio, "{:.3R},", itEq.NomMinDesignLevel);
-            print(state.files.eio, "{:.3R},", itEq.NomMaxDesignLevel);
+            print(state.files.eio, "{:.3f},", itEq.NomMinDesignLevel);
+            print(state.files.eio, "{:.3f},", itEq.NomMaxDesignLevel);
 
             Real64 SchMin, SchMax;
             // weekdays
             std::tie(SchMin, SchMax) = itEq.operSched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::Weekday);
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower * SchMin);
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower * SchMax);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower * SchMin);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower * SchMax);
 
             // weekends/holidays
             std::tie(SchMin, SchMax) = itEq.operSched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WeekEndHoliday);
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower * SchMin);
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower * SchMax);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower * SchMin);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower * SchMax);
 
             // summer design days
             std::tie(SchMin, SchMax) = itEq.operSched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::SummerDesignDay);
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower * SchMin);
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower * SchMax);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower * SchMin);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower * SchMax);
 
             // winter design days
             std::tie(SchMin, SchMax) = itEq.operSched->getMinMaxValsByDayType(state, Sched::DayTypeGroup::WinterDesignDay);
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower * SchMin);
-            print(state.files.eio, "{:.3R},", itEq.DesignTotalPower * SchMax);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower * SchMin);
+            print(state.files.eio, "{:.3f},", itEq.DesignTotalPower * SchMax);
 
-            print(state.files.eio, "{:.10R}\n", itEq.DesignAirVolFlowRate);
+            print(state.files.eio, "{:.10f}\n", itEq.DesignAirVolFlowRate);
         }
 
         for (int Loop = 1; Loop <= state.dataHeatBal->TotBBHeat; ++Loop) {
@@ -3278,12 +3274,12 @@ namespace InternalHeatGains {
                   zone.FloorArea,
                   zone.TotOccupants);
 
-            print(state.files.eio, "{:.3R},", bbHeat.CapatLowTemperature);
-            print(state.files.eio, "{:.3R},", bbHeat.LowTemperature);
-            print(state.files.eio, "{:.3R},", bbHeat.CapatHighTemperature);
-            print(state.files.eio, "{:.3R},", bbHeat.HighTemperature);
-            print(state.files.eio, "{:.3R},", bbHeat.FractionRadiant);
-            print(state.files.eio, "{:.3R},", bbHeat.FractionConvected);
+            print(state.files.eio, "{:.3f},", bbHeat.CapatLowTemperature);
+            print(state.files.eio, "{:.3f},", bbHeat.LowTemperature);
+            print(state.files.eio, "{:.3f},", bbHeat.CapatHighTemperature);
+            print(state.files.eio, "{:.3f},", bbHeat.HighTemperature);
+            print(state.files.eio, "{:.3f},", bbHeat.FractionRadiant);
+            print(state.files.eio, "{:.3f},", bbHeat.FractionConvected);
             print(state.files.eio, "{}\n", bbHeat.EndUseSubcategory);
         }
     }
@@ -3457,8 +3453,7 @@ namespace InternalHeatGains {
             if (inputValue < 0.0) {
                 ShowSevereError(
                     state,
-                    EnergyPlus::format(
-                        "{}{}=\"{}\", invalid {}, value  [<0.0]={:.3R}", RoutineName, objectType, inputObject.Name, fieldName, inputValue));
+                    std::format("{}{}=\"{}\", invalid {}, value  [<0.0]={:.3f}", RoutineName, objectType, inputObject.Name, fieldName, inputValue));
                 ErrorsFound = true;
             }
         } break;
@@ -3468,8 +3463,7 @@ namespace InternalHeatGains {
             if (inputValue <= 0.0) {
                 ShowSevereError(
                     state,
-                    EnergyPlus::format(
-                        "{}{}=\"{}\", invalid {}, value  [<=0.0]={:.3R}", RoutineName, objectType, inputObject.Name, fieldName, inputValue));
+                    std::format("{}{}=\"{}\", invalid {}, value  [<=0.0]={:.3f}", RoutineName, objectType, inputObject.Name, fieldName, inputValue));
                 ErrorsFound = true;
             }
         } break;


### PR DESCRIPTION
## Purpose
Continues the remove-`fmt` campaign (#11553, #11588, #11592). Converts the `I*`
source files from `EnergyPlus::format`/`fmt::format` to C++20 `std::format` and
replaces the custom `{:.NR}` flag with standard specifiers.

## Scope
| File | calls converted |
|---|---|
| InternalHeatGains.cc | 148 |
| IceThermalStorage.cc | 7 |
| ICEngineElectricGenerator.cc | 4 |

0 `{R}`/`{T}` and 0 `EnergyPlus::format` remain in these files. The DoubleWrapper /
Fortran-format machinery in `IOFiles.hh` is left untouched (later PR).

## Specifier mapping (the bit to sanity-check)
Following the A–H precedent, chosen to minimize regression diffs:
- `{:.NR}` for |v| >= 0.1 (the common case) -> `{:.Nf}` — reproduces the old fixed
  output exactly, so zero diff.
- Genuinely-tiny values (CO2 rate ~3.8e-8) -> `{:.NE}` — matches the old scientific
  mantissa with no truncation; avoids `{:.Nf}` rounding it to `0.000`.
- People counts -> `{:.1f}` — matches the old 1-decimal echo.

Note on `{:#G}`/`{:G}`: this PR doesn't use it, but that's **not** a departure from
the campaign convention. None of the I* fields are the `m3/s/W` sizing/flow class
that #11553's `{:G}` normalization targets — these are density/count echo fields
whose baseline was fixed `{:.NR}`, so `{:.Nf}`/`{:.NE}` reproduce them exactly while
`{:#G}` would reveal extra sig figs and add avoidable small diffs. (The `{:#G}` ->
`{:.5f}` revert in #11592, `bd0c1a1048`, is the precedent for preferring a fixed
spec where it matches and avoids platform-divergence risk.)

## Verification (energyplus-regressions vs develop, local)
- **0 numeric result diffs** — ESO/MTR/SSZ/ZSZ/JSON byte-identical.
- Table diffs are display-only (Initialization Summary echo): 503 small + 10 big.
  The 10 big are irreducible `x.x5` people-count flips — old `{R}` rounds half-up,
  `std::format` rounds half-to-even. Same benign class accepted in #11588/#11592.
- Local regression is Windows-only; CI (Linux/mac) is the authoritative check on
  the specifier choices.

## Indentation note
Whitespace-only line changes are clang-format v19 reflow: `std::format` is 7 chars
shorter than `EnergyPlus::format`, so wrapped calls collapse under the 150-col
limit. `pre-commit run clang-format` passes clean.

## Question for review
Is the `{:.Nf}` / `{:.NE}` / `{:.1f}` mapping the approach you want for this value
class, and are the 10 half-even count-flip diffs acceptable (consistent with prior
parts)?
