### PR TITLE
Remove fmt: convert S-Z files to std::format (part 6)

### DIFF
--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -6772,7 +6772,7 @@ namespace AirflowNetwork {
                             if (ErrCountVar == 0) {
                                 ++ErrCountVar;
                                 ShowWarningError(m_state, "Iteration limit exceeded pressure setpoint using an exhaust fan. Simulation continues.");
-                                ShowContinueErrorTimeStamp(m_state, EnergyPlus::format("Exhaust fan flow rate = {:.4R}", ExhaustFanMassFlowRate));
+                                ShowContinueErrorTimeStamp(m_state, std::format("Exhaust fan flow rate = {:.5G}", ExhaustFanMassFlowRate));
                             } else {
                                 ++ErrCountVar;
                                 ShowRecurringWarningErrorAtEnd(m_state,
@@ -6861,7 +6861,7 @@ namespace AirflowNetwork {
                             if (ErrCountVar == 0) {
                                 ++ErrCountVar;
                                 ShowWarningError(m_state, "Iteration limit exceeded pressure setpoint using relief air. Simulation continues.");
-                                ShowContinueErrorTimeStamp(m_state, EnergyPlus::format("Relief air flow rate = {:.4R}", ReliefMassFlowRate));
+                                ShowContinueErrorTimeStamp(m_state, std::format("Relief air flow rate = {:.5G}", ReliefMassFlowRate));
                             } else {
                                 ++ErrCountVar;
                                 ShowRecurringWarningErrorAtEnd(m_state,
@@ -9812,10 +9812,9 @@ namespace AirflowNetwork {
                                           "calculated based on the mass flow rate during HVAC operation.");
                         ShowContinueError(
                             m_state,
-                            EnergyPlus::format(
-                                "The mass flow rate during HVAC operation = {:.2R} The mass flow rate during no HVAC operation = {:.2R}",
-                                m_state.dataAirLoop->AirLoopAFNInfo(AirLoopNum).LoopSystemOnMassFlowrate,
-                                m_state.dataAirLoop->AirLoopAFNInfo(AirLoopNum).LoopSystemOffMassFlowrate));
+                            std::format("The mass flow rate during HVAC operation = {:.3G} The mass flow rate during no HVAC operation = {:.3G}",
+                                        m_state.dataAirLoop->AirLoopAFNInfo(AirLoopNum).LoopSystemOnMassFlowrate,
+                                        m_state.dataAirLoop->AirLoopAFNInfo(AirLoopNum).LoopSystemOffMassFlowrate));
                         UpdateAirflowNetworkMyOneTimeFlag = false;
                     }
                 }
@@ -9852,9 +9851,9 @@ namespace AirflowNetwork {
                                                  AirflowNetworkLinkageData(i).Name + "'.");
                             ShowContinueError(
                                 m_state,
-                                EnergyPlus::format("The system node max mass flow rate = {:.3R} kg/s. The AFN node mass flow rate = {:.3R} kg.s.",
-                                                   NodeMass,
-                                                   AFNMass));
+                                std::format("The system node max mass flow rate = {:.4G} kg/s. The AFN node mass flow rate = {:.4G} kg.s.",
+                                            NodeMass,
+                                            AFNMass));
                             WriteFlag = true;
                         }
                     }

--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -353,13 +353,12 @@ namespace AirflowNetwork {
                 if (fields.find("reference_barometric_pressure") != fields.end()) { // not required field, has default value
                     pressure = fields.at("reference_barometric_pressure").get<Real64>();
                     if (std::abs((pressure - m_state.dataEnvrn->StdBaroPress) / m_state.dataEnvrn->StdBaroPress) > 0.1) { // 10% off
-                        ShowWarningError(
-                            m_state,
-                            EnergyPlus::format("{}: {}: Pressure = {:.0R} differs by more than 10% from Standard Barometric Pressure = {:.0R}.",
-                                               RoutineName,
-                                               CurrentModuleObject,
-                                               pressure,
-                                               m_state.dataEnvrn->StdBaroPress));
+                        ShowWarningError(m_state,
+                                         std::format("{}: {}: Pressure = {:.0f} differs by more than 10% from Standard Barometric Pressure = {:.0f}.",
+                                                     RoutineName,
+                                                     CurrentModuleObject,
+                                                     pressure,
+                                                     m_state.dataEnvrn->StdBaroPress));
                         ShowContinueError(m_state, "...occurs in " + CurrentModuleObject + " = " + thisObjectName);
                     }
                     if (pressure <= 31000.0) {
@@ -902,7 +901,7 @@ namespace AirflowNetwork {
                         ShowContinueError(
                             m_state,
                             "..This object specifies that only 3 opening factors will be used. So, the value of Opening Factor #2 is set to 1.0.");
-                        ShowContinueError(m_state, EnergyPlus::format("..Input value was {:.2R}", MultizoneCompDetOpeningData(i).OpenFac2));
+                        ShowContinueError(m_state, std::format("..Input value was {:.2f}", MultizoneCompDetOpeningData(i).OpenFac2));
                         MultizoneCompDetOpeningData(i).OpenFac2 = 1.0;
                     }
                 } else if (N >= 3) {
@@ -918,7 +917,7 @@ namespace AirflowNetwork {
                             ShowContinueError(m_state,
                                               "..This object specifies that 4 opening factors will be used. So, the value of Opening Factor #4 "
                                               "is set to 1.0.");
-                            ShowContinueError(m_state, EnergyPlus::format("..Input value was {:.2R}", MultizoneCompDetOpeningData(i).OpenFac4));
+                            ShowContinueError(m_state, std::format("..Input value was {:.2f}", MultizoneCompDetOpeningData(i).OpenFac4));
                             MultizoneCompDetOpeningData(i).OpenFac4 = 1.0;
                         }
                         MultizoneCompDetOpeningData(i).DischCoeff4 = cds[3];                 // Discharge coefficient for opening factor #4
@@ -931,7 +930,7 @@ namespace AirflowNetwork {
                             ShowContinueError(m_state,
                                               "..This object specifies that only 3 opening factors will be used. So, the value of Opening Factor #3 "
                                               "is set to 1.0.");
-                            ShowContinueError(m_state, EnergyPlus::format("..Input value was {:.2R}", MultizoneCompDetOpeningData(i).OpenFac3));
+                            ShowContinueError(m_state, std::format("..Input value was {:.2f}", MultizoneCompDetOpeningData(i).OpenFac3));
                             MultizoneCompDetOpeningData(i).OpenFac3 = 1.0;
                         }
                     }
@@ -1806,8 +1805,7 @@ namespace AirflowNetwork {
                     // Code will never be executed, validation will catch invalid input
                     ShowWarningError(m_state, std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(1) + " < 0.0");
                     ShowContinueError(
-                        m_state,
-                        EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 0.0", OccupantVentilationControl(i).MinOpeningTime));
+                        m_state, std::format("..Input value = {:.1f}, Value will be reset to 0.0", OccupantVentilationControl(i).MinOpeningTime));
                     ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + OccupantVentilationControl(i).Name);
                     OccupantVentilationControl(i).MinOpeningTime = 0.0;
                 }
@@ -1816,8 +1814,7 @@ namespace AirflowNetwork {
                     // Code will never be executed, validation will catch invalid input
                     ShowWarningError(m_state, std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(2) + " < 0.0");
                     ShowContinueError(
-                        m_state,
-                        EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 0.0", OccupantVentilationControl(i).MinClosingTime));
+                        m_state, std::format("..Input value = {:.1f}, Value will be reset to 0.0", OccupantVentilationControl(i).MinClosingTime));
                     ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + OccupantVentilationControl(i).Name);
                     OccupantVentilationControl(i).MinClosingTime = 0.0;
                 }
@@ -1871,8 +1868,8 @@ namespace AirflowNetwork {
                         // Code will never be executed, validation will catch invalid input
                         ShowWarningError(m_state, std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(3) + " < 0.0");
                         ShowContinueError(m_state,
-                                          EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 10.0 as default",
-                                                             OccupantVentilationControl(i).ComfortBouPoint));
+                                          std::format("..Input value = {:.1f}, Value will be reset to 10.0 as default",
+                                                      OccupantVentilationControl(i).ComfortBouPoint));
                         ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + OccupantVentilationControl(i).Name);
                         OccupantVentilationControl(i).ComfortBouPoint = 10.0;
                     }
@@ -1886,8 +1883,7 @@ namespace AirflowNetwork {
                                             " object: The difference of both curve values at boundary point > 0.1");
                         ShowContinueError(m_state, "Both curve names are = " + cAlphaFields(2) + " and " + cAlphaFields(3));
                         ShowContinueError(
-                            m_state,
-                            EnergyPlus::format("The input value of {} = {:.1R}", cNumericFields(3), OccupantVentilationControl(i).ComfortBouPoint));
+                            m_state, std::format("The input value of {} = {:.1f}", cNumericFields(3), OccupantVentilationControl(i).ComfortBouPoint));
                         ErrorsFound = true;
                     }
                 }
@@ -1897,9 +1893,9 @@ namespace AirflowNetwork {
                         // Code will never be executed, validation will catch invalid input
                         ShowWarningError(m_state,
                                          std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(4) + " beyond 0.0 and 100.0");
-                        ShowContinueError(m_state,
-                                          EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 10.0 as default",
-                                                             OccupantVentilationControl(i).MaxPPD));
+                        ShowContinueError(
+                            m_state,
+                            std::format("..Input value = {:.1f}, Value will be reset to 10.0 as default", OccupantVentilationControl(i).MaxPPD));
                         ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + OccupantVentilationControl(i).Name);
                         OccupantVentilationControl(i).MaxPPD = 10.0;
                     }
@@ -2482,7 +2478,7 @@ namespace AirflowNetwork {
                 // Code will never be executed, validation will catch invalid input
                 ShowWarningError(m_state,
                                  std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(1) + " is out of range [0.0,1.0]");
-                ShowContinueError(m_state, EnergyPlus::format("..Input value = {:.2R}, Value will be set to 1.0", MultizoneZoneData(i).OpenFactor));
+                ShowContinueError(m_state, std::format("..Input value = {:.2f}, Value will be set to 1.0", MultizoneZoneData(i).OpenFactor));
                 MultizoneZoneData(i).OpenFactor = 1.0;
             }
 
@@ -2494,15 +2490,15 @@ namespace AirflowNetwork {
                         // Code will never be executed, validation will catch invalid input
                         ShowWarningError(m_state, std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(2) + " < 0.0");
                         ShowContinueError(m_state,
-                                          EnergyPlus::format("..Input value = {:.1R}, Value will be set to 0.0", MultizoneZoneData(i).LowValueTemp));
+                                          std::format("..Input value = {:.1f}, Value will be set to 0.0", MultizoneZoneData(i).LowValueTemp));
                         ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + MultizoneZoneData(i).ZoneName);
                         MultizoneZoneData(i).LowValueTemp = 0.0;
                     }
                     if (MultizoneZoneData(i).LowValueTemp >= 100.0) {
                         // Code will never be executed, validation will catch invalid input
                         ShowWarningError(m_state, std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(2) + " >= 100.0");
-                        ShowContinueError(
-                            m_state, EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 0.0", MultizoneZoneData(i).LowValueTemp));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value = {:.1f}, Value will be reset to 0.0", MultizoneZoneData(i).LowValueTemp));
                         ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + MultizoneZoneData(i).ZoneName);
                         MultizoneZoneData(i).LowValueTemp = 0.0;
                     }
@@ -2510,9 +2506,9 @@ namespace AirflowNetwork {
                         ShowWarningError(
                             m_state, std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(3) + " <= " + cNumericFields(2));
                         ShowContinueError(m_state,
-                                          EnergyPlus::format("..Input value for {} = {:.1R}, Value will be reset to 100.0",
-                                                             cNumericFields(3),
-                                                             MultizoneZoneData(i).UpValueTemp));
+                                          std::format("..Input value for {} = {:.1f}, Value will be reset to 100.0",
+                                                      cNumericFields(3),
+                                                      MultizoneZoneData(i).UpValueTemp));
                         ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + MultizoneZoneData(i).ZoneName);
                         MultizoneZoneData(i).UpValueTemp = 100.0;
                     }
@@ -2521,16 +2517,16 @@ namespace AirflowNetwork {
                     if (MultizoneZoneData(i).LowValueEnth < 0.0) {
                         // Code will never be executed, validation will catch invalid input
                         ShowWarningError(m_state, std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(4) + " < 0.0");
-                        ShowContinueError(
-                            m_state, EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 0.0", MultizoneZoneData(i).LowValueEnth));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value = {:.1f}, Value will be reset to 0.0", MultizoneZoneData(i).LowValueEnth));
                         ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + MultizoneZoneData(i).ZoneName);
                         MultizoneZoneData(i).LowValueEnth = 0.0;
                     }
                     if (MultizoneZoneData(i).LowValueEnth >= 300000.0) {
                         // Code will never be executed, validation will catch invalid input
                         ShowWarningError(m_state, std::format(RoutineName) + CurrentModuleObject + " object, " + cNumericFields(4) + " >= 300000.0");
-                        ShowContinueError(
-                            m_state, EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 0.0.", MultizoneZoneData(i).LowValueEnth));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value = {:.1f}, Value will be reset to 0.0.", MultizoneZoneData(i).LowValueEnth));
                         ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + MultizoneZoneData(i).ZoneName);
                         MultizoneZoneData(i).LowValueEnth = 0.0;
                     }
@@ -2538,9 +2534,9 @@ namespace AirflowNetwork {
                         ShowWarningError(
                             m_state, std::format("{}{} object, {} <= {}", RoutineName, CurrentModuleObject, cNumericFields(5), cNumericFields(4)));
                         ShowContinueError(m_state,
-                                          EnergyPlus::format("..Input value for {}= {:.1R}, Value will be reset to 300000.0",
-                                                             cNumericFields(5),
-                                                             MultizoneZoneData(i).UpValueEnth));
+                                          std::format("..Input value for {}= {:.1f}, Value will be reset to 300000.0",
+                                                      cNumericFields(5),
+                                                      MultizoneZoneData(i).UpValueEnth));
                         ShowContinueError(m_state, "..for " + cAlphaFields(1) + " = \"" + MultizoneZoneData(i).ZoneName);
                         MultizoneZoneData(i).UpValueEnth = 300000.0;
                     }
@@ -2588,7 +2584,7 @@ namespace AirflowNetwork {
                         ShowWarningError(m_state,
                                          std::format(RoutineName) + CurrentModuleObject + " object =" + Alphas(1) + ". The input of " +
                                              cNumericFields(1) + " is required, but a blank is found.");
-                        ShowContinueError(m_state, EnergyPlus::format("The default value is assigned as {:.1R}", Numbers(1)));
+                        ShowContinueError(m_state, std::format("The default value is assigned as {:.1f}", Numbers(1)));
                     }
                     MultizoneExternalNodeData(i).ExtNum = AirflowNetworkNumOfZones + i;            // External node number
                     MultizoneExternalNodeData(i).curve = Curve::GetCurveIndex(m_state, Alphas(2)); // Wind pressure curve
@@ -2729,8 +2725,7 @@ namespace AirflowNetwork {
                     ShowWarningError(m_state,
                                      std::format(RoutineName) + CurrentModuleObject + " object=" + MultizoneSurfaceData(i).SurfName + ", " +
                                          cNumericFields(1) + " is out of range (0.0,1.0]");
-                    ShowContinueError(m_state,
-                                      EnergyPlus::format("..Input value = {:.2R}, Value will be set to 1.0", MultizoneSurfaceData(i).Factor));
+                    ShowContinueError(m_state, std::format("..Input value = {:.2f}, Value will be set to 1.0", MultizoneSurfaceData(i).Factor));
                     MultizoneSurfaceData(i).Factor = 1.0;
                 }
                 // Get input of ventilation control and associated data
@@ -3164,7 +3159,7 @@ namespace AirflowNetwork {
                     found = false;
                 }
                 print(m_state.files.eio,
-                      "AirflowNetwork Model:Equivalent Rectangle Surface, {}, {:.2R},{:.2R}\n",
+                      "AirflowNetwork Model:Equivalent Rectangle Surface, {}, {:.2f},{:.2f}\n",
                       MultizoneSurfaceData(i).SurfName,
                       MultizoneSurfaceData(i).Height,
                       MultizoneSurfaceData(i).Width);
@@ -3297,16 +3292,16 @@ namespace AirflowNetwork {
                     if (MultizoneSurfaceData(i).LowValueTemp < 0.0) {
                         ShowWarningError(m_state,
                                          std::format(RoutineName) + CurrentModuleObject + " object, Low Temperature difference value < 0.0d0");
-                        ShowContinueError(
-                            m_state, EnergyPlus::format("..Input value={:.1R}, Value will be reset to 0.0.", MultizoneSurfaceData(i).LowValueTemp));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value={:.1f}, Value will be reset to 0.0.", MultizoneSurfaceData(i).LowValueTemp));
                         ShowContinueError(m_state, "..for Surface = \"" + MultizoneSurfaceData(i).SurfName + "\"");
                         MultizoneSurfaceData(i).LowValueTemp = 0.0;
                     }
                     if (MultizoneSurfaceData(i).LowValueTemp >= 100.0) {
                         ShowWarningError(m_state,
                                          std::format(RoutineName) + CurrentModuleObject + " object, Low Temperature difference value >= 100.0d0");
-                        ShowContinueError(
-                            m_state, EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 0.0", MultizoneSurfaceData(i).LowValueTemp));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value = {:.1f}, Value will be reset to 0.0", MultizoneSurfaceData(i).LowValueTemp));
                         ShowContinueError(m_state, "..for Surface = \"" + MultizoneSurfaceData(i).SurfName + "\"");
                         MultizoneZoneData(i).LowValueTemp = 0.0;
                     }
@@ -3314,8 +3309,8 @@ namespace AirflowNetwork {
                         ShowWarningError(m_state,
                                          std::format(RoutineName) + CurrentModuleObject +
                                              " object, Upper Temperature <= Lower Temperature difference value.");
-                        ShowContinueError(
-                            m_state, EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 100.0", MultizoneSurfaceData(i).UpValueTemp));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value = {:.1f}, Value will be reset to 100.0", MultizoneSurfaceData(i).UpValueTemp));
                         ShowContinueError(m_state, "..for Surface = \"" + MultizoneSurfaceData(i).SurfName + "\"");
                         MultizoneSurfaceData(i).UpValueTemp = 100.0;
                     }
@@ -3334,25 +3329,24 @@ namespace AirflowNetwork {
                     }
                     if (MultizoneSurfaceData(i).LowValueEnth < 0.0) {
                         ShowWarningError(m_state, std::format(RoutineName) + CurrentModuleObject + " object, Low Enthalpy difference value < 0.0d0");
-                        ShowContinueError(
-                            m_state, EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 0.0", MultizoneSurfaceData(i).LowValueEnth));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value = {:.1f}, Value will be reset to 0.0", MultizoneSurfaceData(i).LowValueEnth));
                         ShowContinueError(m_state, "..for Surface = \"" + MultizoneSurfaceData(i).SurfName + "\"");
                         MultizoneSurfaceData(i).LowValueEnth = 0.0;
                     }
                     if (MultizoneSurfaceData(i).LowValueEnth >= 300000.0) {
                         ShowWarningError(m_state,
                                          std::format(RoutineName) + CurrentModuleObject + " object, Low Enthalpy difference value >= 300000.0");
-                        ShowContinueError(
-                            m_state, EnergyPlus::format("..Input value = {:.1R}, Value will be reset to 0.0", MultizoneSurfaceData(i).LowValueEnth));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value = {:.1f}, Value will be reset to 0.0", MultizoneSurfaceData(i).LowValueEnth));
                         ShowContinueError(m_state, "..for Surface = \"" + MultizoneSurfaceData(i).SurfName + "\"");
                         MultizoneZoneData(i).LowValueEnth = 0.0;
                     }
                     if (MultizoneSurfaceData(i).UpValueEnth <= MultizoneSurfaceData(i).LowValueEnth) {
                         ShowWarningError(
                             m_state, std::format(RoutineName) + CurrentModuleObject + " object, Upper Enthalpy <= Lower Enthalpy difference value.");
-                        ShowContinueError(
-                            m_state,
-                            EnergyPlus::format("..Input value = {:.1R}, Value will be set to 300000.0", MultizoneSurfaceData(i).UpValueEnth));
+                        ShowContinueError(m_state,
+                                          std::format("..Input value = {:.1f}, Value will be set to 300000.0", MultizoneSurfaceData(i).UpValueEnth));
                         ShowContinueError(m_state, "..for Surface = \"" + MultizoneSurfaceData(i).SurfName + "\"");
                         MultizoneSurfaceData(i).UpValueEnth = 300000.0;
                     }
@@ -3505,9 +3499,9 @@ namespace AirflowNetwork {
             }
 
             for (int i = 0; i < numWinDirs; ++i) {
-                print(m_state.files.eio, "{:.1R},", i * angleDelta);
+                print(m_state.files.eio, "{:.1f},", i * angleDelta);
             }
-            print(m_state.files.eio, "{:.1R}\n", numWinDirs * angleDelta);
+            print(m_state.files.eio, "{:.1f}\n", numWinDirs * angleDelta);
 
             print(m_state.files.eio,
                   "! <AirflowNetwork Model:Wind Pressure Coefficients>, Name, Wind Pressure Coefficients #1 to n (dimensionless)\n");
@@ -3521,9 +3515,9 @@ namespace AirflowNetwork {
                 print(m_state.files.eio, "AirflowNetwork Model:Wind Pressure Coefficients, {}, ", Curve::GetCurveName(m_state, index));
 
                 for (int j = 0; j < numWinDirs; ++j) {
-                    print(m_state.files.eio, "{:.2R},", Curve::CurveValue(m_state, index, j * angleDelta));
+                    print(m_state.files.eio, "{:.2f},", Curve::CurveValue(m_state, index, j * angleDelta));
                 }
-                print(m_state.files.eio, "{:.2R}\n", Curve::CurveValue(m_state, index, numWinDirs * angleDelta));
+                print(m_state.files.eio, "{:.2f}\n", Curve::CurveValue(m_state, index, numWinDirs * angleDelta));
             }
 
             if (AirflowNetworkNumOfSingleSideZones > 0) {
@@ -3533,9 +3527,9 @@ namespace AirflowNetwork {
                               "AirflowNetwork: Advanced Single-Sided Model: Difference in Opening Wind Pressure Coefficients (DeltaCP), ");
                         print(m_state.files.eio, "{}, ", MultizoneZoneData(i).ZoneName);
                         for (unsigned j = 1; j <= EPDeltaCP(i).WindDir.size() - 1; ++j) {
-                            print(m_state.files.eio, "{:.2R},", EPDeltaCP(i).WindDir(j));
+                            print(m_state.files.eio, "{:.2f},", EPDeltaCP(i).WindDir(j));
                         }
-                        print(m_state.files.eio, "{:.2R}\n", EPDeltaCP(i).WindDir(static_cast<int>(EPDeltaCP(i).WindDir.size())));
+                        print(m_state.files.eio, "{:.2f}\n", EPDeltaCP(i).WindDir(static_cast<int>(EPDeltaCP(i).WindDir.size())));
                     }
                 }
             }
@@ -6630,7 +6624,7 @@ namespace AirflowNetwork {
                                              "AirflowNetwork: The window or door is open during HVAC system operation " +
                                                  MultizoneSurfaceData(i).SurfName);
                             ShowContinueError(m_state,
-                                              EnergyPlus::format("The window or door opening factor is {:.2R}", MultizoneSurfaceData(i).OpenFactor));
+                                              std::format("The window or door opening factor is {:.2f}", MultizoneSurfaceData(i).OpenFactor));
                             ShowContinueErrorTimeStamp(m_state, "");
                         } else {
                             ShowRecurringWarningErrorAtEnd(m_state,
@@ -6729,7 +6723,7 @@ namespace AirflowNetwork {
                                          "The calculated pressure with minimum exhaust fan rate is lower than the pressure setpoint. The pressure "
                                          "control is unable to perform.");
                         ShowContinueErrorTimeStamp(
-                            m_state, EnergyPlus::format("Calculated pressure = {:.2R}[Pa], Pressure setpoint ={:.2R}", ZonePressure1, PressureSet));
+                            m_state, std::format("Calculated pressure = {:.2f}[Pa], Pressure setpoint ={:.2f}", ZonePressure1, PressureSet));
                     } else {
                         ++ErrCountLowPre;
                         ShowRecurringWarningErrorAtEnd(m_state,
@@ -6753,8 +6747,7 @@ namespace AirflowNetwork {
                                              "The calculated pressure with maximum exhaust fan rate is higher than the pressure setpoint. The "
                                              "pressure control is unable to perform.");
                             ShowContinueErrorTimeStamp(
-                                m_state,
-                                EnergyPlus::format("Calculated pressure = {:.2R}[Pa], Pressure setpoint = {:.2R}", ZonePressure2, PressureSet));
+                                m_state, std::format("Calculated pressure = {:.2f}[Pa], Pressure setpoint = {:.2f}", ZonePressure2, PressureSet));
                         } else {
                             ++ErrCountHighPre;
                             ShowRecurringWarningErrorAtEnd(
@@ -6819,7 +6812,7 @@ namespace AirflowNetwork {
                                          "The calculated pressure with minimum relief air rate is lower than the pressure setpoint. The pressure "
                                          "control is unable to perform.");
                         ShowContinueErrorTimeStamp(
-                            m_state, EnergyPlus::format("Calculated pressure = {:.2R}[Pa], Pressure setpoint ={:.2R}", ZonePressure1, PressureSet));
+                            m_state, std::format("Calculated pressure = {:.2f}[Pa], Pressure setpoint ={:.2f}", ZonePressure1, PressureSet));
                     } else {
                         ++ErrCountLowPre;
                         ShowRecurringWarningErrorAtEnd(m_state,
@@ -6844,8 +6837,7 @@ namespace AirflowNetwork {
                                              "The calculated pressure with maximum relief air rate is higher than the pressure setpoint. The "
                                              "pressure control is unable to perform.");
                             ShowContinueErrorTimeStamp(
-                                m_state,
-                                EnergyPlus::format("Calculated pressure = {:.2R}[Pa], Pressure setpoint = {:.2R}", ZonePressure2, PressureSet));
+                                m_state, std::format("Calculated pressure = {:.2f}[Pa], Pressure setpoint = {:.2f}", ZonePressure2, PressureSet));
                         } else {
                             ++ErrCountHighPre;
                             ShowRecurringWarningErrorAtEnd(
@@ -12691,8 +12683,7 @@ namespace AirflowNetwork {
                                     ++ErrCountDuct; // TODO: Why is the error count shared among all heat pump units?
                                     ShowWarningError(m_state,
                                                      "AirflowNetwork Duct Autosizing: Iteration limit exceeded calculating Supply Duct Trunk size.");
-                                    ShowContinueErrorTimeStamp(m_state,
-                                                               EnergyPlus::format("Supply Duct Hydronic Diameter={:.2R}", hydraulicDiameter));
+                                    ShowContinueErrorTimeStamp(m_state, std::format("Supply Duct Hydronic Diameter={:.2f}", hydraulicDiameter));
                                 } else {
                                     ++ErrCountDuct;
                                     ShowRecurringWarningErrorAtEnd(
@@ -12726,10 +12717,9 @@ namespace AirflowNetwork {
                                 m_state, "AirflowNetwork Duct Sizing: Duct Sizing Method = PressureLossWithMaximumVelocity for Supply Trunk size");
                             ShowContinueError(
                                 m_state,
-                                EnergyPlus::format(
-                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velocity at {:.1R} using PressureLoss",
-                                    simulation_control.ductSizing.max_velocity,
-                                    Velocity));
+                                std::format("The Maximum Airflow Velocity at {:.1f} is less than calculated velocity at {:.1f} using PressureLoss",
+                                            simulation_control.ductSizing.max_velocity,
+                                            Velocity));
                             ShowContinueError(m_state, "..The Maximum Airflow Velocity is used to calculate Supply Trunk Diameter");
                         }
                     }
@@ -12814,8 +12804,7 @@ namespace AirflowNetwork {
                                     ++ErrCountDuct; // TODO: Why is the error count shared among all heat pump units?
                                     ShowWarningError(m_state,
                                                      "AirflowNetwork Duct Autosizing: Iteration limit exceeded calculating Supply Duct Branch size.");
-                                    ShowContinueErrorTimeStamp(m_state,
-                                                               EnergyPlus::format("Supply Duct Hydronic Diameter={:.2R}", hydraulicDiameter));
+                                    ShowContinueErrorTimeStamp(m_state, std::format("Supply Duct Hydronic Diameter={:.2f}", hydraulicDiameter));
                                 } else {
                                     ++ErrCountDuct;
                                     ShowRecurringWarningErrorAtEnd(
@@ -12849,10 +12838,9 @@ namespace AirflowNetwork {
                                 m_state, "AirflowNetwork Duct Sizing: Duct Sizing Method = PressureLossWithMaximumVelocity for Supply Branch size");
                             ShowContinueError(
                                 m_state,
-                                EnergyPlus::format(
-                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velocity at {:.1R} using PressureLoss",
-                                    simulation_control.ductSizing.max_velocity,
-                                    Velocity));
+                                std::format("The Maximum Airflow Velocity at {:.1f} is less than calculated velocity at {:.1f} using PressureLoss",
+                                            simulation_control.ductSizing.max_velocity,
+                                            Velocity));
                             ShowContinueError(m_state, "..The Maximum Airflow Velocity is used to calculate Supply Branch Diameter");
                         }
                     }
@@ -12942,8 +12930,7 @@ namespace AirflowNetwork {
                                     ++ErrCountDuct; // TODO: Why is the error count shared among all heat pump units?
                                     ShowWarningError(m_state,
                                                      "AirflowNetwork Duct Autosizing: Iteration limit exceeded calculating Return Duct Trunk size.");
-                                    ShowContinueErrorTimeStamp(m_state,
-                                                               EnergyPlus::format("Return Duct Hydronic Diameter={:.2R}", hydraulicDiameter));
+                                    ShowContinueErrorTimeStamp(m_state, std::format("Return Duct Hydronic Diameter={:.2f}", hydraulicDiameter));
                                 } else {
                                     ++ErrCountDuct;
                                     ShowRecurringWarningErrorAtEnd(
@@ -12977,10 +12964,9 @@ namespace AirflowNetwork {
                                 m_state, "AirflowNetwork Duct Sizing: Duct Sizing Method = PressureLossWithMaximumVelocity for Return Trunk size");
                             ShowContinueError(
                                 m_state,
-                                EnergyPlus::format(
-                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velocity at {:.1R} using PressureLoss",
-                                    simulation_control.ductSizing.max_velocity,
-                                    Velocity));
+                                std::format("The Maximum Airflow Velocity at {:.1f} is less than calculated velocity at {:.1f} using PressureLoss",
+                                            simulation_control.ductSizing.max_velocity,
+                                            Velocity));
                             ShowContinueError(m_state, "..The Maximum Airflow Velocity is used to calculate Return Trunk Diameter");
                         }
                     }
@@ -13066,8 +13052,7 @@ namespace AirflowNetwork {
                                     ++ErrCountDuct; // TODO: Why is the error count shared among all heat pump units?
                                     ShowWarningError(m_state,
                                                      "AirflowNetwork Duct Autosizing: Iteration limit exceeded calculating Return Duct Branch size.");
-                                    ShowContinueErrorTimeStamp(m_state,
-                                                               EnergyPlus::format("Return Duct Hydronic Diameter={:.2R}", hydraulicDiameter));
+                                    ShowContinueErrorTimeStamp(m_state, std::format("Return Duct Hydronic Diameter={:.2f}", hydraulicDiameter));
                                 } else {
                                     ++ErrCountDuct;
                                     ShowRecurringWarningErrorAtEnd(
@@ -13101,10 +13086,9 @@ namespace AirflowNetwork {
                                 m_state, "AirflowNetwork Duct Sizing: Duct Sizing Method = PressureLossWithMaximumVelocity for Return Branch size");
                             ShowContinueError(
                                 m_state,
-                                EnergyPlus::format(
-                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velocity at {:.1R} using PressureLoss",
-                                    simulation_control.ductSizing.max_velocity,
-                                    Velocity));
+                                std::format("The Maximum Airflow Velocity at {:.1f} is less than calculated velocity at {:.1f} using PressureLoss",
+                                            simulation_control.ductSizing.max_velocity,
+                                            Velocity));
                             ShowContinueError(m_state, "..The Maximum Airflow Velocity is used to calculate Return Branch Diameter");
                         }
                     }
@@ -13161,28 +13145,28 @@ namespace AirflowNetwork {
                       "AirflowNetwork Model:Duct Autosizing, {}, Supply Trunk, {}, ",
                       AirflowNetworkLinkageData(AFNLinkNum).Name,
                       disSysCompDuct.name);
-                print(m_state.files.eio, "{:.4R},{:.4R}\n", SupplyTrunkD, SupplyTrunkArea);
+                print(m_state.files.eio, "{:.4f},{:.4f}\n", SupplyTrunkD, SupplyTrunkArea);
             }
             if (AirflowNetworkLinkageData(AFNLinkNum).ductLineType == DuctLineType::SupplyBranch) {
                 print(m_state.files.eio,
                       "AirflowNetwork Model:Duct Autosizing, {}, Supply Branch, {}, ",
                       AirflowNetworkLinkageData(AFNLinkNum).Name,
                       disSysCompDuct.name);
-                print(m_state.files.eio, "{:.4R},{:.4R}\n", SupplyBranchD, SupplyBranchArea);
+                print(m_state.files.eio, "{:.4f},{:.4f}\n", SupplyBranchD, SupplyBranchArea);
             }
             if (AirflowNetworkLinkageData(AFNLinkNum).ductLineType == DuctLineType::ReturnTrunk) {
                 print(m_state.files.eio,
                       "AirflowNetwork Model:Duct Autosizing, {}, Return Trunk, {}, ",
                       AirflowNetworkLinkageData(AFNLinkNum).Name,
                       disSysCompDuct.name);
-                print(m_state.files.eio, "{:.4R},{:.4R}\n", ReturnTrunkD, ReturnTrunkArea);
+                print(m_state.files.eio, "{:.4f},{:.4f}\n", ReturnTrunkD, ReturnTrunkArea);
             }
             if (AirflowNetworkLinkageData(AFNLinkNum).ductLineType == DuctLineType::ReturnBranch) {
                 print(m_state.files.eio,
                       "AirflowNetwork Model:Duct Autosizing, {}, Return Branch, {}, ",
                       AirflowNetworkLinkageData(AFNLinkNum).Name,
                       disSysCompDuct.name);
-                print(m_state.files.eio, "{:.4R},{:.4R}\n", ReturnBranchD, ReturnBranchArea);
+                print(m_state.files.eio, "{:.4f},{:.4f}\n", ReturnBranchD, ReturnBranchArea);
             }
         }
     }

--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -12727,7 +12727,7 @@ namespace AirflowNetwork {
                             ShowContinueError(
                                 m_state,
                                 EnergyPlus::format(
-                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velosity at {:.1R} using PressureLoss",
+                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velocity at {:.1R} using PressureLoss",
                                     simulation_control.ductSizing.max_velocity,
                                     Velocity));
                             ShowContinueError(m_state, "..The Maximum Airflow Velocity is used to calculate Supply Trunk Diameter");
@@ -12850,7 +12850,7 @@ namespace AirflowNetwork {
                             ShowContinueError(
                                 m_state,
                                 EnergyPlus::format(
-                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velosity at {:.1R} using PressureLoss",
+                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velocity at {:.1R} using PressureLoss",
                                     simulation_control.ductSizing.max_velocity,
                                     Velocity));
                             ShowContinueError(m_state, "..The Maximum Airflow Velocity is used to calculate Supply Branch Diameter");
@@ -12978,7 +12978,7 @@ namespace AirflowNetwork {
                             ShowContinueError(
                                 m_state,
                                 EnergyPlus::format(
-                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velosity at {:.1R} using PressureLoss",
+                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velocity at {:.1R} using PressureLoss",
                                     simulation_control.ductSizing.max_velocity,
                                     Velocity));
                             ShowContinueError(m_state, "..The Maximum Airflow Velocity is used to calculate Return Trunk Diameter");
@@ -13102,7 +13102,7 @@ namespace AirflowNetwork {
                             ShowContinueError(
                                 m_state,
                                 EnergyPlus::format(
-                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velosity at {:.1R} using PressureLoss",
+                                    "The Maximum Airflow Velocity at {:.1R} is less than calculated velocity at {:.1R} using PressureLoss",
                                     simulation_control.ductSizing.max_velocity,
                                     Velocity));
                             ShowContinueError(m_state, "..The Maximum Airflow Velocity is used to calculate Return Branch Diameter");

--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -6772,7 +6772,7 @@ namespace AirflowNetwork {
                             if (ErrCountVar == 0) {
                                 ++ErrCountVar;
                                 ShowWarningError(m_state, "Iteration limit exceeded pressure setpoint using an exhaust fan. Simulation continues.");
-                                ShowContinueErrorTimeStamp(m_state, std::format("Exhaust fan flow rate = {:.5G}", ExhaustFanMassFlowRate));
+                                ShowContinueErrorTimeStamp(m_state, std::format("Exhaust fan flow rate = {:.4f}", ExhaustFanMassFlowRate));
                             } else {
                                 ++ErrCountVar;
                                 ShowRecurringWarningErrorAtEnd(m_state,
@@ -6861,7 +6861,7 @@ namespace AirflowNetwork {
                             if (ErrCountVar == 0) {
                                 ++ErrCountVar;
                                 ShowWarningError(m_state, "Iteration limit exceeded pressure setpoint using relief air. Simulation continues.");
-                                ShowContinueErrorTimeStamp(m_state, std::format("Relief air flow rate = {:.5G}", ReliefMassFlowRate));
+                                ShowContinueErrorTimeStamp(m_state, std::format("Relief air flow rate = {:.4f}", ReliefMassFlowRate));
                             } else {
                                 ++ErrCountVar;
                                 ShowRecurringWarningErrorAtEnd(m_state,
@@ -9812,7 +9812,7 @@ namespace AirflowNetwork {
                                           "calculated based on the mass flow rate during HVAC operation.");
                         ShowContinueError(
                             m_state,
-                            std::format("The mass flow rate during HVAC operation = {:.3G} The mass flow rate during no HVAC operation = {:.3G}",
+                            std::format("The mass flow rate during HVAC operation = {:.2f} The mass flow rate during no HVAC operation = {:.2f}",
                                         m_state.dataAirLoop->AirLoopAFNInfo(AirLoopNum).LoopSystemOnMassFlowrate,
                                         m_state.dataAirLoop->AirLoopAFNInfo(AirLoopNum).LoopSystemOffMassFlowrate));
                         UpdateAirflowNetworkMyOneTimeFlag = false;
@@ -9851,7 +9851,7 @@ namespace AirflowNetwork {
                                                  AirflowNetworkLinkageData(i).Name + "'.");
                             ShowContinueError(
                                 m_state,
-                                std::format("The system node max mass flow rate = {:.4G} kg/s. The AFN node mass flow rate = {:.4G} kg.s.",
+                                std::format("The system node max mass flow rate = {:.3f} kg/s. The AFN node mass flow rate = {:.3f} kg.s.",
                                             NodeMass,
                                             AFNMass));
                             WriteFlag = true;

--- a/src/EnergyPlus/InternalHeatGains.cc
+++ b/src/EnergyPlus/InternalHeatGains.cc
@@ -7070,8 +7070,8 @@ namespace InternalHeatGains {
                         if (std::abs(LowTemperatureDes - thisBBHeat.LowTemperature) > state.dataSize->AutoVsHardSizingDeltaTempThreshold) {
                             ShowMessage(state,
                                         EnergyPlus::format("{}: Potential issue with equipment sizing for {} {}", RoutineName, CompType, CompName));
-                            ShowContinueError(state, EnergyPlus::format("User-Specified {} = {:.1f}", SizingString, thisBBHeat.LowTemperature));
-                            ShowContinueError(state, EnergyPlus::format("differs from Design Size {} = {:.1f}", SizingString, LowTemperatureDes));
+                            ShowContinueError(state, EnergyPlus::format("User-Specified {} = {:.2f}", SizingString, thisBBHeat.LowTemperature));
+                            ShowContinueError(state, EnergyPlus::format("differs from Design Size {} = {:.2f}", SizingString, LowTemperatureDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -7104,8 +7104,8 @@ namespace InternalHeatGains {
                         if (std::abs(HighTemperatureDes - thisBBHeat.HighTemperature) > state.dataSize->AutoVsHardSizingDeltaTempThreshold) {
                             ShowMessage(state,
                                         EnergyPlus::format("{}: Potential issue with equipment sizing for {} {}", RoutineName, CompType, CompName));
-                            ShowContinueError(state, EnergyPlus::format("User-Specified {} = {:.1f}", SizingString, thisBBHeat.HighTemperature));
-                            ShowContinueError(state, EnergyPlus::format("differs from Design Size {} = {:.1f}", SizingString, HighTemperatureDes));
+                            ShowContinueError(state, EnergyPlus::format("User-Specified {} = {:.2f}", SizingString, thisBBHeat.HighTemperature));
+                            ShowContinueError(state, EnergyPlus::format("differs from Design Size {} = {:.2f}", SizingString, HighTemperatureDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }

--- a/src/EnergyPlus/InternalHeatGains.cc
+++ b/src/EnergyPlus/InternalHeatGains.cc
@@ -7070,8 +7070,8 @@ namespace InternalHeatGains {
                         if (std::abs(LowTemperatureDes - thisBBHeat.LowTemperature) > state.dataSize->AutoVsHardSizingDeltaTempThreshold) {
                             ShowMessage(state,
                                         EnergyPlus::format("{}: Potential issue with equipment sizing for {} {}", RoutineName, CompType, CompName));
-                            ShowContinueError(state, EnergyPlus::format("User-Specified {} = {:.1R}", SizingString, thisBBHeat.LowTemperature));
-                            ShowContinueError(state, EnergyPlus::format("differs from Design Size {} = {:.1R}", SizingString, LowTemperatureDes));
+                            ShowContinueError(state, EnergyPlus::format("User-Specified {} = {:.1f}", SizingString, thisBBHeat.LowTemperature));
+                            ShowContinueError(state, EnergyPlus::format("differs from Design Size {} = {:.1f}", SizingString, LowTemperatureDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -7104,8 +7104,8 @@ namespace InternalHeatGains {
                         if (std::abs(HighTemperatureDes - thisBBHeat.HighTemperature) > state.dataSize->AutoVsHardSizingDeltaTempThreshold) {
                             ShowMessage(state,
                                         EnergyPlus::format("{}: Potential issue with equipment sizing for {} {}", RoutineName, CompType, CompName));
-                            ShowContinueError(state, EnergyPlus::format("User-Specified {} = {:.1R}", SizingString, thisBBHeat.HighTemperature));
-                            ShowContinueError(state, EnergyPlus::format("differs from Design Size {} = {:.1R}", SizingString, HighTemperatureDes));
+                            ShowContinueError(state, EnergyPlus::format("User-Specified {} = {:.1f}", SizingString, thisBBHeat.HighTemperature));
+                            ShowContinueError(state, EnergyPlus::format("differs from Design Size {} = {:.1f}", SizingString, HighTemperatureDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }

--- a/src/EnergyPlus/ScheduleManager.cc
+++ b/src/EnergyPlus/ScheduleManager.cc
@@ -551,8 +551,7 @@ namespace Sched {
         NumAlphas = 0;
         NumNumbers = 0;
         if (NumCommaFileShading > 1) {
-            ShowWarningError(state,
-                             EnergyPlus::format("{}: More than 1 occurrence of this object found, only first will be used.", CurrentModuleObject));
+            ShowWarningError(state, std::format("{}: More than 1 occurrence of this object found, only first will be used.", CurrentModuleObject));
         }
 
         std::map<fs::path, nlohmann::json>::iterator schedule_file_shading_result;
@@ -675,10 +674,10 @@ namespace Sched {
                 int NumCSVAllColumnsSchedules =
                     schedule_file_shading_result->second["header"].get<std::set<std::string>>().size() - 1; // -1 to account for timestamp column
                 ShowWarningError(state,
-                                 EnergyPlus::format("{}: {}=\"{}\" Removing last column of the CSV since it has '()' for the surface name.",
-                                                    routineName,
-                                                    CurrentModuleObject,
-                                                    Alphas(1)));
+                                 std::format("{}: {}=\"{}\" Removing last column of the CSV since it has '()' for the surface name.",
+                                             routineName,
+                                             CurrentModuleObject,
+                                             Alphas(1)));
                 ShowContinueError(state, "This was a problem in E+ 22.2.0 and below, consider removing it from the file to suppress this warning.");
                 schedule_file_shading_result->second["header"].erase(NumCSVAllColumnsSchedules);
                 assert(schedule_file_shading_result->second["header"].size() == schedule_file_shading_result->second["values"].size());
@@ -686,16 +685,13 @@ namespace Sched {
 
             if (rowCnt != rowLimitCount) {
                 if (rowCnt < rowLimitCount) {
-                    ShowSevereError(state,
-                                    EnergyPlus::format("{}: {}=\"{}\" {} data values read.", routineName, CurrentModuleObject, Alphas(1), rowCnt));
+                    ShowSevereError(state, std::format("{}: {}=\"{}\" {} data values read.", routineName, CurrentModuleObject, Alphas(1), rowCnt));
                 } else if (rowCnt > rowLimitCount) {
-                    ShowSevereError(state,
-                                    EnergyPlus::format("{}: {}=\"{}\" too many data values read.", routineName, CurrentModuleObject, Alphas(1)));
+                    ShowSevereError(state, std::format("{}: {}=\"{}\" too many data values read.", routineName, CurrentModuleObject, Alphas(1)));
                 }
                 ShowContinueError(
                     state,
-                    EnergyPlus::format("Number of rows in the shading file must be a full year multiplied by the simulation TimeStep: {}.",
-                                       rowLimitCount));
+                    std::format("Number of rows in the shading file must be a full year multiplied by the simulation TimeStep: {}.", rowLimitCount));
                 ShowFatalError(state, "Program terminates due to previous condition.");
             }
 
@@ -705,7 +701,7 @@ namespace Sched {
             if (numerrors > 0) {
                 ShowWarningError(
                     state,
-                    EnergyPlus::format(
+                    std::format(
                         "{}:{}=\"{}\" {} records had errors - these values are set to 0.", routineName, CurrentModuleObject, Alphas(1), numerrors));
             }
         }
@@ -782,12 +778,12 @@ namespace Sched {
                     ShowSevereCustom(
                         state,
                         eoh,
-                        EnergyPlus::format("{} [{:.2R}] > {} [{:.2R}].", cNumericFields(1), schedType->minVal, cNumericFields(2), schedType->maxVal));
+                        std::format("{} [{:.2f}] > {} [{:.2f}].", cNumericFields(1), schedType->minVal, cNumericFields(2), schedType->maxVal));
                 } else {
                     ShowSevereCustom(
                         state,
                         eoh,
-                        EnergyPlus::format("{} [{:.0R}] > {} [{:.0R}].", cNumericFields(1), schedType->minVal, cNumericFields(2), schedType->maxVal));
+                        std::format("{} [{:.0f}] > {} [{:.0f}].", cNumericFields(1), schedType->minVal, cNumericFields(2), schedType->maxVal));
                 }
                 ShowContinueError(state, "  Other warning/severes about schedule values may appear.");
             }
@@ -842,11 +838,11 @@ namespace Sched {
             }
 
             if (daySched->checkValsForLimitViolations(state)) {
-                ShowWarningCustom(state, eoh, EnergyPlus::format("Values are outside of range for {}={}", cAlphaFields(2), Alphas(2)));
+                ShowWarningCustom(state, eoh, std::format("Values are outside of range for {}={}", cAlphaFields(2), Alphas(2)));
             }
 
             if (daySched->checkValsForBadIntegers(state)) {
-                ShowWarningCustom(state, eoh, EnergyPlus::format("One or more values are not integer in {}={}", cAlphaFields(2), Alphas(2)));
+                ShowWarningCustom(state, eoh, std::format("One or more values are not integer in {}={}", cAlphaFields(2), Alphas(2)));
             }
 
         } // for (Loop)
@@ -892,9 +888,9 @@ namespace Sched {
             if (NumFields == 0) {
                 ShowSevereCustom(state,
                                  eoh,
-                                 EnergyPlus::format("Insufficient data entered for a full schedule day."
-                                                    "Number of interval fields == [{}].",
-                                                    NumFields));
+                                 std::format("Insufficient data entered for a full schedule day."
+                                             "Number of interval fields == [{}].",
+                                             NumFields));
                 ErrorsFound = true;
             }
 
@@ -921,11 +917,11 @@ namespace Sched {
             daySched->populateFromMinuteVals(state, minuteVals);
 
             if (daySched->checkValsForLimitViolations(state)) {
-                ShowWarningCustom(state, eoh, EnergyPlus::format("Values are outside of range for {}={}", cAlphaFields(2), Alphas(2)));
+                ShowWarningCustom(state, eoh, std::format("Values are outside of range for {}={}", cAlphaFields(2), Alphas(2)));
             }
 
             if (daySched->checkValsForBadIntegers(state)) {
-                ShowWarningCustom(state, eoh, EnergyPlus::format("One or more values are not integer in {}={}", cAlphaFields(2), Alphas(2)));
+                ShowWarningCustom(state, eoh, std::format("One or more values are not integer in {}={}", cAlphaFields(2), Alphas(2)));
             }
         }
 
@@ -972,19 +968,19 @@ namespace Sched {
             if (Numbers(1) <= 0.0) {
                 ShowSevereCustom(state,
                                  eoh,
-                                 EnergyPlus::format("Insufficient data entered for a full schedule day."
-                                                    "...Minutes per Item field = [{}].",
-                                                    Numbers(1)));
+                                 std::format("Insufficient data entered for a full schedule day."
+                                             "...Minutes per Item field = [{}].",
+                                             Numbers(1)));
                 ErrorsFound = true;
                 continue;
             }
             if (NumNumbers < 25) {
                 ShowSevereCustom(state,
                                  eoh,
-                                 EnergyPlus::format("Insufficient data entered for a full schedule day."
-                                                    "...Minutes per Item field = [{}] and only [{}] to apply to list fields.",
-                                                    Numbers(1),
-                                                    NumNumbers - 1));
+                                 std::format("Insufficient data entered for a full schedule day."
+                                             "...Minutes per Item field = [{}] and only [{}] to apply to list fields.",
+                                             Numbers(1),
+                                             NumNumbers - 1));
                 ErrorsFound = true;
                 continue;
             }
@@ -994,12 +990,12 @@ namespace Sched {
             if ((NumNumbers - 1) != NumExpectedItems) {
                 ShowSevereCustom(state,
                                  eoh,
-                                 EnergyPlus::format("Number of Entered Items={} not equal number of expected items={}"
-                                                    "based on {}={}",
-                                                    NumNumbers - 1,
-                                                    NumExpectedItems,
-                                                    cNumericFields(1),
-                                                    MinutesPerItem));
+                                 std::format("Number of Entered Items={} not equal number of expected items={}"
+                                             "based on {}={}",
+                                             NumNumbers - 1,
+                                             NumExpectedItems,
+                                             cNumericFields(1),
+                                             MinutesPerItem));
                 ErrorsFound = true;
                 continue;
             }
@@ -2264,9 +2260,9 @@ namespace Sched {
         for (auto const *schedType : state.dataSched->scheduleTypes) {
             if (schedType->isLimited) {
                 YesNoLimited = "Yes";
-                minValStr = EnergyPlus::format("{:.2R}", schedType->minVal);
+                minValStr = std::format("{:.2f}", schedType->minVal);
                 strip(minValStr);
-                maxValStr = EnergyPlus::format("{:.2R}", schedType->maxVal);
+                maxValStr = std::format("{:.2f}", schedType->maxVal);
                 strip(maxValStr);
                 if (schedType->isReal) {
                     YesNoContinous = "Yes";
@@ -2381,12 +2377,12 @@ namespace Sched {
 
             if (LevelOfDetail == ReportLevel::Hourly) {
                 for (int hr = 0; hr < Constant::iHoursInDay; ++hr) {
-                    print(state.files.eio, ",{:.2R}", daySched->tsVals[(hr + 1) * s_glob->TimeStepsInHour - 1]);
+                    print(state.files.eio, ",{:.2f}", daySched->tsVals[(hr + 1) * s_glob->TimeStepsInHour - 1]);
                 }
             } else if (LevelOfDetail == ReportLevel::TimeStep) {
                 for (int hr = 0; hr < Constant::iHoursInDay; ++hr) {
                     for (int ts = 0; ts < s_glob->TimeStepsInHour; ++ts) {
-                        print(state.files.eio, ",{:.2R}", daySched->tsVals[hr * s_glob->TimeStepsInHour + ts]);
+                        print(state.files.eio, ",{:.2f}", daySched->tsVals[hr * s_glob->TimeStepsInHour + ts]);
                     }
                 }
             } else {

--- a/src/EnergyPlus/SetPointManager.cc
+++ b/src/EnergyPlus/SetPointManager.cc
@@ -306,7 +306,7 @@ void GetSetPointManagerInputs(EnergyPlusData &state)
         GetSetPointManagerInputData(state, ErrorsFound);
 
         if (ErrorsFound) {
-            ShowFatalError(state, EnergyPlus::format("{}: Errors found in input.  Program terminates.", routineName));
+            ShowFatalError(state, std::format("{}: Errors found in input.  Program terminates.", routineName));
         }
         state.dataSetPointManager->GetInputFlag = false;
     }
@@ -589,12 +589,11 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                 spm->minSetTemp = ip->getRealFieldValue(fields, props, "minimum_setpoint_temperature");
                 spm->maxSetTemp = ip->getRealFieldValue(fields, props, "maximum_setpoint_temperature");
                 if (spm->maxSetTemp < spm->minSetTemp) {
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spm->Name));
-                    ShowContinueError(
-                        state,
-                        EnergyPlus::format("...maximum_supply_air_temperature=[{:.1R}] is less than minimum_supply_air_temperature=[{:.1R}].",
-                                           spm->maxSetTemp,
-                                           spm->minSetTemp));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spm->Name));
+                    ShowContinueError(state,
+                                      std::format("...maximum_supply_air_temperature=[{:.1f}] is less than minimum_supply_air_temperature=[{:.1f}].",
+                                                  spm->maxSetTemp,
+                                                  spm->minSetTemp));
                 }
             } break;
 
@@ -604,12 +603,11 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                 spm->minSetTemp = ip->getRealFieldValue(fields, props, "minimum_supply_air_temperature");
                 spm->maxSetTemp = ip->getRealFieldValue(fields, props, "maximum_supply_air_temperature");
                 if (spm->maxSetTemp < spm->minSetTemp) {
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spm->Name));
-                    ShowContinueError(
-                        state,
-                        EnergyPlus::format("...maximum_supply_air_temperature=[{:.1R}] is less than minimum_supply_air_temperature=[{:.1R}].",
-                                           spm->maxSetTemp,
-                                           spm->minSetTemp));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spm->Name));
+                    ShowContinueError(state,
+                                      std::format("...maximum_supply_air_temperature=[{:.1f}] is less than minimum_supply_air_temperature=[{:.1f}].",
+                                                  spm->maxSetTemp,
+                                                  spm->minSetTemp));
                 }
             } break;
 
@@ -617,12 +615,11 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                 spm->minSetTemp = ip->getRealFieldValue(fields, props, "minimum_limit_setpoint_temperature");
                 spm->maxSetTemp = ip->getRealFieldValue(fields, props, "maximum_limit_setpoint_temperature");
                 if (spm->maxSetTemp < spm->minSetTemp) {
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spm->Name));
-                    ShowContinueError(
-                        state,
-                        EnergyPlus::format("...maximum_supply_air_temperature=[{:.1R}] is less than minimum_supply_air_temperature=[{:.1R}].",
-                                           spm->maxSetTemp,
-                                           spm->minSetTemp));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spm->Name));
+                    ShowContinueError(state,
+                                      std::format("...maximum_supply_air_temperature=[{:.1f}] is less than minimum_supply_air_temperature=[{:.1f}].",
+                                                  spm->maxSetTemp,
+                                                  spm->minSetTemp));
                 }
             } break;
 
@@ -641,23 +638,23 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                 spm->minSetHum = ip->getRealFieldValue(fields, props, "minimum_setpoint_humidity_ratio");
                 spm->maxSetHum = ip->getRealFieldValue(fields, props, "maximum_setpoint_humidity_ratio");
                 if (spm->maxSetHum < spm->minSetHum) {
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spm->Name));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spm->Name));
                     ShowContinueError(
                         state,
-                        EnergyPlus::format("...maximum_setpoint_humidity_ratio=[{:.1R}] is less than minimum_setpoint_humidity_ratio=[{:.1R}].",
-                                           spm->maxSetHum,
-                                           spm->minSetHum));
+                        std::format("...maximum_setpoint_humidity_ratio=[{:.1f}] is less than minimum_setpoint_humidity_ratio=[{:.1f}].",
+                                    spm->maxSetHum,
+                                    spm->minSetHum));
                 }
 
                 // Because a zero humidity ratio setpoint is a special value indicating "off" or "no load"
                 // must not allow MinSetHumRat or MaxSetHumRat to be <=0.0
                 if (spm->minSetHum <= 0.0) {
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\", invalid value.", routineName, cCurrentModuleObject, spm->Name));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\", invalid value.", routineName, cCurrentModuleObject, spm->Name));
                     ShowContinueError(state, "Minimum setpoint humidity ratio <=0.0, resetting to 0.00001");
                     spm->minSetHum = 0.00001;
                 }
                 if (spm->maxSetHum <= 0.0) {
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\", invalid value.", routineName, cCurrentModuleObject, spm->Name));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\", invalid value.", routineName, cCurrentModuleObject, spm->Name));
                     ShowContinueError(state, "Maximum setpoint humidity ratio <=0.0, resetting to 0.00001");
                     spm->maxSetHum = 0.00001;
                 }
@@ -770,11 +767,11 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                     if (spmOA->high2 < spmOA->low2) {
                         ShowWarningCustom(state,
                                           eoh,
-                                          EnergyPlus::format("...{}=[{:.1R}] is less than {}=[{:.1R}].",
-                                                             "outdoor_high_temperature_2",
-                                                             spmOA->high2,
-                                                             "outdoor_low_temperature_2",
-                                                             spmOA->low2));
+                                          std::format("...{}=[{:.1f}] is less than {}=[{:.1f}].",
+                                                      "outdoor_high_temperature_2",
+                                                      spmOA->high2,
+                                                      "outdoor_low_temperature_2",
+                                                      spmOA->low2));
                     }
                 } else { // !foundSched
                     spmOA->sched = nullptr;
@@ -894,8 +891,8 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
 
                 // only allow one control zone for now
                 if (NumNodes > 1) {
-                    ShowSevereError(state, EnergyPlus::format("{}: {}=\"{}\", entered nodelist.", routineName, cCurrentModuleObject, spmSZHum->Name));
-                    ShowContinueError(state, EnergyPlus::format("..invalid ctrl_zone_node_name=\"{}\".", ctrlZoneNodeName));
+                    ShowSevereError(state, std::format("{}: {}=\"{}\", entered nodelist.", routineName, cCurrentModuleObject, spmSZHum->Name));
+                    ShowContinueError(state, std::format("..invalid ctrl_zone_node_name=\"{}\".", ctrlZoneNodeName));
                     ShowContinueError(state, "..only one control zone is allowed.");
                     ErrorsFound = true;
                 }
@@ -986,13 +983,13 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                                                             Node::ObjectIsNotParent);
 
                 if (std::find(spmOAP->ctrlNodeNums.begin(), spmOAP->ctrlNodeNums.end(), spmOAP->refNodeNum) != spmOAP->ctrlNodeNums.end()) {
-                    ShowSevereError(state, EnergyPlus::format("{}: {}=\"{}\", reference node.", routineName, cCurrentModuleObject, spmOAP->Name));
+                    ShowSevereError(state, std::format("{}: {}=\"{}\", reference node.", routineName, cCurrentModuleObject, spmOAP->Name));
                     if (spmOAP->ctrlNodeNums.size() > 1) {
                         ShowContinueError(state, "..Reference Node is the same as one of the nodes in SetPoint NodeList");
                     } else {
                         ShowContinueError(state, "..Reference Node is the same as the SetPoint Node");
                     }
-                    ShowContinueError(state, EnergyPlus::format("Reference Node Name=\"{}\".", state.dataLoopNodes->NodeID(spmOAP->refNodeNum)));
+                    ShowContinueError(state, std::format("Reference Node Name=\"{}\".", state.dataLoopNodes->NodeID(spmOAP->refNodeNum)));
                     ErrorsFound = true;
                 }
             } break;
@@ -1031,8 +1028,8 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
 
                 spmWTF->minTurndown = ip->getRealFieldValue(fields, props, "minimum_turndown_ratio");
                 if (spmWTF->minTurndown >= 0.8) {
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spmWTF->Name));
-                    ShowContinueError(state, EnergyPlus::format("...minimum_turndown_ratio=[{:.2R}] is greater than 0.8;", spmWTF->minTurndown));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spmWTF->Name));
+                    ShowContinueError(state, std::format("...minimum_turndown_ratio=[{:.2f}] is greater than 0.8;", spmWTF->minTurndown));
                     ShowContinueError(state, "...typical values for minimum_turndown_ratio are less than 0.8.");
                 }
 
@@ -1128,13 +1125,13 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                 if (state.dataSetPointManager->NoGroundTempObjWarning[(int)spmFGT->refTempType]) {
                     if (!state.dataEnvrn->GroundTempInputs[(int)spmFGT->refTempType]) {
                         ShowWarningError(state,
-                                         EnergyPlus::format("{}: {}=\"{}\" requires \"Site:GroundTemperature:BuildingSurface\" in the input..",
-                                                            routineName,
-                                                            cCurrentModuleObject,
-                                                            spmFGT->Name));
+                                         std::format("{}: {}=\"{}\" requires \"Site:GroundTemperature:BuildingSurface\" in the input..",
+                                                     routineName,
+                                                     cCurrentModuleObject,
+                                                     spmFGT->Name));
                         ShowContinueError(state,
-                                          EnergyPlus::format("Defaults, constant throughout the year of ({:.1R}) will be used.",
-                                                             state.dataEnvrn->GroundTemp[(int)spmFGT->refTempType]));
+                                          std::format("Defaults, constant throughout the year of ({:.1f}) will be used.",
+                                                      state.dataEnvrn->GroundTemp[(int)spmFGT->refTempType]));
                     }
                     state.dataSetPointManager->NoGroundTempObjWarning[(int)spmFGT->refTempType] = false;
                 }
@@ -1175,12 +1172,12 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                 spmCET->towerDesignInletAirWetBulbTemp = ip->getRealFieldValue(fields, props, "cooling_tower_design_inlet_air_wet_bulb_temperature");
 
                 if (spmCET->maxCondenserEnteringTemp < spmCET->towerDesignInletAirWetBulbTemp) {
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spmCET->Name));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spmCET->Name));
                     ShowContinueError(state,
-                                      EnergyPlus::format("...maximum_condenser_entering_water_temperature=[{:.1R}] is less than "
-                                                         "cooling_tower_design_inlet_air_wet-bulb_temperature=[{:.1R}].",
-                                                         spmCET->maxCondenserEnteringTemp,
-                                                         spmCET->towerDesignInletAirWetBulbTemp));
+                                      std::format("...maximum_condenser_entering_water_temperature=[{:.1f}] is less than "
+                                                  "cooling_tower_design_inlet_air_wet-bulb_temperature=[{:.1f}].",
+                                                  spmCET->maxCondenserEnteringTemp,
+                                                  spmCET->towerDesignInletAirWetBulbTemp));
                 }
 
             } break;
@@ -1210,12 +1207,12 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
 
                 if (spmSZOSC->coolingOffSetPt < spmSZOSC->coolingOnSetPt) {
                     // throw warning, off must be warmer than on
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spmSZOSC->Name));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spmSZOSC->Name));
                     ShowContinueError(state,
-                                      EnergyPlus::format("...cooling_stage_off_supply_air_setpoint_temperature=[{:.1R}] is less than "
-                                                         "cooling_stage_on_supply_air_setpoint_temperature=[{:.1R}].",
-                                                         spmSZOSC->coolingOffSetPt,
-                                                         spmSZOSC->coolingOnSetPt));
+                                      std::format("...cooling_stage_off_supply_air_setpoint_temperature=[{:.1f}] is less than "
+                                                  "cooling_stage_on_supply_air_setpoint_temperature=[{:.1f}].",
+                                                  spmSZOSC->coolingOffSetPt,
+                                                  spmSZOSC->coolingOnSetPt));
                 }
 
                 std::string ctrlZoneName = ip->getAlphaFieldValue(fields, props, "control_zone_name");
@@ -1228,9 +1225,8 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
                     spmSZOSC->zoneNodeNum = GetSystemNodeNumberForZone(state, spmSZOSC->ctrlZoneNum);
                     if (allocated(state.dataZoneCtrls->StageZoneLogic)) {
                         if (!state.dataZoneCtrls->StageZoneLogic(spmSZOSC->ctrlZoneNum)) {
-                            ShowSevereError(state,
-                                            EnergyPlus::format("{}: {}=\"{}\", invalid field.", routineName, cCurrentModuleObject, spmSZOSC->Name));
-                            ShowContinueError(state, EnergyPlus::format("..invalid control_zone_name=\"{}\".", ctrlZoneName));
+                            ShowSevereError(state, std::format("{}: {}=\"{}\", invalid field.", routineName, cCurrentModuleObject, spmSZOSC->Name));
+                            ShowContinueError(state, std::format("..invalid control_zone_name=\"{}\".", ctrlZoneName));
                             ShowContinueError(state, "Zone thermostat must use ZoneControl:Thermostat:StagedDualSetpoint.");
                             ErrorsFound = true;
                         }
@@ -1248,12 +1244,12 @@ void GetSetPointManagerInputData(EnergyPlusData &state, bool &ErrorsFound)
 
                 if (spmSZOSH->heatingOffSetPt > spmSZOSH->heatingOnSetPt) {
                     // throw warning, off must be warmer than on
-                    ShowWarningError(state, EnergyPlus::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spmSZOSH->Name));
+                    ShowWarningError(state, std::format("{}: {}=\"{}\",", routineName, cCurrentModuleObject, spmSZOSH->Name));
                     ShowContinueError(state,
-                                      EnergyPlus::format("...heating_stage_off_supply_air_setpoint_temperature=[{:.1R}] is less than "
-                                                         "heating_stage_on_supply_air_setpoint_temperature=[{:.1R}].",
-                                                         spmSZOSH->heatingOffSetPt,
-                                                         spmSZOSH->heatingOnSetPt));
+                                      std::format("...heating_stage_off_supply_air_setpoint_temperature=[{:.1f}] is less than "
+                                                  "heating_stage_on_supply_air_setpoint_temperature=[{:.1f}].",
+                                                  spmSZOSH->heatingOffSetPt,
+                                                  spmSZOSH->heatingOnSetPt));
                 }
 
                 std::string ctrlZoneName = ip->getAlphaFieldValue(fields, props, "control_zone_name");

--- a/src/EnergyPlus/SimAirServingZones.cc
+++ b/src/EnergyPlus/SimAirServingZones.cc
@@ -451,13 +451,13 @@ void GetAirPathData(EnergyPlusData &state)
         primaryAirSystems.Name = Alphas(1);
         airLoopZoneInfo.AirLoopName = Alphas(1);
         if (NumAlphas < 9) {
-            ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", insufficient information.", RoutineName, CurrentModuleObject, Alphas(1)));
+            ShowSevereError(state, std::format("{}{}=\"{}\", insufficient information.", RoutineName, CurrentModuleObject, Alphas(1)));
             ShowContinueError(state, "...Have supplied less than 9 alpha fields.");
             ErrorsFound = true;
             continue;
         }
         if (NumNumbers < 1) {
-            ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", insufficient information.", RoutineName, CurrentModuleObject, Alphas(1)));
+            ShowSevereError(state, std::format("{}{}=\"{}\", insufficient information.", RoutineName, CurrentModuleObject, Alphas(1)));
             ShowContinueError(state, "...Have supplied less than 1 numeric field.");
             ErrorsFound = true;
             continue;
@@ -507,11 +507,11 @@ void GetAirPathData(EnergyPlusData &state)
             TestUniqueNodes(state.dataSimAirServingZones->TestUniqueNodesNum).FieldName = cAlphaFields(6);
             TestUniqueNodes(state.dataSimAirServingZones->TestUniqueNodesNum).NodeNameUsed = true;
         } else {
-            ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", duplicate node name.", RoutineName, CurrentModuleObject, Alphas(1)));
-            ShowContinueError(state, EnergyPlus::format("...used for {}=\"{}\"", cAlphaFields(6), Alphas(6)));
+            ShowSevereError(state, std::format("{}{}=\"{}\", duplicate node name.", RoutineName, CurrentModuleObject, Alphas(1)));
+            ShowContinueError(state, std::format("...used for {}=\"{}\"", cAlphaFields(6), Alphas(6)));
             ShowContinueError(
                 state,
-                EnergyPlus::format(
+                std::format(
                     "...first used in {}=\"{}\" for {}", CurrentModuleObject, TestUniqueNodes(test).AirLoopName, TestUniqueNodes(test).FieldName));
             ErrorsFound = true;
         }
@@ -524,13 +524,13 @@ void GetAirPathData(EnergyPlusData &state)
                 TestUniqueNodes(state.dataSimAirServingZones->TestUniqueNodesNum).FieldName = cAlphaFields(7);
                 TestUniqueNodes(state.dataSimAirServingZones->TestUniqueNodesNum).NodeNameUsed = true;
             } else {
-                ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", duplicate node name.", RoutineName, CurrentModuleObject, Alphas(1)));
-                ShowContinueError(state, EnergyPlus::format("...used for {}=\"{}\"", cAlphaFields(7), Alphas(7)));
+                ShowSevereError(state, std::format("{}{}=\"{}\", duplicate node name.", RoutineName, CurrentModuleObject, Alphas(1)));
+                ShowContinueError(state, std::format("...used for {}=\"{}\"", cAlphaFields(7), Alphas(7)));
                 ShowContinueError(state,
-                                  EnergyPlus::format("...first used in {}=\"{}\" for {}",
-                                                     CurrentModuleObject,
-                                                     TestUniqueNodes(test).AirLoopName,
-                                                     TestUniqueNodes(test).FieldName));
+                                  std::format("...first used in {}=\"{}\" for {}",
+                                              CurrentModuleObject,
+                                              TestUniqueNodes(test).AirLoopName,
+                                              TestUniqueNodes(test).FieldName));
                 ErrorsFound = true;
             }
         }
@@ -542,11 +542,11 @@ void GetAirPathData(EnergyPlusData &state)
             TestUniqueNodes(state.dataSimAirServingZones->TestUniqueNodesNum).FieldName = cAlphaFields(8);
             TestUniqueNodes(state.dataSimAirServingZones->TestUniqueNodesNum).NodeNameUsed = true;
         } else {
-            ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", duplicate node name/list.", RoutineName, CurrentModuleObject, Alphas(1)));
-            ShowContinueError(state, EnergyPlus::format("...used for {}=\"{}\"", cAlphaFields(8), Alphas(8)));
+            ShowSevereError(state, std::format("{}{}=\"{}\", duplicate node name/list.", RoutineName, CurrentModuleObject, Alphas(1)));
+            ShowContinueError(state, std::format("...used for {}=\"{}\"", cAlphaFields(8), Alphas(8)));
             ShowContinueError(
                 state,
-                EnergyPlus::format(
+                std::format(
                     "...first used in {}=\"{}\" for {}", CurrentModuleObject, TestUniqueNodes(test).AirLoopName, TestUniqueNodes(test).FieldName));
             ErrorsFound = true;
         }
@@ -558,11 +558,11 @@ void GetAirPathData(EnergyPlusData &state)
             TestUniqueNodes(state.dataSimAirServingZones->TestUniqueNodesNum).FieldName = cAlphaFields(9);
             TestUniqueNodes(state.dataSimAirServingZones->TestUniqueNodesNum).NodeNameUsed = true;
         } else {
-            ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", duplicate node name/list.", RoutineName, CurrentModuleObject, Alphas(1)));
-            ShowContinueError(state, EnergyPlus::format("...used for {}=\"{}\"", cAlphaFields(9), Alphas(9)));
+            ShowSevereError(state, std::format("{}{}=\"{}\", duplicate node name/list.", RoutineName, CurrentModuleObject, Alphas(1)));
+            ShowContinueError(state, std::format("...used for {}=\"{}\"", cAlphaFields(9), Alphas(9)));
             ShowContinueError(
                 state,
-                EnergyPlus::format(
+                std::format(
                     "...first used in {}=\"{}\" for {}", CurrentModuleObject, TestUniqueNodes(test).AirLoopName, TestUniqueNodes(test).FieldName));
             ErrorsFound = true;
         }
@@ -589,9 +589,9 @@ void GetAirPathData(EnergyPlusData &state)
             }
         }
         if ((test == 0) && (airLoopZoneInfo.NumReturnNodes > 0) && !lAlphaBlanks(7)) {
-            ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", invalid.", RoutineName, CurrentModuleObject, Alphas(1)));
-            ShowContinueError(
-                state, EnergyPlus::format("{} (Return Air Path or ZoneHVAC:EquipmentConnections) not valid = \"{}\".", cAlphaFields(7), Alphas(7)));
+            ShowSevereError(state, std::format("{}{}=\"{}\", invalid.", RoutineName, CurrentModuleObject, Alphas(1)));
+            ShowContinueError(state,
+                              std::format("{} (Return Air Path or ZoneHVAC:EquipmentConnections) not valid = \"{}\".", cAlphaFields(7), Alphas(7)));
             ErrorsFound = true;
         }
         // Get the supply nodes
@@ -614,8 +614,8 @@ void GetAirPathData(EnergyPlusData &state)
         }
         // Allow at most 3 supply nodes (for a 3 deck system)
         if (NumNodes > 3) {
-            ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", too many nodes.", RoutineName, CurrentModuleObject, primaryAirSystems.Name));
-            ShowContinueError(state, EnergyPlus::format("Only 1st 3 Nodes will be used from {}=\"{}\".", cAlphaFields(8), Alphas(8)));
+            ShowSevereError(state, std::format("{}{}=\"{}\", too many nodes.", RoutineName, CurrentModuleObject, primaryAirSystems.Name));
+            ShowContinueError(state, std::format("Only 1st 3 Nodes will be used from {}=\"{}\".", cAlphaFields(8), Alphas(8)));
             ErrorsFound = true;
         }
         if (NumNodes == 0) {
@@ -4124,11 +4124,11 @@ void SizeAirLoopBranches(EnergyPlusData &state, int const AirLoopNum, int const 
         }
         if (PrimaryAirSystems(AirLoopNum).DesignVolFlowRate < HVAC::SmallAirVolFlow) {
             ShowSevereError(state,
-                            EnergyPlus::format("SizeAirLoopBranches: AirLoopHVAC {} has air flow less than {:.4R} m3/s.",
-                                               PrimaryAirSystems(AirLoopNum).Name,
-                                               HVAC::SmallAirVolFlow));
-            ShowContinueError(
-                state, EnergyPlus::format("Primary air system volumetric flow rate = {:.4R} m3/s.", PrimaryAirSystems(AirLoopNum).DesignVolFlowRate));
+                            std::format("SizeAirLoopBranches: AirLoopHVAC {} has air flow less than {:.4f} m3/s.",
+                                        PrimaryAirSystems(AirLoopNum).Name,
+                                        HVAC::SmallAirVolFlow));
+            ShowContinueError(state,
+                              std::format("Primary air system volumetric flow rate = {:.4f} m3/s.", PrimaryAirSystems(AirLoopNum).DesignVolFlowRate));
             ShowContinueError(state, "Check flow rate inputs for components in this air loop and,");
             ShowContinueError(state, "if autosized, check Sizing:Zone and Sizing:System objects and related inputs.");
         }

--- a/src/EnergyPlus/SimulationManager.cc
+++ b/src/EnergyPlus/SimulationManager.cc
@@ -1360,16 +1360,16 @@ namespace SimulationManager {
                             state.dataConvergeParams->MaxZoneTempDiff = fields.at("maxzonetempdiff").get<Real64>();
                             ShowWarningError(
                                 state,
-                                EnergyPlus::format("PerformancePrecisionTradeoffs using the Advanced Override Mode, MaxZoneTempDiff set to: {:.4R}",
-                                                   state.dataConvergeParams->MaxZoneTempDiff));
+                                std::format("PerformancePrecisionTradeoffs using the Advanced Override Mode, MaxZoneTempDiff set to: {:.4f}",
+                                            state.dataConvergeParams->MaxZoneTempDiff));
                             advancedModeUsed = true;
                         }
                         if (fields.find("maxalloweddeltemp") != fields.end()) { // not required field, has default value
                             state.dataHeatBal->MaxAllowedDelTemp = fields.at("maxalloweddeltemp").get<Real64>();
                             ShowWarningError(
                                 state,
-                                EnergyPlus::format("PerformancePrecisionTradeoffs using the Advanced Override Mode, MaxAllowedDelTemp set to: {:.4R}",
-                                                   state.dataHeatBal->MaxAllowedDelTemp));
+                                std::format("PerformancePrecisionTradeoffs using the Advanced Override Mode, MaxAllowedDelTemp set to: {:.4f}",
+                                            state.dataHeatBal->MaxAllowedDelTemp));
                             advancedModeUsed = true;
                         }
                         if (advancedModeUsed) {
@@ -1538,9 +1538,9 @@ namespace SimulationManager {
         } else {
             Alphas(7) = "No";
         }
-        Alphas(8) = EnergyPlus::format("{:.1R}", state.dataConvergeParams->MinTimeStepSys * 60.0);
-        Alphas(9) = EnergyPlus::format("{:.3R}", state.dataConvergeParams->MaxZoneTempDiff);
-        Alphas(10) = EnergyPlus::format("{:.4R}", state.dataHeatBal->MaxAllowedDelTemp);
+        Alphas(8) = std::format("{:.1f}", state.dataConvergeParams->MinTimeStepSys * 60.0);
+        Alphas(9) = std::format("{:.3f}", state.dataConvergeParams->MaxZoneTempDiff);
+        Alphas(10) = std::format("{:.4f}", state.dataHeatBal->MaxAllowedDelTemp);
         std::string pptHeader = "! <Performance Precision Tradeoffs>, Use Coil Direct Simulation, "
                                 "Zone Radiant Exchange Algorithm, Override Mode, Number of Timestep In Hour, "
                                 "Force Euler Method, Minimum Number of Warmup Days, Force Suppress All Begin Environment Resets, "
@@ -1556,7 +1556,7 @@ namespace SimulationManager {
               "{}\n",
               "! <Output Reporting Tolerances>, Tolerance for Time Heating Setpoint Not Met, Tolerance for Zone Cooling Setpoint Not Met Time");
         // Formats
-        static constexpr std::string_view Format_751(" Output Reporting Tolerances, {:.3R}, {:.3R}, \n");
+        static constexpr std::string_view Format_751(" Output Reporting Tolerances, {:.3f}, {:.3f}, \n");
 
         print(state.files.eio, Format_751, std::abs(deviationFromSetPtThresholdHtg), deviationFromSetPtThresholdClg);
 
@@ -1598,9 +1598,9 @@ namespace SimulationManager {
         Util::appendPerfLog(state, "Number of Timesteps per Hour", std::to_string(state.dataGlobal->TimeStepsInHour));
         Util::appendPerfLog(state, "Minimum Number of Warmup Days", std::to_string(state.dataHeatBal->MinNumberOfWarmupDays));
         Util::appendPerfLog(state, "SuppressAllBeginEnvironmentResets", bool_to_string(state.dataEnvrn->forceBeginEnvResetSuppress));
-        Util::appendPerfLog(state, "Minimum System Timestep", EnergyPlus::format("{:.1R}", state.dataConvergeParams->MinTimeStepSys * 60.0));
-        Util::appendPerfLog(state, "MaxZoneTempDiff", EnergyPlus::format("{:.2R}", state.dataConvergeParams->MaxZoneTempDiff));
-        Util::appendPerfLog(state, "MaxAllowedDelTemp", EnergyPlus::format("{:.4R}", state.dataHeatBal->MaxAllowedDelTemp));
+        Util::appendPerfLog(state, "Minimum System Timestep", std::format("{:.1f}", state.dataConvergeParams->MinTimeStepSys * 60.0));
+        Util::appendPerfLog(state, "MaxZoneTempDiff", std::format("{:.2f}", state.dataConvergeParams->MaxZoneTempDiff));
+        Util::appendPerfLog(state, "MaxAllowedDelTemp", std::format("{:.4f}", state.dataHeatBal->MaxAllowedDelTemp));
     }
 
     std::string bool_to_string(bool logical)
@@ -1923,7 +1923,7 @@ namespace SimulationManager {
             print(
                 state.files.eio, "{}\n", "! <ConductionFiniteDifference Numerical Parameters>, Starting Relaxation Factor, Final Relaxation Factor");
             print(state.files.eio,
-                  "ConductionFiniteDifference Numerical Parameters, {:.3R}, {:.3R}\n",
+                  "ConductionFiniteDifference Numerical Parameters, {:.3f}, {:.3f}\n",
                   state.dataHeatBal->CondFDRelaxFactorInput,
                   state.dataHeatBal->CondFDRelaxFactor);
         }

--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -142,26 +142,25 @@ void SimulateSingleDuct(
     if (CompIndex == 0) {
         SysNum = Util::FindItemInList(CompName, state.dataSingleDuct->sd_airterminal, &SingleDuctAirTerminal::SysName);
         if (SysNum == 0) {
-            ShowFatalError(state, EnergyPlus::format("SimulateSingleDuct: System not found={}", CompName));
+            ShowFatalError(state, std::format("SimulateSingleDuct: System not found={}", CompName));
         }
         CompIndex = SysNum;
     } else {
         SysNum = CompIndex;
         if (SysNum > state.dataSingleDuct->NumSDAirTerminal || SysNum < 1) {
             ShowFatalError(state,
-                           EnergyPlus::format("SimulateSingleDuct: Invalid CompIndex passed={}, Number of Systems={}, System name={}",
-                                              CompIndex,
-                                              state.dataSingleDuct->NumSDAirTerminal,
-                                              CompName));
+                           std::format("SimulateSingleDuct: Invalid CompIndex passed={}, Number of Systems={}, System name={}",
+                                       CompIndex,
+                                       state.dataSingleDuct->NumSDAirTerminal,
+                                       CompName));
         }
         if (state.dataSingleDuct->CheckEquipName(SysNum)) {
             if (CompName != state.dataSingleDuct->sd_airterminal(SysNum).SysName) {
-                ShowFatalError(
-                    state,
-                    EnergyPlus::format("SimulateSingleDuct: Invalid CompIndex passed={}, System name={}, stored System Name for that index={}",
-                                       CompIndex,
-                                       CompName,
-                                       state.dataSingleDuct->sd_airterminal(SysNum).SysName));
+                ShowFatalError(state,
+                               std::format("SimulateSingleDuct: Invalid CompIndex passed={}, System name={}, stored System Name for that index={}",
+                                           CompIndex,
+                                           CompName,
+                                           state.dataSingleDuct->sd_airterminal(SysNum).SysName));
             }
             state.dataSingleDuct->CheckEquipName(SysNum) = false;
         }
@@ -380,8 +379,8 @@ void GetSysInput(EnergyPlusData &state)
             airTerm.reheatCoilType = HVAC::CoilType::HeatingSteam;
             airTerm.ReheatComp_PlantType = DataPlant::PlantEquipmentType::CoilSteamAirHeating;
         } else if (!airTerm.ReheatComp.empty()) {
-            ShowSevereError(state, EnergyPlus::format("Illegal {} = {}.", cAlphaFields(8), airTerm.ReheatComp));
-            ShowContinueError(state, EnergyPlus::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
+            ShowSevereError(state, std::format("Illegal {} = {}.", cAlphaFields(8), airTerm.ReheatComp));
+            ShowContinueError(state, std::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
             ErrorsFound = true;
         }
 
@@ -444,8 +443,8 @@ void GetSysInput(EnergyPlusData &state)
         } else if (Util::SameString(Alphas(5), "Scheduled")) {
             airTerm.ZoneMinAirFracMethod = MinFlowFraction::Scheduled;
         } else {
-            ShowSevereError(state, EnergyPlus::format("{} = {} not found.", cAlphaFields(5), Alphas(5)));
-            ShowContinueError(state, EnergyPlus::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
+            ShowSevereError(state, std::format("{} = {} not found.", cAlphaFields(5), Alphas(5)));
+            ShowContinueError(state, std::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
             ErrorsFound = true;
         }
 
@@ -457,9 +456,8 @@ void GetSysInput(EnergyPlusData &state)
             airTerm.ConstantMinAirFracSetByUser = true;
             airTerm.DesignMinAirFrac = Numbers(2);
             if (airTerm.ZoneMinAirFracMethod == MinFlowFraction::Fixed) {
-                ShowWarningError(state,
-                                 EnergyPlus::format("Since {} = {}, input for {} will be ignored.", cAlphaFields(5), Alphas(5), cNumericFields(2)));
-                ShowContinueError(state, EnergyPlus::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
+                ShowWarningError(state, std::format("Since {} = {}, input for {} will be ignored.", cAlphaFields(5), Alphas(5), cNumericFields(2)));
+                ShowContinueError(state, std::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
                 airTerm.ZoneMinAirFracDes = 0.0;
             }
         }
@@ -472,9 +470,8 @@ void GetSysInput(EnergyPlusData &state)
             airTerm.FixedMinAirSetByUser = true;
             airTerm.DesignMinAirFrac = Numbers(3);
             if (airTerm.ZoneMinAirFracMethod == MinFlowFraction::Constant) {
-                ShowWarningError(state,
-                                 EnergyPlus::format("Since {} = {}, input for {} will be ignored.", cAlphaFields(5), Alphas(5), cNumericFields(3)));
-                ShowContinueError(state, EnergyPlus::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
+                ShowWarningError(state, std::format("Since {} = {}, input for {} will be ignored.", cAlphaFields(5), Alphas(5), cNumericFields(3)));
+                ShowContinueError(state, std::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
                 airTerm.ZoneFixedMinAir = 0.0;
             }
         }
@@ -498,14 +495,14 @@ void GetSysInput(EnergyPlusData &state)
                 IsNotOK = false;
                 airTerm.ReheatControlNode = GetCoilSteamInletNode(state, airTerm.ReheatComp, airTerm.ReheatName, IsNotOK);
                 if (IsNotOK) {
-                    ShowContinueError(state, EnergyPlus::format("..Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
+                    ShowContinueError(state, std::format("..Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
                     ErrorsFound = true;
                 }
             } else {
                 IsNotOK = false;
                 airTerm.ReheatControlNode = GetCoilWaterInletNode(state, airTerm.ReheatComp, airTerm.ReheatName, IsNotOK);
                 if (IsNotOK) {
-                    ShowContinueError(state, EnergyPlus::format("..Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
+                    ShowContinueError(state, std::format("..Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
                     ErrorsFound = true;
                 }
             }
@@ -539,8 +536,8 @@ void GetSysInput(EnergyPlusData &state)
         } else if (Util::SameString(Alphas(10), "ReverseWithLimits")) {
             airTerm.DamperHeatingAction = Action::ReverseWithLimits;
         } else {
-            ShowSevereError(state, EnergyPlus::format("{} = {} not found.", cAlphaFields(10), Alphas(10)));
-            ShowContinueError(state, EnergyPlus::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
+            ShowSevereError(state, std::format("{} = {} not found.", cAlphaFields(10), Alphas(10)));
+            ShowContinueError(state, std::format("Occurs in {} = {}", airTerm.sysType, airTerm.SysName));
             ErrorsFound = true;
         }
 
@@ -561,10 +558,9 @@ void GetSysInput(EnergyPlusData &state)
         }
         // one assumes if there isn't one assigned, it's an error?
         if (airTerm.ADUNum == 0) {
-            ShowSevereError(
-                state,
-                EnergyPlus::format("{}No matching Air Distribution Unit, for System = [{},{}].", RoutineName, airTerm.sysType, airTerm.SysName));
-            ShowContinueError(state, EnergyPlus::format("...should have outlet node = {}", state.dataLoopNodes->NodeID(airTerm.ReheatAirOutletNode)));
+            ShowSevereError(state,
+                            std::format("{}No matching Air Distribution Unit, for System = [{},{}].", RoutineName, airTerm.sysType, airTerm.SysName));
+            ShowContinueError(state, std::format("...should have outlet node = {}", state.dataLoopNodes->NodeID(airTerm.ReheatAirOutletNode)));
             ErrorsFound = true;
         } else {
 
@@ -578,8 +574,7 @@ void GetSysInput(EnergyPlusData &state)
                         if (state.dataZoneEquip->ZoneEquipConfig(CtrlZone).AirDistUnitCool(SupAirIn).OutNode > 0) {
                             ShowSevereError(state, "Error in connecting a terminal unit to a zone");
                             ShowContinueError(
-                                state,
-                                EnergyPlus::format("{} already connects to another zone", state.dataLoopNodes->NodeID(airTerm.ReheatAirOutletNode)));
+                                state, std::format("{} already connects to another zone", state.dataLoopNodes->NodeID(airTerm.ReheatAirOutletNode)));
                             ShowContinueError(state, std::format("Occurs for terminal unit {} = {}", airTerm.sysType, airTerm.SysName));
                             ShowContinueError(state, "Check terminal unit node names for errors");
                             ErrorsFound = true;
@@ -2463,10 +2458,9 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                                         std::format("SizeHVACSingleDuct: Potential issue with equipment sizing for {} = \"{}\".",
                                                     this->sysType,
                                                     this->SysName));
+                            ShowContinueError(state, std::format("User-Specified Maximum Air Flow Rate of {:.5f} [m3/s]", MaxAirVolFlowRateUser));
                             ShowContinueError(state,
-                                              EnergyPlus::format("User-Specified Maximum Air Flow Rate of {:.5R} [m3/s]", MaxAirVolFlowRateUser));
-                            ShowContinueError(
-                                state, EnergyPlus::format("differs from Design Size Maximum Air Flow Rate of {:.5R} [m3/s]", MaxAirVolFlowRateDes));
+                                              std::format("differs from Design Size Maximum Air Flow Rate of {:.5f} [m3/s]", MaxAirVolFlowRateDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -2523,11 +2517,10 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                                                     this->sysType,
                                                     this->SysName));
                             ShowContinueError(
+                                state, std::format("User-Specified Maximum Heating Air Flow Rate of {:.5f} [m3/s]", MaxHeatAirVolFlowRateUser));
+                            ShowContinueError(
                                 state,
-                                EnergyPlus::format("User-Specified Maximum Heating Air Flow Rate of {:.5R} [m3/s]", MaxHeatAirVolFlowRateUser));
-                            ShowContinueError(state,
-                                              EnergyPlus::format("differs from Design Size Maximum Heating Air Flow Rate of {:.5R} [m3/s]",
-                                                                 MaxHeatAirVolFlowRateDes));
+                                std::format("differs from Design Size Maximum Heating Air Flow Rate of {:.5f} [m3/s]", MaxHeatAirVolFlowRateDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -2612,10 +2605,9 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                         ShowContinueError(
                             state,
                             "The flow is lower than the minimum flow rate calculated following the ASHRAE Standard 62.1 Simplified Procedure:");
-                        ShowContinueError(state, EnergyPlus::format(" User-specified maximum air flow rate: {:.3R} m3/s.", this->MaxAirVolFlowRate));
+                        ShowContinueError(state, std::format(" User-specified maximum air flow rate: {:.3f} m3/s.", this->MaxAirVolFlowRate));
                         ShowContinueError(
-                            state,
-                            EnergyPlus::format(" Calculated minimum air flow rate: {:.3R} m3/s.", this->MaxAirVolFlowRate * MinAirFlowFracDes));
+                            state, std::format(" Calculated minimum air flow rate: {:.3f} m3/s.", this->MaxAirVolFlowRate * MinAirFlowFracDes));
                         MinAirFlowFracDes = 1.0;
                     }
                 }
@@ -2650,9 +2642,8 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                     ShowMessage(
                         state,
                         std::format("SizeHVACSingleDuct: Potential issue with equipment sizing for {} = \"{}\".", this->sysType, this->SysName));
-                    ShowContinueError(state, EnergyPlus::format("User-Specified Minimum Cooling Air Flow Fraction of {:.5R}", MinAirFlowFracUser));
-                    ShowContinueError(state,
-                                      EnergyPlus::format("differs from Design Size Minimum Cooling Air Flow Fraction of {:.5R}", MinAirFlowFracDes));
+                    ShowContinueError(state, std::format("User-Specified Minimum Cooling Air Flow Fraction of {:.5f}", MinAirFlowFracUser));
+                    ShowContinueError(state, std::format("differs from Design Size Minimum Cooling Air Flow Fraction of {:.5f}", MinAirFlowFracDes));
                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                 }
@@ -2714,8 +2705,8 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                         ShowContinueError(
                             state,
                             "The flow is lower than the minimum flow rate calculated following the ASHRAE Standard 62.1 Simplified Procedure:");
-                        ShowContinueError(state, EnergyPlus::format(" User-specified maximum air flow rate: {:.3R} m3/s.", this->MaxAirVolFlowRate));
-                        ShowContinueError(state, EnergyPlus::format(" Calculated minimum air flow rate: {:.3R} m3/s.", FixedMinAirDes));
+                        ShowContinueError(state, std::format(" User-specified maximum air flow rate: {:.3f} m3/s.", this->MaxAirVolFlowRate));
+                        ShowContinueError(state, std::format(" Calculated minimum air flow rate: {:.3f} m3/s.", FixedMinAirDes));
                         FixedMinAirDes = this->MaxAirVolFlowRate;
                     }
                 }
@@ -2746,9 +2737,8 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                     ShowMessage(
                         state,
                         std::format("SizeHVACSingleDuct: Potential issue with equipment sizing for {} = \"{}\".", this->sysType, this->SysName));
-                    ShowContinueError(state, EnergyPlus::format("User-Specified Minimum Cooling Air Flow Rate of {:.5R} [m3/s]", FixedMinAirUser));
-                    ShowContinueError(state,
-                                      EnergyPlus::format("differs from Design Size Minimum Cooling Air Flow Rate of {:.5R} [m3/s]", FixedMinAirDes));
+                    ShowContinueError(state, std::format("User-Specified Minimum Cooling Air Flow Rate of {:.5f} [m3/s]", FixedMinAirUser));
+                    ShowContinueError(state, std::format("differs from Design Size Minimum Cooling Air Flow Rate of {:.5f} [m3/s]", FixedMinAirDes));
                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                 }
@@ -2854,11 +2844,10 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                         state,
                         std::format("SizeHVACSingleDuct: Potential issue with equipment sizing for {} = \"{}\".", this->sysType, this->SysName));
                     ShowContinueError(
+                        state, std::format("User-Specified Maximum Flow Fraction during Reheat of {:.5f} []", MaxAirVolFractionDuringReheatUser));
+                    ShowContinueError(
                         state,
-                        EnergyPlus::format("User-Specified Maximum Flow Fraction during Reheat of {:.5R} []", MaxAirVolFractionDuringReheatUser));
-                    ShowContinueError(state,
-                                      EnergyPlus::format("differs from Design Size Maximum Flow Fraction during Reheat of {:.5R} []",
-                                                         MaxAirVolFractionDuringReheatDes));
+                        std::format("differs from Design Size Maximum Flow Fraction during Reheat of {:.5f} []", MaxAirVolFractionDuringReheatDes));
                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                 }
@@ -2891,12 +2880,11 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                         state,
                         std::format("SizeHVACSingleDuct: Potential issue with equipment sizing for {} = \"{}\".", this->sysType, this->SysName));
                     ShowContinueError(state,
-                                      EnergyPlus::format("User-Specified Maximum Flow per Zone Floor Area during Reheat of {:.5R} [m3/s-m2]",
-                                                         MaxAirVolFlowRateDuringReheatUser));
-                    ShowContinueError(
-                        state,
-                        EnergyPlus::format("differs from Design Size Maximum Flow per Zone Floor Area during Reheat of {:.5R} [m3/s-m2]",
-                                           MaxAirVolFlowRateDuringReheatDes));
+                                      std::format("User-Specified Maximum Flow per Zone Floor Area during Reheat of {:.5f} [m3/s-m2]",
+                                                  MaxAirVolFlowRateDuringReheatUser));
+                    ShowContinueError(state,
+                                      std::format("differs from Design Size Maximum Flow per Zone Floor Area during Reheat of {:.5f} [m3/s-m2]",
+                                                  MaxAirVolFlowRateDuringReheatDes));
                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                 }
@@ -2932,11 +2920,10 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                         state,
                         std::format("SizeHVACSingleDuct: Potential issue with equipment sizing for {} = \"{}\".", this->sysType, this->SysName));
                     ShowContinueError(
+                        state, std::format("User-Specified Maximum Flow Fraction during Reheat of {:.5f} []", MaxAirVolFractionDuringReheatUser));
+                    ShowContinueError(
                         state,
-                        EnergyPlus::format("User-Specified Maximum Flow Fraction during Reheat of {:.5R} []", MaxAirVolFractionDuringReheatUser));
-                    ShowContinueError(state,
-                                      EnergyPlus::format("differs from Design Size Maximum Flow Fraction during Reheat of {:.5R} []",
-                                                         MaxAirVolFractionDuringReheatDes));
+                        std::format("differs from Design Size Maximum Flow Fraction during Reheat of {:.5f} []", MaxAirVolFractionDuringReheatDes));
                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                 }
@@ -2948,12 +2935,11 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                         state,
                         std::format("SizeHVACSingleDuct: Potential issue with equipment sizing for {} = \"{}\".", this->sysType, this->SysName));
                     ShowContinueError(state,
-                                      EnergyPlus::format("User-Specified Maximum Flow per Zone Floor Area during Reheat of {:.5R} [m3/s-m2]",
-                                                         MaxAirVolFlowRateDuringReheatUser));
-                    ShowContinueError(
-                        state,
-                        EnergyPlus::format("differs from Design Size Maximum Flow per Zone Floor Area during Reheat of {:.5R} [m3/s-m2]",
-                                           MaxAirVolFlowRateDuringReheatDes));
+                                      std::format("User-Specified Maximum Flow per Zone Floor Area during Reheat of {:.5f} [m3/s-m2]",
+                                                  MaxAirVolFlowRateDuringReheatUser));
+                    ShowContinueError(state,
+                                      std::format("differs from Design Size Maximum Flow per Zone Floor Area during Reheat of {:.5f} [m3/s-m2]",
+                                                  MaxAirVolFlowRateDuringReheatDes));
                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                 }
@@ -3038,21 +3024,20 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
             ShowMessage(state,
                         std::format("SizeHVACSingleDuct: Potential issue with equipment sizing for {} = \"{}\".", this->sysType, this->SysName));
             ShowContinueError(state,
-                              EnergyPlus::format("Terminal unit design air flow rate during Reheat of {:.5R} [m3/s] used to size the heating coil",
-                                                 TermUnitSizing(state.dataSize->CurTermUnitSizingNum).AirVolFlow));
+                              std::format("Terminal unit design air flow rate during Reheat of {:.5f} [m3/s] used to size the heating coil",
+                                          TermUnitSizing(state.dataSize->CurTermUnitSizingNum).AirVolFlow));
             ShowContinueError(state,
-                              EnergyPlus::format("is less than the zone design heating air flow rate of {:.5R} [m3/s]",
-                                                 state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).DesHeatVolFlow));
+                              std::format("is less than the zone design heating air flow rate of {:.5f} [m3/s]",
+                                          state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).DesHeatVolFlow));
+            ShowContinueError(
+                state,
+                std::format("and this {} Maximum Flow Fraction During Reheat is {:.5f} []", this->sysType, this->MaxAirVolFractionDuringReheat));
             ShowContinueError(state,
-                              EnergyPlus::format("and this {} Maximum Flow Fraction During Reheat is {:.5R} []",
-                                                 this->sysType,
-                                                 this->MaxAirVolFractionDuringReheat));
+                              std::format("For reference the zone design cooling air flow rate is {:.5f} [m3/s]",
+                                          state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).DesCoolVolFlow));
             ShowContinueError(state,
-                              EnergyPlus::format("For reference the zone design cooling air flow rate is {:.5R} [m3/s]",
-                                                 state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).DesCoolVolFlow));
-            ShowContinueError(state,
-                              EnergyPlus::format("For reference the zone design minimum cooling air flow rate is {:.5R} [m3/s]",
-                                                 state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).DesCoolVolFlowMin));
+                              std::format("For reference the zone design minimum cooling air flow rate is {:.5f} [m3/s]",
+                                          state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).DesCoolVolFlowMin));
             int zoneNum = state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).ZoneNum;
             if (zoneNum > 0) {
                 int SizingInputNum =
@@ -3062,17 +3047,16 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                 }
                 if (state.dataSize->ZoneSizingInput.size() > 0 && state.dataSize->ZoneSizingInput(SizingInputNum).DesHeatMaxAirFlowFrac < 1.0) {
                     ShowContinueError(state,
-                                      EnergyPlus::format("Sizing:Zone Heating Maximum Air Flow Fraction = {:.5R}",
-                                                         state.dataSize->ZoneSizingInput(SizingInputNum).DesHeatMaxAirFlowFrac));
+                                      std::format("Sizing:Zone Heating Maximum Air Flow Fraction = {:.5f}",
+                                                  state.dataSize->ZoneSizingInput(SizingInputNum).DesHeatMaxAirFlowFrac));
                     ShowContinueError(state,
-                                      EnergyPlus::format("Sizing:Zone Heating Maximum Air Flow per Zone Floor Area = {:.5R} [m3/s/m2]",
-                                                         state.dataSize->ZoneSizingInput(SizingInputNum).DesHeatMaxAirFlowPerArea));
-                    ShowContinueError(
-                        state, EnergyPlus::format("For reference the Zone Floor Area = {:.5R} [m3]", state.dataHeatBal->Zone(zoneNum).FloorArea));
-                    ShowContinueError(
-                        state,
-                        EnergyPlus::format("For reference the zone design maximum heating air flow rate is {:.5R} [m3/s]",
-                                           state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).DesHeatVolFlowMax));
+                                      std::format("Sizing:Zone Heating Maximum Air Flow per Zone Floor Area = {:.5f} [m3/s/m2]",
+                                                  state.dataSize->ZoneSizingInput(SizingInputNum).DesHeatMaxAirFlowPerArea));
+                    ShowContinueError(state,
+                                      std::format("For reference the Zone Floor Area = {:.5f} [m3]", state.dataHeatBal->Zone(zoneNum).FloorArea));
+                    ShowContinueError(state,
+                                      std::format("For reference the zone design maximum heating air flow rate is {:.5f} [m3/s]",
+                                                  state.dataSize->TermUnitFinalZoneSizing(state.dataSize->CurTermUnitSizingNum).DesHeatVolFlowMax));
                 }
             }
             ShowContinueError(state, "Verify that the values entered are intended and are consistent with other components.");
@@ -3212,11 +3196,10 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                                                         this->sysType,
                                                         this->SysName));
                                 ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("User-Specified Maximum Reheat Water Flow Rate of {:.5R} [m3/s]", MaxReheatWaterVolFlowUser));
+                                    state, std::format("User-Specified Maximum Reheat Water Flow Rate of {:.5f} [m3/s]", MaxReheatWaterVolFlowUser));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("differs from Design Size Maximum Reheat Water Flow Rate of {:.5R} [m3/s]",
-                                                                     MaxReheatWaterVolFlowDes));
+                                                  std::format("differs from Design Size Maximum Reheat Water Flow Rate of {:.5f} [m3/s]",
+                                                              MaxReheatWaterVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -3310,11 +3293,10 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                                                         this->sysType,
                                                         this->SysName));
                                 ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("User-Specified Maximum Reheat Steam Flow Rate of {:.5R} [m3/s]", MaxReheatSteamVolFlowUser));
+                                    state, std::format("User-Specified Maximum Reheat Steam Flow Rate of {:.5f} [m3/s]", MaxReheatSteamVolFlowUser));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("differs from Design Size Maximum Reheat Steam Flow Rate of {:.5R} [m3/s]",
-                                                                     MaxReheatSteamVolFlowDes));
+                                                  std::format("differs from Design Size Maximum Reheat Steam Flow Rate of {:.5f} [m3/s]",
+                                                              MaxReheatSteamVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -3352,13 +3334,13 @@ void SingleDuctAirTerminal::SizeSys(EnergyPlusData &state)
                                  "reheat maximum");
                 ShowContinueError(state, std::format("Air Terminal Unit name = {}", this->SysName));
                 ShowContinueError(state,
-                                  EnergyPlus::format("Maximum terminal flow during reheat = {:.6R} [m3/s] or flow fraction = {:.4R}",
-                                                     this->MaxAirVolFlowRateDuringReheat,
-                                                     (this->MaxAirVolFlowRateDuringReheat / this->MaxAirVolFlowRate)));
+                                  std::format("Maximum terminal flow during reheat = {:.6f} [m3/s] or flow fraction = {:.4f}",
+                                              this->MaxAirVolFlowRateDuringReheat,
+                                              (this->MaxAirVolFlowRateDuringReheat / this->MaxAirVolFlowRate)));
                 ShowContinueError(state,
-                                  EnergyPlus::format("Minimum terminal flow = {:.6R} [m3/s] or flow fraction = {:.4R}",
-                                                     (this->ZoneMinAirFracDes * this->MaxAirVolFlowRate),
-                                                     this->ZoneMinAirFracDes));
+                                  std::format("Minimum terminal flow = {:.6f} [m3/s] or flow fraction = {:.4f}",
+                                              (this->ZoneMinAirFracDes * this->MaxAirVolFlowRate),
+                                              this->ZoneMinAirFracDes));
                 ShowContinueError(state, "The reheat maximum flow limit will be replaced by the minimum limit, and the simulation continues");
             }
             this->MaxAirVolFlowRateDuringReheat = (this->ZoneMinAirFracDes * this->MaxAirVolFlowRate);
@@ -5586,10 +5568,10 @@ void CalcATMixer(EnergyPlusData &state, int const SysNum)
         if (std::abs(priInNode.MassFlowRate + secInNode.MassFlowRate - MixedAirMassFlowRate) > SmallMassFlow) {
             ShowSevereError(state, std::format("CalcATMixer: Invalid mass flow rates in AirTerminal:SingleDuct:Mixer={}", atMixer.Name));
             ShowContinueErrorTimeStamp(state,
-                                       EnergyPlus::format("Primary mass flow rate={:.6R}Secondary mass flow rate={:.6R}Mixed mass flow rate={:.6R}",
-                                                          priInNode.MassFlowRate,
-                                                          secInNode.MassFlowRate,
-                                                          MixedAirMassFlowRate));
+                                       std::format("Primary mass flow rate={:.6f}Secondary mass flow rate={:.6f}Mixed mass flow rate={:.6f}",
+                                                   priInNode.MassFlowRate,
+                                                   secInNode.MassFlowRate,
+                                                   MixedAirMassFlowRate));
             ShowFatalError(state, "Simulation terminates.");
         }
     }

--- a/src/EnergyPlus/SizingAnalysisObjects.cc
+++ b/src/EnergyPlus/SizingAnalysisObjects.cc
@@ -552,7 +552,7 @@ void PlantCoinicidentAnalysis::ResolveDesignFlowRate(EnergyPlusData &state, int 
     }
 
     print(state.files.eio,
-          "Plant Coincident Sizing Algorithm,{},{},{:.7R},{:.2R},{:.7R},{},{:.6R},{:.6R},{},{:.4R},{:.6R},{:.4R},{:.4R}\n",
+          "Plant Coincident Sizing Algorithm,{},{},{:.7f},{:.2f},{:.7f},{},{:.6f},{:.6f},{},{:.4f},{:.6f},{:.4f},{:.4f}\n",
           name,
           chIteration,
           newFoundMassFlowRateTimeStamp.runningAvgDataValue,

--- a/src/EnergyPlus/SizingManager.cc
+++ b/src/EnergyPlus/SizingManager.cc
@@ -4393,9 +4393,9 @@ void reportZoneSizingEio(EnergyPlusData &state,
     }
 
     static constexpr std::string_view Format_991_Space(
-        " Space Sizing Information, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {:.5f}\n");
+        " Space Sizing Information, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {}, {}, {:.5f}, {:.5E}, {:.5f}, {:.5f}, {:.5f}, {:.5f}\n");
     static constexpr std::string_view Format_991_Zone(
-        " Zone Sizing Information, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {:.5f}\n");
+        " Zone Sizing Information, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {}, {}, {:.5f}, {:.5E}, {:.5f}, {:.5f}, {:.5f}, {:.5f}\n");
     if (isSpace) {
         print(state.files.eio,
               Format_991_Space,

--- a/src/EnergyPlus/SizingManager.cc
+++ b/src/EnergyPlus/SizingManager.cc
@@ -172,7 +172,7 @@ void ManageSizing(EnergyPlusData &state)
     if (state.dataGlobal->DoZoneSizing || state.dataGlobal->DoSystemSizing) {
         if ((state.dataSize->NumSysSizInput > 0 && state.dataSize->NumZoneSizingInput == 0) ||
             (!state.dataGlobal->DoZoneSizing && state.dataGlobal->DoSystemSizing && state.dataSize->NumSysSizInput > 0)) {
-            ShowSevereError(state, EnergyPlus::format("{}Requested System Sizing but did not request Zone Sizing.", RoutineName));
+            ShowSevereError(state, std::format("{}Requested System Sizing but did not request Zone Sizing.", RoutineName));
             ShowContinueError(state, "System Sizing cannot be done without Zone Sizing");
             ShowFatalError(state, "Program terminates for preceding conditions.");
         }
@@ -190,14 +190,14 @@ void ManageSizing(EnergyPlusData &state)
             if (fileHasSizingPeriodDays) {
                 ShowWarningError(
                     state,
-                    EnergyPlus::format(
+                    std::format(
                         "{}The ZoneComponentLoadSummary report was requested but no sizing objects were found so that report cannot be generated.",
                         RoutineName));
             } else {
                 ShowWarningError(state,
-                                 EnergyPlus::format("{}The ZoneComponentLoadSummary report was requested but no SizingPeriod:DesignDay or "
-                                                    "SizingPeriod:WeatherFileDays objects were found so that report cannot be generated.",
-                                                    RoutineName));
+                                 std::format("{}The ZoneComponentLoadSummary report was requested but no SizingPeriod:DesignDay or "
+                                             "SizingPeriod:WeatherFileDays objects were found so that report cannot be generated.",
+                                             RoutineName));
             }
         }
     }
@@ -210,9 +210,8 @@ void ManageSizing(EnergyPlusData &state)
     if ((state.dataGlobal->DoZoneSizing) && (state.dataSize->NumZoneSizingInput == 0)) {
         ShowWarningError(
             state,
-            EnergyPlus::format(
-                "{}For a zone sizing run, there must be at least 1 Sizing:Zone input object. SimulationControl Zone Sizing option ignored.",
-                RoutineName));
+            std::format("{}For a zone sizing run, there must be at least 1 Sizing:Zone input object. SimulationControl Zone Sizing option ignored.",
+                        RoutineName));
     }
 
     if ((state.dataSize->NumZoneSizingInput > 0) &&
@@ -302,9 +301,8 @@ void ManageSizing(EnergyPlusData &state)
                             } else {
                                 DisplayString(state, "Performing Zone Sizing Simulation for Load Component Report");
                             }
-                            DisplayString(
-                                state,
-                                EnergyPlus::format("...for Sizing Period: #{} {}", NumSizingPeriodsPerformed, state.dataEnvrn->EnvironmentName));
+                            DisplayString(state,
+                                          std::format("...for Sizing Period: #{} {}", NumSizingPeriodsPerformed, state.dataEnvrn->EnvironmentName));
                         }
                         UpdateZoneSizing(state, Constant::CallIndicator::BeginDay);
                         UpdateFacilitySizing(state, Constant::CallIndicator::BeginDay);
@@ -352,7 +350,7 @@ void ManageSizing(EnergyPlusData &state)
                                 TimeStepInDay = (state.dataGlobal->HourOfDay - 1) * state.dataGlobal->TimeStepsInHour + state.dataGlobal->TimeStep;
                                 if (state.dataGlobal->HourOfDay == 1 && state.dataGlobal->TimeStep == 1) {
                                     state.dataSize->DesDayWeath(state.dataSize->CurOverallSimDay).DateString =
-                                        EnergyPlus::format("{}/{}", state.dataEnvrn->Month, state.dataEnvrn->DayOfMonth);
+                                        std::format("{}/{}", state.dataEnvrn->Month, state.dataEnvrn->DayOfMonth);
                                 }
                                 state.dataSize->DesDayWeath(state.dataSize->CurOverallSimDay).Temp(TimeStepInDay) = state.dataEnvrn->OutDryBulbTemp;
                                 state.dataSize->DesDayWeath(state.dataSize->CurOverallSimDay).HumRat(TimeStepInDay) = state.dataEnvrn->OutHumRat;
@@ -394,8 +392,8 @@ void ManageSizing(EnergyPlusData &state)
                 UpdateFacilitySizing(state, Constant::CallIndicator::EndZoneSizingCalc);
                 state.dataSize->ZoneSizingRunDone = true;
             } else {
-                ShowSevereError(
-                    state, EnergyPlus::format("{}No Sizing periods were performed for Zone Sizing. No Zone Sizing calculations saved.", RoutineName));
+                ShowSevereError(state,
+                                std::format("{}No Sizing periods were performed for Zone Sizing. No Zone Sizing calculations saved.", RoutineName));
                 ErrorsFound = true;
             }
 
@@ -422,7 +420,7 @@ void ManageSizing(EnergyPlusData &state)
     if ((state.dataGlobal->DoSystemSizing) && (state.dataSize->NumSysSizInput == 0) && (state.dataSizingManager->NumAirLoops > 0)) {
         ShowWarningError(
             state,
-            EnergyPlus::format(
+            std::format(
                 "{}For a system sizing run, there must be at least 1 Sizing:System object input. SimulationControl System Sizing option ignored.",
                 RoutineName));
     }
@@ -494,8 +492,8 @@ void ManageSizing(EnergyPlusData &state)
                 } else { // (.NOT.WarmupFlag)
                     if (state.dataGlobal->DayOfSim == 1) {
                         DisplayString(state, "Calculating System sizing");
-                        DisplayString(
-                            state, EnergyPlus::format("...for Sizing Period: #{} {}", NumSizingPeriodsPerformed, state.dataEnvrn->EnvironmentName));
+                        DisplayString(state,
+                                      std::format("...for Sizing Period: #{} {}", NumSizingPeriodsPerformed, state.dataEnvrn->EnvironmentName));
                     }
                     UpdateSysSizing(state, Constant::CallIndicator::BeginDay);
                 }
@@ -557,8 +555,8 @@ void ManageSizing(EnergyPlusData &state)
             UpdateSysSizing(state, Constant::CallIndicator::EndSysSizingCalc);
             state.dataSize->SysSizingRunDone = true;
         } else {
-            ShowSevereError(
-                state, EnergyPlus::format("{}No Sizing periods were performed for System Sizing. No System Sizing calculations saved.", RoutineName));
+            ShowSevereError(state,
+                            std::format("{}No Sizing periods were performed for System Sizing. No System Sizing calculations saved.", RoutineName));
             ErrorsFound = true;
         }
     } else if ((state.dataSize->NumZoneSizingInput > 0) &&
@@ -627,17 +625,17 @@ void ManageSizing(EnergyPlusData &state)
             curName = finalSysSizing.AirPriLoopName;
             PreDefTableEntry(state, state.dataOutRptPredefined->pdchSysSizCalcClAir, curName, calcSysSizing.DesCoolVolFlow);
             if (std::abs(calcSysSizing.DesCoolVolFlow) <= 1.e-8) {
-                ShowWarningError(state,
-                                 EnergyPlus::format(
-                                     "{}Calculated Cooling Design Air Flow Rate for System={} is zero.", RoutineName, finalSysSizing.AirPriLoopName));
+                ShowWarningError(
+                    state,
+                    std::format("{}Calculated Cooling Design Air Flow Rate for System={} is zero.", RoutineName, finalSysSizing.AirPriLoopName));
                 ShowContinueError(state, "Check Sizing:Zone and ZoneControl:Thermostat inputs.");
             }
             PreDefTableEntry(state, state.dataOutRptPredefined->pdchSysSizUserClAir, curName, finalSysSizing.DesCoolVolFlow);
             PreDefTableEntry(state, state.dataOutRptPredefined->pdchSysSizCalcHtAir, curName, calcSysSizing.DesHeatVolFlow);
             if (std::abs(calcSysSizing.DesHeatVolFlow) <= 1.e-8) {
-                ShowWarningError(state,
-                                 EnergyPlus::format(
-                                     "{}Calculated Heating Design Air Flow Rate for System={} is zero.", RoutineName, finalSysSizing.AirPriLoopName));
+                ShowWarningError(
+                    state,
+                    std::format("{}Calculated Heating Design Air Flow Rate for System={} is zero.", RoutineName, finalSysSizing.AirPriLoopName));
                 ShowContinueError(state, "Check Sizing:Zone and ZoneControl:Thermostat inputs.");
             }
             std::string_view coolPeakLoadKind;
@@ -732,7 +730,7 @@ void ManageSizing(EnergyPlusData &state)
     if ((state.dataGlobal->DoPlantSizing) && (state.dataSize->NumPltSizInput == 0)) {
         ShowWarningError(
             state,
-            EnergyPlus::format(
+            std::format(
                 "{}For a plant sizing run, there must be at least 1 Sizing:Plant object input. SimulationControl Plant Sizing option ignored.",
                 RoutineName));
     }
@@ -2132,7 +2130,7 @@ void DetermineSystemPopulationDiversity(EnergyPlusData &state)
                                 TimeMinsInt = 0;
                             }
                             state.dataSize->PeakPsOccurrenceDateTimeStringBySys(AirLoopNum) =
-                                EnergyPlus::format("{:02}/{:02} {:02}:{:02}", Month, DayOfMonth, TimeHrsInt, TimeMinsInt);
+                                std::format("{:02}/{:02} {:02}:{:02}", Month, DayOfMonth, TimeHrsInt, TimeMinsInt);
                             state.dataSize->PeakPsOccurrenceEnvironmentStringBySys(AirLoopNum) = "Full Year Schedule";
                         }
                     } // if autosized and VRP
@@ -2167,7 +2165,7 @@ void DetermineSystemPopulationDiversity(EnergyPlusData &state)
             state.dataSize->DBySys(AirLoopNum) = 1.0;
             ShowWarningError(
                 state,
-                EnergyPlus::format(
+                std::format(
                     "The {} air loop serves a single zone. The Occupant Diversity was calculated or set to a value less than 1.0. Single-zone air "
                     "loops should have an Occupant Diversity of 1.0. The Occupant Diversity value for that air loop has been reset to 1.0",
                     finalSysSizing.AirPriLoopName));
@@ -2280,7 +2278,7 @@ void GetOARequirements(EnergyPlusData &state)
                 if (Util::FindItemInList(thisOAReqName, state.dataSize->OARequirements) > 0) {
                     ShowSevereError(
                         state,
-                        EnergyPlus::format(
+                        std::format(
                             "{}{}=\"{}\" is a duplicate DesignSpecification:OutdoorAir name.", RoutineName, cCurrentModuleObject2, thisOAReqName));
                     ErrorsFound = true;
                 }
@@ -2303,8 +2301,8 @@ void GetOARequirements(EnergyPlusData &state)
                             thisOAReq.dsoaIndexes.emplace_back(thisDsoaNum);
                             ++thisOAReq.numDSOA;
                         } else {
-                            ShowSevereError(state, EnergyPlus::format("{}{}={}", RoutineName, cCurrentModuleObject2, thisOAReq.Name));
-                            ShowContinueError(state, EnergyPlus::format("DesignSpecification:OutdoorAir={} not found.", thisDsoaName));
+                            ShowSevereError(state, std::format("{}{}={}", RoutineName, cCurrentModuleObject2, thisOAReq.Name));
+                            ShowContinueError(state, std::format("DesignSpecification:OutdoorAir={} not found.", thisDsoaName));
                             ErrorsFound = true;
                         }
                     }
@@ -2929,10 +2927,10 @@ void GetZoneSizingInput(EnergyPlusData &state)
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolDesHumRat = 0.0;
                 } else if (state.dataIPShortCut->rNumericArgs(5) < 0.0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}: incorrect {}: {:.2R}",
-                                                       cCurrentModuleObject,
-                                                       state.dataIPShortCut->cNumericFieldNames(5),
-                                                       state.dataIPShortCut->rNumericArgs(5)));
+                                    std::format("{}: incorrect {}: {:.2f}",
+                                                cCurrentModuleObject,
+                                                state.dataIPShortCut->cNumericFieldNames(5),
+                                                state.dataIPShortCut->rNumericArgs(5)));
                     ShowContinueError(
                         state, std::format(".. value should not be negative. Occurs in Sizing Object={}", state.dataIPShortCut->cAlphaArgs(1)));
                     ErrorsFound = true;
@@ -2948,10 +2946,10 @@ void GetZoneSizingInput(EnergyPlusData &state)
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).HeatDesHumRat = 0.0;
                 } else if (state.dataIPShortCut->rNumericArgs(6) < 0.0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}: incorrect {}: {:.2R}",
-                                                       cCurrentModuleObject,
-                                                       state.dataIPShortCut->cNumericFieldNames(6),
-                                                       state.dataIPShortCut->rNumericArgs(6)));
+                                    std::format("{}: incorrect {}: {:.2f}",
+                                                cCurrentModuleObject,
+                                                state.dataIPShortCut->cNumericFieldNames(6),
+                                                state.dataIPShortCut->rNumericArgs(6)));
                     ShowContinueError(
                         state, std::format(".. value should not be negative. Occurs in Sizing Object={}", state.dataIPShortCut->cAlphaArgs(1)));
                     ErrorsFound = true;
@@ -2987,9 +2985,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(7) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(7),
-                                                         state.dataIPShortCut->rNumericArgs(7)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(7),
+                                                  state.dataIPShortCut->rNumericArgs(7)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).HeatSizingFactor = state.dataIPShortCut->rNumericArgs(7);
@@ -3002,9 +3000,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(8) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(8),
-                                                         state.dataIPShortCut->rNumericArgs(8)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(8),
+                                                  state.dataIPShortCut->rNumericArgs(8)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).CoolSizingFactor = state.dataIPShortCut->rNumericArgs(8);
@@ -3022,9 +3020,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(9) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(9),
-                                                         state.dataIPShortCut->rNumericArgs(9)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(9),
+                                                  state.dataIPShortCut->rNumericArgs(9)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).DesCoolAirFlow = state.dataIPShortCut->rNumericArgs(9);
@@ -3045,9 +3043,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(10) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(108),
-                                                         state.dataIPShortCut->rNumericArgs(10)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(108),
+                                                  state.dataIPShortCut->rNumericArgs(10)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).DesCoolMinAirFlowPerArea = state.dataIPShortCut->rNumericArgs(10);
@@ -3063,9 +3061,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(11) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(11),
-                                                         state.dataIPShortCut->rNumericArgs(11)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(11),
+                                                  state.dataIPShortCut->rNumericArgs(11)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).DesCoolMinAirFlow = state.dataIPShortCut->rNumericArgs(11);
@@ -3074,9 +3072,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 if (state.dataIPShortCut->rNumericArgs(12) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(12),
-                                                         state.dataIPShortCut->rNumericArgs(12)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(12),
+                                                  state.dataIPShortCut->rNumericArgs(12)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).DesCoolMinAirFlowFrac = state.dataIPShortCut->rNumericArgs(12);
@@ -3095,9 +3093,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(13) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(13),
-                                                         state.dataIPShortCut->rNumericArgs(13)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(13),
+                                                  state.dataIPShortCut->rNumericArgs(13)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).DesHeatAirFlow = state.dataIPShortCut->rNumericArgs(13);
@@ -3119,9 +3117,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(14) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(14),
-                                                         state.dataIPShortCut->rNumericArgs(14)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(14),
+                                                  state.dataIPShortCut->rNumericArgs(14)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).DesHeatMaxAirFlowPerArea = state.dataIPShortCut->rNumericArgs(14);
@@ -3144,9 +3142,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(15) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(15),
-                                                         state.dataIPShortCut->rNumericArgs(15)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(15),
+                                                  state.dataIPShortCut->rNumericArgs(15)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).DesHeatMaxAirFlow = state.dataIPShortCut->rNumericArgs(15);
@@ -3168,9 +3166,9 @@ void GetZoneSizingInput(EnergyPlusData &state)
                 } else if (state.dataIPShortCut->rNumericArgs(16) < 0.0) {
                     ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                         state.dataIPShortCut->cNumericFieldNames(16),
-                                                         state.dataIPShortCut->rNumericArgs(16)));
+                                      std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                                  state.dataIPShortCut->cNumericFieldNames(16),
+                                                  state.dataIPShortCut->rNumericArgs(16)));
                     ErrorsFound = true;
                 } else {
                     state.dataSize->ZoneSizingInput(ZoneSizIndex).DesHeatMaxAirFlowFrac = state.dataIPShortCut->rNumericArgs(16);
@@ -3316,20 +3314,20 @@ void ReportTemperatureInputError(
         if (shouldFlagSevere) { // heating supply air temperature is lower than cooling supply air temperature--not allowed
             ShowSevereError(state, std::format("{}=\"{}\" has invalid data.", cObjectName, state.dataIPShortCut->cAlphaArgs(1)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}] is less than {}=[{:.2R}]",
-                                                 state.dataIPShortCut->cNumericFieldNames(paramNum),
-                                                 state.dataIPShortCut->rNumericArgs(paramNum),
-                                                 state.dataIPShortCut->cNumericFieldNames(paramNum - 2),
-                                                 state.dataIPShortCut->rNumericArgs(paramNum - 2)));
+                              std::format("... incorrect {}=[{:.2f}] is less than {}=[{:.2f}]",
+                                          state.dataIPShortCut->cNumericFieldNames(paramNum),
+                                          state.dataIPShortCut->rNumericArgs(paramNum),
+                                          state.dataIPShortCut->cNumericFieldNames(paramNum - 2),
+                                          state.dataIPShortCut->rNumericArgs(paramNum - 2)));
             ShowContinueError(state, "This is not allowed.  Please check and revise your input.");
             ErrorsFound = true;
         } else { // then input is lower than comparison temperature--just produce a warning for user to check input
             ShowWarningError(state, std::format("{}=\"{}\" has invalid data.", cObjectName, state.dataIPShortCut->cAlphaArgs(1)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}] is less than [{:.2R}]",
-                                                 state.dataIPShortCut->cNumericFieldNames(paramNum),
-                                                 state.dataIPShortCut->rNumericArgs(paramNum),
-                                                 comparisonTemperature));
+                              std::format("... incorrect {}=[{:.2f}] is less than [{:.2f}]",
+                                          state.dataIPShortCut->cNumericFieldNames(paramNum),
+                                          state.dataIPShortCut->rNumericArgs(paramNum),
+                                          comparisonTemperature));
             ShowContinueError(state, "Please check your input to make sure this is correct.");
         }
     }
@@ -3555,9 +3553,9 @@ void GetSystemSizingInput(EnergyPlusData &state)
                    state.dataIPShortCut->rNumericArgs(iDesignOAVolFlowNumericNum) != AutoSize) {
             ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(iNameAlphaNum)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                 state.dataIPShortCut->cNumericFieldNames(iDesignOAVolFlowNumericNum),
-                                                 state.dataIPShortCut->rNumericArgs(iDesignOAVolFlowNumericNum)));
+                              std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                          state.dataIPShortCut->cNumericFieldNames(iDesignOAVolFlowNumericNum),
+                                          state.dataIPShortCut->rNumericArgs(iDesignOAVolFlowNumericNum)));
             ErrorsFound = true;
         } else {
             SysSizInput(SysSizIndex).DesOutAirVolFlow = state.dataIPShortCut->rNumericArgs(iDesignOAVolFlowNumericNum);
@@ -3580,9 +3578,9 @@ void GetSystemSizingInput(EnergyPlusData &state)
                 state,
                 std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(iMinSysAirFlowRatioNumericNum)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                 state.dataIPShortCut->cNumericFieldNames(iMinSysAirFlowRatioNumericNum),
-                                                 state.dataIPShortCut->rNumericArgs(iMinSysAirFlowRatioNumericNum)));
+                              std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                          state.dataIPShortCut->cNumericFieldNames(iMinSysAirFlowRatioNumericNum),
+                                          state.dataIPShortCut->rNumericArgs(iMinSysAirFlowRatioNumericNum)));
             ErrorsFound = true;
         } else {
             SysSizInput(SysSizIndex).SysAirMinFlowRat = state.dataIPShortCut->rNumericArgs(iMinSysAirFlowRatioNumericNum);
@@ -3625,9 +3623,9 @@ void GetSystemSizingInput(EnergyPlusData &state)
         } else if (state.dataIPShortCut->rNumericArgs(iMaxCoolAirVolFlowNumericNum) < 0.0) {
             ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(iNameAlphaNum)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                 state.dataIPShortCut->cNumericFieldNames(iMaxCoolAirVolFlowNumericNum),
-                                                 state.dataIPShortCut->rNumericArgs(iMaxCoolAirVolFlowNumericNum)));
+                              std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                          state.dataIPShortCut->cNumericFieldNames(iMaxCoolAirVolFlowNumericNum),
+                                          state.dataIPShortCut->rNumericArgs(iMaxCoolAirVolFlowNumericNum)));
             ErrorsFound = true;
         } else {
             SysSizInput(SysSizIndex).DesCoolAirFlow = state.dataIPShortCut->rNumericArgs(iMaxCoolAirVolFlowNumericNum);
@@ -3652,9 +3650,9 @@ void GetSystemSizingInput(EnergyPlusData &state)
         } else if (state.dataIPShortCut->rNumericArgs(iMaxHeatAirVolFlowNumericNum) < 0.0) {
             ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(iNameAlphaNum)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                 state.dataIPShortCut->cNumericFieldNames(iMaxHeatAirVolFlowNumericNum),
-                                                 state.dataIPShortCut->rNumericArgs(iMaxHeatAirVolFlowNumericNum)));
+                              std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                          state.dataIPShortCut->cNumericFieldNames(iMaxHeatAirVolFlowNumericNum),
+                                          state.dataIPShortCut->rNumericArgs(iMaxHeatAirVolFlowNumericNum)));
             ErrorsFound = true;
         } else {
             SysSizInput(SysSizIndex).DesHeatAirFlow = state.dataIPShortCut->rNumericArgs(iMaxHeatAirVolFlowNumericNum);
@@ -3673,9 +3671,9 @@ void GetSystemSizingInput(EnergyPlusData &state)
         } else if (state.dataIPShortCut->rNumericArgs(iZoneMaxOAFractionNumericNum) < 0.0) {
             ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(iNameAlphaNum)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                 state.dataIPShortCut->cNumericFieldNames(iZoneMaxOAFractionNumericNum),
-                                                 state.dataIPShortCut->rNumericArgs(iZoneMaxOAFractionNumericNum)));
+                              std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                          state.dataIPShortCut->cNumericFieldNames(iZoneMaxOAFractionNumericNum),
+                                          state.dataIPShortCut->rNumericArgs(iZoneMaxOAFractionNumericNum)));
             ErrorsFound = true;
         } else {
             SysSizInput(SysSizIndex).MaxZoneOAFraction = state.dataIPShortCut->rNumericArgs(iZoneMaxOAFractionNumericNum);
@@ -3971,17 +3969,17 @@ void GetSystemSizingInput(EnergyPlusData &state)
                    state.dataIPShortCut->rNumericArgs(iOccupantDiversity) != AutoSize) {
             ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(iNameAlphaNum)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be negative.",
-                                                 state.dataIPShortCut->cNumericFieldNames(iOccupantDiversity),
-                                                 state.dataIPShortCut->rNumericArgs(iOccupantDiversity)));
+                              std::format("... incorrect {}=[{:.2f}],  value should not be negative.",
+                                          state.dataIPShortCut->cNumericFieldNames(iOccupantDiversity),
+                                          state.dataIPShortCut->rNumericArgs(iOccupantDiversity)));
             ErrorsFound = true;
         } else if (state.dataIPShortCut->rNumericArgs(iOccupantDiversity) > 1.0 &&
                    state.dataIPShortCut->rNumericArgs(iOccupantDiversity) != AutoSize) {
             ShowSevereError(state, std::format("{}=\"{}\", invalid data.", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(iNameAlphaNum)));
             ShowContinueError(state,
-                              EnergyPlus::format("... incorrect {}=[{:.2R}],  value should not be greater than 1.0.",
-                                                 state.dataIPShortCut->cNumericFieldNames(iOccupantDiversity),
-                                                 state.dataIPShortCut->rNumericArgs(iOccupantDiversity)));
+                              std::format("... incorrect {}=[{:.2f}],  value should not be greater than 1.0.",
+                                          state.dataIPShortCut->cNumericFieldNames(iOccupantDiversity),
+                                          state.dataIPShortCut->rNumericArgs(iOccupantDiversity)));
             ErrorsFound = true;
         } else {
             SysSizInput(SysSizIndex).OccupantDiversity = state.dataIPShortCut->rNumericArgs(iOccupantDiversity);
@@ -4395,9 +4393,9 @@ void reportZoneSizingEio(EnergyPlusData &state,
     }
 
     static constexpr std::string_view Format_991_Space(
-        " Space Sizing Information, {}, {}, {:.5R}, {:.5R}, {:.5R}, {:.5R}, {}, {}, {:.5R}, {:.5R}, {:.5R}, {:.5R}, {:.5R}, {:.5R}\n");
+        " Space Sizing Information, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {:.5f}\n");
     static constexpr std::string_view Format_991_Zone(
-        " Zone Sizing Information, {}, {}, {:.5R}, {:.5R}, {:.5R}, {:.5R}, {}, {}, {:.5R}, {:.5R}, {:.5R}, {:.5R}, {:.5R}, {:.5R}\n");
+        " Zone Sizing Information, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {}, {}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {:.5f}, {:.5f}\n");
     if (isSpace) {
         print(state.files.eio,
               Format_991_Space,
@@ -4475,7 +4473,7 @@ void ReportSysSizing(EnergyPlusData &state,
     }
     std::string dateHrMin = DesDayDate + " " + TimeIndexToHrMinString(state, TimeStepIndex);
     print(state.files.eio,
-          " System Sizing Information, {}, {}, {}, {:.2R}, {:.5R}, {:.5R}, {}, {}\n",
+          " System Sizing Information, {}, {}, {}, {:.2f}, {:.5f}, {:.5f}, {}, {}\n",
           SysName,
           LoadType,
           PeakLoadKind,

--- a/src/EnergyPlus/SolarCollectors.cc
+++ b/src/EnergyPlus/SolarCollectors.cc
@@ -106,8 +106,7 @@ namespace SolarCollectors {
             }
         }
         // If we didn't find it, fatal
-        ShowFatalError(state,
-                       EnergyPlus::format("LocalSolarCollectorFactory: Error getting inputs for object named: {}", objectName)); // LCOV_EXCL_LINE
+        ShowFatalError(state, std::format("LocalSolarCollectorFactory: Error getting inputs for object named: {}", objectName)); // LCOV_EXCL_LINE
         // Shut up the compiler
         return nullptr; // LCOV_EXCL_LINE
     }
@@ -228,10 +227,10 @@ namespace SolarCollectors {
                         state.dataIPShortCut->rNumericArgs(2) * Psychrometrics::RhoH2O(Constant::InitConvTemp);
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}:  flow rate must be greater than zero for {}",
-                                                       CurrentModuleParamObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       state.dataIPShortCut->cNumericFieldNames(2)));
+                                    std::format("{} = {}:  flow rate must be greater than zero for {}",
+                                                CurrentModuleParamObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                state.dataIPShortCut->cNumericFieldNames(2)));
                     ErrorsFound = true;
                 }
 
@@ -239,11 +238,11 @@ namespace SolarCollectors {
                 state.dataSolarCollectors->Parameters(ParametersNum).TestType = static_cast<TestTypeEnum>(getEnumValue(testTypesUC, key));
                 if (state.dataSolarCollectors->Parameters(ParametersNum).TestType == TestTypeEnum::INVALID) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}: {} is not supported for {}",
-                                                       CurrentModuleParamObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       key,
-                                                       state.dataIPShortCut->cAlphaFieldNames(3)));
+                                    std::format("{} = {}: {} is not supported for {}",
+                                                CurrentModuleParamObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                key,
+                                                state.dataIPShortCut->cAlphaFieldNames(3)));
                     ErrorsFound = true;
                 }
 
@@ -272,7 +271,7 @@ namespace SolarCollectors {
             } // ParametersNum
 
             if (ErrorsFound) {
-                ShowFatalError(state, EnergyPlus::format("Errors in {} input.", CurrentModuleParamObject));
+                ShowFatalError(state, std::format("Errors in {} input.", CurrentModuleParamObject));
             }
         }
 
@@ -306,11 +305,11 @@ namespace SolarCollectors {
 
                 if (ParametersNum == 0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}: {} object called {} not found.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       CurrentModuleParamObject,
-                                                       state.dataIPShortCut->cAlphaArgs(2)));
+                                    std::format("{} = {}: {} object called {} not found.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                CurrentModuleParamObject,
+                                                state.dataIPShortCut->cAlphaArgs(2)));
                     ErrorsFound = true;
                 } else {
                     state.dataSolarCollectors->Collector(CollectorNum).Parameters = ParametersNum;
@@ -321,34 +320,33 @@ namespace SolarCollectors {
 
                 if (SurfNum == 0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}:  Surface {} not found.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       state.dataIPShortCut->cAlphaArgs(3)));
+                                    std::format("{} = {}:  Surface {} not found.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                state.dataIPShortCut->cAlphaArgs(3)));
                     ErrorsFound = true;
                     continue; // avoid hard crash
                 }
                 if (!state.dataSurface->Surface(SurfNum).ExtSolar) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("{} = {}:  Surface {} is not exposed to exterior radiation.",
-                                                        CurrentModuleObject,
-                                                        state.dataIPShortCut->cAlphaArgs(1),
-                                                        state.dataIPShortCut->cAlphaArgs(3)));
+                                     std::format("{} = {}:  Surface {} is not exposed to exterior radiation.",
+                                                 CurrentModuleObject,
+                                                 state.dataIPShortCut->cAlphaArgs(1),
+                                                 state.dataIPShortCut->cAlphaArgs(3)));
                 }
 
                 // check surface orientation, warn if upside down
                 if ((state.dataSurface->Surface(SurfNum).Tilt < -95.0) || (state.dataSurface->Surface(SurfNum).Tilt > 95.0)) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("Suspected input problem with {} = {}",
-                                                        state.dataIPShortCut->cAlphaFieldNames(3),
-                                                        state.dataIPShortCut->cAlphaArgs(3)));
+                                     std::format("Suspected input problem with {} = {}",
+                                                 state.dataIPShortCut->cAlphaFieldNames(3),
+                                                 state.dataIPShortCut->cAlphaArgs(3)));
+                    ShowContinueError(
+                        state, std::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                    ShowContinueError(state, "Surface used for solar collector faces down");
                     ShowContinueError(
                         state,
-                        EnergyPlus::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
-                    ShowContinueError(state, "Surface used for solar collector faces down");
-                    ShowContinueError(state,
-                                      EnergyPlus::format("Surface tilt angle (degrees from ground outward normal) = {:.2R}",
-                                                         state.dataSurface->Surface(SurfNum).Tilt));
+                        std::format("Surface tilt angle (degrees from ground outward normal) = {:.2f}", state.dataSurface->Surface(SurfNum).Tilt));
                 }
 
                 // Check to make sure other solar collectors are not using the same surface
@@ -356,11 +354,11 @@ namespace SolarCollectors {
                 for (int CollectorNum2 = 1; CollectorNum2 <= NumFlatPlateUnits; ++CollectorNum2) {
                     if (state.dataSolarCollectors->Collector(CollectorNum2).Surface == SurfNum) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{} = {}:  Surface {} is referenced by more than one {}",
-                                                           CurrentModuleObject,
-                                                           state.dataIPShortCut->cAlphaArgs(1),
-                                                           state.dataIPShortCut->cAlphaArgs(3),
-                                                           CurrentModuleObject));
+                                        std::format("{} = {}:  Surface {} is referenced by more than one {}",
+                                                    CurrentModuleObject,
+                                                    state.dataIPShortCut->cAlphaArgs(1),
+                                                    state.dataIPShortCut->cAlphaArgs(3),
+                                                    CurrentModuleObject));
                         ErrorsFound = true;
                         break;
                     }
@@ -374,11 +372,10 @@ namespace SolarCollectors {
                             state.dataSurface->Surface(SurfNum).Area >
                         0.01) {
 
-                    ShowWarningError(
-                        state,
-                        EnergyPlus::format("{} = {}:  Gross Area of solar collector parameters and surface object differ by more than 1%.",
-                                           CurrentModuleObject,
-                                           state.dataIPShortCut->cAlphaArgs(1)));
+                    ShowWarningError(state,
+                                     std::format("{} = {}:  Gross Area of solar collector parameters and surface object differ by more than 1%.",
+                                                 CurrentModuleObject,
+                                                 state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state, "Area of surface object will be used in all calculations.");
                 }
 
@@ -462,19 +459,19 @@ namespace SolarCollectors {
                 // NOTE:  This collector gross area is used in all the calculations.
                 state.dataSolarCollectors->Parameters(ParametersNum).Area = state.dataIPShortCut->rNumericArgs(1);
                 if (state.dataIPShortCut->rNumericArgs(1) <= 0.0) {
-                    ShowSevereError(state, EnergyPlus::format("{} = {}", CurrentModuleParamObject, state.dataIPShortCut->cAlphaArgs(1)));
-                    ShowContinueError(state,
-                                      EnergyPlus::format(
-                                          "Illegal {} = {:.2R}", state.dataIPShortCut->cNumericFieldNames(1), state.dataIPShortCut->rNumericArgs(1)));
+                    ShowSevereError(state, std::format("{} = {}", CurrentModuleParamObject, state.dataIPShortCut->cAlphaArgs(1)));
+                    ShowContinueError(
+                        state,
+                        std::format("Illegal {} = {:.2f}", state.dataIPShortCut->cNumericFieldNames(1), state.dataIPShortCut->rNumericArgs(1)));
                     ShowContinueError(state, " Collector gross area must be always greater than zero.");
                     ErrorsFound = true;
                 }
                 state.dataSolarCollectors->Parameters(ParametersNum).Volume = state.dataIPShortCut->rNumericArgs(2);
                 if (state.dataIPShortCut->rNumericArgs(2) <= 0.0) {
-                    ShowSevereError(state, EnergyPlus::format("{} = {}", CurrentModuleParamObject, state.dataIPShortCut->cAlphaArgs(1)));
-                    ShowContinueError(state,
-                                      EnergyPlus::format(
-                                          "Illegal {} = {:.2R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
+                    ShowSevereError(state, std::format("{} = {}", CurrentModuleParamObject, state.dataIPShortCut->cAlphaArgs(1)));
+                    ShowContinueError(
+                        state,
+                        std::format("Illegal {} = {:.2f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
                     ShowContinueError(state, " Collector water volume must be always greater than zero.");
                     ErrorsFound = true;
                 }
@@ -501,7 +498,7 @@ namespace SolarCollectors {
                         state.dataSolarCollectors->Parameters(ParametersNum).ExtCoefTimesThickness[1] = state.dataIPShortCut->rNumericArgs(14);
                         state.dataSolarCollectors->Parameters(ParametersNum).EmissOfCover[1] = state.dataIPShortCut->rNumericArgs(15);
                     } else {
-                        ShowSevereError(state, EnergyPlus::format("{} = {}", CurrentModuleParamObject, state.dataIPShortCut->cAlphaArgs(1)));
+                        ShowSevereError(state, std::format("{} = {}", CurrentModuleParamObject, state.dataIPShortCut->cAlphaArgs(1)));
                         ShowContinueError(state, "Illegal input for one of the three inputs of the inner cover optical properties");
                         ErrorsFound = true;
                     }
@@ -513,10 +510,10 @@ namespace SolarCollectors {
                     // Outer cover emissivity
                     state.dataSolarCollectors->Parameters(ParametersNum).EmissOfCover[0] = state.dataIPShortCut->rNumericArgs(12);
                 } else {
-                    ShowSevereError(state, EnergyPlus::format("{} = {}", CurrentModuleParamObject, state.dataIPShortCut->cAlphaArgs(1)));
-                    ShowContinueError(state,
-                                      EnergyPlus::format(
-                                          "Illegal {} = {:.2R}", state.dataIPShortCut->cNumericFieldNames(8), state.dataIPShortCut->rNumericArgs(8)));
+                    ShowSevereError(state, std::format("{} = {}", CurrentModuleParamObject, state.dataIPShortCut->cAlphaArgs(1)));
+                    ShowContinueError(
+                        state,
+                        std::format("Illegal {} = {:.2f}", state.dataIPShortCut->cNumericFieldNames(8), state.dataIPShortCut->rNumericArgs(8)));
                     ErrorsFound = true;
                 }
                 // Solar absorptance of the absorber plate
@@ -527,7 +524,7 @@ namespace SolarCollectors {
             } // end of ParametersNum
 
             if (ErrorsFound) {
-                ShowFatalError(state, EnergyPlus::format("Errors in {} input.", CurrentModuleParamObject));
+                ShowFatalError(state, std::format("Errors in {} input.", CurrentModuleParamObject));
             }
 
             CurrentModuleObject = "SolarCollector:IntegralCollectorStorage";
@@ -567,11 +564,11 @@ namespace SolarCollectors {
 
                 if (ParametersNum == 0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}: {} object called {} not found.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       CurrentModuleParamObject,
-                                                       state.dataIPShortCut->cAlphaArgs(2)));
+                                    std::format("{} = {}: {} object called {} not found.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                CurrentModuleParamObject,
+                                                state.dataIPShortCut->cAlphaArgs(2)));
                     ErrorsFound = true;
                 } else {
                     state.dataSolarCollectors->Collector(CollectorNum).Parameters = ParametersNum;
@@ -598,10 +595,10 @@ namespace SolarCollectors {
 
                 if (SurfNum == 0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}:  Surface {} not found.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       state.dataIPShortCut->cAlphaArgs(3)));
+                                    std::format("{} = {}:  Surface {} not found.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                state.dataIPShortCut->cAlphaArgs(3)));
                     ErrorsFound = true;
                     continue; // avoid hard crash
                 }
@@ -622,9 +619,9 @@ namespace SolarCollectors {
                     ShowContinueError(
                         state, std::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state, "Surface used for solar collector faces down");
-                    ShowContinueError(state,
-                                      EnergyPlus::format("Surface tilt angle (degrees from ground outward normal) = {:.2R}",
-                                                         state.dataSurface->Surface(SurfNum).Tilt));
+                    ShowContinueError(
+                        state,
+                        std::format("Surface tilt angle (degrees from ground outward normal) = {:.2f}", state.dataSurface->Surface(SurfNum).Tilt));
                 }
 
                 // Check to make sure other solar collectors are not using the same surface

--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -444,8 +444,7 @@ void GetShadowingInput(EnergyPlusData &state)
     NumAlphas = 0;
     NumNumbers = 0;
     if (NumItems > 1) {
-        ShowWarningError(state,
-                         EnergyPlus::format("{}: More than 1 occurrence of this object found, only first will be used.", cCurrentModuleObject));
+        ShowWarningError(state, std::format("{}: More than 1 occurrence of this object found, only first will be used.", cCurrentModuleObject));
     }
 
     if (NumItems != 0) {
@@ -469,9 +468,9 @@ void GetShadowingInput(EnergyPlusData &state)
         state.dataSolarShading->ShadowingCalcFrequency = 20;
     }
     if (state.dataSolarShading->ShadowingCalcFrequency > 31) {
-        ShowWarningError(state, EnergyPlus::format("{}: suspect {}", cCurrentModuleObject, state.dataIPShortCut->cNumericFieldNames(1)));
-        ShowContinueError(
-            state, EnergyPlus::format("Value entered=[{:.0R}], Shadowing Calculations will be inaccurate.", state.dataIPShortCut->rNumericArgs(1)));
+        ShowWarningError(state, std::format("{}: suspect {}", cCurrentModuleObject, state.dataIPShortCut->cNumericFieldNames(1)));
+        ShowContinueError(state,
+                          std::format("Value entered=[{:.0f}], Shadowing Calculations will be inaccurate.", state.dataIPShortCut->rNumericArgs(1)));
     }
 
     if (state.dataIPShortCut->rNumericArgs(2) > 199.0) {
@@ -491,11 +490,11 @@ void GetShadowingInput(EnergyPlusData &state)
                 state.dataSysVars->shadingMethod = ShadingMethod::Imported;
                 state.dataIPShortCut->cAlphaArgs(aNum) = "Imported";
             } else {
-                ShowWarningError(state, EnergyPlus::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
+                ShowWarningError(state, std::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
                 ShowContinueError(
                     state,
-                    EnergyPlus::format("Value entered=\"{}\" while no Schedule:File:Shading object is defined, InternalCalculation will be used.",
-                                       state.dataIPShortCut->cAlphaArgs(aNum)));
+                    std::format("Value entered=\"{}\" while no Schedule:File:Shading object is defined, InternalCalculation will be used.",
+                                state.dataIPShortCut->cAlphaArgs(aNum)));
             }
         } else if (Util::SameString(state.dataIPShortCut->cAlphaArgs(aNum), "PolygonClipping")) {
             state.dataSysVars->shadingMethod = ShadingMethod::PolygonClipping;
@@ -507,8 +506,8 @@ void GetShadowingInput(EnergyPlusData &state)
                 pixelRes = (unsigned)state.dataIPShortCut->rNumericArgs(3);
             }
 #ifdef EP_NO_OPENGL
-            ShowWarningError(state, EnergyPlus::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
-            ShowContinueError(state, EnergyPlus::format("Value entered=\"{}\"", state.dataIPShortCut->cAlphaArgs(aNum)));
+            ShowWarningError(state, std::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
+            ShowContinueError(state, std::format("Value entered=\"{}\"", state.dataIPShortCut->cAlphaArgs(aNum)));
             ShowContinueError(state, "This version of EnergyPlus was not compiled to use OpenGL (required for PixelCounting)");
             ShowContinueError(state, "PolygonClipping will be used instead");
             state.dataSysVars->shadingMethod = ShadingMethod::PolygonClipping;
@@ -527,9 +526,8 @@ void GetShadowingInput(EnergyPlusData &state)
             }
 #endif
         } else {
-            ShowWarningError(state, EnergyPlus::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
-            ShowContinueError(state,
-                              EnergyPlus::format("Value entered=\"{}\", PolygonClipping will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
+            ShowWarningError(state, std::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
+            ShowContinueError(state, std::format("Value entered=\"{}\", PolygonClipping will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
         }
     } else {
         state.dataIPShortCut->cAlphaArgs(aNum) = "PolygonClipping";
@@ -545,8 +543,8 @@ void GetShadowingInput(EnergyPlusData &state)
             state.dataSysVars->DetailedSolarTimestepIntegration = true;
             state.dataIPShortCut->cAlphaArgs(aNum) = "Timestep";
         } else {
-            ShowWarningError(state, EnergyPlus::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
-            ShowContinueError(state, EnergyPlus::format("Value entered=\"{}\", Periodic will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
+            ShowWarningError(state, std::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
+            ShowContinueError(state, std::format("Value entered=\"{}\", Periodic will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
             state.dataSysVars->DetailedSolarTimestepIntegration = false;
             state.dataIPShortCut->cAlphaArgs(aNum) = "Periodic";
         }
@@ -578,18 +576,18 @@ void GetShadowingInput(EnergyPlusData &state)
                 }
             }
         } else {
-            ShowWarningError(state, EnergyPlus::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
+            ShowWarningError(state, std::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
             if (!state.dataSysVars->SutherlandHodgman) {
-                ShowContinueError(
-                    state, EnergyPlus::format("Value entered=\"{}\", ConvexWeilerAtherton will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
+                ShowContinueError(state,
+                                  std::format("Value entered=\"{}\", ConvexWeilerAtherton will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
             } else {
                 if (!state.dataSysVars->SlaterBarsky) {
-                    ShowContinueError(
-                        state, EnergyPlus::format("Value entered=\"{}\", SutherlandHodgman will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
-                } else {
                     ShowContinueError(state,
-                                      EnergyPlus::format("Value entered=\"{}\", SlaterBarskyandSutherlandHodgman will be used.",
-                                                         state.dataIPShortCut->cAlphaArgs(aNum)));
+                                      std::format("Value entered=\"{}\", SutherlandHodgman will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
+                } else {
+                    ShowContinueError(
+                        state,
+                        std::format("Value entered=\"{}\", SlaterBarskyandSutherlandHodgman will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
                 }
             }
         }
@@ -617,9 +615,9 @@ void GetShadowingInput(EnergyPlusData &state)
             state.dataSysVars->DetailedSkyDiffuseAlgorithm = false;
             state.dataIPShortCut->cAlphaArgs(aNum) = "SimpleSkyDiffuseModeling";
         } else {
-            ShowWarningError(state, EnergyPlus::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
-            ShowContinueError(
-                state, EnergyPlus::format("Value entered=\"{}\", SimpleSkyDiffuseModeling will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
+            ShowWarningError(state, std::format("{}: invalid {}", cCurrentModuleObject, state.dataIPShortCut->cAlphaFieldNames(aNum)));
+            ShowContinueError(state,
+                              std::format("Value entered=\"{}\", SimpleSkyDiffuseModeling will be used.", state.dataIPShortCut->cAlphaArgs(aNum)));
         }
     } else {
         state.dataIPShortCut->cAlphaArgs(aNum) = "SimpleSkyDiffuseModeling";
@@ -3366,7 +3364,7 @@ void ComputeIntSolarAbsorpFactors(EnergyPlusData &state)
             thisEnclosure.FloorArea = HorizAreaSum;
             ShowWarningError(state, "ComputeIntSolarAbsorpFactors: Solar distribution model is set to place solar gains on the zone floor,");
             ShowContinueError(state, std::format("...Enclosure=\"{}\" has no floor, but has approximate horizontal surfaces.", thisEnclosure.Name));
-            ShowContinueError(state, EnergyPlus::format("...these Tilt > 120 degrees, (area=[{:.2R}] m2) will be used.", HorizAreaSum));
+            ShowContinueError(state, std::format("...these Tilt > 120 degrees, (area=[{:.2f}] m2) will be used.", HorizAreaSum));
         }
 
         // Compute ISABSF

--- a/src/EnergyPlus/StandardRatings.cc
+++ b/src/EnergyPlus/StandardRatings.cc
@@ -602,10 +602,10 @@ namespace StandardRatings {
                     General::SolveRoot(state, Acc, IterMax, SolFla, CondenserOutletTemp, f, CondenserOutletTemp0, CondenserOutletTemp1);
                     if (SolFla == -1) {
                         ShowWarningError(state, "Iteration limit exceeded in calculating Reform Chiller IPLV");
-                        ShowContinueError(state, EnergyPlus::format("Reformulated Chiller IPLV calculation failed for {}", ChillerName));
+                        ShowContinueError(state, std::format("Reformulated Chiller IPLV calculation failed for {}", ChillerName));
                     } else if (SolFla == -2) {
                         ShowWarningError(state, "Bad starting values for calculating Reform Chiller IPLV");
-                        ShowContinueError(state, EnergyPlus::format("Reformulated Chiller IPLV calculation failed for {}", ChillerName));
+                        ShowContinueError(state, std::format("Reformulated Chiller IPLV calculation failed for {}", ChillerName));
                     }
 
                     if (RedCapNum == 0) {
@@ -675,42 +675,41 @@ namespace StandardRatings {
                 } else {
                     {
                         if (ChillerType == DataPlant::PlantEquipmentType::Chiller_ElectricEIR) {
-                            ShowWarningError(state,
-                                             EnergyPlus::format("Chiller:Electric:EIR = {}:  Integrated Part Load Value (IPLV) cannot be calculated.",
-                                                                ChillerName));
+                            ShowWarningError(
+                                state,
+                                std::format("Chiller:Electric:EIR = {}:  Integrated Part Load Value (IPLV) cannot be calculated.", ChillerName));
                         } else if (ChillerType == DataPlant::PlantEquipmentType::Chiller_ElectricReformEIR) {
 
                             ShowWarningError(
                                 state,
-                                EnergyPlus::format("Chiller:Electric:ReformulatedEIR = {}:  Integrated Part Load Value (IPLV) cannot be calculated.",
-                                                   ChillerName));
+                                std::format("Chiller:Electric:ReformulatedEIR = {}:  Integrated Part Load Value (IPLV) cannot be calculated.",
+                                            ChillerName));
                         }
                     }
                     if (RefCap <= 0.0) {
                         ShowContinueError(
                             state,
-                            EnergyPlus::format(
-                                " Check the chiller autosized or user specified capacity. Autosized or specified chiller capacity = {:.2R}", RefCap));
+                            std::format(" Check the chiller autosized or user specified capacity. Autosized or specified chiller capacity = {:.2f}",
+                                        RefCap));
                     }
                     if (RefCOP <= 0.0) {
-                        ShowContinueError(state,
-                                          EnergyPlus::format(" Check the chiller reference or rated COP specified. Specified COP = {:.2R}", RefCOP));
+                        ShowContinueError(state, std::format(" Check the chiller reference or rated COP specified. Specified COP = {:.2f}", RefCOP));
                     }
                     if (ChillerCapFT <= 0.0) {
                         ShowContinueError(
                             state,
-                            EnergyPlus::format(" Check limits in Cooling Capacity Function of Temperature Curve, Curve Type = {}, Curve Name = {}.",
-                                               Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
-                                               GetCurveName(state, CapFTempCurveIndex)));
-                        ShowContinueError(state, EnergyPlus::format(" ..ChillerCapFT value at standard test condition = {:.2R}", ChillerCapFT));
+                            std::format(" Check limits in Cooling Capacity Function of Temperature Curve, Curve Type = {}, Curve Name = {}.",
+                                        Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
+                                        GetCurveName(state, CapFTempCurveIndex)));
+                        ShowContinueError(state, std::format(" ..ChillerCapFT value at standard test condition = {:.2f}", ChillerCapFT));
                     }
                     if (ChillerEIRFT <= 0.0) {
                         ShowContinueError(
                             state,
-                            EnergyPlus::format(" Check limits in EIR Function of Temperature Curve, Curve Type = {}, Curve Name = {}.",
-                                               Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
-                                               GetCurveName(state, EIRFTempCurveIndex)));
-                        ShowContinueError(state, EnergyPlus::format(" ..ChillerEIRFT value at standard test condition = {:.2R}", ChillerEIRFT));
+                            std::format(" Check limits in EIR Function of Temperature Curve, Curve Type = {}, Curve Name = {}.",
+                                        Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
+                                        GetCurveName(state, EIRFTempCurveIndex)));
+                        ShowContinueError(state, std::format(" ..ChillerEIRFT value at standard test condition = {:.2f}", ChillerEIRFT));
                     }
                     IPLV = 0.0;
                     break;
@@ -758,7 +757,7 @@ namespace StandardRatings {
         }
 
         {
-            static constexpr std::string_view Format_991(" Chiller Standard Rating Information, {}, {}, {:.2R}, {:.2R}\n");
+            static constexpr std::string_view Format_991(" Chiller Standard Rating Information, {}, {}, {:.2f}, {:.2f}\n");
             if (ChillerType == DataPlant::PlantEquipmentType::Chiller_ElectricEIR) {
 
                 print(state.files.eio, Format_991, "Chiller:Electric:EIR", ChillerName, IPLVValueSI, IPLVValueIP);
@@ -860,30 +859,27 @@ namespace StandardRatings {
 
                     ShowWarningError(
                         state,
-                        EnergyPlus::format(
-                            "Chiller:Electric:EIR = {}:  Integrated Part Load Value (IPLV) calculated is not at the AHRI test condition.",
-                            ChillerName));
+                        std::format("Chiller:Electric:EIR = {}:  Integrated Part Load Value (IPLV) calculated is not at the AHRI test condition.",
+                                    ChillerName));
                 } else if (ChillerType == DataPlant::PlantEquipmentType::Chiller_ElectricReformEIR) {
 
                     ShowWarningError(
                         state,
-                        EnergyPlus::format(
+                        std::format(
                             "Chiller:Electric:ReformulatedEIR = {}:  Integrated Part Load Value (IPLV) calculated is not at the AHRI test condition.",
                             ChillerName));
                 }
                 if (CapCurveIPLVLimitsExceeded) {
-                    ShowContinueError(
-                        state,
-                        EnergyPlus::format(" Check limits in Cooling Capacity Function of Temperature Curve, Curve Type = {}, Curve Name = {}",
-                                           Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
-                                           GetCurveName(state, CapFTempCurveIndex)));
+                    ShowContinueError(state,
+                                      std::format(" Check limits in Cooling Capacity Function of Temperature Curve, Curve Type = {}, Curve Name = {}",
+                                                  Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
+                                                  GetCurveName(state, CapFTempCurveIndex)));
                 }
                 if (EIRCurveIPLVLimitsExceeded) {
-                    ShowContinueError(
-                        state,
-                        EnergyPlus::format(" Check limits in EIR Function of Temperature Curve, Curve Type = {}, Curve Name = {}",
-                                           Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
-                                           GetCurveName(state, EIRFTempCurveIndex)));
+                    ShowContinueError(state,
+                                      std::format(" Check limits in EIR Function of Temperature Curve, Curve Type = {}, Curve Name = {}",
+                                                  Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
+                                                  GetCurveName(state, EIRFTempCurveIndex)));
                 }
             }
         }
@@ -2122,65 +2118,62 @@ namespace StandardRatings {
         if (TotCapTempModFacRated < 0.0 || CapTempModFacH2Test < 0.0 || CapTempModFacH3Test < 0.0 || EIRTempModFacRated < 0.0 ||
             EIRTempModFacH2Test < 0.0 || EIRTempModFacH3Test < 0.0) {
             if (TotCapTempModFacRated < 0.0) {
-                ShowSevereError(state,
-                                EnergyPlus::format(
-                                    " Invalid Total Heating Capacity Function of Temperature Curve value = {:.2R}, Curve Type = {}, Curve Name = {}",
-                                    TotCapTempModFacRated,
-                                    Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
-                                    GetCurveName(state, CapFTempCurveIndex)));
+                ShowSevereError(
+                    state,
+                    std::format(" Invalid Total Heating Capacity Function of Temperature Curve value = {:.2f}, Curve Type = {}, Curve Name = {}",
+                                TotCapTempModFacRated,
+                                Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
+                                GetCurveName(state, CapFTempCurveIndex)));
                 ShowContinueError(state,
                                   " ...Net heating capacity at high temperature is set to zero. The curve value must be > 0. Check the curve.");
                 NetHeatingCapRated = 0.0;
                 NetHeatingCapRated_2023 = 0.0;
             }
             if (CapTempModFacH3Test < 0.0) {
-                ShowSevereError(state,
-                                EnergyPlus::format(
-                                    " Invalid Total Heating Capacity Function of Temperature Curve value = {:.2R}, Curve Type = {}, Curve Name = {}",
-                                    CapTempModFacH3Test,
-                                    Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
-                                    GetCurveName(state, CapFTempCurveIndex)));
+                ShowSevereError(
+                    state,
+                    std::format(" Invalid Total Heating Capacity Function of Temperature Curve value = {:.2f}, Curve Type = {}, Curve Name = {}",
+                                CapTempModFacH3Test,
+                                Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
+                                GetCurveName(state, CapFTempCurveIndex)));
                 ShowContinueError(state, " ...Net heating capacity at low temperature is set to zero. The curve value must be > 0. Check the curve.");
                 NetHeatingCapH3Test = 0.0;
                 NetHeatingCapH3Test_2023 = 0.0;
             }
             if (CapTempModFacH2Test < 0.0) {
-                ShowSevereError(state,
-                                EnergyPlus::format(
-                                    " Invalid Total Heating Capacity Function of Temperature Curve value = {:.2R}, Curve Type = {}, Curve Name = {}",
-                                    CapTempModFacH2Test,
-                                    Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
-                                    GetCurveName(state, CapFTempCurveIndex)));
+                ShowSevereError(
+                    state,
+                    std::format(" Invalid Total Heating Capacity Function of Temperature Curve value = {:.2f}, Curve Type = {}, Curve Name = {}",
+                                CapTempModFacH2Test,
+                                Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(CapFTempCurveIndex)->curveType)],
+                                GetCurveName(state, CapFTempCurveIndex)));
                 ShowContinueError(state, " ...HSPF calculation is incorrect. The curve value must be > 0. Check the curve.");
                 NetHeatingCapH3Test = 0.0;
                 NetHeatingCapH3Test_2023 = 0.0;
             }
             // check EIR curve values
             if (EIRTempModFacRated < 0.0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format(" Invalid EIR Function of Temperature Curve value = {:.2R}, Curve Type = {}, Curve Name = {}",
-                                       EIRTempModFacRated,
-                                       Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
-                                       GetCurveName(state, EIRFTempCurveIndex)));
+                ShowSevereError(state,
+                                std::format(" Invalid EIR Function of Temperature Curve value = {:.2f}, Curve Type = {}, Curve Name = {}",
+                                            EIRTempModFacRated,
+                                            Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
+                                            GetCurveName(state, EIRFTempCurveIndex)));
                 ShowContinueError(state, " ...HSPF calculation is incorrect. The curve value must be > 0. Check the curve.");
             }
             if (EIRTempModFacH2Test < 0.0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format(" Invalid EIR Function of Temperature Curve value = {:.2R}, Curve Type = {}, Curve Name = {}",
-                                       EIRTempModFacH2Test,
-                                       Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
-                                       GetCurveName(state, EIRFTempCurveIndex)));
+                ShowSevereError(state,
+                                std::format(" Invalid EIR Function of Temperature Curve value = {:.2f}, Curve Type = {}, Curve Name = {}",
+                                            EIRTempModFacH2Test,
+                                            Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
+                                            GetCurveName(state, EIRFTempCurveIndex)));
                 ShowContinueError(state, " ...HSPF calculation is incorrect. The curve value must be > 0. Check the curve.");
             }
             if (EIRTempModFacH3Test < 0.0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format(" Invalid EIR Function of Temperature Curve value = {:.2R}, Curve Type = {}, Curve Name = {}",
-                                       EIRTempModFacH3Test,
-                                       Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
-                                       GetCurveName(state, EIRFTempCurveIndex)));
+                ShowSevereError(state,
+                                std::format(" Invalid EIR Function of Temperature Curve value = {:.2f}, Curve Type = {}, Curve Name = {}",
+                                            EIRTempModFacH3Test,
+                                            Curve::objectNames[static_cast<int>(state.dataCurveManager->curves(EIRFTempCurveIndex)->curveType)],
+                                            GetCurveName(state, EIRFTempCurveIndex)));
                 ShowContinueError(state, " ...HSPF calculation is incorrect. The curve value must be > 0. Check the curve.");
             }
             ShowContinueError(state, " ...HSPF value has been reset to 0.0 and simulation is continuing.");
@@ -3777,12 +3770,11 @@ namespace StandardRatings {
             }
 
         } else {
-            ShowSevereError(
-                state,
-                EnergyPlus::format("Standard Ratings: {} {} has esither zero rated total cooling capacity or zero rated air volume flow rate. "
-                                   "Standard ratings cannot be calculated.",
-                                   HVAC::coilTypeNames[(int)coilType],
-                                   DXCoilName));
+            ShowSevereError(state,
+                            std::format("Standard Ratings: {} {} has esither zero rated total cooling capacity or zero rated air volume flow rate. "
+                                        "Standard ratings cannot be calculated.",
+                                        HVAC::coilTypeNames[(int)coilType],
+                                        DXCoilName));
         }
         return StandarRatingResults;
     }
@@ -3885,11 +3877,10 @@ namespace StandardRatings {
                 }
             }
         } else {
-            ShowSevereError(
-                state,
-                EnergyPlus::format("Standard Ratings: {} {} has zero rated total cooling capacity. Capacity and Power cannot be calculated.",
-                                   HVAC::coilTypeNames[(int)coilType],
-                                   DXCoilName));
+            ShowSevereError(state,
+                            std::format("Standard Ratings: {} {} has zero rated total cooling capacity. Capacity and Power cannot be calculated.",
+                                        HVAC::coilTypeNames[(int)coilType],
+                                        DXCoilName));
         }
     }
 
@@ -5662,9 +5653,9 @@ namespace StandardRatings {
 
         } else {
             ShowSevereError(state,
-                            EnergyPlus::format("Standard Ratings: Coil:Cooling:DX {}"
-                                               " has zero rated total cooling capacity. Standard ratings cannot be calculated.",
-                                               DXCoilName)); // TODO: Use dynamic COIL TYPE and COIL INSTANCE name later);
+                            std::format("Standard Ratings: Coil:Cooling:DX {}"
+                                        " has zero rated total cooling capacity. Standard ratings cannot be calculated.",
+                                        DXCoilName)); // TODO: Use dynamic COIL TYPE and COIL INSTANCE name later);
         }
 
         // From SEER2 implementation
@@ -6775,7 +6766,7 @@ namespace StandardRatings {
                 }
 
                 static constexpr std::string_view Format_991(
-                    " DX Cooling Coil Standard Rating Information, {}, {}, {:.1R}, {:.2R}, {:.2R}, {:.2R}, {:.2R}, {:.1R}\n");
+                    " DX Cooling Coil Standard Rating Information, {}, {}, {:.1f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.1f}\n");
                 print(state.files.eio,
                       Format_991,
                       HVAC::coilTypeNames[(int)coilType],
@@ -6831,7 +6822,7 @@ namespace StandardRatings {
                 }
 
                 static constexpr std::string_view Format_991_(
-                    " DX Cooling Coil AHRI 2023 Standard Rating Information, {}, {}, {:.1R}, {:.2R}, {:.2R}, {:.2R}, {:.2R}, {:.1R}\n");
+                    " DX Cooling Coil AHRI 2023 Standard Rating Information, {}, {}, {:.1f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.1f}\n");
                 print(state.files.eio,
                       Format_991_,
                       HVAC::coilTypeNames[(int)coilType],
@@ -6888,7 +6879,7 @@ namespace StandardRatings {
                     state.dataHVACGlobal->StandardRatingsMyHeatOneTimeFlag = false;
                 }
 
-                static constexpr std::string_view Format_993(" DX Heating Coil Standard Rating Information, {}, {}, {:.1R}, {:.1R}, {:.2R}, {}\n");
+                static constexpr std::string_view Format_993(" DX Heating Coil Standard Rating Information, {}, {}, {:.1f}, {:.1f}, {:.2f}, {}\n");
                 print(state.files.eio,
                       Format_993,
                       HVAC::coilTypeNames[(int)coilType],
@@ -6918,7 +6909,7 @@ namespace StandardRatings {
                 }
 
                 static constexpr std::string_view Format_993_(
-                    " DX Heating Coil AHRI 2023 Standard Rating Information, {}, {}, {:.1R}, {:.1R}, {:.2R}, {}\n");
+                    " DX Heating Coil AHRI 2023 Standard Rating Information, {}, {}, {:.1f}, {:.1f}, {:.2f}, {}\n");
                 print(state.files.eio,
                       Format_993_,
                       HVAC::coilTypeNames[(int)coilType],
@@ -6955,7 +6946,7 @@ namespace StandardRatings {
                 }
 
                 static constexpr std::string_view Format_995(
-                    " DX Cooling Coil Standard Rating Information, {}, {}, {:.1R}, {:.2R}, {:.2R}, {:.2R}, {:.2R}, {}\n");
+                    " DX Cooling Coil Standard Rating Information, {}, {}, {:.1f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {}\n");
                 print(state.files.eio,
                       Format_995,
                       HVAC::coilTypeNames[(int)coilType],
@@ -7009,7 +7000,7 @@ namespace StandardRatings {
                 }
 
                 static constexpr std::string_view Format_995_(
-                    " DX Cooling Coil AHRI 2023 Standard Rating Information, {}, {}, {:.1R}, {:.2R}, {:.2R}, {:.2R}, {:.2R}, {:.1R}\n");
+                    " DX Cooling Coil AHRI 2023 Standard Rating Information, {}, {}, {:.1f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.1f}\n");
                 print(state.files.eio,
                       Format_995_,
                       HVAC::coilTypeNames[(int)coilType],
@@ -7104,11 +7095,11 @@ namespace StandardRatings {
             }
             for (int ClassNum = 1; ClassNum <= 4; ++ClassNum) {
                 int Num = (ClassNum - 1) * 4;
-                std::string ClassName = EnergyPlus::format("Class {}", ClassNum);
-                std::string CompNameNew = EnergyPlus::format("{}({})", CompName, ClassName);
+                std::string ClassName = std::format("Class {}", ClassNum);
+                std::string CompNameNew = std::format("{}({})", CompName, ClassName);
                 static constexpr std::string_view Format_102(
-                    " DX Cooling Coil ASHRAE 127 Standard Ratings Information, {}, {}, {}, {:.1R}, {:.1R}, {:.1R}, "
-                    "{:.1R}, {:.1R}, {:.1R}, {:.1R}, {:.1R}\n");
+                    " DX Cooling Coil ASHRAE 127 Standard Ratings Information, {}, {}, {}, {:.1f}, {:.1f}, {:.1f}, "
+                    "{:.1f}, {:.1f}, {:.1f}, {:.1f}, {:.1f}\n");
                 print(state.files.eio,
                       Format_102,
                       HVAC::coilTypeNames[(int)coilType],
@@ -7123,10 +7114,10 @@ namespace StandardRatings {
                       NetCoolingCapRated(Num + 4),
                       TotElectricPowerRated(Num + 4));
                 PreDefTableEntry(state, state.dataOutRptPredefined->pdchDXCoolCoilType2, CompNameNew, HVAC::coilTypeNames[(int)coilType]);
-                // Note: If you call format("{:.1R}", NetCoolingCapRated(Num + 1)),
+                // Note: If you call format("{:.1f}", NetCoolingCapRated(Num + 1)),
                 // Then it's not the OutputReportPredefined::PreDefTableEntry prototype with Real64 that is called.
                 // As a result, the entry isn't marked as being Real (origEntryIsReal) and unit conversion does not occur
-                // Bad: PreDefTableEntry(state, pdchDXCoolCoilNetCapSIA, CompNameNew, format("{:.1R}", NetCoolingCapRated(Num + 1)));
+                // Bad: PreDefTableEntry(state, pdchDXCoolCoilNetCapSIA, CompNameNew, format("{:.1f}", NetCoolingCapRated(Num + 1)));
                 PreDefTableEntry(state, state.dataOutRptPredefined->pdchDXCoolCoilNetCapSIA, CompNameNew, NetCoolingCapRated(Num + 1), 1);
                 PreDefTableEntry(state, state.dataOutRptPredefined->pdchDXCoolCoilNetCapSIB, CompNameNew, NetCoolingCapRated(Num + 2), 1);
                 PreDefTableEntry(state, state.dataOutRptPredefined->pdchDXCoolCoilNetCapSIC, CompNameNew, NetCoolingCapRated(Num + 3), 1);
@@ -7303,16 +7294,15 @@ namespace StandardRatings {
 
                 ShowWarningError(
                     state,
-                    EnergyPlus::format("The Standard Ratings is calculated for {} = {} but not at the AHRI test condition due to curve out of bound.",
-                                       HVAC::coilTypeNames[(int)coilType],
-                                       DXCoilName));
+                    std::format("The Standard Ratings is calculated for {} = {} but not at the AHRI test condition due to curve out of bound.",
+                                HVAC::coilTypeNames[(int)coilType],
+                                DXCoilName));
                 ShowContinueError(state,
                                   " Review the Standard Ratings calculations in the Engineering Reference for this coil type. Also, use "
                                   "Output:Diagnostics, DisplayExtraWarnings for further guidance.");
 
                 if (state.dataGlobal->DisplayExtraWarnings) {
-                    ShowContinueError(state,
-                                      EnergyPlus::format("{}The max and/or min limits specified in the corresponding curve objects", RoutineName));
+                    ShowContinueError(state, std::format("{}The max and/or min limits specified in the corresponding curve objects", RoutineName));
                     ShowContinueError(state,
                                       " do not include the AHRI test conditions required to calculate one or more of the Standard Rating values.");
                 }

--- a/src/EnergyPlus/SteamBaseboardRadiator.cc
+++ b/src/EnergyPlus/SteamBaseboardRadiator.cc
@@ -143,26 +143,25 @@ namespace SteamBaseboardRadiator {
         if (CompIndex == 0) {
             BaseboardNum = Util::FindItemInList(EquipName, state.dataSteamBaseboardRadiator->SteamBaseboard, &SteamBaseboardParams::Name);
             if (BaseboardNum == 0) {
-                ShowFatalError(state, EnergyPlus::format("SimSteamBaseboard: Unit not found={}", EquipName));
+                ShowFatalError(state, std::format("SimSteamBaseboard: Unit not found={}", EquipName));
             }
             CompIndex = BaseboardNum;
         } else {
             BaseboardNum = CompIndex;
             if (BaseboardNum > state.dataSteamBaseboardRadiator->NumSteamBaseboards || BaseboardNum < 1) {
                 ShowFatalError(state,
-                               EnergyPlus::format("SimSteamBaseboard:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
-                                                  BaseboardNum,
-                                                  state.dataSteamBaseboardRadiator->NumSteamBaseboards,
-                                                  EquipName));
+                               std::format("SimSteamBaseboard:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
+                                           BaseboardNum,
+                                           state.dataSteamBaseboardRadiator->NumSteamBaseboards,
+                                           EquipName));
             }
             if (state.dataSteamBaseboardRadiator->CheckEquipName(BaseboardNum)) {
                 if (EquipName != state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).Name) {
-                    ShowFatalError(
-                        state,
-                        EnergyPlus::format("SimSteamBaseboard: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
-                                           BaseboardNum,
-                                           EquipName,
-                                           state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).Name));
+                    ShowFatalError(state,
+                                   std::format("SimSteamBaseboard: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
+                                               BaseboardNum,
+                                               EquipName,
+                                               state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).Name));
                 }
                 state.dataSteamBaseboardRadiator->CheckEquipName(BaseboardNum) = false;
             }
@@ -216,8 +215,8 @@ namespace SteamBaseboardRadiator {
                 } break;
                 default: {
                     ShowSevereError(state,
-                                    EnergyPlus::format("SimSteamBaseboard: Errors in Baseboard={}",
-                                                       state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).Name));
+                                    std::format("SimSteamBaseboard: Errors in Baseboard={}",
+                                                state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).Name));
                     ShowContinueError(state,
                                       EnergyPlus::format("Invalid or unimplemented equipment type={}",
                                                          state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).EquipType));
@@ -242,7 +241,7 @@ namespace SteamBaseboardRadiator {
             ReportSteamBaseboard(state, BaseboardNum);
 
         } else {
-            ShowFatalError(state, EnergyPlus::format("SimSteamBaseboard: Unit not found={}", EquipName));
+            ShowFatalError(state, std::format("SimSteamBaseboard: Unit not found={}", EquipName));
         }
     }
 
@@ -360,44 +359,44 @@ namespace SteamBaseboardRadiator {
                         state.dataIPShortCut->rNumericArgs(iHeatCapacityPerFloorAreaNumericNum);
                     if (state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).DesignScaledHeatingCapacity <= 0.0) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{} = {}",
-                                                           state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
-                                                           state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
+                                        std::format("{} = {}",
+                                                    state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
+                                                    state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
                         ShowContinueError(state,
-                                          EnergyPlus::format("Input for {} = {}",
-                                                             state.dataIPShortCut->cAlphaFieldNames(iHeatCAPMAlphaNum),
-                                                             state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum)));
+                                          std::format("Input for {} = {}",
+                                                      state.dataIPShortCut->cAlphaFieldNames(iHeatCAPMAlphaNum),
+                                                      state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum)));
                         ShowContinueError(state,
-                                          EnergyPlus::format("Illegal {} = {:.7f}",
-                                                             state.dataIPShortCut->cNumericFieldNames(iHeatCapacityPerFloorAreaNumericNum),
-                                                             state.dataIPShortCut->rNumericArgs(iHeatCapacityPerFloorAreaNumericNum)));
+                                          std::format("Illegal {} = {:.7f}",
+                                                      state.dataIPShortCut->cNumericFieldNames(iHeatCapacityPerFloorAreaNumericNum),
+                                                      state.dataIPShortCut->rNumericArgs(iHeatCapacityPerFloorAreaNumericNum)));
                         ErrorsFound = true;
                     } else if (state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).DesignScaledHeatingCapacity == AutoSize) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{} = {}",
-                                                           state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
-                                                           state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
+                                        std::format("{} = {}",
+                                                    state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
+                                                    state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
                         ShowContinueError(state,
-                                          EnergyPlus::format("Input for {} = {}",
-                                                             state.dataIPShortCut->cAlphaFieldNames(iHeatCAPMAlphaNum),
-                                                             state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum)));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Illegal {} = Autosize",
-                                                             state.dataIPShortCut->cNumericFieldNames(iHeatCapacityPerFloorAreaNumericNum)));
+                                          std::format("Input for {} = {}",
+                                                      state.dataIPShortCut->cAlphaFieldNames(iHeatCAPMAlphaNum),
+                                                      state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum)));
+                        ShowContinueError(
+                            state,
+                            std::format("Illegal {} = Autosize", state.dataIPShortCut->cNumericFieldNames(iHeatCapacityPerFloorAreaNumericNum)));
                         ErrorsFound = true;
                     }
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}",
-                                                       state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
-                                                       state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
+                                    std::format("{} = {}",
+                                                state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
+                                                state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
                     ShowContinueError(state,
-                                      EnergyPlus::format("Input for {} = {}",
-                                                         state.dataIPShortCut->cAlphaFieldNames(iHeatCAPMAlphaNum),
-                                                         state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum)));
-                    ShowContinueError(state,
-                                      EnergyPlus::format("Blank field not allowed for {}",
-                                                         state.dataIPShortCut->cNumericFieldNames(iHeatCapacityPerFloorAreaNumericNum)));
+                                      std::format("Input for {} = {}",
+                                                  state.dataIPShortCut->cAlphaFieldNames(iHeatCAPMAlphaNum),
+                                                  state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum)));
+                    ShowContinueError(
+                        state,
+                        std::format("Blank field not allowed for {}", state.dataIPShortCut->cNumericFieldNames(iHeatCapacityPerFloorAreaNumericNum)));
                     ErrorsFound = true;
                 }
             } else if (Util::SameString(state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum), "FractionOfAutosizedHeatingCapacity")) {
@@ -407,24 +406,24 @@ namespace SteamBaseboardRadiator {
                         state.dataIPShortCut->rNumericArgs(iHeatFracOfAutosizedCapacityNumericNum);
                     if (state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).DesignScaledHeatingCapacity < 0.0) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{} = {}",
-                                                           state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
-                                                           state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
+                                        std::format("{} = {}",
+                                                    state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
+                                                    state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
                         ShowContinueError(state,
-                                          EnergyPlus::format("Illegal {} = {:.7f}",
-                                                             state.dataIPShortCut->cNumericFieldNames(iHeatFracOfAutosizedCapacityNumericNum),
-                                                             state.dataIPShortCut->rNumericArgs(iHeatFracOfAutosizedCapacityNumericNum)));
+                                          std::format("Illegal {} = {:.7f}",
+                                                      state.dataIPShortCut->cNumericFieldNames(iHeatFracOfAutosizedCapacityNumericNum),
+                                                      state.dataIPShortCut->rNumericArgs(iHeatFracOfAutosizedCapacityNumericNum)));
                         ErrorsFound = true;
                     }
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}",
-                                                       state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
-                                                       state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
+                                    std::format("{} = {}",
+                                                state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
+                                                state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).designName));
                     ShowContinueError(state,
-                                      EnergyPlus::format("Input for {} = {}",
-                                                         state.dataIPShortCut->cAlphaFieldNames(iHeatCAPMAlphaNum),
-                                                         state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum)));
+                                      std::format("Input for {} = {}",
+                                                  state.dataIPShortCut->cAlphaFieldNames(iHeatCAPMAlphaNum),
+                                                  state.dataIPShortCut->cAlphaArgs(iHeatCAPMAlphaNum)));
                     ShowContinueError(state,
                                       std::format("Blank field not allowed for {}",
                                                   state.dataIPShortCut->cNumericFieldNames(iHeatFracOfAutosizedCapacityNumericNum)));
@@ -464,7 +463,7 @@ namespace SteamBaseboardRadiator {
                                              state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
                                              state.dataIPShortCut->cAlphaArgs(1),
                                              state.dataIPShortCut->cNumericFieldNames(4)));
-                ShowContinueError(state, EnergyPlus::format("...reset to minimum value=[{:.3R}].", MinFraction));
+                ShowContinueError(state, std::format("...reset to minimum value=[{:.3f}].", MinFraction));
                 state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).FracRadiant = MinFraction;
             } else if (state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).FracRadiant > MaxFraction) {
                 ShowWarningError(state,
@@ -473,7 +472,7 @@ namespace SteamBaseboardRadiator {
                                              state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
                                              state.dataIPShortCut->cAlphaArgs(1),
                                              state.dataIPShortCut->cNumericFieldNames(4)));
-                ShowContinueError(state, EnergyPlus::format("...reset to maximum value=[{:.3R}].", MaxFraction));
+                ShowContinueError(state, std::format("...reset to maximum value=[{:.3f}].", MaxFraction));
                 state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).FracRadiant = MaxFraction;
             }
 
@@ -486,7 +485,7 @@ namespace SteamBaseboardRadiator {
                                              state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
                                              state.dataIPShortCut->cAlphaArgs(1),
                                              state.dataIPShortCut->cNumericFieldNames(5)));
-                ShowContinueError(state, EnergyPlus::format("...reset to minimum value=[{:.3R}].", MinFraction));
+                ShowContinueError(state, std::format("...reset to minimum value=[{:.3f}].", MinFraction));
                 state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).FracDistribPerson = MinFraction;
             }
             if (state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).FracDistribPerson > MaxFraction) {
@@ -496,7 +495,7 @@ namespace SteamBaseboardRadiator {
                                              state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam_Design,
                                              state.dataIPShortCut->cAlphaArgs(1),
                                              state.dataIPShortCut->cNumericFieldNames(5)));
-                ShowContinueError(state, EnergyPlus::format("...reset to maximum value=[{:.3R}].", MaxFraction));
+                ShowContinueError(state, std::format("...reset to maximum value=[{:.3f}].", MaxFraction));
                 state.dataSteamBaseboardRadiator->SteamBaseboardDesign(BaseboardDesignNum).FracDistribPerson = MaxFraction;
             }
         }
@@ -638,7 +637,7 @@ namespace SteamBaseboardRadiator {
                                              state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam,
                                              state.dataIPShortCut->cAlphaArgs(1),
                                              state.dataIPShortCut->cNumericFieldNames(3)));
-                ShowContinueError(state, EnergyPlus::format("...reset to maximum value=[{:.2R}].", MaxSteamFlowRate));
+                ShowContinueError(state, std::format("...reset to maximum value=[{:.2f}].", MaxSteamFlowRate));
                 state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamVolFlowRateMax = MaxSteamFlowRate;
             } else if (state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamVolFlowRateMax <= MinSteamFlowRate &&
                        state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamVolFlowRateMax != AutoSize) {
@@ -648,7 +647,7 @@ namespace SteamBaseboardRadiator {
                                              state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam,
                                              state.dataIPShortCut->cAlphaArgs(1),
                                              state.dataIPShortCut->cNumericFieldNames(3)));
-                ShowContinueError(state, EnergyPlus::format("...reset to minimum value=[{:.2R}].", MinSteamFlowRate));
+                ShowContinueError(state, std::format("...reset to minimum value=[{:.2f}].", MinSteamFlowRate));
                 state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SteamVolFlowRateMax = MinSteamFlowRate;
             }
             // Remaining fraction is added to the zone as convective heat transfer
@@ -735,7 +734,7 @@ namespace SteamBaseboardRadiator {
                                                  state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam,
                                                  state.dataIPShortCut->cAlphaArgs(1),
                                                  state.dataIPShortCut->cNumericFieldNames(SurfNum + 3)));
-                    ShowContinueError(state, EnergyPlus::format("...reset to maximum value=[{:.1R}].", MaxFraction));
+                    ShowContinueError(state, std::format("...reset to maximum value=[{:.1f}].", MaxFraction));
                     state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).TotSurfToDistrib = MaxFraction;
                 }
                 if (state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).FracDistribToSurf(SurfNum) < MinFraction) {
@@ -745,7 +744,7 @@ namespace SteamBaseboardRadiator {
                                                  state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam,
                                                  state.dataIPShortCut->cAlphaArgs(1),
                                                  state.dataIPShortCut->cNumericFieldNames(SurfNum + 3)));
-                    ShowContinueError(state, EnergyPlus::format("...reset to maximum value=[{:.1R}].", MinFraction));
+                    ShowContinueError(state, std::format("...reset to maximum value=[{:.1f}].", MinFraction));
                     state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).TotSurfToDistrib = MinFraction;
                 }
                 if (state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).SurfacePtr(SurfNum) != 0) {
@@ -1200,11 +1199,10 @@ namespace SteamBaseboardRadiator {
                                                             "ZoneHVAC:Baseboard:RadiantConvective:Steam=\"{}\".",
                                                             state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).Name));
                                     ShowContinueError(
+                                        state, std::format("User-Specified Maximum Steam Flow Rate of {:.5f} [m3/s]", SteamVolFlowRateMaxUser));
+                                    ShowContinueError(
                                         state,
-                                        EnergyPlus::format("User-Specified Maximum Steam Flow Rate of {:.5R} [m3/s]", SteamVolFlowRateMaxUser));
-                                    ShowContinueError(state,
-                                                      EnergyPlus::format("differs from Design Size Maximum Steam Flow Rate of {:.5R} [m3/s]",
-                                                                         SteamVolFlowRateMaxDes));
+                                        std::format("differs from Design Size Maximum Steam Flow Rate of {:.5f} [m3/s]", SteamVolFlowRateMaxDes));
                                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                                 }
@@ -1497,12 +1495,12 @@ namespace SteamBaseboardRadiator {
                     if (ThisSurfIntensity > MaxRadHeatFlux) { // CR 8074, trap for excessive intensity (throws off surface balance )
                         ShowSevereError(state, "DistributeBBSteamRadGains:  excessive thermal radiation heat flux intensity detected");
                         ShowContinueError(state, std::format("Surface = {}", state.dataSurface->Surface(SurfNum).Name));
-                        ShowContinueError(state, EnergyPlus::format("Surface area = {:.3R} [m2]", state.dataSurface->Surface(SurfNum).Area));
+                        ShowContinueError(state, std::format("Surface area = {:.3f} [m2]", state.dataSurface->Surface(SurfNum).Area));
                         ShowContinueError(state,
                                           std::format("Occurs in {} = {}",
                                                       state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam,
                                                       state.dataSteamBaseboardRadiator->SteamBaseboard(BaseboardNum).Name));
-                        ShowContinueError(state, EnergyPlus::format("Radiation intensity = {:.2R} [W/m2]", ThisSurfIntensity));
+                        ShowContinueError(state, std::format("Radiation intensity = {:.2f} [W/m2]", ThisSurfIntensity));
                         ShowContinueError(state,
                                           std::format("Assign a larger surface area or more surfaces in {}",
                                                       state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam));
@@ -1511,7 +1509,7 @@ namespace SteamBaseboardRadiator {
                 } else { // small surface
                     ShowSevereError(state, "DistributeBBSteamRadGains:  surface not large enough to receive thermal radiation heat flux");
                     ShowContinueError(state, std::format("Surface = {}", state.dataSurface->Surface(SurfNum).Name));
-                    ShowContinueError(state, EnergyPlus::format("Surface area = {:.3R} [m2]", state.dataSurface->Surface(SurfNum).Area));
+                    ShowContinueError(state, std::format("Surface area = {:.3f} [m2]", state.dataSurface->Surface(SurfNum).Area));
                     ShowContinueError(state,
                                       std::format("Occurs in {} = {}",
                                                   state.dataSteamBaseboardRadiator->cCMO_BBRadiator_Steam,

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -403,7 +403,7 @@ namespace SurfaceGeometry {
                         thisZone.ExtWindowArea + thisSurface.GrossArea * thisSurface.Multiplier * thisZone.Multiplier * thisZone.ListMultiplier;
                     if (DetailedWWR) {
                         print(state.files.debug,
-                              "{},Window,{:.2R},{:.1R}\n",
+                              "{},Window,{:.2f},{:.1f}\n",
                               thisSurface.Name,
                               thisSurface.GrossArea * thisSurface.Multiplier * thisZone.Multiplier * thisZone.ListMultiplier,
                               thisSurface.Tilt);
@@ -423,7 +423,7 @@ namespace SurfaceGeometry {
                         thisSpace.extPerimeter += thisSurface.Width;
                         if (DetailedWWR) {
                             print(state.files.debug,
-                                  "{},Wall,{:.2R},{:.1R}\n",
+                                  "{},Wall,{:.2f},{:.1f}\n",
                                   thisSurface.Name,
                                   thisSurface.GrossArea * thisZone.Multiplier * thisZone.ListMultiplier,
                                   thisSurface.Tilt);
@@ -437,7 +437,7 @@ namespace SurfaceGeometry {
                         thisZone.ExtGrossGroundWallArea_Multiplied += thisSurface.GrossArea * thisZone.Multiplier * thisZone.ListMultiplier;
                         if (DetailedWWR) {
                             print(state.files.debug,
-                                  "{},Wall-GroundContact,{:.2R},{:.1R}\n",
+                                  "{},Wall-GroundContact,{:.2f},{:.1f}\n",
                                   thisSurface.Name,
                                   thisSurface.GrossArea * thisZone.Multiplier * thisZone.ListMultiplier,
                                   thisSurface.Tilt);
@@ -463,7 +463,7 @@ namespace SurfaceGeometry {
             Real64 ZCeilAvg = 0.0;
             Real64 ZFlrAvg = 0.0;
             if (DetailedWWR) {
-                print(state.files.debug, "{},{:.2R},{:.2R}\n", thisZone.Name, thisZone.ExtGrossWallArea, thisZone.ExtWindowArea);
+                print(state.files.debug, "{},{:.2f},{:.2f}\n", thisZone.Name, thisZone.ExtGrossWallArea, thisZone.ExtWindowArea);
             }
             for (int spaceNum : thisZone.spaceIndexes) {
                 auto const &thisSpace = state.dataHeatBal->space(spaceNum);
@@ -756,8 +756,8 @@ namespace SurfaceGeometry {
 
             static constexpr std::string_view Format_720(
                 " Zone Information, "
-                "{},{:.1R},{:.2R},{:.2R},{:.2R},{:.2R},{:.2R},{:.2R},{},{},{},{:.2R},{:.2R},{:.2R},{:.2R},{:.2R},{:.2R},"
-                "{:.2R},{:.2R},{},{},{:.2R},{:.2R},{:.2R},{:.2R},{},{},{},{}\n");
+                "{},{:.1f},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},{},{},{},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},"
+                "{:.2f},{:.2f},{},{},{:.2f},{:.2f},{:.2f},{:.2f},{},{},{},{}\n");
 
             print(state.files.eio,
                   Format_720,
@@ -1903,9 +1903,8 @@ namespace SurfaceGeometry {
                                                       "back side values");
                                     ShowContinueError(
                                         state,
-                                        EnergyPlus::format(
-                                            "...but Nominal U values are similar, diff=[{:.4R}] ... simulation proceeds.",
-                                            std::abs(state.dataHeatBal->NominalU(ConstrNum) - state.dataHeatBal->NominalU(ConstrNumFound))));
+                                        std::format("...but Nominal U values are similar, diff=[{:.4f}] ... simulation proceeds.",
+                                                    std::abs(state.dataHeatBal->NominalU(ConstrNum) - state.dataHeatBal->NominalU(ConstrNumFound))));
                                     if (!izConstDiffMsg) {
                                         ShowContinueError(state,
                                                           "...if the two zones are expected to have significantly different temperatures, the proper "
@@ -2321,27 +2320,25 @@ namespace SurfaceGeometry {
                                 if (ErrCount == 1 && !state.dataGlobal->DisplayExtraWarnings) {
                                     ShowWarningError(
                                         state,
-                                        EnergyPlus::format(
-                                            "{}Entered Space Floor Area(s) differ more than {:.0R}% from calculated Space Floor Area(s).",
-                                            std::string(RoutineName),
-                                            floorAreaPercentTolerance));
+                                        std::format("{}Entered Space Floor Area(s) differ more than {:.0f}% from calculated Space Floor Area(s).",
+                                                    std::string(RoutineName),
+                                                    floorAreaPercentTolerance));
                                     ShowContinueError(state,
                                                       "...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual Spaces.");
                                 }
                                 if (state.dataGlobal->DisplayExtraWarnings) {
                                     // Warn user of using specified Space Floor Area
-                                    ShowWarningError(state,
-                                                     EnergyPlus::format(
-                                                         "{}Entered Floor Area for Space=\"{}\" is {:.1R}% different from the calculated Floor Area.",
-                                                         std::string(RoutineName),
-                                                         thisSpace.Name,
-                                                         diffp * 100.0));
-                                    ShowContinueError(
+                                    ShowWarningError(
                                         state,
-                                        EnergyPlus::format("Entered Space Floor Area={:.2R}, Calculated Space Floor Area={:.2R}, entered "
-                                                           "Floor Area will be used.",
-                                                           thisSpace.userEnteredFloorArea,
-                                                           calcFloorArea));
+                                        std::format("{}Entered Floor Area for Space=\"{}\" is {:.1f}% different from the calculated Floor Area.",
+                                                    std::string(RoutineName),
+                                                    thisSpace.Name,
+                                                    diffp * 100.0));
+                                    ShowContinueError(state,
+                                                      std::format("Entered Space Floor Area={:.2f}, Calculated Space Floor Area={:.2f}, entered "
+                                                                  "Floor Area will be used.",
+                                                                  thisSpace.userEnteredFloorArea,
+                                                                  calcFloorArea));
                                 }
                             }
                         }
@@ -2371,26 +2368,24 @@ namespace SurfaceGeometry {
                                 if (ErrCount == 1 && !state.dataGlobal->DisplayExtraWarnings) {
                                     ShowWarningError(
                                         state,
-                                        EnergyPlus::format(
-                                            "{}Entered Zone Floor Area(s) differ more than {:.0R}% from the sum of the Space Floor Area(s).",
-                                            std::string(RoutineName),
-                                            floorAreaPercentTolerance));
+                                        std::format("{}Entered Zone Floor Area(s) differ more than {:.0f}% from the sum of the Space Floor Area(s).",
+                                                    std::string(RoutineName),
+                                                    floorAreaPercentTolerance));
                                     ShowContinueError(state,
                                                       "...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual zones.");
                                 }
                                 if (state.dataGlobal->DisplayExtraWarnings) {
                                     // Warn user of using specified Zone Floor Area
-                                    ShowWarningError(
-                                        state,
-                                        EnergyPlus::format("{}Entered Floor Area for Zone=\"{}\" is {:.1R}% different from the sum of the "
-                                                           "Space Floor Area(s).",
-                                                           std::string(RoutineName),
-                                                           thisZone.Name,
-                                                           diffp * 100.0));
+                                    ShowWarningError(state,
+                                                     std::format("{}Entered Floor Area for Zone=\"{}\" is {:.1f}% different from the sum of the "
+                                                                 "Space Floor Area(s).",
+                                                                 std::string(RoutineName),
+                                                                 thisZone.Name,
+                                                                 diffp * 100.0));
                                     ShowContinueError(state,
-                                                      EnergyPlus::format("Entered Zone Floor Area={:.2R}, Sum of Space Floor Area(s)={:.2R}",
-                                                                         thisZone.UserEnteredFloorArea,
-                                                                         zoneCalcFloorArea));
+                                                      std::format("Entered Zone Floor Area={:.2f}, Sum of Space Floor Area(s)={:.2f}",
+                                                                  thisZone.UserEnteredFloorArea,
+                                                                  zoneCalcFloorArea));
                                     ShowContinueError(
                                         state, "Entered Zone Floor Area will be used and Space Floor Area(s) will be adjusted proportionately.");
                                 }
@@ -2446,18 +2441,18 @@ namespace SurfaceGeometry {
         for (int SurfNum = 1; SurfNum <= MovedSurfs; ++SurfNum) { // TotSurfaces
             if (state.dataSurface->Surface(SurfNum).Area < 1.e-06) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{}Zero or negative surface area[{:.5R}], Surface={}",
-                                                   RoutineName,
-                                                   state.dataSurface->Surface(SurfNum).Area,
-                                                   state.dataSurface->Surface(SurfNum).Name));
+                                std::format("{}Zero or negative surface area[{:.5f}], Surface={}",
+                                            RoutineName,
+                                            state.dataSurface->Surface(SurfNum).Area,
+                                            state.dataSurface->Surface(SurfNum).Name));
                 SurfError = true;
             }
             if (state.dataSurface->Surface(SurfNum).Area >= 1.e-06 && state.dataSurface->Surface(SurfNum).Area < 0.001) {
                 ShowWarningError(state,
-                                 EnergyPlus::format("{}Very small surface area[{:.5R}], Surface={}",
-                                                    RoutineName,
-                                                    state.dataSurface->Surface(SurfNum).Area,
-                                                    state.dataSurface->Surface(SurfNum).Name));
+                                 std::format("{}Very small surface area[{:.5f}], Surface={}",
+                                             RoutineName,
+                                             state.dataSurface->Surface(SurfNum).Area,
+                                             state.dataSurface->Surface(SurfNum).Name));
             }
         }
 
@@ -3099,40 +3094,36 @@ namespace SurfaceGeometry {
             if (((General::rotAzmDiffDeg(baseSurface.Azimuth, subSurface.Azimuth) > errorTolerance) && !baseSurfHoriz) ||
                 (std::abs(baseSurface.Tilt - subSurface.Tilt) > errorTolerance)) {
                 surfaceError = true;
-                ShowSevereError(state,
-                                EnergyPlus::format(
-                                    "checkSubSurfAzTiltNorm: Outward facing angle of subsurface differs more than {:.1R} degrees from base surface.",
-                                    errorTolerance));
+                ShowSevereError(
+                    state,
+                    std::format("checkSubSurfAzTiltNorm: Outward facing angle of subsurface differs more than {:.1f} degrees from base surface.",
+                                errorTolerance));
+                ShowContinueError(
+                    state, std::format("Subsurface=\"{}\" Tilt = {:.1f}  Azimuth = {:.1f}", subSurface.Name, subSurface.Tilt, subSurface.Azimuth));
                 ShowContinueError(
                     state,
-                    EnergyPlus::format("Subsurface=\"{}\" Tilt = {:.1R}  Azimuth = {:.1R}", subSurface.Name, subSurface.Tilt, subSurface.Azimuth));
-                ShowContinueError(
-                    state,
-                    EnergyPlus::format(
-                        "Base surface=\"{}\" Tilt = {:.1R}  Azimuth = {:.1R}", baseSurface.Name, baseSurface.Tilt, baseSurface.Azimuth));
+                    std::format("Base surface=\"{}\" Tilt = {:.1f}  Azimuth = {:.1f}", baseSurface.Name, baseSurface.Tilt, baseSurface.Azimuth));
             } else if (((General::rotAzmDiffDeg(baseSurface.Azimuth, subSurface.Azimuth) > warningTolerance) && !baseSurfHoriz) ||
                        (std::abs(baseSurface.Tilt - subSurface.Tilt) > warningTolerance)) {
                 ++state.dataSurfaceGeometry->checkSubSurfAzTiltNormErrCount;
                 if (state.dataSurfaceGeometry->checkSubSurfAzTiltNormErrCount == 1 && !state.dataGlobal->DisplayExtraWarnings) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("checkSubSurfAzTiltNorm: Some Outward Facing angles of subsurfaces differ more than {:.1R} "
-                                                        "degrees from base surface.",
-                                                        warningTolerance));
+                                     std::format("checkSubSurfAzTiltNorm: Some Outward Facing angles of subsurfaces differ more than {:.1f} "
+                                                 "degrees from base surface.",
+                                                 warningTolerance));
                     ShowContinueError(state, "...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual surfaces.");
                 }
                 if (state.dataGlobal->DisplayExtraWarnings) {
                     ShowWarningError(
                         state,
-                        EnergyPlus::format(
-                            "checkSubSurfAzTiltNorm: Outward facing angle of subsurface differs more than {:.1R} degrees from base surface.",
-                            warningTolerance));
-                    ShowContinueError(state,
-                                      EnergyPlus::format(
-                                          "Subsurface=\"{}\" Tilt = {:.1R}  Azimuth = {:.1R}", subSurface.Name, subSurface.Tilt, subSurface.Azimuth));
+                        std::format("checkSubSurfAzTiltNorm: Outward facing angle of subsurface differs more than {:.1f} degrees from base surface.",
+                                    warningTolerance));
                     ShowContinueError(
                         state,
-                        EnergyPlus::format(
-                            "Base surface=\"{}\" Tilt = {:.1R}  Azimuth = {:.1R}", baseSurface.Name, baseSurface.Tilt, baseSurface.Azimuth));
+                        std::format("Subsurface=\"{}\" Tilt = {:.1f}  Azimuth = {:.1f}", subSurface.Name, subSurface.Tilt, subSurface.Azimuth));
+                    ShowContinueError(
+                        state,
+                        std::format("Base surface=\"{}\" Tilt = {:.1f}  Azimuth = {:.1f}", baseSurface.Name, baseSurface.Tilt, baseSurface.Azimuth));
                 }
             }
         }
@@ -3517,11 +3508,10 @@ namespace SurfaceGeometry {
                     if (mod(NumNumbers - 1, 3) != 0) {
                         ShowWarningError(
                             state,
-                            std::format(
-                                "{}=\"{}\", {}",
-                                s_ipsc->cCurrentModuleObject,
-                                surfTemp.Name,
-                                EnergyPlus::format("{} not even multiple of 3. Will read in {}", s_ipsc->cNumericFieldNames(1), surfTemp.Sides)));
+                            std::format("{}=\"{}\", {}",
+                                        s_ipsc->cCurrentModuleObject,
+                                        surfTemp.Name,
+                                        std::format("{} not even multiple of 3. Will read in {}", s_ipsc->cNumericFieldNames(1), surfTemp.Sides)));
                     }
                     if (numSides < 3) {
                         ShowSevereError(state,
@@ -4009,8 +3999,8 @@ namespace SurfaceGeometry {
                                              "GetHTSurfaceData: Surfaces with interface to Ground found but no \"Ground Temperatures\" were input.");
                             ShowContinueError(state, std::format("Found first in surface={}", s_ipsc->cAlphaArgs(1)));
                             ShowContinueError(state,
-                                              EnergyPlus::format("Defaults, constant throughout the year of ({:.1R}) will be used.",
-                                                                 state.dataEnvrn->GroundTemp[(int)DataEnvironment::GroundTempType::BuildingSurface]));
+                                              std::format("Defaults, constant throughout the year of ({:.1f}) will be used.",
+                                                          state.dataEnvrn->GroundTemp[(int)DataEnvironment::GroundTempType::BuildingSurface]));
                         }
                         state.dataSurfaceGeometry->NoGroundTempObjWarning = false;
                     }
@@ -4276,11 +4266,10 @@ namespace SurfaceGeometry {
                     if (mod(SurfaceNumProp - 2, 3) != 0) {
                         ShowWarningError(
                             state,
-                            std::format(
-                                "{}=\"{}\", {}",
-                                s_ipsc->cCurrentModuleObject,
-                                surfTemp.Name,
-                                EnergyPlus::format("{} not even multiple of 3. Will read in {}", s_ipsc->cNumericFieldNames(2), surfTemp.Sides)));
+                            std::format("{}=\"{}\", {}",
+                                        s_ipsc->cCurrentModuleObject,
+                                        surfTemp.Name,
+                                        std::format("{} not even multiple of 3. Will read in {}", s_ipsc->cNumericFieldNames(2), surfTemp.Sides)));
                     }
                     if (numSides < 3) {
                         ShowSevereError(state,
@@ -4675,8 +4664,8 @@ namespace SurfaceGeometry {
                                              "GetRectSurfaces: Surfaces with interface to Ground found but no \"Ground Temperatures\" were input.");
                             ShowContinueError(state, std::format("Found first in surface={}", s_ipsc->cAlphaArgs(1)));
                             ShowContinueError(state,
-                                              EnergyPlus::format("Defaults, constant throughout the year of ({:.1R}) will be used.",
-                                                                 state.dataEnvrn->GroundTemp[(int)DataEnvironment::GroundTempType::BuildingSurface]));
+                                              std::format("Defaults, constant throughout the year of ({:.1f}) will be used.",
+                                                          state.dataEnvrn->GroundTemp[(int)DataEnvironment::GroundTempType::BuildingSurface]));
                         }
                         state.dataSurfaceGeometry->NoGroundTempObjWarning = false;
                     }
@@ -5247,7 +5236,7 @@ namespace SurfaceGeometry {
                         std::format("{}=\"{}\", {}",
                                     s_ipsc->cCurrentModuleObject,
                                     surfTemp.Name,
-                                    EnergyPlus::format("{} not even multiple of 3. Will read in {}", s_ipsc->cNumericFieldNames(3), surfTemp.Sides)));
+                                    std::format("{} not even multiple of 3. Will read in {}", s_ipsc->cNumericFieldNames(3), surfTemp.Sides)));
                 }
                 if (s_ipsc->rNumericArgs(3) < 3) {
                     ShowSevereError(state,
@@ -5897,18 +5886,18 @@ namespace SurfaceGeometry {
                                                       state.dataConstruction->Construct(ConstrNumSh).Name);
                                 ShowContinueError(state, "for window " + surfTemp.Name + ", which has a between-glass blind.");
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("..Material={} thickness={:.3R} -",
-                                                                     s_mat->materials(MatGap)->Name,
-                                                                     s_mat->materials(MatGap)->Thickness));
+                                                  std::format("..Material={} thickness={:.3f} -",
+                                                              s_mat->materials(MatGap)->Name,
+                                                              s_mat->materials(MatGap)->Thickness));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("..( Material={} thickness={:.3R} +",
-                                                                     s_mat->materials(MatGap1)->Name,
-                                                                     s_mat->materials(MatGap1)->Thickness));
+                                                  std::format("..( Material={} thickness={:.3f} +",
+                                                              s_mat->materials(MatGap1)->Name,
+                                                              s_mat->materials(MatGap1)->Thickness));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("..Material={} thickness={:.3R} )=[{:.3R}] >.001",
-                                                                     s_mat->materials(MatGap2)->Name,
-                                                                     s_mat->materials(MatGap2)->Thickness,
-                                                                     MatGapCalc));
+                                                  std::format("..Material={} thickness={:.3f} )=[{:.3f}] >.001",
+                                                              s_mat->materials(MatGap2)->Name,
+                                                              s_mat->materials(MatGap2)->Thickness,
+                                                              MatGapCalc));
                                 ErrorsFound = true;
                             }
                         } else { // Between-glass shade
@@ -5925,22 +5914,22 @@ namespace SurfaceGeometry {
                                                       state.dataConstruction->Construct(ConstrNumSh).Name);
                                 ShowContinueError(state, "for window " + surfTemp.Name + ", which has a between-glass shade.");
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("..Material={} thickness={:.3R} -",
-                                                                     s_mat->materials(MatGap)->Name,
-                                                                     s_mat->materials(MatGap)->Thickness));
+                                                  std::format("..Material={} thickness={:.3f} -",
+                                                              s_mat->materials(MatGap)->Name,
+                                                              s_mat->materials(MatGap)->Thickness));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("...( Material={} thickness={:.3R} +",
-                                                                     s_mat->materials(MatGap1)->Name,
-                                                                     s_mat->materials(MatGap1)->Thickness));
+                                                  std::format("...( Material={} thickness={:.3f} +",
+                                                              s_mat->materials(MatGap1)->Name,
+                                                              s_mat->materials(MatGap1)->Thickness));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("..Material={} thickness={:.3R} +",
-                                                                     s_mat->materials(MatGap2)->Name,
-                                                                     s_mat->materials(MatGap2)->Thickness));
+                                                  std::format("..Material={} thickness={:.3f} +",
+                                                              s_mat->materials(MatGap2)->Name,
+                                                              s_mat->materials(MatGap2)->Thickness));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("..Material={} thickness={:.3R} )=[{:.3R}] >.001",
-                                                                     s_mat->materials(MatSh)->Name,
-                                                                     s_mat->materials(MatSh)->Thickness,
-                                                                     MatGapCalc));
+                                                  std::format("..Material={} thickness={:.3f} )=[{:.3f}] >.001",
+                                                              s_mat->materials(MatSh)->Name,
+                                                              s_mat->materials(MatSh)->Thickness,
+                                                              MatGapCalc));
                                 ErrorsFound = true;
                             }
                         }
@@ -6010,8 +5999,8 @@ namespace SurfaceGeometry {
                                                           "Divider cannot be specified because the construction has a between-glass shade or blind.");
                                         ShowContinueError(state, "Calculation will proceed without the divider for this window.");
                                         ShowContinueError(state,
-                                                          EnergyPlus::format("Divider width = [{:.2R}].",
-                                                                             state.dataSurface->FrameDivider(surfTemp.FrameDivider).DividerWidth));
+                                                          std::format("Divider width = [{:.2f}].",
+                                                                      state.dataSurface->FrameDivider(surfTemp.FrameDivider).DividerWidth));
                                         state.dataSurface->FrameDivider(surfTemp.FrameDivider).DividerWidth = 0.0;
                                     }
                                 } // End of check if window has divider
@@ -6453,7 +6442,7 @@ namespace SurfaceGeometry {
                         std::format("{}=\"{}\", {}",
                                     s_ipsc->cCurrentModuleObject,
                                     surfTemp.Name,
-                                    EnergyPlus::format("{} not even multiple of 3. Will read in {}", s_ipsc->cNumericFieldNames(1), surfTemp.Sides)));
+                                    std::format("{} not even multiple of 3. Will read in {}", s_ipsc->cNumericFieldNames(1), surfTemp.Sides)));
                 }
                 if (s_ipsc->rNumericArgs(1) < 3) {
                     ShowSevereError(state,
@@ -6647,10 +6636,10 @@ namespace SurfaceGeometry {
 
                     if (Length * Depth <= 0.0) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}=\"{}\", illegal surface area=[{:.2R}]. Surface will NOT be entered.",
-                                                           s_ipsc->cCurrentModuleObject,
-                                                           s_ipsc->cAlphaArgs(1),
-                                                           Length * Depth));
+                                        std::format("{}=\"{}\", illegal surface area=[{:.2f}]. Surface will NOT be entered.",
+                                                    s_ipsc->cCurrentModuleObject,
+                                                    s_ipsc->cAlphaArgs(1),
+                                                    Length * Depth));
                         continue;
                     }
 
@@ -6730,10 +6719,10 @@ namespace SurfaceGeometry {
                     MakeFin = true;
                     if (Length * Depth <= 0.0) {
                         ShowWarningError(state,
-                                         EnergyPlus::format("{}=Left Fin of \"{}\", illegal surface area=[{:.2R}]. Surface will NOT be entered.",
-                                                            s_ipsc->cCurrentModuleObject,
-                                                            s_ipsc->cAlphaArgs(1),
-                                                            Length * Depth));
+                                         std::format("{}=Left Fin of \"{}\", illegal surface area=[{:.2f}]. Surface will NOT be entered.",
+                                                     s_ipsc->cCurrentModuleObject,
+                                                     s_ipsc->cAlphaArgs(1),
+                                                     Length * Depth));
                         MakeFin = false;
                     }
 
@@ -6833,10 +6822,10 @@ namespace SurfaceGeometry {
                     MakeFin = true;
                     if (Length * Depth <= 0.0) {
                         ShowWarningError(state,
-                                         EnergyPlus::format("{}=Right Fin of \"{}\", illegal surface area=[{:.2R}]. Surface will NOT be entered.",
-                                                            s_ipsc->cCurrentModuleObject,
-                                                            s_ipsc->cAlphaArgs(1),
-                                                            Length * Depth));
+                                         std::format("{}=Right Fin of \"{}\", illegal surface area=[{:.2f}]. Surface will NOT be entered.",
+                                                     s_ipsc->cCurrentModuleObject,
+                                                     s_ipsc->cAlphaArgs(1),
+                                                     Length * Depth));
                         MakeFin = false;
                     }
 
@@ -7355,7 +7344,7 @@ namespace SurfaceGeometry {
                 continue;
             }
 
-            constexpr std::string_view fmt = "ShadingProperty Reflectance,{},{},{:.2R},{:.2R},{:.2R}, {}\n";
+            constexpr std::string_view fmt = "ShadingProperty Reflectance,{},{},{:.2f},{:.2f},{:.2f}, {}\n";
             if (state.dataSurface->SurfShadowGlazingConstruct(SurfNum) != 0) {
                 print(state.files.eio,
                       fmt,
@@ -8910,7 +8899,7 @@ namespace SurfaceGeometry {
 
         int numberOfHeatTransferAlgosUsed = 0;
         // Formats
-        static constexpr std::string_view Format_725("Surface Heat Transfer Algorithm, {},{:.0R},{:.2R},{:.1R}\n");
+        static constexpr std::string_view Format_725("Surface Heat Transfer Algorithm, {},{:.0f},{:.2f},{:.1f}\n");
 
         if (state.dataHeatBal->AnyCTF) {
             constexpr std::string_view AlgoName = "CTF - ConductionTransferFunction";
@@ -9289,13 +9278,11 @@ namespace SurfaceGeometry {
                                                                                         : (poppedVertexIndex == nSides && keptVertexIndex == 1);
 
                     if (printPoppedFirst) {
-                        ShowContinueError(state, EnergyPlus::format("Vertex [{}]=({:.2R},{:.2R},{:.2R})", poppedVertexIndex, it->x, it->y, it->z));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Vertex [{}]=({:.2R},{:.2R},{:.2R})", keptVertexIndex, itKept->x, itKept->y, itKept->z));
+                        ShowContinueError(state, std::format("Vertex [{}]=({:.2f},{:.2f},{:.2f})", poppedVertexIndex, it->x, it->y, it->z));
+                        ShowContinueError(state, std::format("Vertex [{}]=({:.2f},{:.2f},{:.2f})", keptVertexIndex, itKept->x, itKept->y, itKept->z));
                     } else {
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Vertex [{}]=({:.2R},{:.2R},{:.2R})", keptVertexIndex, itKept->x, itKept->y, itKept->z));
-                        ShowContinueError(state, EnergyPlus::format("Vertex [{}]=({:.2R},{:.2R},{:.2R})", poppedVertexIndex, it->x, it->y, it->z));
+                        ShowContinueError(state, std::format("Vertex [{}]=({:.2f},{:.2f},{:.2f})", keptVertexIndex, itKept->x, itKept->y, itKept->z));
+                        ShowContinueError(state, std::format("Vertex [{}]=({:.2f},{:.2f},{:.2f})", poppedVertexIndex, it->x, it->y, it->z));
                     }
                 }
                 ++state.dataErrTracking->TotalCoincidentVertices;
@@ -9333,7 +9320,7 @@ namespace SurfaceGeometry {
                 surfTemp.Vertex, SurfWorldAz, SurfTilt, surfTemp.lcsx, surfTemp.lcsy, surfTemp.lcsz, surfTemp.NewellSurfaceNormalVector);
             dotp = dot(surfTemp.NewellSurfaceNormalVector, TestVector);
             if (surfTemp.Class == SurfaceClass::Roof && dotp < -0.000001) {
-                TiltString = EnergyPlus::format("{:.1R}", SurfTilt);
+                TiltString = std::format("{:.1f}", SurfTilt);
                 ShowWarningError(state,
                                  std::format("{}Roof/Ceiling is upside down! Tilt angle=[{}], should be near 0, Surface=\"{}\", in Zone=\"{}\".",
                                              RoutineName,
@@ -9343,7 +9330,7 @@ namespace SurfaceGeometry {
                 ShowContinueError(state, "Automatic fix is attempted.");
                 ReverseAndRecalculate(state, SurfNum, surfTemp.Sides, SurfWorldAz, SurfTilt);
             } else if (surfTemp.Class == SurfaceClass::Roof && SurfTilt > 80.0) {
-                TiltString = EnergyPlus::format("{:.1R}", SurfTilt);
+                TiltString = std::format("{:.1f}", SurfTilt);
                 ShowWarningError(
                     state,
                     std::format("{}Roof/Ceiling is not oriented correctly! Tilt angle=[{}], should be near 0, Surface=\"{}\", in Zone=\"{}\".",
@@ -9353,7 +9340,7 @@ namespace SurfaceGeometry {
                                 surfTemp.ZoneName));
             }
             if (surfTemp.Class == SurfaceClass::Floor && dotp > 0.000001) {
-                TiltString = EnergyPlus::format("{:.1R}", SurfTilt);
+                TiltString = std::format("{:.1f}", SurfTilt);
                 ShowWarningError(state,
                                  std::format("{}Floor is upside down! Tilt angle=[{}], should be near 180, Surface=\"{}\", in Zone=\"{}\".",
                                              RoutineName,
@@ -9363,7 +9350,7 @@ namespace SurfaceGeometry {
                 ShowContinueError(state, "Automatic fix is attempted.");
                 ReverseAndRecalculate(state, SurfNum, surfTemp.Sides, SurfWorldAz, SurfTilt);
             } else if (surfTemp.Class == SurfaceClass::Floor && SurfTilt < 158.2) { // slope/grade = 40%!
-                TiltString = EnergyPlus::format("{:.1R}", SurfTilt);
+                TiltString = std::format("{:.1f}", SurfTilt);
                 ShowWarningError(
                     state,
                     std::format("{}Floor is not oriented correctly! Tilt angle=[{}], should be near 180, Surface=\"{}\", in Zone=\"{}\".",
@@ -9477,7 +9464,7 @@ namespace SurfaceGeometry {
         Vectors::DetermineAzimuthAndTilt(
             surfTemp.Vertex, SurfAzimuth, SurfTilt, surfTemp.lcsx, surfTemp.lcsy, surfTemp.lcsz, surfTemp.NewellSurfaceNormalVector);
         if (surfTemp.Class == SurfaceClass::Roof && SurfTilt > 80.0) {
-            TiltString = EnergyPlus::format("{:.1R}", SurfTilt);
+            TiltString = std::format("{:.1f}", SurfTilt);
             ShowWarningError(
                 state,
                 std::format("{}Roof/Ceiling is still upside down! Tilt angle=[{}], should be near 0, please fix manually.", RoutineName, TiltString));
@@ -10434,8 +10421,8 @@ namespace SurfaceGeometry {
                                                   state.dataSurface->StormWindow(StormWinNum).DayOfMonthOn,
                                                   state.dataSurface->StormWindow(StormWinNum).MonthOff,
                                                   state.dataSurface->StormWindow(StormWinNum).DayOfMonthOff));
-                    ShowContinueError(
-                        state, EnergyPlus::format("these times may be reversed for your building latitude={:.2R} deg.", state.dataEnvrn->Latitude));
+                    ShowContinueError(state,
+                                      std::format("these times may be reversed for your building latitude={:.2f} deg.", state.dataEnvrn->Latitude));
                 }
             }
         }
@@ -11511,14 +11498,14 @@ namespace SurfaceGeometry {
             if (!s_ipsc->lNumericFieldBlanks(10)) {
                 state.dataSurface->OSC(OSCNum).MinLimitPresent = true;
                 state.dataSurface->OSC(OSCNum).MinTempLimit = s_ipsc->rNumericArgs(10);
-                cOSCLimitsString = EnergyPlus::format("{:.3R}", s_ipsc->rNumericArgs(10));
+                cOSCLimitsString = std::format("{:.3f}", s_ipsc->rNumericArgs(10));
             } else {
                 cOSCLimitsString = "N/A";
             }
             if (!s_ipsc->lNumericFieldBlanks(11)) {
                 state.dataSurface->OSC(OSCNum).MaxLimitPresent = true;
                 state.dataSurface->OSC(OSCNum).MaxTempLimit = s_ipsc->rNumericArgs(11);
-                cOSCLimitsString += EnergyPlus::format(",{:.3R}", s_ipsc->rNumericArgs(10));
+                cOSCLimitsString += std::format(",{:.3f}", s_ipsc->rNumericArgs(10));
             } else {
                 cOSCLimitsString += ",N/A";
             }
@@ -11536,7 +11523,7 @@ namespace SurfaceGeometry {
                 print(state.files.eio, "{}\n", OSCFormat1);
             }
             if (state.dataSurface->OSC(Loop).SurfFilmCoef > 0.0) {
-                s_ipsc->cAlphaArgs(1) = EnergyPlus::format("{:.3R}", state.dataSurface->OSC(Loop).SurfFilmCoef);
+                s_ipsc->cAlphaArgs(1) = std::format("{:.3f}", state.dataSurface->OSC(Loop).SurfFilmCoef);
                 SetupOutputVariable(state,
                                     "Surface Other Side Coefficients Exterior Air Drybulb Temperature",
                                     Constant::Units::C,
@@ -11549,11 +11536,10 @@ namespace SurfaceGeometry {
             }
 
             print(state.files.eio,
-                  "Other Side Coefficients,{},{},{},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R},{},{},{:.3R},{:.3R},{}\n",
+                  "Other Side Coefficients,{},{},{},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f},{},{},{:.3f},{:.3f},{}\n",
                   state.dataSurface->OSC(Loop).Name,
                   s_ipsc->cAlphaArgs(1),
-                  (state.dataSurface->OSC(Loop).constTempSched != nullptr) ? "N/A"
-                                                                           : EnergyPlus::format("{:.2R}", state.dataSurface->OSC(Loop).ConstTemp),
+                  (state.dataSurface->OSC(Loop).constTempSched != nullptr) ? "N/A" : std::format("{:.2f}", state.dataSurface->OSC(Loop).ConstTemp),
                   state.dataSurface->OSC(Loop).ConstTempCoef,
                   state.dataSurface->OSC(Loop).ExtDryBulbCoef,
                   state.dataSurface->OSC(Loop).GroundTempCoef,
@@ -11842,9 +11828,9 @@ namespace SurfaceGeometry {
                                                     s_ipsc->cAlphaArgs(2)));
                         ShowContinueError(state, "\"Outside\", invalid material for movable insulation.");
                         ShowContinueError(state,
-                                          EnergyPlus::format("Material=\"{}\",Resistance=[{:.3R}], must be > 0 for use in Movable Insulation.",
-                                                             thisMaterial->Name,
-                                                             thisMaterial->Resistance));
+                                          std::format("Material=\"{}\",Resistance=[{:.3f}], must be > 0 for use in Movable Insulation.",
+                                                      thisMaterial->Name,
+                                                      thisMaterial->Resistance));
                         ErrorsFound = true;
                     } else if (thisMaterial->Conductivity > 0.0) {
                         thisMaterial->Resistance = thisMaterial->Thickness / thisMaterial->Conductivity;
@@ -11860,9 +11846,9 @@ namespace SurfaceGeometry {
                                                     s_ipsc->cAlphaArgs(2)));
                         ShowContinueError(state, "\"Outside\", invalid material for movable insulation.");
                         ShowContinueError(state,
-                                          EnergyPlus::format("Material=\"{}\",Conductivity=[{:.3R}], must be > 0 for use in Movable Insulation.",
-                                                             thisMaterial->Name,
-                                                             thisMaterial->Conductivity));
+                                          std::format("Material=\"{}\",Conductivity=[{:.3f}], must be > 0 for use in Movable Insulation.",
+                                                      thisMaterial->Name,
+                                                      thisMaterial->Conductivity));
                         ErrorsFound = true;
                     }
                 }
@@ -11889,9 +11875,9 @@ namespace SurfaceGeometry {
                                                     s_ipsc->cAlphaArgs(2)));
                         ShowContinueError(state, "\"Inside\", invalid material for movable insulation.");
                         ShowContinueError(state,
-                                          EnergyPlus::format("Material=\"{}\",Resistance=[{:.3R}], must be > 0 for use in Movable Insulation.",
-                                                             thisMaterial->Name,
-                                                             thisMaterial->Resistance));
+                                          std::format("Material=\"{}\",Resistance=[{:.3f}], must be > 0 for use in Movable Insulation.",
+                                                      thisMaterial->Name,
+                                                      thisMaterial->Resistance));
                         ErrorsFound = true;
                     } else if (thisMaterial->Conductivity > 0.0) {
                         thisMaterial->Resistance = thisMaterial->Thickness / thisMaterial->Conductivity;
@@ -12101,10 +12087,9 @@ namespace SurfaceGeometry {
                             }
                             ShowContinueError(state, surfaceNames);
                         }
-                        ShowContinueError(
-                            state, EnergyPlus::format("    Vertex start {{ {:.4R}, {:.4R}, {:.4R}}}", edge.start.x, edge.start.y, edge.start.z));
                         ShowContinueError(state,
-                                          EnergyPlus::format("    Vertex end   {{ {:.4R}, {:.4R}, {:.4R}}}", edge.end.x, edge.end.y, edge.end.z));
+                                          std::format("    Vertex start {{ {:.4f}, {:.4f}, {:.4f}}}", edge.start.x, edge.start.y, edge.start.z));
+                        ShowContinueError(state, std::format("    Vertex end   {{ {:.4f}, {:.4f}, {:.4f}}}", edge.end.x, edge.end.y, edge.end.z));
                     }
                 }
             }
@@ -12133,10 +12118,10 @@ namespace SurfaceGeometry {
                                 std::format("Entered Volume entered for Zone=\"{}\" significantly different from calculated Volume", thisZone.Name));
                             ShowContinueError(
                                 state,
-                                EnergyPlus::format("Entered Zone Volume value={:.2R}, Calculated Zone Volume value={:.2R}, entered volume will be "
-                                                   "used in calculations.",
-                                                   thisZone.Volume,
-                                                   CalcVolume));
+                                std::format("Entered Zone Volume value={:.2f}, Calculated Zone Volume value={:.2f}, entered volume will be "
+                                            "used in calculations.",
+                                            thisZone.Volume,
+                                            CalcVolume));
                         }
                     }
                 }
@@ -12152,7 +12137,7 @@ namespace SurfaceGeometry {
 
             if (thisZone.Volume <= 0.0) {
                 ShowWarningError(state, std::format("Indicated Zone Volume <= 0.0 for Zone={}", thisZone.Name));
-                ShowContinueError(state, EnergyPlus::format("The calculated Zone Volume was={:.2R}", thisZone.Volume));
+                ShowContinueError(state, std::format("The calculated Zone Volume was={:.2f}", thisZone.Volume));
                 ShowContinueError(state, "The simulation will continue with the Zone Volume set to 10.0 m3. ");
                 ShowContinueError(state, "...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual zones.");
                 thisZone.Volume = 10.;
@@ -13813,10 +13798,9 @@ namespace SurfaceGeometry {
                                      std::format("SurfaceGeometry: ModifyWindow: Window {} uses the Window5 Data File Construction {}",
                                                  surfTemp.Name,
                                                  state.dataConstruction->Construct(IConst).Name));
+                    ShowContinueError(state, std::format("The height {:.3f}(m) or width  (m) of this window differs by more than 10%{:.3f}", H, W));
                     ShowContinueError(state,
-                                      EnergyPlus::format("The height {:.3R}(m) or width  (m) of this window differs by more than 10%{:.3R}", H, W));
-                    ShowContinueError(
-                        state, EnergyPlus::format("from the corresponding height {:.3R} (m) or width  (m) on the Window5 Data file.{:.3R}", h1, w1));
+                                      std::format("from the corresponding height {:.3f} (m) or width  (m) on the Window5 Data file.{:.3f}", h1, w1));
                     ShowContinueError(state, "This will affect the frame heat transfer calculation if the frame in the Data File entry");
                     ShowContinueError(state, "is not uniform, i.e., has sections with different geometry and/or thermal properties.");
                 } else {
@@ -14064,8 +14048,7 @@ namespace SurfaceGeometry {
                                         state.dataSurfaceGeometry->SurfaceTmp(surfTemp.BaseSurf).Name));
             ShowContinueError(state, std::format("Subsurface (window) creating error={}", surfTemp.Name));
             ShowContinueError(
-                state,
-                EnergyPlus::format("This window has been replaced by two windows from the Window5 Data File of total area {:.2R} m2", AreaNew));
+                state, std::format("This window has been replaced by two windows from the Window5 Data File of total area {:.2f} m2", AreaNew));
             ErrorsFound = true;
         }
 
@@ -14573,10 +14556,9 @@ namespace SurfaceGeometry {
         if (negZcount > 0) {
             ShowWarningError(state, std::format("CalcSurfaceCentroid: {} Surfaces have the Z coordinate < 0.", negZcount));
             ShowContinueError(state, "...in any calculations, Wind Speed will be 0.0 for these surfaces.");
-            ShowContinueError(
-                state,
-                EnergyPlus::format("...in any calculations, Outside temperatures will be the outside temperature + {:.3R} for these surfaces.",
-                                   state.dataEnvrn->WeatherFileTempModCoeff));
+            ShowContinueError(state,
+                              std::format("...in any calculations, Outside temperatures will be the outside temperature + {:.3f} for these surfaces.",
+                                          state.dataEnvrn->WeatherFileTempModCoeff));
             ShowContinueError(state, "...that is, these surfaces will have conditions as though at ground level.");
         }
     }
@@ -15231,11 +15213,11 @@ namespace SurfaceGeometry {
                         Np2 -= NSides;
                     }
                     ShowContinueError(state, std::format("...vertex {} to vertex {} to vertex {}", n, Np1, Np2));
-                    ShowContinueError(state, EnergyPlus::format("...vertex {}=[{:.2R},{:.2R},{:.2R}]", n, X(n), Y(n), Z(n)));
-                    ShowContinueError(state, EnergyPlus::format("...vertex {}=[{:.2R},{:.2R},{:.2R}]", Np1, X(n + 1), Y(n + 1), Z(n + 1)));
-                    ShowContinueError(state, EnergyPlus::format("...vertex {}=[{:.2R},{:.2R},{:.2R}]", Np2, X(n + 2), Y(n + 2), Z(n + 2)));
-                    // ShowContinueError(state, format("...theta angle=[{:.6R}]", Theta));
-                    // ShowContinueError(state, format("...last theta angle=[{:.6R}]", LastTheta));
+                    ShowContinueError(state, std::format("...vertex {}=[{:.2f},{:.2f},{:.2f}]", n, X(n), Y(n), Z(n)));
+                    ShowContinueError(state, std::format("...vertex {}=[{:.2f},{:.2f},{:.2f}]", Np1, X(n + 1), Y(n + 1), Z(n + 1)));
+                    ShowContinueError(state, std::format("...vertex {}=[{:.2f},{:.2f},{:.2f}]", Np2, X(n + 2), Y(n + 2), Z(n + 2)));
+                    // ShowContinueError(state, format("...theta angle=[{:.6f}]", Theta));
+                    // ShowContinueError(state, format("...last theta angle=[{:.6f}]", LastTheta));
                 }
                 surfaceTmp.IsConvex = false;
                 // #10103 - We do not want to break early, because we do want to consistently remove colinear vertices

--- a/src/EnergyPlus/SurfaceGroundHeatExchanger.cc
+++ b/src/EnergyPlus/SurfaceGroundHeatExchanger.cc
@@ -142,7 +142,7 @@ namespace SurfaceGroundHeatExchanger {
             }
         }
         // If we didn't find it, fatal
-        ShowFatalError(state, EnergyPlus::format("Surface Ground Heat Exchanger: Error getting inputs for pipe named: {}", objectName));
+        ShowFatalError(state, std::format("Surface Ground Heat Exchanger: Error getting inputs for pipe named: {}", objectName));
         // Shut up the compiler
         return nullptr;
     }
@@ -226,17 +226,15 @@ namespace SurfaceGroundHeatExchanger {
                 Util::FindItemInList(state.dataIPShortCut->cAlphaArgs(2), state.dataConstruction->Construct);
 
             if (state.dataSurfaceGroundHeatExchangers->SurfaceGHE(Item).ConstructionNum == 0) {
-                ShowSevereError(state,
-                                EnergyPlus::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(2), state.dataIPShortCut->cAlphaArgs(2)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(2), state.dataIPShortCut->cAlphaArgs(2)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ErrorsFound = true;
             }
 
             // Error checking for surfaces, zones, and construction information
             if (!state.dataConstruction->Construct(state.dataSurfaceGroundHeatExchangers->SurfaceGHE(Item).ConstructionNum).SourceSinkPresent) {
-                ShowSevereError(state,
-                                EnergyPlus::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(2), state.dataIPShortCut->cAlphaArgs(2)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(2), state.dataIPShortCut->cAlphaArgs(2)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(
                     state, "Construction must have internal source/sink and be referenced by a ConstructionProperty:InternalHeatSource object");
                 ErrorsFound = true;
@@ -255,9 +253,8 @@ namespace SurfaceGroundHeatExchanger {
                                   Node::CompFluidStream::Primary,
                                   Node::ObjectIsNotParent);
             if (state.dataSurfaceGroundHeatExchangers->SurfaceGHE(Item).InletNodeNum == 0) {
-                ShowSevereError(state,
-                                EnergyPlus::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(3), state.dataIPShortCut->cAlphaArgs(3)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(3), state.dataIPShortCut->cAlphaArgs(3)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ErrorsFound = true;
             }
 
@@ -274,9 +271,8 @@ namespace SurfaceGroundHeatExchanger {
                                   Node::CompFluidStream::Primary,
                                   Node::ObjectIsNotParent);
             if (state.dataSurfaceGroundHeatExchangers->SurfaceGHE(Item).OutletNodeNum == 0) {
-                ShowSevereError(state,
-                                EnergyPlus::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(4), state.dataIPShortCut->cAlphaArgs(4)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(4), state.dataIPShortCut->cAlphaArgs(4)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ErrorsFound = true;
             }
 
@@ -293,18 +289,16 @@ namespace SurfaceGroundHeatExchanger {
             state.dataSurfaceGroundHeatExchangers->SurfaceGHE(Item).TubeSpacing = state.dataIPShortCut->rNumericArgs(3);
 
             if (state.dataIPShortCut->rNumericArgs(2) == 0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.2R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.2f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Value must be greater than 0.0");
                 ErrorsFound = true;
             }
             if (state.dataIPShortCut->rNumericArgs(3) == 0.0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.2R}", state.dataIPShortCut->cNumericFieldNames(3), state.dataIPShortCut->rNumericArgs(3)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.2f}", state.dataIPShortCut->cNumericFieldNames(3), state.dataIPShortCut->rNumericArgs(3)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Value must be greater than 0.0");
                 ErrorsFound = true;
             }
@@ -313,18 +307,16 @@ namespace SurfaceGroundHeatExchanger {
             state.dataSurfaceGroundHeatExchangers->SurfaceGHE(Item).SurfaceLength = state.dataIPShortCut->rNumericArgs(4);
             state.dataSurfaceGroundHeatExchangers->SurfaceGHE(Item).SurfaceWidth = state.dataIPShortCut->rNumericArgs(5);
             if (state.dataIPShortCut->rNumericArgs(4) <= 0.0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.2R}", state.dataIPShortCut->cNumericFieldNames(4), state.dataIPShortCut->rNumericArgs(4)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.2f}", state.dataIPShortCut->cNumericFieldNames(4), state.dataIPShortCut->rNumericArgs(4)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Value must be greater than 0.0");
                 ErrorsFound = true;
             }
             if (state.dataIPShortCut->rNumericArgs(5) <= 0.0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("Invalid {}={:.2R}", state.dataIPShortCut->cNumericFieldNames(5), state.dataIPShortCut->rNumericArgs(5)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state,
+                                std::format("Invalid {}={:.2f}", state.dataIPShortCut->cNumericFieldNames(5), state.dataIPShortCut->rNumericArgs(5)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Value must be greater than 0.0");
                 ErrorsFound = true;
             }
@@ -335,9 +327,8 @@ namespace SurfaceGroundHeatExchanger {
             } else if (Util::SameString(state.dataIPShortCut->cAlphaArgs(5), "EXPOSED")) {
                 state.dataSurfaceGroundHeatExchangers->SurfaceGHE(Item).LowerSurfCond = SurfCond_Exposed;
             } else {
-                ShowSevereError(state,
-                                EnergyPlus::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(5), state.dataIPShortCut->cAlphaArgs(5)));
-                ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("Invalid {}={}", state.dataIPShortCut->cAlphaFieldNames(5), state.dataIPShortCut->cAlphaArgs(5)));
+                ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state, "Only \"Ground\" or \"Exposed\" is allowed.");
                 ErrorsFound = true;
             }
@@ -346,7 +337,7 @@ namespace SurfaceGroundHeatExchanger {
 
         // final error check
         if (ErrorsFound) {
-            ShowFatalError(state, EnergyPlus::format("Errors found in processing input for {}", cCurrentModuleObject));
+            ShowFatalError(state, std::format("Errors found in processing input for {}", cCurrentModuleObject));
         }
 
         // Set up the output variables
@@ -441,8 +432,8 @@ namespace SurfaceGroundHeatExchanger {
             if (!state.dataEnvrn->GroundTempInputs[(int)DataEnvironment::GroundTempType::Shallow]) {
                 ShowWarningError(state, "GetSurfaceGroundHeatExchanger: No \"Site:GroundTemperature:Shallow\" were input.");
                 ShowContinueError(state,
-                                  EnergyPlus::format("Defaults, constant throughout the year of ({:.1R}) will be used.",
-                                                     state.dataEnvrn->GroundTemp[(int)DataEnvironment::GroundTempType::Shallow]));
+                                  std::format("Defaults, constant throughout the year of ({:.1f}) will be used.",
+                                              state.dataEnvrn->GroundTemp[(int)DataEnvironment::GroundTempType::Shallow]));
             }
             state.dataSurfaceGroundHeatExchangers->NoSurfaceGroundTempObjWarning = false;
         }
@@ -694,10 +685,9 @@ namespace SurfaceGroundHeatExchanger {
                 // Check for non-convergence
                 if (iter > Maxiter) {
                     if (this->ConvErrIndex1 == 0) {
-                        ShowWarningMessage(state,
-                                           EnergyPlus::format("CalcSurfaceGroundHeatExchanger=\"{}\", Did not converge (part 1), Iterations={}",
-                                                              this->Name,
-                                                              Maxiter));
+                        ShowWarningMessage(
+                            state,
+                            std::format("CalcSurfaceGroundHeatExchanger=\"{}\", Did not converge (part 1), Iterations={}", this->Name, Maxiter));
                         ShowContinueErrorTimeStamp(state, "");
                     }
                     ShowRecurringWarningErrorAtEnd(
@@ -797,10 +787,9 @@ namespace SurfaceGroundHeatExchanger {
                     // Check for non-convergence
                     if (iter1 > Maxiter1) {
                         if (this->ConvErrIndex2 == 0) {
-                            ShowWarningMessage(state,
-                                               EnergyPlus::format("CalcSurfaceGroundHeatExchanger=\"{}\", Did not converge (part 2), Iterations={}",
-                                                                  this->Name,
-                                                                  Maxiter));
+                            ShowWarningMessage(
+                                state,
+                                std::format("CalcSurfaceGroundHeatExchanger=\"{}\", Did not converge (part 2), Iterations={}", this->Name, Maxiter));
                             ShowContinueErrorTimeStamp(state, "");
                         }
                         ShowRecurringWarningErrorAtEnd(
@@ -1156,10 +1145,9 @@ namespace SurfaceGroundHeatExchanger {
                 if (this->FrozenErrIndex1 == 0) {
                     ShowWarningMessage(
                         state,
-                        EnergyPlus::format(
-                            "GroundHeatExchanger:Surface=\"{}\", water is frozen; Model not valid. Calculated Water Temperature=[{:.2R}] C",
-                            this->Name,
-                            this->InletTemp));
+                        std::format("GroundHeatExchanger:Surface=\"{}\", water is frozen; Model not valid. Calculated Water Temperature=[{:.2f}] C",
+                                    this->Name,
+                                    this->InletTemp));
                     ShowContinueErrorTimeStamp(state, "");
                 }
                 ShowRecurringWarningErrorAtEnd(state,

--- a/src/EnergyPlus/SystemReports.cc
+++ b/src/EnergyPlus/SystemReports.cc
@@ -2351,10 +2351,9 @@ void CreateEnergyReportStructure(EnergyPlusData &state)
                                 thisSubSubComponent.NodeNumOut = OutletNodeNumbers(SubSubCompNum);
                                 NumLeft = Node::GetNumChildren(state, SubCompTypes(SubSubCompNum), SubCompNames(SubSubCompNum));
                                 if (NumLeft > 0) {
-                                    ShowSevereError(state,
-                                                    EnergyPlus::format("Hanging Children for component={}:{}",
-                                                                       thisSubSubComponent.TypeOf,
-                                                                       SubCompNames(SubSubCompNum)));
+                                    ShowSevereError(
+                                        state,
+                                        std::format("Hanging Children for component={}:{}", thisSubSubComponent.TypeOf, SubCompNames(SubSubCompNum)));
                                 }
                             }
                         }
@@ -4944,15 +4943,14 @@ void reportAirLoopToplogy(EnergyPlusData &state)
     int rowCounter = 1;
     for (int airLoopNum = 1; airLoopNum <= state.dataHVACGlobal->NumPrimaryAirSys; ++airLoopNum) {
         auto &pas = state.dataAirSystemsData->PrimaryAirSystems(airLoopNum);
-        OutputReportPredefined::PreDefTableEntry(state, orp->pdchTopAirLoopName, EnergyPlus::format("{}", rowCounter), pas.Name);
+        OutputReportPredefined::PreDefTableEntry(state, orp->pdchTopAirLoopName, std::format("{}", rowCounter), pas.Name);
         ++rowCounter;
         for (int BranchNum = 1; BranchNum <= pas.NumBranches; ++BranchNum) {
             auto &pasBranch = pas.Branch(BranchNum);
             if (pas.Splitter.Exists) {
                 for (int outNum : pas.Splitter.BranchNumOut) {
                     if (outNum == BranchNum) {
-                        OutputReportPredefined::PreDefTableEntry(
-                            state, orp->pdchTopAirSplitName, EnergyPlus::format("{}", rowCounter), pas.Splitter.Name);
+                        OutputReportPredefined::PreDefTableEntry(state, orp->pdchTopAirSplitName, std::format("{}", rowCounter), pas.Splitter.Name);
                         break;
                     }
                 }
@@ -4964,21 +4962,20 @@ void reportAirLoopToplogy(EnergyPlusData &state)
                 for (int SubCompNum = 1; SubCompNum <= pasBranchComp.NumSubComps; ++SubCompNum) {
                     auto &pasBranchSubComp = pasBranchComp.SubComp(SubCompNum);
                     OutputReportPredefined::PreDefTableEntry(
-                        state, orp->pdchTopAirSubCompType, EnergyPlus::format("{}", rowCounter), pasBranchSubComp.TypeOf);
-                    OutputReportPredefined::PreDefTableEntry(
-                        state, orp->pdchTopAirSubCompName, EnergyPlus::format("{}", rowCounter), pasBranchSubComp.Name);
+                        state, orp->pdchTopAirSubCompType, std::format("{}", rowCounter), pasBranchSubComp.TypeOf);
+                    OutputReportPredefined::PreDefTableEntry(state, orp->pdchTopAirSubCompName, std::format("{}", rowCounter), pasBranchSubComp.Name);
                     fillAirloopToplogyComponentRow(
                         state, pas.Name, pasBranch.Name, pasBranch.DuctType, pasBranchComp.TypeOf, pasBranchComp.Name, rowCounter);
                     for (int SubSubCompNum = 1; SubSubCompNum <= pasBranchSubComp.NumSubSubComps; ++SubSubCompNum) {
                         auto &pasBranchSubSubComp = pasBranchSubComp.SubSubComp(SubSubCompNum);
                         OutputReportPredefined::PreDefTableEntry(
-                            state, orp->pdchTopAirSubCompType, EnergyPlus::format("{}", rowCounter), pasBranchSubComp.TypeOf);
+                            state, orp->pdchTopAirSubCompType, std::format("{}", rowCounter), pasBranchSubComp.TypeOf);
                         OutputReportPredefined::PreDefTableEntry(
-                            state, orp->pdchTopAirSubCompName, EnergyPlus::format("{}", rowCounter), pasBranchSubComp.Name);
+                            state, orp->pdchTopAirSubCompName, std::format("{}", rowCounter), pasBranchSubComp.Name);
                         OutputReportPredefined::PreDefTableEntry(
-                            state, orp->pdchTopAirSubSubCompType, EnergyPlus::format("{}", rowCounter), pasBranchSubSubComp.TypeOf);
+                            state, orp->pdchTopAirSubSubCompType, std::format("{}", rowCounter), pasBranchSubSubComp.TypeOf);
                         OutputReportPredefined::PreDefTableEntry(
-                            state, orp->pdchTopAirSubSubCompName, EnergyPlus::format("{}", rowCounter), pasBranchSubSubComp.Name);
+                            state, orp->pdchTopAirSubSubCompName, std::format("{}", rowCounter), pasBranchSubSubComp.Name);
                         fillAirloopToplogyComponentRow(
                             state, pas.Name, pasBranch.Name, pasBranch.DuctType, pasBranchComp.TypeOf, pasBranchComp.Name, rowCounter);
                     }
@@ -4987,8 +4984,7 @@ void reportAirLoopToplogy(EnergyPlusData &state)
             if (pas.Mixer.Exists) {
                 for (int inNum : pas.Mixer.BranchNumIn) {
                     if (inNum == BranchNum) {
-                        OutputReportPredefined::PreDefTableEntry(
-                            state, orp->pdchTopAirMixName, EnergyPlus::format("{}", rowCounter - 1), pas.Mixer.Name);
+                        OutputReportPredefined::PreDefTableEntry(state, orp->pdchTopAirMixName, std::format("{}", rowCounter - 1), pas.Mixer.Name);
                         break;
                     }
                 }
@@ -5011,7 +5007,7 @@ void reportAirLoopToplogy(EnergyPlusData &state)
     for (int airLoopNum = 1; airLoopNum <= state.dataHVACGlobal->NumPrimaryAirSys; ++airLoopNum) {
         auto &pas = state.dataAirSystemsData->PrimaryAirSystems(airLoopNum);
         auto &thisAtoZInfo = state.dataAirLoop->AirToZoneNodeInfo(airLoopNum);
-        OutputReportPredefined::PreDefTableEntry(state, orp->pdchTopAirDemandName, EnergyPlus::format("{}", rowCounter), thisAtoZInfo.AirLoopName);
+        OutputReportPredefined::PreDefTableEntry(state, orp->pdchTopAirDemandName, std::format("{}", rowCounter), thisAtoZInfo.AirLoopName);
         ++rowCounter;
         for (int ductNum = 1; ductNum <= thisAtoZInfo.NumSupplyNodes; ++ductNum) {
             auto &thisBranch = pas.Branch(thisAtoZInfo.SupplyDuctBranchNum(ductNum));
@@ -5019,15 +5015,14 @@ void reportAirLoopToplogy(EnergyPlusData &state)
                 auto &thisSupplyPath = state.dataZoneEquip->SupplyAirPath(thisAtoZInfo.SupplyAirPathNum(ductNum));
                 for (int compNum = 1; compNum <= thisSupplyPath.NumOfComponents; ++compNum) {
                     OutputReportPredefined::PreDefTableEntry(
-                        state, orp->pdchTopAirDemandName, EnergyPlus::format("{}", rowCounter), thisAtoZInfo.AirLoopName);
+                        state, orp->pdchTopAirDemandName, std::format("{}", rowCounter), thisAtoZInfo.AirLoopName);
+                    OutputReportPredefined::PreDefTableEntry(state, orp->pdchTopAirSupplyBranchName, std::format("{}", rowCounter), thisBranch.Name);
                     OutputReportPredefined::PreDefTableEntry(
-                        state, orp->pdchTopAirSupplyBranchName, EnergyPlus::format("{}", rowCounter), thisBranch.Name);
+                        state, orp->pdchTopAirSupplyDuctType, std::format("{}", rowCounter), HVAC::airDuctTypeNames[(int)thisBranch.DuctType]);
                     OutputReportPredefined::PreDefTableEntry(
-                        state, orp->pdchTopAirSupplyDuctType, EnergyPlus::format("{}", rowCounter), HVAC::airDuctTypeNames[(int)thisBranch.DuctType]);
+                        state, orp->pdchTopAirSupplyPCompType, std::format("{}", rowCounter), thisSupplyPath.ComponentType(compNum));
                     OutputReportPredefined::PreDefTableEntry(
-                        state, orp->pdchTopAirSupplyPCompType, EnergyPlus::format("{}", rowCounter), thisSupplyPath.ComponentType(compNum));
-                    OutputReportPredefined::PreDefTableEntry(
-                        state, orp->pdchTopAirSupplyPCompName, EnergyPlus::format("{}", rowCounter), thisSupplyPath.ComponentName(compNum));
+                        state, orp->pdchTopAirSupplyPCompName, std::format("{}", rowCounter), thisSupplyPath.ComponentName(compNum));
                     ++rowCounter;
                 }
                 if (thisBranch.DuctType == HVAC::AirDuctType::Cooling || thisBranch.DuctType == HVAC::AirDuctType::Main) {
@@ -5043,14 +5038,10 @@ void reportAirLoopToplogy(EnergyPlusData &state)
                             }
                             if (thisCoolADU.SupplyAirPathExists) {
                                 int spCompNum = thisSupplyPath.OutletNodeSupplyPathCompNum(thisCoolADU.SupplyAirPathOutNodeIndex);
-                                OutputReportPredefined::PreDefTableEntry(state,
-                                                                         orp->pdchTopAirSupplyPCompType,
-                                                                         EnergyPlus::format("{}", rowCounter),
-                                                                         thisSupplyPath.ComponentType(spCompNum));
-                                OutputReportPredefined::PreDefTableEntry(state,
-                                                                         orp->pdchTopAirSupplyPCompName,
-                                                                         EnergyPlus::format("{}", rowCounter),
-                                                                         thisSupplyPath.ComponentName(spCompNum));
+                                OutputReportPredefined::PreDefTableEntry(
+                                    state, orp->pdchTopAirSupplyPCompType, std::format("{}", rowCounter), thisSupplyPath.ComponentType(spCompNum));
+                                OutputReportPredefined::PreDefTableEntry(
+                                    state, orp->pdchTopAirSupplyPCompName, std::format("{}", rowCounter), thisSupplyPath.ComponentName(spCompNum));
                             }
                             OutputReportPredefined::PreDefTableEntry(
                                 state, orp->pdchTopAirDemandName, std::format("{}", rowCounter), thisAtoZInfo.AirLoopName);

--- a/src/EnergyPlus/ThermalChimney.cc
+++ b/src/EnergyPlus/ThermalChimney.cc
@@ -47,6 +47,7 @@
 
 // C++ Headers
 #include <cmath>
+#include <format>
 
 // EnergyPlus Headers
 #include <EnergyPlus/Data/EnergyPlusData.hh>
@@ -191,18 +192,17 @@ namespace ThermalChimney {
             state.dataThermalChimneys->ThermalChimneySys(Loop).RealZonePtr =
                 Util::FindItemInList(state.dataIPShortCut->cAlphaArgs(2), state.dataHeatBal->Zone);
             if (state.dataThermalChimneys->ThermalChimneySys(Loop).RealZonePtr == 0) {
-                ShowSevereError(state, EnergyPlus::format("{}=\"{} invalid Zone", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
-                ShowContinueError(state,
-                                  EnergyPlus::format("invalid - not found {}=\"{}\".",
-                                                     state.dataIPShortCut->cAlphaFieldNames(2),
-                                                     state.dataIPShortCut->cAlphaArgs(2)));
+                ShowSevereError(state, std::format("{}=\"{} invalid Zone", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowContinueError(
+                    state,
+                    std::format("invalid - not found {}=\"{}\".", state.dataIPShortCut->cAlphaFieldNames(2), state.dataIPShortCut->cAlphaArgs(2)));
                 ErrorsFound = true;
             } else if (!state.dataHeatBal->Zone(state.dataThermalChimneys->ThermalChimneySys(Loop).RealZonePtr).HasWindow) {
-                ShowSevereError(state, EnergyPlus::format("{}=\"{} invalid Zone", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
+                ShowSevereError(state, std::format("{}=\"{} invalid Zone", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(state,
-                                  EnergyPlus::format("...invalid - no window(s) in {}=\"{}\".",
-                                                     state.dataIPShortCut->cAlphaFieldNames(2),
-                                                     state.dataIPShortCut->cAlphaArgs(2)));
+                                  std::format("...invalid - no window(s) in {}=\"{}\".",
+                                              state.dataIPShortCut->cAlphaFieldNames(2),
+                                              state.dataIPShortCut->cAlphaArgs(2)));
                 ShowContinueError(state, "...thermal chimney zones must have window(s).");
                 ErrorsFound = true;
             }
@@ -219,22 +219,22 @@ namespace ThermalChimney {
             state.dataThermalChimneys->ThermalChimneySys(Loop).AbsorberWallWidth = state.dataIPShortCut->rNumericArgs(1);
             if (state.dataThermalChimneys->ThermalChimneySys(Loop).AbsorberWallWidth < 0.0) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{}=\"{} invalid {} must be >= 0, entered value=[{:.2R}].",
-                                                   cCurrentModuleObject,
-                                                   state.dataIPShortCut->cAlphaArgs(1),
-                                                   state.dataIPShortCut->cNumericFieldNames(1),
-                                                   state.dataIPShortCut->rNumericArgs(1)));
+                                std::format("{}=\"{} invalid {} must be >= 0, entered value=[{:.2f}].",
+                                            cCurrentModuleObject,
+                                            state.dataIPShortCut->cAlphaArgs(1),
+                                            state.dataIPShortCut->cNumericFieldNames(1),
+                                            state.dataIPShortCut->rNumericArgs(1)));
                 ErrorsFound = true;
             }
 
             state.dataThermalChimneys->ThermalChimneySys(Loop).AirOutletCrossArea = state.dataIPShortCut->rNumericArgs(2);
             if (state.dataThermalChimneys->ThermalChimneySys(Loop).AirOutletCrossArea < 0.0) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{}=\"{} invalid {} must be >= 0, entered value=[{:.2R}].",
-                                                   cCurrentModuleObject,
-                                                   state.dataIPShortCut->cAlphaArgs(1),
-                                                   state.dataIPShortCut->cNumericFieldNames(2),
-                                                   state.dataIPShortCut->rNumericArgs(2)));
+                                std::format("{}=\"{} invalid {} must be >= 0, entered value=[{:.2f}].",
+                                            cCurrentModuleObject,
+                                            state.dataIPShortCut->cAlphaArgs(1),
+                                            state.dataIPShortCut->cNumericFieldNames(2),
+                                            state.dataIPShortCut->rNumericArgs(2)));
                 ErrorsFound = true;
             }
 
@@ -242,11 +242,11 @@ namespace ThermalChimney {
             if ((state.dataThermalChimneys->ThermalChimneySys(Loop).DischargeCoeff <= 0.0) ||
                 (state.dataThermalChimneys->ThermalChimneySys(Loop).DischargeCoeff > 1.0)) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{}=\"{} invalid {} must be > 0 and <=1.0, entered value=[{:.2R}].",
-                                                   cCurrentModuleObject,
-                                                   state.dataIPShortCut->cAlphaArgs(1),
-                                                   state.dataIPShortCut->cNumericFieldNames(3),
-                                                   state.dataIPShortCut->rNumericArgs(3)));
+                                std::format("{}=\"{} invalid {} must be > 0 and <=1.0, entered value=[{:.2f}].",
+                                            cCurrentModuleObject,
+                                            state.dataIPShortCut->cAlphaArgs(1),
+                                            state.dataIPShortCut->cNumericFieldNames(3),
+                                            state.dataIPShortCut->rNumericArgs(3)));
                 ErrorsFound = true;
             }
 
@@ -288,55 +288,55 @@ namespace ThermalChimney {
                 //!! Error trap for zones that do not exist or zones not in the zone the thermal chimney is in
                 if (state.dataThermalChimneys->ThermalChimneySys(Loop).ZonePtr(TCZoneNum) == 0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{} invalid {}=\"{}\" not found.",
-                                                       cCurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       state.dataIPShortCut->cAlphaFieldNames(TCZoneNum + 3),
-                                                       state.dataIPShortCut->cAlphaArgs(TCZoneNum + 3)));
+                                    std::format("{}=\"{} invalid {}=\"{}\" not found.",
+                                                cCurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                state.dataIPShortCut->cAlphaFieldNames(TCZoneNum + 3),
+                                                state.dataIPShortCut->cAlphaArgs(TCZoneNum + 3)));
                     ErrorsFound = true;
                 } else if (state.dataThermalChimneys->ThermalChimneySys(Loop).ZonePtr(TCZoneNum) ==
                            state.dataThermalChimneys->ThermalChimneySys(Loop).RealZonePtr) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{} invalid reference {}=\"{}",
-                                                       cCurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       state.dataIPShortCut->cAlphaFieldNames(2),
-                                                       state.dataIPShortCut->cAlphaArgs(2)));
+                                    std::format("{}=\"{} invalid reference {}=\"{}",
+                                                cCurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                state.dataIPShortCut->cAlphaFieldNames(2),
+                                                state.dataIPShortCut->cAlphaArgs(2)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("...must not have same zone as reference= {}=\"{}\".",
-                                                         state.dataIPShortCut->cAlphaFieldNames(TCZoneNum + 3),
-                                                         state.dataIPShortCut->cAlphaArgs(TCZoneNum + 3)));
+                                      std::format("...must not have same zone as reference= {}=\"{}\".",
+                                                  state.dataIPShortCut->cAlphaFieldNames(TCZoneNum + 3),
+                                                  state.dataIPShortCut->cAlphaArgs(TCZoneNum + 3)));
                     ErrorsFound = true;
                 }
 
                 if (state.dataThermalChimneys->ThermalChimneySys(Loop).DistanceThermChimInlet(TCZoneNum) < 0.0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{} invalid {} must be >= 0, entered value=[{:.2R}].",
-                                                       cCurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       state.dataIPShortCut->cNumericFieldNames(3 * TCZoneNum + 1),
-                                                       state.dataIPShortCut->rNumericArgs(3 * TCZoneNum + 1)));
+                                    std::format("{}=\"{} invalid {} must be >= 0, entered value=[{:.2f}].",
+                                                cCurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                state.dataIPShortCut->cNumericFieldNames(3 * TCZoneNum + 1),
+                                                state.dataIPShortCut->rNumericArgs(3 * TCZoneNum + 1)));
                     ErrorsFound = true;
                 }
 
                 if ((state.dataThermalChimneys->ThermalChimneySys(Loop).RatioThermChimAirFlow(TCZoneNum) <= 0.0) ||
                     (state.dataThermalChimneys->ThermalChimneySys(Loop).RatioThermChimAirFlow(TCZoneNum) > 1.0)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{} invalid {} must be > 0 and <=1.0, entered value=[{:.2R}].",
-                                                       cCurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       state.dataIPShortCut->cNumericFieldNames(3 * TCZoneNum + 2),
-                                                       state.dataIPShortCut->rNumericArgs(3 * TCZoneNum + 2)));
+                                    std::format("{}=\"{} invalid {} must be > 0 and <=1.0, entered value=[{:.2f}].",
+                                                cCurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                state.dataIPShortCut->cNumericFieldNames(3 * TCZoneNum + 2),
+                                                state.dataIPShortCut->rNumericArgs(3 * TCZoneNum + 2)));
                     ErrorsFound = true;
                 }
 
                 if (state.dataThermalChimneys->ThermalChimneySys(Loop).EachAirInletCrossArea(TCZoneNum) < 0.0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{} invalid {} must be >= 0, entered value=[{:.2R}].",
-                                                       cCurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       state.dataIPShortCut->cNumericFieldNames(3 * TCZoneNum + 3),
-                                                       state.dataIPShortCut->rNumericArgs(3 * TCZoneNum + 3)));
+                                    std::format("{}=\"{} invalid {} must be >= 0, entered value=[{:.2f}].",
+                                                cCurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                state.dataIPShortCut->cNumericFieldNames(3 * TCZoneNum + 3),
+                                                state.dataIPShortCut->rNumericArgs(3 * TCZoneNum + 3)));
                     ErrorsFound = true;
                 }
 
@@ -347,10 +347,10 @@ namespace ThermalChimney {
             // Error trap if the sum of fractions is not equal to 1.0
             if (std::abs(AllRatiosSummed - 1.0) > FlowFractionTolerance) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{}=\"{} invalid sum of fractions, must be =1.0, entered value (summed from entries)=[{:.4R}].",
-                                                   cCurrentModuleObject,
-                                                   state.dataIPShortCut->cAlphaArgs(1),
-                                                   AllRatiosSummed));
+                                std::format("{}=\"{} invalid sum of fractions, must be =1.0, entered value (summed from entries)=[{:.4f}].",
+                                            cCurrentModuleObject,
+                                            state.dataIPShortCut->cAlphaArgs(1),
+                                            AllRatiosSummed));
                 ErrorsFound = true;
             }
 
@@ -585,9 +585,9 @@ namespace ThermalChimney {
                                 state.dataThermalChimneys->ThermalChimneySys(Loop).ZonePtr(TCZoneNum1)) {
                                 ShowSevereError(
                                     state,
-                                    EnergyPlus::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two ZoneThermalChimney "
-                                                       "objects associated with it",
-                                                       state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
+                                    std::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two ZoneThermalChimney "
+                                                "objects associated with it",
+                                                state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
                                 ErrorsFound = true;
                             }
                         }
@@ -596,9 +596,9 @@ namespace ThermalChimney {
                                 state.dataThermalChimneys->ThermalChimneySys(Loop).ZonePtr(TCZoneNum1)) {
                                 ShowSevereError(
                                     state,
-                                    EnergyPlus::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two ZoneThermalChimney "
-                                                       "objects associated with it",
-                                                       state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
+                                    std::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two ZoneThermalChimney "
+                                                "objects associated with it",
+                                                state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
                                 ErrorsFound = true;
                             }
                         }
@@ -608,9 +608,9 @@ namespace ThermalChimney {
                                 state.dataThermalChimneys->ThermalChimneySys(Loop).ZonePtr(TCZoneNum1)) {
                                 ShowSevereError(
                                     state,
-                                    EnergyPlus::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two ZoneThermalChimney "
-                                                       "objects associated with it",
-                                                       state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
+                                    std::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two ZoneThermalChimney "
+                                                "objects associated with it",
+                                                state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
                                 ErrorsFound = true;
                             }
                         }
@@ -632,9 +632,9 @@ namespace ThermalChimney {
                                 if (state.dataThermalChimneys->ThermalChimneySys(Loop).ZonePtr(TCZoneNum) ==
                                     state.dataThermalChimneys->ThermalChimneySys(Loop1).ZonePtr(TCZoneNum1)) {
                                     ShowSevereError(state,
-                                                    EnergyPlus::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two "
-                                                                       "ZoneThermalChimney objects associated with it",
-                                                                       state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
+                                                    std::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two "
+                                                                "ZoneThermalChimney objects associated with it",
+                                                                state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
                                     ErrorsFound = true;
                                 }
                             }
@@ -646,9 +646,9 @@ namespace ThermalChimney {
                                 if (state.dataThermalChimneys->ThermalChimneySys(Loop).ZonePtr(TCZoneNum) ==
                                     state.dataThermalChimneys->ThermalChimneySys(Loop1).ZonePtr(TCZoneNum1)) {
                                     ShowSevereError(state,
-                                                    EnergyPlus::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two "
-                                                                       "ZoneThermalChimney objects associated with it",
-                                                                       state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
+                                                    std::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two "
+                                                                "ZoneThermalChimney objects associated with it",
+                                                                state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
                                     ErrorsFound = true;
                                 }
                             }
@@ -661,9 +661,9 @@ namespace ThermalChimney {
                                 if (state.dataThermalChimneys->ThermalChimneySys(Loop).ZonePtr(TCZoneNum) ==
                                     state.dataThermalChimneys->ThermalChimneySys(Loop1).ZonePtr(TCZoneNum1)) {
                                     ShowSevereError(state,
-                                                    EnergyPlus::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two "
-                                                                       "ZoneThermalChimney objects associated with it",
-                                                                       state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
+                                                    std::format("Only one ZoneThermalChimney object allowed per zone but zone {} has two "
+                                                                "ZoneThermalChimney objects associated with it",
+                                                                state.dataThermalChimneys->ThermalChimneySys(Loop).ZoneName(TCZoneNum)));
                                     ErrorsFound = true;
                                 }
                             }
@@ -675,7 +675,7 @@ namespace ThermalChimney {
         } // IF (TotThermalChimney > 1) THEN
 
         if (ErrorsFound) {
-            ShowFatalError(state, EnergyPlus::format("{} Errors found in input.  Preceding condition(s) cause termination.", cCurrentModuleObject));
+            ShowFatalError(state, std::format("{} Errors found in input.  Preceding condition(s) cause termination.", cCurrentModuleObject));
         }
     }
 

--- a/src/EnergyPlus/ThermalComfort.cc
+++ b/src/EnergyPlus/ThermalComfort.cc
@@ -2029,9 +2029,9 @@ namespace ThermalComfort {
                                 std::format("{}=\"{}\", invalid - Sum[AngleFactors]", cCurrentModuleObject, state.dataIPShortCut->cAlphaArgs(1)));
                 ShowContinueError(
                     state,
-                    EnergyPlus::format("...Sum of Angle Factors [{:.3R}] should not deviate from expected sum [1.0] by more than limit [{:.3R}].",
-                                       AllAngleFacSummed,
-                                       AngleFacLimit));
+                    std::format("...Sum of Angle Factors [{:.3f}] should not deviate from expected sum [1.0] by more than limit [{:.3f}].",
+                                AllAngleFacSummed,
+                                AngleFacLimit));
                 ErrorsFound = true;
             }
         }
@@ -2433,7 +2433,7 @@ namespace ThermalComfort {
             }
             // if any zones should be warning print it out
             if (showWarning) {
-                ShowWarningError(state, EnergyPlus::format("More than 4% of time ({:.1R} hours) uncomfortable in one or more zones ", allowedHours));
+                ShowWarningError(state, std::format("More than 4% of time ({:.1f} hours) uncomfortable in one or more zones ", allowedHours));
                 ShowContinueError(state, "Based on ASHRAE 55-2004 graph (Section 5.2.1.1)");
                 if (state.dataEnvrn->RunPeriodEnvironment) {
                     ShowContinueError(
@@ -2448,9 +2448,9 @@ namespace ThermalComfort {
                     if (state.dataThermalComforts->ThermalComfortInASH55(iZone).Enable55Warning) {
                         if (state.dataThermalComforts->ThermalComfortInASH55(iZone).totalTimeNotEither > allowedHours) {
                             ShowContinueError(state,
-                                              EnergyPlus::format("{:.1R} hours were uncomfortable in zone: {}",
-                                                                 state.dataThermalComforts->ThermalComfortInASH55(iZone).totalTimeNotEither,
-                                                                 state.dataHeatBal->Zone(iZone).Name));
+                                              std::format("{:.1f} hours were uncomfortable in zone: {}",
+                                                          state.dataThermalComforts->ThermalComfortInASH55(iZone).totalTimeNotEither,
+                                                          state.dataHeatBal->Zone(iZone).Name));
                         }
                     }
                 }

--- a/src/EnergyPlus/TranspiredCollector.cc
+++ b/src/EnergyPlus/TranspiredCollector.cc
@@ -154,28 +154,26 @@ namespace TranspiredCollector {
         if (CompIndex == 0) {
             UTSCNum = Util::FindItemInList(CompName, state.dataTranspiredCollector->UTSC);
             if (UTSCNum == 0) {
-                ShowFatalError(state, EnergyPlus::format("Transpired Collector not found={}", CompName));
+                ShowFatalError(state, std::format("Transpired Collector not found={}", CompName));
             }
             CompIndex = UTSCNum;
         } else {
             UTSCNum = CompIndex;
             if (UTSCNum > state.dataTranspiredCollector->NumUTSC || UTSCNum < 1) {
-                ShowFatalError(
-                    state,
-                    EnergyPlus::format("SimTranspiredCollector: Invalid CompIndex passed={}, Number of Transpired Collectors={}, UTSC name={}",
-                                       UTSCNum,
-                                       state.dataTranspiredCollector->NumUTSC,
-                                       CompName));
+                ShowFatalError(state,
+                               std::format("SimTranspiredCollector: Invalid CompIndex passed={}, Number of Transpired Collectors={}, UTSC name={}",
+                                           UTSCNum,
+                                           state.dataTranspiredCollector->NumUTSC,
+                                           CompName));
             }
             if (state.dataTranspiredCollector->CheckEquipName(UTSCNum)) {
                 if (CompName != state.dataTranspiredCollector->UTSC(UTSCNum).Name) {
-                    ShowFatalError(
-                        state,
-                        EnergyPlus::format("SimTranspiredCollector: Invalid CompIndex passed={}, Transpired Collector name={}, stored Transpired "
-                                           "Collector Name for that index={}",
-                                           UTSCNum,
-                                           CompName,
-                                           state.dataTranspiredCollector->UTSC(UTSCNum).Name));
+                    ShowFatalError(state,
+                                   std::format("SimTranspiredCollector: Invalid CompIndex passed={}, Transpired Collector name={}, stored Transpired "
+                                               "Collector Name for that index={}",
+                                               UTSCNum,
+                                               CompName,
+                                               state.dataTranspiredCollector->UTSC(UTSCNum).Name));
                 }
                 state.dataTranspiredCollector->CheckEquipName(UTSCNum) = false;
             }
@@ -286,11 +284,10 @@ namespace TranspiredCollector {
         state.dataInputProcessing->inputProcessor->getObjectDefMaxArgs(state, CurrentModuleObject, Dummy, MaxNumAlphas, MaxNumNumbers);
 
         if (MaxNumNumbers != 11) {
-            ShowSevereError(
-                state,
-                EnergyPlus::format("GetTranspiredCollectorInput: {} Object Definition indicates not = 11 Number Objects, Number Indicated={}",
-                                   CurrentModuleObject,
-                                   MaxNumNumbers));
+            ShowSevereError(state,
+                            std::format("GetTranspiredCollectorInput: {} Object Definition indicates not = 11 Number Objects, Number Indicated={}",
+                                        CurrentModuleObject,
+                                        MaxNumNumbers));
             ErrorsFound = true;
         }
         Alphas.allocate(MaxNumAlphas);
@@ -332,9 +329,9 @@ namespace TranspiredCollector {
                 if (MaxNumNumbersSplit != 0) {
                     ShowSevereError(
                         state,
-                        EnergyPlus::format("GetTranspiredCollectorInput: {} Object Definition indicates not = 0 Number Objects, Number Indicated={}",
-                                           CurrentModuleMultiObject,
-                                           MaxNumNumbersSplit));
+                        std::format("GetTranspiredCollectorInput: {} Object Definition indicates not = 0 Number Objects, Number Indicated={}",
+                                    CurrentModuleMultiObject,
+                                    MaxNumNumbersSplit));
                     ErrorsFound = true;
                 }
                 if (!allocated(AlphasSplit)) {
@@ -353,9 +350,9 @@ namespace TranspiredCollector {
                     if (mod((NumAlphasSplit), 4) != 1) {
                         ShowSevereError(
                             state,
-                            EnergyPlus::format("GetTranspiredCollectorInput: {} Object Definition indicates not uniform quadtuples of nodes for {}",
-                                               CurrentModuleMultiObject,
-                                               AlphasSplit(1)));
+                            std::format("GetTranspiredCollectorInput: {} Object Definition indicates not uniform quadtuples of nodes for {}",
+                                        CurrentModuleMultiObject,
+                                        AlphasSplit(1)));
                         ErrorsFound = true;
                     }
                     state.dataTranspiredCollector->UTSC(Item).InletNode.allocate(state.dataTranspiredCollector->UTSC(Item).NumOASysAttached);
@@ -426,11 +423,11 @@ namespace TranspiredCollector {
             Found = Util::FindItemInList(state.dataTranspiredCollector->UTSC(Item).OSCMName, state.dataSurface->OSCM);
             if (Found == 0) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{} not found={} in {} ={}",
-                                                   state.dataIPShortCut->cAlphaFieldNames(2),
-                                                   state.dataTranspiredCollector->UTSC(Item).OSCMName,
-                                                   CurrentModuleObject,
-                                                   state.dataTranspiredCollector->UTSC(Item).Name));
+                                std::format("{} not found={} in {} ={}",
+                                            state.dataIPShortCut->cAlphaFieldNames(2),
+                                            state.dataTranspiredCollector->UTSC(Item).OSCMName,
+                                            CurrentModuleObject,
+                                            state.dataTranspiredCollector->UTSC(Item).Name));
                 ErrorsFound = true;
             }
             state.dataTranspiredCollector->UTSC(Item).OSCMPtr = Found;
@@ -513,11 +510,11 @@ namespace TranspiredCollector {
                 state.dataTranspiredCollector->UTSC(Item).Layout = Layout_Square;
             } else {
                 ShowSevereError(state,
-                                EnergyPlus::format("{} has incorrect entry of {} in {} ={}",
-                                                   state.dataIPShortCut->cAlphaFieldNames(9),
-                                                   Alphas(9),
-                                                   CurrentModuleObject,
-                                                   state.dataTranspiredCollector->UTSC(Item).Name));
+                                std::format("{} has incorrect entry of {} in {} ={}",
+                                            state.dataIPShortCut->cAlphaFieldNames(9),
+                                            Alphas(9),
+                                            CurrentModuleObject,
+                                            state.dataTranspiredCollector->UTSC(Item).Name));
                 ErrorsFound = true;
                 continue;
             }
@@ -528,11 +525,11 @@ namespace TranspiredCollector {
                 state.dataTranspiredCollector->UTSC(Item).Correlation = Correlation_VanDeckerHollandsBrunger2001;
             } else {
                 ShowSevereError(state,
-                                EnergyPlus::format("{} has incorrect entry of {} in {} ={}",
-                                                   state.dataIPShortCut->cAlphaFieldNames(10),
-                                                   Alphas(9),
-                                                   CurrentModuleObject,
-                                                   state.dataTranspiredCollector->UTSC(Item).Name));
+                                std::format("{} has incorrect entry of {} in {} ={}",
+                                            state.dataIPShortCut->cAlphaFieldNames(10),
+                                            Alphas(9),
+                                            CurrentModuleObject,
+                                            state.dataTranspiredCollector->UTSC(Item).Name));
                 ErrorsFound = true;
                 continue;
             }
@@ -561,21 +558,20 @@ namespace TranspiredCollector {
             // Was it set?
             if (state.dataTranspiredCollector->UTSC(Item).CollRoughness == Material::SurfaceRoughness::Invalid) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{} has incorrect entry of {} in {} ={}",
-                                                   state.dataIPShortCut->cAlphaFieldNames(11),
-                                                   Alphas(11),
-                                                   CurrentModuleObject,
-                                                   state.dataTranspiredCollector->UTSC(Item).Name));
+                                std::format("{} has incorrect entry of {} in {} ={}",
+                                            state.dataIPShortCut->cAlphaFieldNames(11),
+                                            Alphas(11),
+                                            CurrentModuleObject,
+                                            state.dataTranspiredCollector->UTSC(Item).Name));
                 ErrorsFound = true;
             }
 
             AlphaOffset = 11;
             state.dataTranspiredCollector->UTSC(Item).NumSurfs = NumAlphas - AlphaOffset;
             if (state.dataTranspiredCollector->UTSC(Item).NumSurfs == 0) {
-                ShowSevereError(state,
-                                EnergyPlus::format("No underlying surfaces specified in {} ={}",
-                                                   CurrentModuleObject,
-                                                   state.dataTranspiredCollector->UTSC(Item).Name));
+                ShowSevereError(
+                    state,
+                    std::format("No underlying surfaces specified in {} ={}", CurrentModuleObject, state.dataTranspiredCollector->UTSC(Item).Name));
                 ErrorsFound = true;
                 continue;
             }
@@ -585,62 +581,61 @@ namespace TranspiredCollector {
                 Found = Util::FindItemInList(Alphas(ThisSurf + AlphaOffset), state.dataSurface->Surface);
                 if (Found == 0) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("Surface Name not found={} in {} ={}",
-                                                       Alphas(ThisSurf + AlphaOffset),
-                                                       CurrentModuleObject,
-                                                       state.dataTranspiredCollector->UTSC(Item).Name));
+                                    std::format("Surface Name not found={} in {} ={}",
+                                                Alphas(ThisSurf + AlphaOffset),
+                                                CurrentModuleObject,
+                                                state.dataTranspiredCollector->UTSC(Item).Name));
                     ErrorsFound = true;
                     continue;
                 }
                 // check that surface is appropriate, Heat transfer, Sun, Wind,
                 if (!state.dataSurface->Surface(Found).HeatTransSurf) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("Surface {} not of Heat Transfer type in {} ={}",
-                                                       Alphas(ThisSurf + AlphaOffset),
-                                                       CurrentModuleObject,
-                                                       state.dataTranspiredCollector->UTSC(Item).Name));
+                                    std::format("Surface {} not of Heat Transfer type in {} ={}",
+                                                Alphas(ThisSurf + AlphaOffset),
+                                                CurrentModuleObject,
+                                                state.dataTranspiredCollector->UTSC(Item).Name));
                     ErrorsFound = true;
                     continue;
                 }
                 if (!state.dataSurface->Surface(Found).ExtSolar) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("Surface {} not exposed to sun in {} ={}",
-                                                       Alphas(ThisSurf + AlphaOffset),
-                                                       CurrentModuleObject,
-                                                       state.dataTranspiredCollector->UTSC(Item).Name));
+                                    std::format("Surface {} not exposed to sun in {} ={}",
+                                                Alphas(ThisSurf + AlphaOffset),
+                                                CurrentModuleObject,
+                                                state.dataTranspiredCollector->UTSC(Item).Name));
                     ErrorsFound = true;
                     continue;
                 }
                 if (!state.dataSurface->Surface(Found).ExtWind) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("Surface {} not exposed to wind in {} ={}",
-                                                       Alphas(ThisSurf + AlphaOffset),
-                                                       CurrentModuleObject,
-                                                       state.dataTranspiredCollector->UTSC(Item).Name));
+                                    std::format("Surface {} not exposed to wind in {} ={}",
+                                                Alphas(ThisSurf + AlphaOffset),
+                                                CurrentModuleObject,
+                                                state.dataTranspiredCollector->UTSC(Item).Name));
                     ErrorsFound = true;
                     continue;
                 }
                 if (state.dataSurface->Surface(Found).ExtBoundCond != OtherSideCondModeledExt) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("Surface {} does not have OtherSideConditionsModel for exterior boundary conditions in {} ={}",
-                                                       Alphas(ThisSurf + AlphaOffset),
-                                                       CurrentModuleObject,
-                                                       state.dataTranspiredCollector->UTSC(Item).Name));
+                                    std::format("Surface {} does not have OtherSideConditionsModel for exterior boundary conditions in {} ={}",
+                                                Alphas(ThisSurf + AlphaOffset),
+                                                CurrentModuleObject,
+                                                state.dataTranspiredCollector->UTSC(Item).Name));
                     ErrorsFound = true;
                     continue;
                 }
                 // check surface orientation, warn if upside down
                 if ((state.dataSurface->Surface(Found).Tilt < -95.0) || (state.dataSurface->Surface(Found).Tilt > 95.0)) {
-                    ShowWarningError(state,
-                                     EnergyPlus::format("Suspected input problem with collector surface = {}", Alphas(ThisSurf + AlphaOffset)));
+                    ShowWarningError(state, std::format("Suspected input problem with collector surface = {}", Alphas(ThisSurf + AlphaOffset)));
                     ShowContinueError(state,
-                                      EnergyPlus::format("Entered in {} = {}",
-                                                         state.dataIPShortCut->cCurrentModuleObject,
-                                                         state.dataTranspiredCollector->UTSC(Item).Name));
+                                      std::format("Entered in {} = {}",
+                                                  state.dataIPShortCut->cCurrentModuleObject,
+                                                  state.dataTranspiredCollector->UTSC(Item).Name));
                     ShowContinueError(state, "Surface used for solar collector faces down");
-                    ShowContinueError(state,
-                                      EnergyPlus::format("Surface tilt angle (degrees from ground outward normal) = {:.2R}",
-                                                         state.dataSurface->Surface(Found).Tilt));
+                    ShowContinueError(
+                        state,
+                        std::format("Surface tilt angle (degrees from ground outward normal) = {:.2f}", state.dataSurface->Surface(Found).Tilt));
                 }
 
                 state.dataTranspiredCollector->UTSC(Item).SurfPtrs(ThisSurf) = Found;
@@ -1133,7 +1128,7 @@ namespace TranspiredCollector {
                 ShowWarningMessage(state,
                                    std::format("Solar Collector:Unglazed Transpired=\"{}\", Suction velocity is outside of range for a good design",
                                                state.dataTranspiredCollector->UTSC(UTSCNum).Name));
-                ShowContinueErrorTimeStamp(state, EnergyPlus::format("Suction velocity ={:.4R}", Vsuction));
+                ShowContinueErrorTimeStamp(state, std::format("Suction velocity ={:.4f}", Vsuction));
                 if (Vsuction < 0.003) {
                     ShowContinueError(state, "Velocity is low -- suggest decreasing area of transpired collector");
                 }

--- a/src/EnergyPlus/UFADManager.cc
+++ b/src/EnergyPlus/UFADManager.cc
@@ -47,6 +47,7 @@
 
 // C++ Headers
 #include <cmath>
+#include <format>
 
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array1D.hh>
@@ -255,8 +256,7 @@ namespace RoomAir {
             if (zoneU.WinWidth <= 0.0) {
                 ShowWarningError(
                     state,
-                    EnergyPlus::format("For RoomAirSettings:UnderFloorAirDistributionExterior for Zone {} there are no exterior windows.",
-                                       zoneU.ZoneName));
+                    std::format("For RoomAirSettings:UnderFloorAirDistributionExterior for Zone {} there are no exterior windows.", zoneU.ZoneName));
                 ShowContinueError(state, "  The zone will be treated as a UFAD interior zone");
             }
         } // if (model == RoomAirModel::UFADExt)
@@ -285,11 +285,11 @@ namespace RoomAir {
             (zoneU.A_Kc != Constant::AutoCalculate || zoneU.B_Kc != Constant::AutoCalculate || zoneU.C_Kc != Constant::AutoCalculate ||
              zoneU.D_Kc != Constant::AutoCalculate || zoneU.E_Kc != Constant::AutoCalculate)) {
             ShowWarningError(state,
-                             EnergyPlus::format("For {} for Zone {}, input for Coefficients A - E will be "
-                                                "ignored when Floor Diffuser Type = {}.",
-                                                cCMO,
-                                                zoneU.ZoneName,
-                                                diffuserNamesUC[(int)zoneU.DiffuserType]));
+                             std::format("For {} for Zone {}, input for Coefficients A - E will be "
+                                         "ignored when Floor Diffuser Type = {}.",
+                                         cCMO,
+                                         zoneU.ZoneName,
+                                         diffuserNamesUC[(int)zoneU.DiffuserType]));
             ShowContinueError(state, "  To input these Coefficients, use Floor Diffuser Type = Custom.");
         }
 
@@ -320,10 +320,10 @@ namespace RoomAir {
         } else if (zoneU.A_Kc == Constant::AutoCalculate || zoneU.B_Kc == Constant::AutoCalculate || zoneU.C_Kc == Constant::AutoCalculate ||
                    zoneU.D_Kc == Constant::AutoCalculate || zoneU.E_Kc == Constant::AutoCalculate) {
             ShowFatalError(state,
-                           EnergyPlus::format("For {} for Zone {}, input for Coefficients A - E must be "
-                                              "specified when Floor Diffuser Type = Custom.",
-                                              cCMO,
-                                              zoneU.ZoneName));
+                           std::format("For {} for Zone {}, input for Coefficients A - E must be "
+                                       "specified when Floor Diffuser Type = Custom.",
+                                       cCMO,
+                                       zoneU.ZoneName));
         }
 
         if (zoneU.PowerPerPlume == Constant::AutoCalculate) {
@@ -458,9 +458,9 @@ namespace RoomAir {
 
             if (std::abs(ZInfSurf - ZSupSurf) < 1.e-10) {
                 ShowSevereError(state, "RoomAirModelUFAD:HcUCSDUF: Surface values will cause divide by zero.");
-                ShowContinueError(state, EnergyPlus::format("Zone=\"{}\", Surface=\"{}\".", state.dataHeatBal->Zone(surf.Zone).Name, surf.Name));
-                ShowContinueError(state, EnergyPlus::format("ZInfSurf=[{:.4R}], LayH=[{:.4R}].", ZInfSurf, LayH));
-                ShowContinueError(state, EnergyPlus::format("ZSupSurf=[{:.4R}], LayH=[{:.4R}].", ZSupSurf, LayH));
+                ShowContinueError(state, std::format("Zone=\"{}\", Surface=\"{}\".", state.dataHeatBal->Zone(surf.Zone).Name, surf.Name));
+                ShowContinueError(state, std::format("ZInfSurf=[{:.4f}], LayH=[{:.4f}].", ZInfSurf, LayH));
+                ShowContinueError(state, std::format("ZSupSurf=[{:.4f}], LayH=[{:.4f}].", ZSupSurf, LayH));
                 ShowFatalError(state, "...Previous condition causes termination.");
             }
 
@@ -1117,9 +1117,8 @@ namespace RoomAir {
             } else if (HeightComfort <= CeilingHeight) {
                 state.dataRoomAir->TCMF(ZoneNum) = state.dataRoomAir->ZTMX(ZoneNum);
             } else {
-                ShowFatalError(
-                    state,
-                    EnergyPlus::format("UFAD comfort height is above ceiling or below floor in Zone: {}", state.dataHeatBal->Zone(ZoneNum).Name));
+                ShowFatalError(state,
+                               std::format("UFAD comfort height is above ceiling or below floor in Zone: {}", state.dataHeatBal->Zone(ZoneNum).Name));
             }
         }
 
@@ -1138,8 +1137,8 @@ namespace RoomAir {
                 state.dataHeatBalFanSys->TempTstatAir(ZoneNum) = state.dataRoomAir->ZTMX(ZoneNum);
             } else {
                 ShowFatalError(state,
-                               EnergyPlus::format("Underfloor air distribution thermostat height is above ceiling or below floor in Zone: {}",
-                                                  state.dataHeatBal->Zone(ZoneNum).Name));
+                               std::format("Underfloor air distribution thermostat height is above ceiling or below floor in Zone: {}",
+                                           state.dataHeatBal->Zone(ZoneNum).Name));
             }
         }
 
@@ -1579,9 +1578,8 @@ namespace RoomAir {
             } else if (HeightComfort <= CeilingHeight) {
                 state.dataRoomAir->TCMF(ZoneNum) = state.dataRoomAir->ZTMX(ZoneNum);
             } else {
-                ShowFatalError(
-                    state,
-                    EnergyPlus::format("UFAD comfort height is above ceiling or below floor in Zone: {}", state.dataHeatBal->Zone(ZoneNum).Name));
+                ShowFatalError(state,
+                               std::format("UFAD comfort height is above ceiling or below floor in Zone: {}", state.dataHeatBal->Zone(ZoneNum).Name));
             }
         }
 
@@ -1600,8 +1598,8 @@ namespace RoomAir {
                 state.dataHeatBalFanSys->TempTstatAir(ZoneNum) = state.dataRoomAir->ZTMX(ZoneNum);
             } else {
                 ShowFatalError(state,
-                               EnergyPlus::format("Underfloor air distribution thermostat height is above ceiling or below floor in Zone: {}",
-                                                  state.dataHeatBal->Zone(ZoneNum).Name));
+                               std::format("Underfloor air distribution thermostat height is above ceiling or below floor in Zone: {}",
+                                           state.dataHeatBal->Zone(ZoneNum).Name));
             }
         }
 

--- a/src/EnergyPlus/UnitHeater.cc
+++ b/src/EnergyPlus/UnitHeater.cc
@@ -139,25 +139,25 @@ namespace UnitHeater {
         if (CompIndex == 0) {
             UnitHeatNum = Util::FindItemInList(CompName, state.dataUnitHeaters->UnitHeat);
             if (UnitHeatNum == 0) {
-                ShowFatalError(state, EnergyPlus::format("SimUnitHeater: Unit not found={}", CompName));
+                ShowFatalError(state, std::format("SimUnitHeater: Unit not found={}", CompName));
             }
             CompIndex = UnitHeatNum;
         } else {
             UnitHeatNum = CompIndex;
             if (UnitHeatNum > state.dataUnitHeaters->NumOfUnitHeats || UnitHeatNum < 1) {
                 ShowFatalError(state,
-                               EnergyPlus::format("SimUnitHeater:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
-                                                  UnitHeatNum,
-                                                  state.dataUnitHeaters->NumOfUnitHeats,
-                                                  CompName));
+                               std::format("SimUnitHeater:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
+                                           UnitHeatNum,
+                                           state.dataUnitHeaters->NumOfUnitHeats,
+                                           CompName));
             }
             if (state.dataUnitHeaters->CheckEquipName(UnitHeatNum)) {
                 if (CompName != state.dataUnitHeaters->UnitHeat(UnitHeatNum).Name) {
                     ShowFatalError(state,
-                                   EnergyPlus::format("SimUnitHeater: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
-                                                      UnitHeatNum,
-                                                      CompName,
-                                                      state.dataUnitHeaters->UnitHeat(UnitHeatNum).Name));
+                                   std::format("SimUnitHeater: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
+                                               UnitHeatNum,
+                                               CompName,
+                                               state.dataUnitHeaters->UnitHeat(UnitHeatNum).Name));
                 }
                 state.dataUnitHeaters->CheckEquipName(UnitHeatNum) = false;
             }
@@ -317,22 +317,21 @@ namespace UnitHeater {
                 FanVolFlow = fan->maxAirFlowRate;
 
                 if (FanVolFlow != DataSizing::AutoSize && unitHeat.MaxAirVolFlow != DataSizing::AutoSize && FanVolFlow < unitHeat.MaxAirVolFlow) {
-                    ShowSevereError(state, EnergyPlus::format("Specified in {} = {}", CurrentModuleObject, unitHeat.Name));
+                    ShowSevereError(state, std::format("Specified in {} = {}", CurrentModuleObject, unitHeat.Name));
                     ShowContinueError(
                         state,
-                        EnergyPlus::format(
-                            "...air flow rate ({:.7f}) in fan object {} is less than the unit heater maximum supply air flow rate ({:.7f}).",
-                            FanVolFlow,
-                            unitHeat.FanName,
-                            unitHeat.MaxAirVolFlow));
+                        std::format("...air flow rate ({:.7f}) in fan object {} is less than the unit heater maximum supply air flow rate ({:.7f}).",
+                                    FanVolFlow,
+                                    unitHeat.FanName,
+                                    unitHeat.MaxAirVolFlow));
                     ShowContinueError(state, "...the fan flow rate must be greater than or equal to the unit heater maximum supply air flow rate.");
                     ErrorsFound = true;
                 } else if (FanVolFlow == DataSizing::AutoSize && unitHeat.MaxAirVolFlow != DataSizing::AutoSize) {
-                    ShowWarningError(state, EnergyPlus::format("Specified in {} = {}", CurrentModuleObject, unitHeat.Name));
+                    ShowWarningError(state, std::format("Specified in {} = {}", CurrentModuleObject, unitHeat.Name));
                     ShowContinueError(state, "...the fan flow rate is autosized while the unit heater flow rate is not.");
                     ShowContinueError(state, "...this can lead to unexpected results where the fan flow rate is less than required.");
                 } else if (FanVolFlow != DataSizing::AutoSize && unitHeat.MaxAirVolFlow == DataSizing::AutoSize) {
-                    ShowWarningError(state, EnergyPlus::format("Specified in {} = {}", CurrentModuleObject, unitHeat.Name));
+                    ShowWarningError(state, std::format("Specified in {} = {}", CurrentModuleObject, unitHeat.Name));
                     ShowContinueError(state, "...the unit heater flow rate is autosized while the fan flow rate is not.");
                     ShowContinueError(state, "...this can lead to unexpected results where the fan flow rate is less than required.");
                 }
@@ -353,8 +352,8 @@ namespace UnitHeater {
                 case HVAC::CoilType::HeatingGasOrOtherFuel:
                     break;
                 default: {
-                    ShowSevereError(state, EnergyPlus::format("Illegal {} = {}", cAlphaFields(7), Alphas(7)));
-                    ShowContinueError(state, EnergyPlus::format("Occurs in {}={}", CurrentModuleObject, unitHeat.Name));
+                    ShowSevereError(state, std::format("Illegal {} = {}", cAlphaFields(7), Alphas(7)));
+                    ShowContinueError(state, std::format("Occurs in {}={}", CurrentModuleObject, unitHeat.Name));
                     ErrorsFound = true;
                     errFlag = true;
                 }
@@ -366,7 +365,7 @@ namespace UnitHeater {
                 unitHeat.HCoilName = Alphas(8);
                 ValidateComponent(state, Alphas(7), unitHeat.HCoilName, IsNotOK, CurrentModuleObject);
                 if (IsNotOK) {
-                    ShowContinueError(state, EnergyPlus::format("specified in {} = \"{}\"", CurrentModuleObject, unitHeat.Name));
+                    ShowContinueError(state, std::format("specified in {} = \"{}\"", CurrentModuleObject, unitHeat.Name));
                     ErrorsFound = true;
                 } else {
                     // The heating coil control node is necessary for hot water and steam coils, but not necessary for an
@@ -383,7 +382,7 @@ namespace UnitHeater {
                         }
                         // Other error checks should trap before it gets to this point in the code, but including just in case.
                         if (errFlag) {
-                            ShowContinueError(state, EnergyPlus::format("that was specified in {} = \"{}\"", CurrentModuleObject, unitHeat.Name));
+                            ShowContinueError(state, std::format("that was specified in {} = \"{}\"", CurrentModuleObject, unitHeat.Name));
                             ErrorsFound = true;
                         }
                     }
@@ -406,8 +405,8 @@ namespace UnitHeater {
             unitHeat.FanOperatesDuringNoHeating = Alphas(10);
             if ((!Util::SameString(unitHeat.FanOperatesDuringNoHeating, "Yes")) && (!Util::SameString(unitHeat.FanOperatesDuringNoHeating, "No"))) {
                 ErrorsFound = true;
-                ShowSevereError(state, EnergyPlus::format("Illegal {} = {}", cAlphaFields(10), Alphas(10)));
-                ShowContinueError(state, EnergyPlus::format("Occurs in {}={}", CurrentModuleObject, unitHeat.Name));
+                ShowSevereError(state, std::format("Illegal {} = {}", cAlphaFields(10), Alphas(10)));
+                ShowContinueError(state, std::format("Occurs in {}={}", CurrentModuleObject, unitHeat.Name));
             } else if (Util::SameString(unitHeat.FanOperatesDuringNoHeating, "No")) {
                 unitHeat.FanOffNoHeating = true;
             }
@@ -431,8 +430,8 @@ namespace UnitHeater {
             if (!lAlphaBlanks(12)) {
                 unitHeat.HVACSizingIndex = Util::FindItemInList(Alphas(12), state.dataSize->ZoneHVACSizing);
                 if (unitHeat.HVACSizingIndex == 0) {
-                    ShowSevereError(state, EnergyPlus::format("{} = {} not found.", cAlphaFields(12), Alphas(12)));
-                    ShowContinueError(state, EnergyPlus::format("Occurs in {} = {}", CurrentModuleObject, unitHeat.Name));
+                    ShowSevereError(state, std::format("{} = {} not found.", cAlphaFields(12), Alphas(12)));
+                    ShowContinueError(state, std::format("Occurs in {} = {}", CurrentModuleObject, unitHeat.Name));
                     ErrorsFound = true;
                 }
             }
@@ -452,12 +451,11 @@ namespace UnitHeater {
             }
             if (ZoneNodeNotFound) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{} = \"{}\". Unit heater air inlet node name must be the same as a zone exhaust node name.",
-                                                   CurrentModuleObject,
-                                                   unitHeat.Name));
+                                std::format("{} = \"{}\". Unit heater air inlet node name must be the same as a zone exhaust node name.",
+                                            CurrentModuleObject,
+                                            unitHeat.Name));
                 ShowContinueError(state, "..Zone exhaust node name is specified in ZoneHVAC:EquipmentConnections object.");
-                ShowContinueError(state,
-                                  EnergyPlus::format("..Unit heater air inlet node name = {}", state.dataLoopNodes->NodeID(unitHeat.AirInNode)));
+                ShowContinueError(state, std::format("..Unit heater air inlet node name = {}", state.dataLoopNodes->NodeID(unitHeat.AirInNode)));
                 ErrorsFound = true;
             }
             // check that unit heater air outlet node is a zone inlet node.
@@ -476,9 +474,9 @@ namespace UnitHeater {
             }
             if (ZoneNodeNotFound) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{} = \"{}\". Unit heater air outlet node name must be the same as a zone inlet node name.",
-                                                   CurrentModuleObject,
-                                                   unitHeat.Name));
+                                std::format("{} = \"{}\". Unit heater air outlet node name must be the same as a zone inlet node name.",
+                                            CurrentModuleObject,
+                                            unitHeat.Name));
                 ShowContinueError(state, "..Zone inlet node name is specified in ZoneHVAC:EquipmentConnections object.");
                 ShowContinueError(state, std::format("..Unit heater air outlet node name = {}", state.dataLoopNodes->NodeID(unitHeat.AirOutNode)));
                 ErrorsFound = true;
@@ -1049,11 +1047,11 @@ namespace UnitHeater {
                                     ShowMessage(state,
                                                 std::format("SizeUnitHeater: Potential issue with equipment sizing for ZoneHVAC:UnitHeater {}",
                                                             state.dataUnitHeaters->UnitHeat(UnitHeatNum).Name));
-                                    ShowContinueError(
-                                        state, EnergyPlus::format("User-Specified Maximum Hot Water Flow of {:.5R} [m3/s]", MaxVolHotWaterFlowUser));
                                     ShowContinueError(state,
-                                                      EnergyPlus::format("differs from Design Size Maximum Hot Water Flow of {:.5R} [m3/s]",
-                                                                         MaxVolHotWaterFlowDes));
+                                                      std::format("User-Specified Maximum Hot Water Flow of {:.5f} [m3/s]", MaxVolHotWaterFlowUser));
+                                    ShowContinueError(
+                                        state,
+                                        std::format("differs from Design Size Maximum Hot Water Flow of {:.5f} [m3/s]", MaxVolHotWaterFlowDes));
                                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                                 }
@@ -1177,11 +1175,10 @@ namespace UnitHeater {
                                     ShowMessage(state,
                                                 std::format("SizeUnitHeater: Potential issue with equipment sizing for ZoneHVAC:UnitHeater {}",
                                                             state.dataUnitHeaters->UnitHeat(UnitHeatNum).Name));
+                                    ShowContinueError(state,
+                                                      std::format("User-Specified Maximum Steam Flow of {:.5f} [m3/s]", MaxVolHotSteamFlowUser));
                                     ShowContinueError(
-                                        state, EnergyPlus::format("User-Specified Maximum Steam Flow of {:.5R} [m3/s]", MaxVolHotSteamFlowUser));
-                                    ShowContinueError(
-                                        state,
-                                        EnergyPlus::format("differs from Design Size Maximum Steam Flow of {:.5R} [m3/s]", MaxVolHotSteamFlowDes));
+                                        state, std::format("differs from Design Size Maximum Steam Flow of {:.5f} [m3/s]", MaxVolHotSteamFlowDes));
                                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                                 }

--- a/src/EnergyPlus/UnitVentilator.cc
+++ b/src/EnergyPlus/UnitVentilator.cc
@@ -150,26 +150,25 @@ namespace UnitVentilator {
         if (CompIndex == 0) {
             UnitVentNum = Util::FindItemInList(CompName, state.dataUnitVentilators->UnitVent);
             if (UnitVentNum == 0) {
-                ShowFatalError(state, EnergyPlus::format("SimUnitVentilator: Unit not found={}", CompName));
+                ShowFatalError(state, std::format("SimUnitVentilator: Unit not found={}", CompName));
             }
             CompIndex = UnitVentNum;
         } else {
             UnitVentNum = CompIndex;
             if (UnitVentNum > state.dataUnitVentilators->NumOfUnitVents || UnitVentNum < 1) {
                 ShowFatalError(state,
-                               EnergyPlus::format("SimUnitVentilator:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
-                                                  UnitVentNum,
-                                                  state.dataUnitVentilators->NumOfUnitVents,
-                                                  CompName));
+                               std::format("SimUnitVentilator:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
+                                           UnitVentNum,
+                                           state.dataUnitVentilators->NumOfUnitVents,
+                                           CompName));
             }
             if (state.dataUnitVentilators->CheckEquipName(UnitVentNum)) {
                 if (CompName != state.dataUnitVentilators->UnitVent(UnitVentNum).Name) {
-                    ShowFatalError(
-                        state,
-                        EnergyPlus::format("SimUnitVentilator: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
-                                           UnitVentNum,
-                                           CompName,
-                                           state.dataUnitVentilators->UnitVent(UnitVentNum).Name));
+                    ShowFatalError(state,
+                                   std::format("SimUnitVentilator: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
+                                               UnitVentNum,
+                                               CompName,
+                                               state.dataUnitVentilators->UnitVent(UnitVentNum).Name));
                 }
                 state.dataUnitVentilators->CheckEquipName(UnitVentNum) = false;
             }
@@ -406,23 +405,23 @@ namespace UnitVentilator {
                 unitVent.fanAvailSched = fan->availSched; // Get the fan's availability schedule
                 FanVolFlow = fan->maxAirFlowRate;
                 if (FanVolFlow != DataSizing::AutoSize && unitVent.MaxAirVolFlow != DataSizing::AutoSize && FanVolFlow < unitVent.MaxAirVolFlow) {
-                    ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
+                    ShowSevereError(state, std::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
                     ShowContinueError(state,
-                                      EnergyPlus::format("...air flow rate [{:.7f}] in fan object {} is less than the unit ventilator maximum "
-                                                         "supply air flow rate [{:.7f}].",
-                                                         FanVolFlow,
-                                                         unitVent.FanName,
-                                                         unitVent.MaxAirVolFlow));
+                                      std::format("...air flow rate [{:.7f}] in fan object {} is less than the unit ventilator maximum "
+                                                  "supply air flow rate [{:.7f}].",
+                                                  FanVolFlow,
+                                                  unitVent.FanName,
+                                                  unitVent.MaxAirVolFlow));
                     ShowContinueError(state,
                                       "...the fan flow rate must be greater than or equal to the unit ventilator maximum supply "
                                       "air flow rate.");
                     ErrorsFound = true;
                 } else if (FanVolFlow == DataSizing::AutoSize && unitVent.MaxAirVolFlow != DataSizing::AutoSize) {
-                    ShowWarningError(state, EnergyPlus::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
+                    ShowWarningError(state, std::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
                     ShowContinueError(state, "...the fan flow rate is autosized while the unit ventilator flow rate is not.");
                     ShowContinueError(state, "...this can lead to unexpected results where the fan flow rate is less than required.");
                 } else if (FanVolFlow != DataSizing::AutoSize && unitVent.MaxAirVolFlow == DataSizing::AutoSize) {
-                    ShowWarningError(state, EnergyPlus::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
+                    ShowWarningError(state, std::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
                     ShowContinueError(state, "...the unit ventilator flow rate is autosized while the fan flow rate is not.");
                     ShowContinueError(state, "...this can lead to unexpected results where the fan flow rate is less than required.");
                 }
@@ -447,8 +446,7 @@ namespace UnitVentilator {
                 if (!lAlphaBlanks(8)) {
                     OutAirNodeManager::CheckAndAddAirNodeNumber(state, unitVent.OutsideAirNode, IsValid);
                     if (!IsValid) {
-                        ShowWarningError(state,
-                                         EnergyPlus::format("{}{} Adding {}={}", RoutineName, CurrentModuleObject, cAlphaFields(8), Alphas(8)));
+                        ShowWarningError(state, std::format("{}{} Adding {}={}", RoutineName, CurrentModuleObject, cAlphaFields(8), Alphas(8)));
                     }
                 }
 
@@ -475,19 +473,18 @@ namespace UnitVentilator {
                 unitVent.OutsideAirNode = unitVent.ATMixerPriNode;
                 unitVent.OAMixerOutNode = unitVent.ATMixerOutNode;
                 if (!lAlphaBlanks(8) || !lAlphaBlanks(9) || !lAlphaBlanks(10)) {
-                    ShowWarningError(state,
-                                     EnergyPlus::format("{}{}=\"{}\" is connected to central DOA.", RoutineName, CurrentModuleObject, unitVent.Name));
+                    ShowWarningError(state, std::format("{}{}=\"{}\" is connected to central DOA.", RoutineName, CurrentModuleObject, unitVent.Name));
                     if (!lAlphaBlanks(8)) {
-                        ShowContinueError(
-                            state, EnergyPlus::format("... input field {} should have been blank. Specified = {}", cAlphaFields(8), Alphas(8)));
+                        ShowContinueError(state,
+                                          std::format("... input field {} should have been blank. Specified = {}", cAlphaFields(8), Alphas(8)));
                     }
                     if (!lAlphaBlanks(9)) {
-                        ShowContinueError(
-                            state, EnergyPlus::format("... input field {} should have been blank. Specified = {}", cAlphaFields(9), Alphas(9)));
+                        ShowContinueError(state,
+                                          std::format("... input field {} should have been blank. Specified = {}", cAlphaFields(9), Alphas(9)));
                     }
                     if (!lAlphaBlanks(10)) {
-                        ShowContinueError(
-                            state, EnergyPlus::format("... input field {} should have been blank. Specified = {}", cAlphaFields(10), Alphas(10)));
+                        ShowContinueError(state,
+                                          std::format("... input field {} should have been blank. Specified = {}", cAlphaFields(10), Alphas(10)));
                     }
                 }
             }
@@ -537,8 +534,8 @@ namespace UnitVentilator {
             if (!lAlphaBlanks(20)) {
                 unitVent.HVACSizingIndex = Util::FindItemInList(Alphas(20), state.dataSize->ZoneHVACSizing);
                 if (unitVent.HVACSizingIndex == 0) {
-                    ShowSevereError(state, EnergyPlus::format("{} = {} not found.", cAlphaFields(20), Alphas(20)));
-                    ShowContinueError(state, EnergyPlus::format("Occurs in {} = \"{}\".", CurrentModuleObject, unitVent.Name));
+                    ShowSevereError(state, std::format("{} = {} not found.", cAlphaFields(20), Alphas(20)));
+                    ShowContinueError(state, std::format("Occurs in {} = \"{}\".", CurrentModuleObject, unitVent.Name));
                     ErrorsFound = true;
                 }
             }
@@ -571,7 +568,7 @@ namespace UnitVentilator {
                     unitVent.HCoilName = Alphas(16);
                     ValidateComponent(state, cHeatingCoilType, unitVent.HCoilName, IsNotOK, CurrentModuleObject);
                     if (IsNotOK) {
-                        ShowContinueError(state, EnergyPlus::format("...specified in {} = \"{}\".", CurrentModuleObject, unitVent.Name));
+                        ShowContinueError(state, std::format("...specified in {} = \"{}\".", CurrentModuleObject, unitVent.Name));
                         ErrorsFound = true;
                     } else {
                         // The heating coil control node is necessary for a hot water coil, but not necessary for electric or gas.
@@ -601,8 +598,8 @@ namespace UnitVentilator {
                         unitVent.HotControlOffset = 0.001;
                     }
                 } else { // heating coil is required for these options
-                    ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
-                    ShowContinueError(state, EnergyPlus::format("a heating coil is required for {}=\"{}\".", cAlphaFields(13), Alphas(13)));
+                    ShowSevereError(state, std::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
+                    ShowContinueError(state, std::format("a heating coil is required for {}=\"{}\".", cAlphaFields(13), Alphas(13)));
                     ErrorsFound = true;
                 } // IF (.NOT. lAlphaBlanks(15)) THEN - from the start of heating coil information
             } // is option both or heating only
@@ -628,7 +625,7 @@ namespace UnitVentilator {
                         } else if (Util::SameString(unitVent.CCoilPlantType, "Coil:Cooling:Water:DetailedGeometry")) {
                             unitVent.CoolingCoilType = DataPlant::PlantEquipmentType::CoilWaterDetailedFlatCooling;
                         } else {
-                            ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
+                            ShowSevereError(state, std::format("{}{}=\"{}\".", RoutineName, CurrentModuleObject, unitVent.Name));
                             ShowContinueError(state, std::format("For: {}=\"{}\".", cAlphaFields(17), Alphas(17)));
                             ShowContinueError(state, std::format("Invalid Coil Type={}, Name={}", unitVent.CCoilPlantType, unitVent.CCoilPlantName));
                             ShowContinueError(state,
@@ -1677,11 +1674,10 @@ namespace UnitVentilator {
                                             std::format("SizeUnitVentilator: Potential issue with equipment sizing for {} {}",
                                                         state.dataUnitVentilators->cMO_UnitVentilator,
                                                         unitVent.Name));
+                                ShowContinueError(state,
+                                                  std::format("User-Specified Maximum Outdoor Air Flow Rate of {:.5f} [m3/s]", OutAirVolFlowUser));
                                 ShowContinueError(
-                                    state, EnergyPlus::format("User-Specified Maximum Outdoor Air Flow Rate of {:.5R} [m3/s]", OutAirVolFlowUser));
-                                ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("differs from Design Size Maximum Outdoor Air Flow Rate of {:.5R} [m3/s]", OutAirVolFlowDes));
+                                    state, std::format("differs from Design Size Maximum Outdoor Air Flow Rate of {:.5f} [m3/s]", OutAirVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -1740,11 +1736,11 @@ namespace UnitVentilator {
                                             std::format("SizeUnitVentilator: Potential issue with equipment sizing for {} = \"{}\".",
                                                         state.dataUnitVentilators->cMO_UnitVentilator,
                                                         unitVent.Name));
-                                ShowContinueError(
-                                    state, EnergyPlus::format("User-Specified Minimum Outdoor Air Flow Rate of {:.5R} [m3/s]", MinOutAirVolFlowUser));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("differs from Design Size Minimum Outdoor Air Flow Rate of {:.5R} [m3/s]",
-                                                                     MinOutAirVolFlowDes));
+                                                  std::format("User-Specified Minimum Outdoor Air Flow Rate of {:.5f} [m3/s]", MinOutAirVolFlowUser));
+                                ShowContinueError(
+                                    state,
+                                    std::format("differs from Design Size Minimum Outdoor Air Flow Rate of {:.5f} [m3/s]", MinOutAirVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -1882,11 +1878,11 @@ namespace UnitVentilator {
                                                 std::format("SizeUnitVentilator: Potential issue with equipment sizing for {} {}",
                                                             state.dataUnitVentilators->cMO_UnitVentilator,
                                                             unitVent.Name));
-                                    ShowContinueError(
-                                        state, EnergyPlus::format("User-Specified Maximum Hot Water Flow of {:.5R} [m3/s]", MaxVolHotWaterFlowUser));
                                     ShowContinueError(state,
-                                                      EnergyPlus::format("differs from Design Size Maximum Hot Water Flow of {:.5R} [m3/s]",
-                                                                         MaxVolHotWaterFlowDes));
+                                                      std::format("User-Specified Maximum Hot Water Flow of {:.5f} [m3/s]", MaxVolHotWaterFlowUser));
+                                    ShowContinueError(
+                                        state,
+                                        std::format("differs from Design Size Maximum Hot Water Flow of {:.5f} [m3/s]", MaxVolHotWaterFlowDes));
                                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                                 }
@@ -2015,11 +2011,10 @@ namespace UnitVentilator {
                                                 std::format("SizeUnitVentilator: Potential issue with equipment sizing for {} = \"{}\"",
                                                             state.dataUnitVentilators->cMO_UnitVentilator,
                                                             unitVent.Name));
+                                    ShowContinueError(state,
+                                                      std::format("User-Specified Maximum Steam Flow of {:.5f} [m3/s]", MaxVolHotSteamFlowUser));
                                     ShowContinueError(
-                                        state, EnergyPlus::format("User-Specified Maximum Steam Flow of {:.5R} [m3/s]", MaxVolHotSteamFlowUser));
-                                    ShowContinueError(
-                                        state,
-                                        EnergyPlus::format("differs from Design Size Maximum Steam Flow of {:.5R} [m3/s]", MaxVolHotSteamFlowDes));
+                                        state, std::format("differs from Design Size Maximum Steam Flow of {:.5f} [m3/s]", MaxVolHotSteamFlowDes));
                                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                                 }
@@ -2173,11 +2168,10 @@ namespace UnitVentilator {
                                                             state.dataUnitVentilators->cMO_UnitVentilator,
                                                             unitVent.Name));
                                     ShowContinueError(
+                                        state, std::format("User-Specified Maximum Cold Water Flow of {:.5f} [m3/s]", MaxVolColdWaterFlowUser));
+                                    ShowContinueError(
                                         state,
-                                        EnergyPlus::format("User-Specified Maximum Cold Water Flow of {:.5R} [m3/s]", MaxVolColdWaterFlowUser));
-                                    ShowContinueError(state,
-                                                      EnergyPlus::format("differs from Design Size Maximum Cold Water Flow of {:.5R} [m3/s]",
-                                                                         MaxVolColdWaterFlowDes));
+                                        std::format("differs from Design Size Maximum Cold Water Flow of {:.5f} [m3/s]", MaxVolColdWaterFlowDes));
                                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                                 }

--- a/src/EnergyPlus/UnitarySystem.cc
+++ b/src/EnergyPlus/UnitarySystem.cc
@@ -211,8 +211,8 @@ namespace UnitarySystems {
                 return &dSpec;
             }
         }
-        ShowSevereError(
-            state, EnergyPlus::format("Design Specification MultiSpeed Heat Pump factory: Error getting inputs for system named: {}", objectName));
+        ShowSevereError(state,
+                        std::format("Design Specification MultiSpeed Heat Pump factory: Error getting inputs for system named: {}", objectName));
         return nullptr;
     }
 
@@ -312,12 +312,11 @@ namespace UnitarySystems {
                             }
                         }
                     } else {
-                        ShowSevereError(state,
-                                        EnergyPlus::format("{}: Error getting inputs for system named: {}", cCurrentModuleObject, thisObjectName));
+                        ShowSevereError(state, std::format("{}: Error getting inputs for system named: {}", cCurrentModuleObject, thisObjectName));
                         ShowContinueError(state,
-                                          EnergyPlus::format("Number of speed inputs ({:.0f} is less than number of speeds ({:.0f}).",
-                                                             Real64(numSpeedInputs),
-                                                             Real64(maxSpeeds)));
+                                          std::format("Number of speed inputs ({:.0f} is less than number of speeds ({:.0f}).",
+                                                      Real64(numSpeedInputs),
+                                                      Real64(maxSpeeds)));
                         errorsFound = true;
                     }
                 }
@@ -341,7 +340,7 @@ namespace UnitarySystems {
                 return &sys;
             }
         }
-        ShowFatalError(state, EnergyPlus::format("UnitarySystem factory: Error getting inputs for system named: {}", objectName));
+        ShowFatalError(state, std::format("UnitarySystem factory: Error getting inputs for system named: {}", objectName));
         return nullptr;
     }
 
@@ -362,8 +361,8 @@ namespace UnitarySystems {
                 return index;
             }
         }
-        ShowSevereError(
-            state, EnergyPlus::format("getDesignSpecMSHPIndex: did not find UnitarySystemPerformance:Multispeed name ={}. Check inputs", objectName));
+        ShowSevereError(state,
+                        std::format("getDesignSpecMSHPIndex: did not find UnitarySystemPerformance:Multispeed name ={}. Check inputs", objectName));
         return index;
     }
 
@@ -466,7 +465,7 @@ namespace UnitarySystems {
                 state.dataAirLoop->AirLoopControlInfo(AirLoopNum).cycFanSched = this->m_fanOpModeSched;
             } else if (AirLoopNum < 0) {
                 if (this->m_ControlType == UnitarySysCtrlType::CCMASHRAE) {
-                    ShowSevereError(state, EnergyPlus::format("{}: {}", this->UnitType, this->Name));
+                    ShowSevereError(state, std::format("{}: {}", this->UnitType, this->Name));
                     ShowContinueError(state, "  Invalid application of Control Type = SingleZoneVAV in outdoor air system.");
                     ShowFatalError(state, "InitUnitarySystems: Program terminated for previous conditions.");
                 }
@@ -495,18 +494,17 @@ namespace UnitarySystems {
                             if (this->m_ActualFanVolFlowRate == this->m_MaxHeatAirVolFlow &&
                                 this->m_ActualFanVolFlowRate == this->m_MaxCoolAirVolFlow &&
                                 this->m_ActualFanVolFlowRate == this->m_MaxNoCoolHeatAirVolFlow) {
-                                ShowWarningError(state, EnergyPlus::format("{} \"{}\"", this->UnitType, this->Name));
-                                ShowContinueError(state,
-                                                  EnergyPlus::format("...For fan type and name = {} \"{}\"",
-                                                                     HVAC::fanTypeNames[(int)this->m_FanType],
-                                                                     this->m_FanName));
+                                ShowWarningError(state, std::format("{} \"{}\"", this->UnitType, this->Name));
+                                ShowContinueError(
+                                    state,
+                                    std::format("...For fan type and name = {} \"{}\"", HVAC::fanTypeNames[(int)this->m_FanType], this->m_FanName));
                                 ShowContinueError(state,
                                                   "...Fan power ratio function of speed ratio curve has no impact if fan volumetric flow rate is the "
                                                   "same as the unitary system volumetric flow rate.");
-                                ShowContinueError(
-                                    state, EnergyPlus::format("...Fan volumetric flow rate            = {:.5R} m3/s.", this->m_ActualFanVolFlowRate));
-                                ShowContinueError(
-                                    state, EnergyPlus::format("...Unitary system volumetric flow rate = {:.5R} m3/s.", this->m_MaxHeatAirVolFlow));
+                                ShowContinueError(state,
+                                                  std::format("...Fan volumetric flow rate            = {:.5f} m3/s.", this->m_ActualFanVolFlowRate));
+                                ShowContinueError(state,
+                                                  std::format("...Unitary system volumetric flow rate = {:.5f} m3/s.", this->m_MaxHeatAirVolFlow));
                             }
                         }
                     }
@@ -1073,7 +1071,7 @@ namespace UnitarySystems {
                                          EnergyPlus::format("{}: {}",
                                                             state.dataFaultsMgr->FaultsCoilSATSensor(this->m_FaultyCoilSATIndex).type,
                                                             state.dataFaultsMgr->FaultsCoilSATSensor(this->m_FaultyCoilSATIndex).Name));
-                        ShowContinueError(state, EnergyPlus::format("For : {}: {}", this->UnitType, this->Name));
+                        ShowContinueError(state, std::format("For : {}: {}", this->UnitType, this->Name));
                         ShowContinueError(state,
                                           "The specified unitary system is not controlled on leaving air temperature. The coil SAT sensor "
                                           "fault model will not be applied.");
@@ -1216,10 +1214,10 @@ namespace UnitarySystems {
                     } else {
                         ShowWarningError(
                             state,
-                            EnergyPlus::format("Developer Error in Heat Pump ACCA Sizing: cooling coil not found for {}:{} with coil type = {}.",
-                                               this->UnitType,
-                                               this->Name,
-                                               HVAC::coilTypeNames[(int)this->m_coolCoilType]));
+                            std::format("Developer Error in Heat Pump ACCA Sizing: cooling coil not found for {}:{} with coil type = {}.",
+                                        this->UnitType,
+                                        this->Name,
+                                        HVAC::coilTypeNames[(int)this->m_coolCoilType]));
                     }
                 }
                 if (this->m_heatCoilType == HVAC::CoilType::HeatingWAHPSimple) {
@@ -1234,12 +1232,11 @@ namespace UnitarySystems {
                         auto const &thisCoil = state.dataDXCoils->DXCoil(this->m_HeatingCoilIndex);
                         hCoilName = thisCoil.Name;
                     } else {
-                        ShowSevereError(
-                            state,
-                            EnergyPlus::format("Developer Error in Heat Pump ACCA Sizing: heating coil not found for {}:{} with coil type = {}.",
-                                               this->UnitType,
-                                               this->Name,
-                                               HVAC::coilTypeNames[(int)this->m_heatCoilType]));
+                        ShowSevereError(state,
+                                        std::format("Developer Error in Heat Pump ACCA Sizing: heating coil not found for {}:{} with coil type = {}.",
+                                                    this->UnitType,
+                                                    this->Name,
+                                                    HVAC::coilTypeNames[(int)this->m_heatCoilType]));
                     }
                 }
                 OutputReportPredefined::PreDefTableEntry(state, state.dataOutRptPredefined->pdchMSHPType, cCoilName, this->UnitType);
@@ -1330,13 +1327,13 @@ namespace UnitarySystems {
                     coilOutNode = this->SuppCoilOutletNodeNum;
                 }
 
-                ShowSevereError(
-                    state, EnergyPlus::format("checkNodeSetPoint: Missing {} set point in {} = {}", coilTypes[CoilType], this->UnitType, this->Name));
+                ShowSevereError(state,
+                                std::format("checkNodeSetPoint: Missing {} set point in {} = {}", coilTypes[CoilType], this->UnitType, this->Name));
                 ShowContinueError(state,
-                                  EnergyPlus::format("...Setpoint is required at system air outlet node = {} or {} coil air outlet node = {}",
-                                                     state.dataLoopNodes->NodeID(this->AirOutNode),
-                                                     coilTypes[CoilType],
-                                                     state.dataLoopNodes->NodeID(coilOutNode)));
+                                  std::format("...Setpoint is required at system air outlet node = {} or {} coil air outlet node = {}",
+                                              state.dataLoopNodes->NodeID(this->AirOutNode),
+                                              coilTypes[CoilType],
+                                              state.dataLoopNodes->NodeID(coilOutNode)));
                 SetPointErrorFlag = true;
             }
             return SetPointErrorFlag;
@@ -1357,15 +1354,13 @@ namespace UnitarySystems {
             if (state.dataLoopNodes->Node(ControlNode).TempSetPoint == Node::SensedNodeFlagValue &&
                 this->m_ControlType == UnitarySysCtrlType::Setpoint) {
                 if (!state.dataGlobal->AnyEnergyManagementSystemInModel) {
-                    ShowSevereError(state,
-                                    EnergyPlus::format("{}: Missing temperature setpoint for unitary system = {}", this->UnitType, this->Name));
+                    ShowSevereError(state, std::format("{}: Missing temperature setpoint for unitary system = {}", this->UnitType, this->Name));
                     ShowContinueError(state, "  use a Setpoint Manager to establish a setpoint at the coil control node.");
                     SetPointErrorFlag = true;
                 } else {
                     EMSManager::CheckIfNodeSetPointManagedByEMS(state, ControlNode, HVAC::CtrlVarType::Temp, SetPointErrorFlag);
                     if (SetPointErrorFlag) {
-                        ShowSevereError(state,
-                                        EnergyPlus::format("{}: Missing temperature setpoint for unitary system = {}", this->UnitType, this->Name));
+                        ShowSevereError(state, std::format("{}: Missing temperature setpoint for unitary system = {}", this->UnitType, this->Name));
                         ShowContinueError(state, "  use a Setpoint Manager to establish a setpoint at the coil control node.");
                         ShowContinueError(state, "  or use an EMS actuator to establish a temperature setpoint at the coil control node.");
                     }
@@ -1377,17 +1372,16 @@ namespace UnitarySystems {
                 if (!state.dataGlobal->AnyEnergyManagementSystemInModel &&
                     state.dataLoopNodes->Node(this->CoolCoilOutletNodeNum).HumRatMax == Node::SensedNodeFlagValue) {
                     ShowSevereError(
-                        state,
-                        EnergyPlus::format("{}: Missing humidity ratio setpoint (HUMRATMAX) for unitary system = {}", this->UnitType, this->Name));
+                        state, std::format("{}: Missing humidity ratio setpoint (HUMRATMAX) for unitary system = {}", this->UnitType, this->Name));
                     ShowContinueError(state, "  use a Setpoint Manager to establish a setpoint at the coil control node.");
                     SetPointErrorFlag = true;
                 } else if (state.dataGlobal->AnyEnergyManagementSystemInModel) {
                     EMSManager::CheckIfNodeSetPointManagedByEMS(state, ControlNode, HVAC::CtrlVarType::MaxHumRat, SetPointErrorFlag);
                     if (SetPointErrorFlag) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}: Missing maximum humidity ratio setpoint (HUMRATMAX) for unitary system = {}",
-                                                           this->UnitType,
-                                                           this->Name));
+                                        std::format("{}: Missing maximum humidity ratio setpoint (HUMRATMAX) for unitary system = {}",
+                                                    this->UnitType,
+                                                    this->Name));
                         ShowContinueError(state, "  use a Setpoint Manager to establish a setpoint at the coil control node.");
                         ShowContinueError(state, "  or use an EMS actuator to establish a maximum humidity ratio setpoint.");
                     }
@@ -1718,7 +1712,7 @@ namespace UnitarySystems {
                 this->m_MaxCoolAirVolFlow = DataSizing::AutoSize;
             } else {
                 // should never happen
-                ShowSevereError(state, EnergyPlus::format("{}: {} = {}", RoutineName, CompType, CompName));
+                ShowSevereError(state, std::format("{}: {} = {}", RoutineName, CompType, CompName));
                 ShowContinueError(state, "Illegal entry for Cooling Supply Air Flow Rate Method.");
             }
 
@@ -2467,12 +2461,12 @@ namespace UnitarySystems {
                                 ShowMessage(state,
                                             std::format("SizePTUnit: Potential issue with equipment sizing for {} {}", this->UnitType, this->Name));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("User-Specified Outdoor Air Flow Rate During Cooling Operation of {:.5R} [m3/s]",
-                                                                     CoolOutAirVolFlowUser));
+                                                  std::format("User-Specified Outdoor Air Flow Rate During Cooling Operation of {:.5f} [m3/s]",
+                                                              CoolOutAirVolFlowUser));
                                 ShowContinueError(
                                     state,
-                                    EnergyPlus::format("differs from Design Size Outdoor Air Flow Rate During Cooling Operation of {:.5R} [m3/s]",
-                                                       CoolOutAirVolFlowDes));
+                                    std::format("differs from Design Size Outdoor Air Flow Rate During Cooling Operation of {:.5f} [m3/s]",
+                                                CoolOutAirVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -2519,12 +2513,12 @@ namespace UnitarySystems {
                                 ShowMessage(state,
                                             std::format("SizePTUnit: Potential issue with equipment sizing for {} {}", this->UnitType, this->Name));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("User-Specified Outdoor Air Flow Rate During Heating Operation of {:.5R} [m3/s]",
-                                                                     HeatOutAirVolFlowUser));
+                                                  std::format("User-Specified Outdoor Air Flow Rate During Heating Operation of {:.5f} [m3/s]",
+                                                              HeatOutAirVolFlowUser));
                                 ShowContinueError(
                                     state,
-                                    EnergyPlus::format("differs from Design Size Outdoor Air Flow Rate During Heating Operation of {:.5R} [m3/s]",
-                                                       HeatOutAirVolFlowDes));
+                                    std::format("differs from Design Size Outdoor Air Flow Rate During Heating Operation of {:.5f} [m3/s]",
+                                                HeatOutAirVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -2576,12 +2570,12 @@ namespace UnitarySystems {
                                             std::format("SizePTUnit: Potential issue with equipment sizing for {} {}", this->UnitType, this->Name));
                                 ShowContinueError(
                                     state,
-                                    EnergyPlus::format("User-Specified Outdoor Air Flow Rate When No Cooling or Heating is Needed of {:.5R} [m3/s]",
-                                                       NoCoolHeatOutAirVolFlowUser));
+                                    std::format("User-Specified Outdoor Air Flow Rate When No Cooling or Heating is Needed of {:.5f} [m3/s]",
+                                                NoCoolHeatOutAirVolFlowUser));
                                 ShowContinueError(
                                     state,
-                                    EnergyPlus::format(
-                                        "differs from Design Size Outdoor Air Flow Rate When No Cooling or Heating is Needed of {:.5R} [m3/s]",
+                                    std::format(
+                                        "differs from Design Size Outdoor Air Flow Rate When No Cooling or Heating is Needed of {:.5f} [m3/s]",
                                         NoCoolHeatOutAirVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
@@ -5538,7 +5532,7 @@ namespace UnitarySystems {
         }
         if (this->m_ControlType != UnitarySysCtrlType::CCMASHRAE && this->DesignMinOutletTemp > 7.5) {
             ShowWarningError(state, std::format("{} = {}", cCurrentModuleObject, thisObjectName));
-            ShowContinueError(state, EnergyPlus::format("Invalid entry for Minimum Supply Air Temperature = {:.4R}", this->DesignMinOutletTemp));
+            ShowContinueError(state, std::format("Invalid entry for Minimum Supply Air Temperature = {:.4f}", this->DesignMinOutletTemp));
             ShowContinueError(state, "The minimum supply air temperature will be limited to 7.5C and the simulation continues.");
             this->DesignMinOutletTemp = 7.5;
         }
@@ -5896,9 +5890,9 @@ namespace UnitarySystems {
                     if (this->m_MaxCoolAirVolFlow <= HVAC::SmallAirVolFlow && this->m_CoolCoilExists) {
                         ShowWarningError(state, std::format("{} = {}", cCurrentModuleObject, thisObjectName));
                         ShowContinueError(state, "Input for Cooling Supply Air Flow Rate Method = SupplyAirFlowRate.");
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Suspicious Cooling Supply Air Flow Rate = {:.7R} when cooling coil is present.",
-                                                             this->m_MaxCoolAirVolFlow));
+                        ShowContinueError(
+                            state,
+                            std::format("Suspicious Cooling Supply Air Flow Rate = {:.7f} when cooling coil is present.", this->m_MaxCoolAirVolFlow));
                     }
                     if (this->m_MaxCoolAirVolFlow < 0.0) {
                         errorsFound = true;
@@ -5922,9 +5916,8 @@ namespace UnitarySystems {
                         ShowContinueError(state, "Input for Cooling Supply Air Flow Rate Method = FlowPerFloorArea.");
                         ShowContinueError(
                             state,
-                            EnergyPlus::format(
-                                "Suspicious Cooling Supply Air Flow Rate Per Floor Area = {:.7R} [m3/s/m2] when cooling coil is present.",
-                                this->m_MaxCoolAirVolFlow));
+                            std::format("Suspicious Cooling Supply Air Flow Rate Per Floor Area = {:.7f} [m3/s/m2] when cooling coil is present.",
+                                        this->m_MaxCoolAirVolFlow));
                         if (this->m_MaxCoolAirVolFlow < 0.0) {
                             errorsFound = true;
                         }
@@ -5953,11 +5946,10 @@ namespace UnitarySystems {
                     if (this->m_MaxCoolAirVolFlow <= HVAC::SmallAirVolFlow && this->m_CoolCoilExists) {
                         ShowSevereError(state, std::format("{} = {}", cCurrentModuleObject, thisObjectName));
                         ShowContinueError(state, "Input for Cooling Supply Air Flow Rate Method = FractionOfAutosizedCoolingValue.");
-                        ShowContinueError(
-                            state,
-                            EnergyPlus::format("Suspicious Cooling Fraction of Autosized Cooling Supply Air Flow Rate = {:.7R} [m3/s/m3] "
-                                               "when cooling coil is present.",
-                                               this->m_MaxCoolAirVolFlow));
+                        ShowContinueError(state,
+                                          std::format("Suspicious Cooling Fraction of Autosized Cooling Supply Air Flow Rate = {:.7f} [m3/s/m3] "
+                                                      "when cooling coil is present.",
+                                                      this->m_MaxCoolAirVolFlow));
                         if (this->m_MaxCoolAirVolFlow < 0.0) {
                             errorsFound = true;
                         }
@@ -6032,9 +6024,9 @@ namespace UnitarySystems {
                     if (this->m_MaxHeatAirVolFlow <= HVAC::SmallAirVolFlow && this->m_HeatCoilExists) {
                         ShowWarningError(state, std::format("{} = {}", cCurrentModuleObject, thisObjectName));
                         ShowContinueError(state, "Input for Heating Supply Air Flow Rate Method = SupplyAirFlowRate.");
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Suspicious Heating Supply Air Flow Rate = {:.7R} when heating coil is present.",
-                                                             this->m_MaxHeatAirVolFlow));
+                        ShowContinueError(
+                            state,
+                            std::format("Suspicious Heating Supply Air Flow Rate = {:.7f} when heating coil is present.", this->m_MaxHeatAirVolFlow));
                     }
                     if (this->m_MaxHeatAirVolFlow < 0.0) {
                         errorsFound = true;
@@ -6056,9 +6048,8 @@ namespace UnitarySystems {
                         ShowContinueError(state, "Input for Heating Supply Air Flow Rate Method = FlowPerFloorArea.");
                         ShowContinueError(
                             state,
-                            EnergyPlus::format(
-                                "Suspicious Heating Supply Air Flow Rate Per Floor Area = {:.7R} [m3/s/m2] when heating coil is present.",
-                                this->m_MaxHeatAirVolFlow));
+                            std::format("Suspicious Heating Supply Air Flow Rate Per Floor Area = {:.7f} [m3/s/m2] when heating coil is present.",
+                                        this->m_MaxHeatAirVolFlow));
                     }
                     if (this->m_MaxHeatAirVolFlow < 0.0) {
                         errorsFound = true;
@@ -6086,11 +6077,10 @@ namespace UnitarySystems {
                     if (this->m_MaxHeatAirVolFlow <= HVAC::SmallAirVolFlow && this->m_HeatCoilExists) {
                         ShowSevereError(state, std::format("{} = {}", cCurrentModuleObject, thisObjectName));
                         ShowContinueError(state, "Input for Heating Supply Air Flow Rate Method = FractionOfAutosizedHeatingValue.");
-                        ShowContinueError(
-                            state,
-                            EnergyPlus::format("Suspicious Heating Fraction of Autosized Heating Supply Air Flow Rate = {:.7R} [m3/s/m3] "
-                                               "when heating coil is present.",
-                                               this->m_MaxHeatAirVolFlow));
+                        ShowContinueError(state,
+                                          std::format("Suspicious Heating Fraction of Autosized Heating Supply Air Flow Rate = {:.7f} [m3/s/m3] "
+                                                      "when heating coil is present.",
+                                                      this->m_MaxHeatAirVolFlow));
                         if (this->m_MaxHeatAirVolFlow < 0.0) {
                             errorsFound = true;
                         }
@@ -6168,8 +6158,7 @@ namespace UnitarySystems {
                     if (this->m_MaxNoCoolHeatAirVolFlow < 0.0) {
                         ShowSevereError(state, std::format("{} = {}", cCurrentModuleObject, thisObjectName));
                         ShowContinueError(state, "Input for No Load Supply Air Flow Rate Method = SupplyAirFlowRate");
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Illegal No Load Supply Air Flow Rate = {:.7R}", this->m_MaxNoCoolHeatAirVolFlow));
+                        ShowContinueError(state, std::format("Illegal No Load Supply Air Flow Rate = {:.7f}", this->m_MaxNoCoolHeatAirVolFlow));
                         errorsFound = true;
                     }
                 }
@@ -6189,8 +6178,8 @@ namespace UnitarySystems {
                         ShowSevereError(state, std::format("{} = {}", cCurrentModuleObject, thisObjectName));
                         ShowContinueError(state, "Input for No Load Supply Air Flow Rate Method = FlowPerFloorArea.");
                         ShowContinueError(state,
-                                          EnergyPlus::format("Suspicious No Load Supply Air Flow Rate Per Floor Area = {:.7R} [m3/s/m2]",
-                                                             this->m_MaxNoCoolHeatAirVolFlow));
+                                          std::format("Suspicious No Load Supply Air Flow Rate Per Floor Area = {:.7f} [m3/s/m2]",
+                                                      this->m_MaxNoCoolHeatAirVolFlow));
                     }
                     if (this->m_MaxNoCoolHeatAirVolFlow < 0.0) {
                         errorsFound = true;
@@ -6220,9 +6209,8 @@ namespace UnitarySystems {
                         ShowContinueError(state, "Input for No Load Supply Air Flow Rate Method = FractionOfAutosizedCoolingValue.");
                         ShowContinueError(
                             state,
-                            EnergyPlus::format(
-                                "Suspicious No Load Supply Air Flow Rate Per Unit of Capacity During Cooling Operation = {:.7R} [m3/s/m3].",
-                                this->m_MaxNoCoolHeatAirVolFlow));
+                            std::format("Suspicious No Load Supply Air Flow Rate Per Unit of Capacity During Cooling Operation = {:.7f} [m3/s/m3].",
+                                        this->m_MaxNoCoolHeatAirVolFlow));
                         if (this->m_MaxNoCoolHeatAirVolFlow < 0.0) {
                             errorsFound = true;
                         }
@@ -6252,9 +6240,8 @@ namespace UnitarySystems {
                         ShowContinueError(state, "Input for No Load Supply Air Flow Rate Method = FractionOfAutosizedHeatingValue.");
                         ShowContinueError(
                             state,
-                            EnergyPlus::format(
-                                "Suspicious No Load Supply Air Flow Rate Per Unit of Capacity During Heating Operation = {:.7R} [m3/s/m3].",
-                                this->m_MaxNoCoolHeatAirVolFlow));
+                            std::format("Suspicious No Load Supply Air Flow Rate Per Unit of Capacity During Heating Operation = {:.7f} [m3/s/m3].",
+                                        this->m_MaxNoCoolHeatAirVolFlow));
                         if (this->m_MaxNoCoolHeatAirVolFlow < 0.0) {
                             errorsFound = true;
                         }
@@ -6949,7 +6936,7 @@ namespace UnitarySystems {
                 ShowContinueError(state,
                                   "... heat recovery nodes must be specified when Design Heat Recovery Water Flow Rate"
                                   " is greater than 0.");
-                ShowContinueError(state, EnergyPlus::format("... Design Heat Recovery Water Flow Rate = {:.7R}", this->m_DesignHRWaterVolumeFlow));
+                ShowContinueError(state, std::format("... Design Heat Recovery Water Flow Rate = {:.7f}", this->m_DesignHRWaterVolumeFlow));
                 errorsFound = true;
             }
         }
@@ -6992,13 +6979,13 @@ namespace UnitarySystems {
                         if (NumOfSpeed != this->m_NumOfSpeedHeating) {
                             ShowWarningError(state, std::format("{} = {}.", cCurrentModuleObject, this->m_HeatingCoilName));
                             ShowContinueError(state,
-                                              EnergyPlus::format("... The number of heating coil speeds in the {} = {:.0R}",
-                                                                 MultispeedType,
-                                                                 double(this->m_NumOfSpeedHeating)));
+                                              std::format("... The number of heating coil speeds in the {} = {:.0f}",
+                                                          MultispeedType,
+                                                          double(this->m_NumOfSpeedHeating)));
                             ShowContinueError(
                                 state,
-                                EnergyPlus::format(
-                                    "... The number of heating coil speeds in Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit = {:.0R}",
+                                std::format(
+                                    "... The number of heating coil speeds in Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit = {:.0f}",
                                     double(NumOfSpeed)));
                             ShowContinueError(state, std::format("... The number of heating coil speeds in the {} will be used.", MultispeedType));
                         }
@@ -7040,13 +7027,13 @@ namespace UnitarySystems {
                         if (NumOfSpeed != this->m_NumOfSpeedCooling) {
                             ShowWarningError(state, std::format("{} = {}.", cCurrentModuleObject, this->m_CoolingCoilName));
                             ShowContinueError(state,
-                                              EnergyPlus::format("... The number of Cooling coil speeds in the {} = {:.0R}",
-                                                                 MultispeedType,
-                                                                 double(this->m_NumOfSpeedCooling)));
+                                              std::format("... The number of Cooling coil speeds in the {} = {:.0f}",
+                                                          MultispeedType,
+                                                          double(this->m_NumOfSpeedCooling)));
                             ShowContinueError(
                                 state,
-                                EnergyPlus::format(
-                                    "... The number of heating coil speeds in Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit = {:.0R}",
+                                std::format(
+                                    "... The number of heating coil speeds in Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit = {:.0f}",
                                     double(NumOfSpeed)));
                             ShowContinueError(state, std::format("... The number of Cooling coil speeds in the {} will be used.", MultispeedType));
                         }
@@ -7132,7 +7119,7 @@ namespace UnitarySystems {
                                                          cCurrentModuleObject,
                                                          this->Name,
                                                          this->input_specs.supply_fan_name));
-                            ShowContinueError(state, EnergyPlus::format("...The number of speed = {:.0R}.", double(fanSystem->numSpeeds)));
+                            ShowContinueError(state, std::format("...The number of speed = {:.0f}.", double(fanSystem->numSpeeds)));
                             ShowContinueError(state, "...Multiple speed fan will be applied to this unit. The speed number is determined by load.");
                         }
                     }
@@ -13412,9 +13399,8 @@ namespace UnitarySystems {
                                                     "{} - Iteration limit exceeded calculating DX unit sensible part-load ratio for unit = {}",
                                                     this->UnitType,
                                                     this->Name));
-                                            ShowContinueError(state,
-                                                              EnergyPlus::format("Estimated part-load ratio   = {:.3R}", (ReqOutput / FullOutput)));
-                                            ShowContinueError(state, EnergyPlus::format("Calculated part-load ratio = {:.3R}", PartLoadFrac));
+                                            ShowContinueError(state, std::format("Estimated part-load ratio   = {:.3f}", (ReqOutput / FullOutput)));
+                                            ShowContinueError(state, std::format("Calculated part-load ratio = {:.3f}", PartLoadFrac));
                                             ShowContinueErrorTimeStamp(
                                                 state, "The calculated part-load ratio will be used and the simulation continues. Occurrence info:");
                                         }
@@ -13437,7 +13423,7 @@ namespace UnitarySystems {
                                                                          "part-load ratio limits exceeded, for unit = {}",
                                                                          this->UnitType,
                                                                          this->Name));
-                                            ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio = {:.3R}", PartLoadFrac));
+                                            ShowContinueError(state, std::format("Estimated part-load ratio = {:.3f}", PartLoadFrac));
                                             ShowContinueErrorTimeStamp(
                                                 state, "The estimated part-load ratio will be used and the simulation continues. Occurrence info:");
                                         }
@@ -13462,7 +13448,7 @@ namespace UnitarySystems {
                                                         "exceeded, for unit = {}",
                                                         this->UnitType,
                                                         this->Name));
-                                        ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio = {:.3R}", PartLoadFrac));
+                                        ShowContinueError(state, std::format("Estimated part-load ratio = {:.3f}", PartLoadFrac));
                                         ShowContinueErrorTimeStamp(
                                             state, "The estimated part-load ratio will be used and the simulation continues. Occurrence info:");
                                     }
@@ -13979,9 +13965,9 @@ namespace UnitarySystems {
                                                 std::format("{} - Iteration limit exceeded calculating DX unit latent part-load ratio for unit = {}",
                                                             this->UnitType,
                                                             this->Name));
-                                            ShowContinueError(
-                                                state, EnergyPlus::format("Estimated latent part-load ratio  = {:.3R}", (ReqOutput / FullOutput)));
-                                            ShowContinueError(state, EnergyPlus::format("Calculated latent part-load ratio = {:.3R}", PartLoadFrac));
+                                            ShowContinueError(state,
+                                                              std::format("Estimated latent part-load ratio  = {:.3f}", (ReqOutput / FullOutput)));
+                                            ShowContinueError(state, std::format("Calculated latent part-load ratio = {:.3f}", PartLoadFrac));
                                             ShowContinueErrorTimeStamp(state,
                                                                        "The calculated latent part-load ratio will be used and the simulation "
                                                                        "continues. Occurrence info:");
@@ -14008,7 +13994,7 @@ namespace UnitarySystems {
                                                             "ratio limits exceeded, for unit = {}",
                                                             this->UnitType,
                                                             this->Name));
-                                            ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio = {:.3R}", PartLoadFrac));
+                                            ShowContinueError(state, std::format("Estimated part-load ratio = {:.3f}", PartLoadFrac));
                                             ShowContinueErrorTimeStamp(
                                                 state, "The estimated part-load ratio will be used and the simulation continues. Occurrence info:");
                                         }
@@ -14032,7 +14018,7 @@ namespace UnitarySystems {
                                                                      "exceeded, for unit = {}",
                                                                      this->UnitType,
                                                                      this->Name));
-                                        ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio = {:.3R}", PartLoadFrac));
+                                        ShowContinueError(state, std::format("Estimated part-load ratio = {:.3f}", PartLoadFrac));
                                         ShowContinueErrorTimeStamp(
                                             state, "The estimated part-load ratio will be used and the simulation continues. Occurrence info:");
                                     }
@@ -14378,9 +14364,8 @@ namespace UnitarySystems {
                     ShowWarningError(
                         state, std::format("{} - Iteration limit exceeded calculating part-load ratio for unit = {}", this->UnitType, this->Name));
                     ShowContinueError(
-                        state,
-                        EnergyPlus::format("Estimated part-load ratio  = {:.3R}", (FullOutput != 0 ? (ReqOutput / FullOutput) : PartLoadFrac)));
-                    ShowContinueError(state, EnergyPlus::format("Calculated part-load ratio = {:.3R}", PartLoadFrac));
+                        state, std::format("Estimated part-load ratio  = {:.3f}", (FullOutput != 0 ? (ReqOutput / FullOutput) : PartLoadFrac)));
+                    ShowContinueError(state, std::format("Calculated part-load ratio = {:.3f}", PartLoadFrac));
                     ShowContinueErrorTimeStamp(state, "The calculated part-load ratio will be used and the simulation continues. Occurrence info:");
                 } else {
                     ShowRecurringWarningErrorAtEnd(
@@ -14403,7 +14388,7 @@ namespace UnitarySystems {
                                      std::format("{} - sensible part-load ratio calculation failed: part-load ratio limits exceeded, for unit = {}",
                                                  this->UnitType,
                                                  this->Name));
-                    ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio = {:.3R}", PartLoadFrac));
+                    ShowContinueError(state, std::format("Estimated part-load ratio = {:.3f}", PartLoadFrac));
                     ShowContinueErrorTimeStamp(state, "The estimated part-load ratio will be used and the simulation continues. Occurrence info:");
                 } else {
                     ShowRecurringWarningErrorAtEnd(
@@ -14425,9 +14410,8 @@ namespace UnitarySystems {
                         state,
                         std::format("{} - Iteration limit exceeded calculating latent part-load ratio for unit = {}", this->UnitType, this->Name));
                     ShowContinueError(
-                        state,
-                        EnergyPlus::format("Estimated part-load ratio  = {:.3R}", (FullOutput != 0 ? (ReqOutput / FullOutput) : PartLoadFrac)));
-                    ShowContinueError(state, EnergyPlus::format("Calculated part-load ratio = {:.3R}", PartLoadFrac));
+                        state, std::format("Estimated part-load ratio  = {:.3f}", (FullOutput != 0 ? (ReqOutput / FullOutput) : PartLoadFrac)));
+                    ShowContinueError(state, std::format("Calculated part-load ratio = {:.3f}", PartLoadFrac));
                     ShowContinueErrorTimeStamp(state, "The calculated part-load ratio will be used and the simulation continues. Occurrence info:");
                 }
                 ShowRecurringWarningErrorAtEnd(
@@ -14452,7 +14436,7 @@ namespace UnitarySystems {
                                      std::format("{} - latent part-load ratio calculation failed: part-load ratio limits exceeded, for unit = {}",
                                                  this->UnitType,
                                                  this->Name));
-                    ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio = {:.3R}", PartLoadFrac));
+                    ShowContinueError(state, std::format("Estimated part-load ratio = {:.3f}", PartLoadFrac));
                     ShowContinueErrorTimeStamp(state, "The estimated part-load ratio will be used and the simulation continues. Occurrence info:");
                 }
                 ShowRecurringWarningErrorAtEnd(state,
@@ -15121,8 +15105,8 @@ namespace UnitarySystems {
                                          std::format("{} - Iteration limit exceeded calculating sensible part-load ratio for unit = {}",
                                                      this->UnitType,
                                                      this->Name));
-                        ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio  = {:.3R}", (ReqOutput / FullOutput)));
-                        ShowContinueError(state, EnergyPlus::format("Calculated part-load ratio = {:.3R}", PartLoadFrac));
+                        ShowContinueError(state, std::format("Estimated part-load ratio  = {:.3f}", (ReqOutput / FullOutput)));
+                        ShowContinueError(state, std::format("Calculated part-load ratio = {:.3f}", PartLoadFrac));
                         ShowContinueErrorTimeStamp(state,
                                                    "The calculated part-load ratio will be used and the simulation continues. Occurrence info:");
                     } else {
@@ -15145,7 +15129,7 @@ namespace UnitarySystems {
                             std::format("{} - sensible part-load ratio calculation failed: part-load ratio limits exceeded, for unit = {}",
                                         this->UnitType,
                                         this->Name));
-                        ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio = {:.3R}", PartLoadFrac));
+                        ShowContinueError(state, std::format("Estimated part-load ratio = {:.3f}", PartLoadFrac));
                         ShowContinueErrorTimeStamp(state,
                                                    "The estimated part-load ratio will be used and the simulation continues. Occurrence info:");
                     } else {
@@ -15524,8 +15508,8 @@ namespace UnitarySystems {
                                                  std::format("{} - Iteration limit exceeded calculating sensible part-load ratio for unit = {}",
                                                              this->UnitType,
                                                              this->Name));
-                                ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio  = {:.3R}", (ReqOutput / FullOutput)));
-                                ShowContinueError(state, EnergyPlus::format("Calculated part-load ratio = {:.3R}", PartLoadFrac));
+                                ShowContinueError(state, std::format("Estimated part-load ratio  = {:.3f}", (ReqOutput / FullOutput)));
+                                ShowContinueError(state, std::format("Calculated part-load ratio = {:.3f}", PartLoadFrac));
                                 ShowContinueErrorTimeStamp(
                                     state, "The calculated part-load ratio will be used and the simulation continues. Occurrence info:");
                             } else {
@@ -15555,7 +15539,7 @@ namespace UnitarySystems {
                                     std::format("{} - sensible part-load ratio calculation failed: part-load ratio limits exceeded, for unit = {}",
                                                 this->UnitType,
                                                 this->Name));
-                                ShowContinueError(state, EnergyPlus::format("Estimated part-load ratio = {:.3R}", PartLoadFrac));
+                                ShowContinueError(state, std::format("Estimated part-load ratio = {:.3f}", PartLoadFrac));
                                 ShowContinueErrorTimeStamp(
                                     state, "The estimated part-load ratio will be used and the simulation continues. Occurrence info:");
                             } else {

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -284,10 +284,10 @@ namespace Util {
         // sent to this routine.
         if (ptrToBeSet <= 0) { // No valid pointer--error in user input
             errorFound = true;
-            ShowSevereError(
-                state, EnergyPlus::format("Object = {} with the Name = {} has an invalid Design Object Name = {}.", itemType, itemName, nameToBeSet));
+            ShowSevereError(state,
+                            std::format("Object = {} with the Name = {} has an invalid Design Object Name = {}.", itemType, itemName, nameToBeSet));
             ShowContinueError(state, "  The Design Object Name was not found or was left blank.  This is not allowed.");
-            ShowContinueError(state, EnergyPlus::format("  A valid Design Object Name must be provided for any {} object.", itemType));
+            ShowContinueError(state, std::format("  A valid Design Object Name must be provided for any {} object.", itemType));
         }
     }
 
@@ -437,15 +437,15 @@ int AbortEnergyPlus(EnergyPlusData &state)
     state.dataResultsFramework->resultsFramework->SimulationInformation.setNumErrorsSizing(NumWarningsDuringSizing, NumSevereDuringSizing);
     state.dataResultsFramework->resultsFramework->SimulationInformation.setNumErrorsSummary(NumWarnings, NumSevere);
 
-    ShowMessage(state,
-                EnergyPlus::format(
-                    "EnergyPlus Warmup Error Summary. During Warmup: {} Warning; {} Severe Errors.", NumWarningsDuringWarmup, NumSevereDuringWarmup));
-    ShowMessage(state,
-                EnergyPlus::format(
-                    "EnergyPlus Sizing Error Summary. During Sizing: {} Warning; {} Severe Errors.", NumWarningsDuringSizing, NumSevereDuringSizing));
-    ShowMessage(state,
-                EnergyPlus::format(
-                    "EnergyPlus Terminated--Fatal Error Detected. {} Warning; {} Severe Errors; Elapsed Time={}", NumWarnings, NumSevere, Elapsed));
+    ShowMessage(
+        state,
+        std::format("EnergyPlus Warmup Error Summary. During Warmup: {} Warning; {} Severe Errors.", NumWarningsDuringWarmup, NumSevereDuringWarmup));
+    ShowMessage(
+        state,
+        std::format("EnergyPlus Sizing Error Summary. During Sizing: {} Warning; {} Severe Errors.", NumWarningsDuringSizing, NumSevereDuringSizing));
+    ShowMessage(
+        state,
+        std::format("EnergyPlus Terminated--Fatal Error Detected. {} Warning; {} Severe Errors; Elapsed Time={}", NumWarnings, NumSevere, Elapsed));
     DisplayString(state, "EnergyPlus Run Time=" + Elapsed);
 
     {
@@ -545,7 +545,7 @@ int EndEnergyPlus(EnergyPlusData &state)
 
     state.dataSysVars->runtimeTimer.tock();
     if (state.dataGlobal->createPerfLog) {
-        Util::appendPerfLog(state, "Run Time [seconds]", EnergyPlus::format("{:.2R}", state.dataSysVars->runtimeTimer.elapsedSeconds()));
+        Util::appendPerfLog(state, "Run Time [seconds]", std::format("{:.2f}", state.dataSysVars->runtimeTimer.elapsedSeconds()));
     }
     const std::string Elapsed = state.dataSysVars->runtimeTimer.formatAsHourMinSecs();
     state.dataResultsFramework->resultsFramework->SimulationInformation.setRunTime(Elapsed);
@@ -558,15 +558,14 @@ int EndEnergyPlus(EnergyPlusData &state)
         Util::appendPerfLog(state, "Number of Warnings", NumWarnings);
         Util::appendPerfLog(state, "Number of Severe", NumSevere, true); // last item so write the perfLog file
     }
-    ShowMessage(state,
-                EnergyPlus::format(
-                    "EnergyPlus Warmup Error Summary. During Warmup: {} Warning; {} Severe Errors.", NumWarningsDuringWarmup, NumSevereDuringWarmup));
-    ShowMessage(state,
-                EnergyPlus::format(
-                    "EnergyPlus Sizing Error Summary. During Sizing: {} Warning; {} Severe Errors.", NumWarningsDuringSizing, NumSevereDuringSizing));
     ShowMessage(
         state,
-        EnergyPlus::format("EnergyPlus Completed Successfully-- {} Warning; {} Severe Errors; Elapsed Time={}", NumWarnings, NumSevere, Elapsed));
+        std::format("EnergyPlus Warmup Error Summary. During Warmup: {} Warning; {} Severe Errors.", NumWarningsDuringWarmup, NumSevereDuringWarmup));
+    ShowMessage(
+        state,
+        std::format("EnergyPlus Sizing Error Summary. During Sizing: {} Warning; {} Severe Errors.", NumWarningsDuringSizing, NumSevereDuringSizing));
+    ShowMessage(state,
+                std::format("EnergyPlus Completed Successfully-- {} Warning; {} Severe Errors; Elapsed Time={}", NumWarnings, NumSevere, Elapsed));
     DisplayString(state, "EnergyPlus Run Time=" + Elapsed);
 
     {
@@ -773,13 +772,12 @@ ShowFatalError(EnergyPlusData &state, std::string const &ErrorMessage, OptionalO
 
     using namespace DataErrorTracking;
 
-    ShowErrorMessage(state, EnergyPlus::format(" **  Fatal  ** {}", ErrorMessage), OutUnit1, OutUnit2);
+    ShowErrorMessage(state, std::format(" **  Fatal  ** {}", ErrorMessage), OutUnit1, OutUnit2);
     DisplayString(state, "**FATAL:" + ErrorMessage);
 
     ShowErrorMessage(state, " ...Summary of Errors that led to program termination:", OutUnit1, OutUnit2);
-    ShowErrorMessage(
-        state, EnergyPlus::format(" ..... Reference severe error count={}", state.dataErrTracking->TotalSevereErrors), OutUnit1, OutUnit2);
-    ShowErrorMessage(state, EnergyPlus::format(" ..... Last severe error={}", state.dataErrTracking->LastSevereError), OutUnit1, OutUnit2);
+    ShowErrorMessage(state, std::format(" ..... Reference severe error count={}", state.dataErrTracking->TotalSevereErrors), OutUnit1, OutUnit2);
+    ShowErrorMessage(state, std::format(" ..... Last severe error={}", state.dataErrTracking->LastSevereError), OutUnit1, OutUnit2);
     if (state.dataSQLiteProcedures->sqlite) {
         state.dataSQLiteProcedures->sqlite->createSQLiteErrorRecord(1, 2, ErrorMessage, 1);
         if (state.dataSQLiteProcedures->sqlite->sqliteWithinTransaction()) {
@@ -820,7 +818,7 @@ void ShowSevereError(EnergyPlusData &state, std::string const &ErrorMessage, Opt
     if (state.dataGlobal->DoingSizing) {
         ++state.dataErrTracking->TotalSevereErrorsDuringSizing;
     }
-    ShowErrorMessage(state, EnergyPlus::format(" ** Severe  ** {}", ErrorMessage), OutUnit1, OutUnit2);
+    ShowErrorMessage(state, std::format(" ** Severe  ** {}", ErrorMessage), OutUnit1, OutUnit2);
     state.dataErrTracking->LastSevereError = ErrorMessage;
 
     //  Could set a variable here that gets checked at some point?
@@ -853,7 +851,7 @@ void ShowSevereMessage(EnergyPlusData &state, std::string const &ErrorMessage, O
         }
     }
 
-    ShowErrorMessage(state, EnergyPlus::format(" ** Severe  ** {}", ErrorMessage), OutUnit1, OutUnit2);
+    ShowErrorMessage(state, std::format(" ** Severe  ** {}", ErrorMessage), OutUnit1, OutUnit2);
     state.dataErrTracking->LastSevereError = ErrorMessage;
 
     //  Could set a variable here that gets checked at some point?
@@ -879,7 +877,7 @@ void ShowContinueError(EnergyPlusData &state, std::string const &Message, Option
     // METHODOLOGY EMPLOYED:
     // Calls ShowErrorMessage utility routine.
 
-    ShowErrorMessage(state, EnergyPlus::format(" **   ~~~   ** {}", Message), OutUnit1, OutUnit2);
+    ShowErrorMessage(state, std::format(" **   ~~~   ** {}", Message), OutUnit1, OutUnit2);
     if (state.dataSQLiteProcedures->sqlite) {
         state.dataSQLiteProcedures->sqlite->updateSQLiteErrorRecord(Message);
     }
@@ -1563,8 +1561,7 @@ void ShowSevereEmptyField(
 {
     ShowSevereError(state, std::format("{}: {} = {}", eoh.routineName, eoh.objectType, eoh.objectName));
     ShowContinueError(
-        state,
-        std::format("{} cannot be empty{}.", fieldName, depFieldName.empty() ? "" : EnergyPlus::format(" when {} = {}", depFieldName, depFieldVal)));
+        state, std::format("{} cannot be empty{}.", fieldName, depFieldName.empty() ? "" : std::format(" when {} = {}", depFieldName, depFieldVal)));
 }
 
 void ShowSevereItemNotFound(EnergyPlusData &state, ErrorObjectHeader const &eoh, std::string_view fieldName, std::string_view fieldVal)
@@ -1768,8 +1765,7 @@ void ShowWarningBadMin(EnergyPlusData &state,
                        std::string_view msg)
 {
     ShowWarningError(state, std::format("{}: {} = {}", eoh.routineName, eoh.objectType, eoh.objectName));
-    ShowContinueError(state,
-                      EnergyPlus::format("{} = {:.2R}, but must be {} {:.2R}", fieldName, fieldVal, cluMin == Clusive::In ? ">=" : ">", minVal));
+    ShowContinueError(state, std::format("{} = {:.2f}, but must be {} {:.2f}", fieldName, fieldVal, cluMin == Clusive::In ? ">=" : ">", minVal));
     if (!msg.empty()) {
         ShowContinueError(state, std::format("{}", msg));
     }
@@ -1784,8 +1780,7 @@ void ShowWarningBadMax(EnergyPlusData &state,
                        std::string_view msg)
 {
     ShowWarningError(state, std::format("{}: {} = {}", eoh.routineName, eoh.objectType, eoh.objectName));
-    ShowContinueError(state,
-                      EnergyPlus::format("{} = {:.2R}, but must be {} {:.2R}", fieldName, fieldVal, cluMax == Clusive::In ? "<=" : "<", maxVal));
+    ShowContinueError(state, std::format("{} = {:.2f}, but must be {} {:.2f}", fieldName, fieldVal, cluMax == Clusive::In ? "<=" : "<", maxVal));
     if (!msg.empty()) {
         ShowContinueError(state, std::format("{}", msg));
     }

--- a/src/EnergyPlus/VariableSpeedCoils.cc
+++ b/src/EnergyPlus/VariableSpeedCoils.cc
@@ -141,23 +141,22 @@ namespace VariableSpeedCoils {
         if (CompIndex == 0) {
             DXCoilNum = Util::FindItemInList(CompName, state.dataVariableSpeedCoils->VarSpeedCoil);
             if (DXCoilNum == 0) {
-                ShowFatalError(state, EnergyPlus::format("WaterToAirHPVSWEquationFit not found={}", CompName));
+                ShowFatalError(state, std::format("WaterToAirHPVSWEquationFit not found={}", CompName));
             }
             CompIndex = DXCoilNum;
         } else {
             DXCoilNum = CompIndex;
             if (DXCoilNum > state.dataVariableSpeedCoils->NumVarSpeedCoils || DXCoilNum < 1) {
-                ShowFatalError(
-                    state,
-                    EnergyPlus::format("SimVariableSpeedCoils: Invalid CompIndex passed={}, Number of Water to Air HPs={}, WaterToAir HP name={}",
-                                       DXCoilNum,
-                                       state.dataVariableSpeedCoils->NumVarSpeedCoils,
-                                       CompName));
+                ShowFatalError(state,
+                               std::format("SimVariableSpeedCoils: Invalid CompIndex passed={}, Number of Water to Air HPs={}, WaterToAir HP name={}",
+                                           DXCoilNum,
+                                           state.dataVariableSpeedCoils->NumVarSpeedCoils,
+                                           CompName));
             }
             if (!CompName.empty() && CompName != state.dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).Name) {
                 ShowFatalError(
                     state,
-                    EnergyPlus::format(
+                    std::format(
                         "SimVariableSpeedCoils: Invalid CompIndex passed={}, WaterToAir HP name={}, stored WaterToAir HP Name for that index={}",
                         DXCoilNum,
                         CompName,
@@ -354,8 +353,8 @@ namespace VariableSpeedCoils {
 
                 cFieldName = "Number of Speeds";
                 if (varSpeedCoil.NumOfSpeeds < 1) {
-                    ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", invalid", RoutineName, CurrentModuleObject, varSpeedCoil.Name));
-                    ShowContinueError(state, EnergyPlus::format("...{} must be >= 1. entered number is {}", cFieldName, varSpeedCoil.NumOfSpeeds));
+                    ShowSevereError(state, std::format("{}{}=\"{}\", invalid", RoutineName, CurrentModuleObject, varSpeedCoil.Name));
+                    ShowContinueError(state, std::format("...{} must be >= 1. entered number is {}", cFieldName, varSpeedCoil.NumOfSpeeds));
                     ErrorsFound = true;
                 }
 
@@ -364,9 +363,9 @@ namespace VariableSpeedCoils {
                 }
                 cFieldName = "Nominal Speed Level";
                 if ((varSpeedCoil.NormSpedLevel > varSpeedCoil.NumOfSpeeds) || (varSpeedCoil.NormSpedLevel <= 0)) {
-                    ShowSevereError(state, EnergyPlus::format("{}{}=\"{}\", invalid", RoutineName, CurrentModuleObject, varSpeedCoil.Name));
-                    ShowContinueError(
-                        state, EnergyPlus::format("...{} must be valid speed level entered number is {}", cFieldName, varSpeedCoil.NormSpedLevel));
+                    ShowSevereError(state, std::format("{}{}=\"{}\", invalid", RoutineName, CurrentModuleObject, varSpeedCoil.Name));
+                    ShowContinueError(state,
+                                      std::format("...{} must be valid speed level entered number is {}", cFieldName, varSpeedCoil.NormSpedLevel));
                     ErrorsFound = true;
                 }
 
@@ -382,33 +381,32 @@ namespace VariableSpeedCoils {
                 } else {
                     CurveVal = Curve::CurveValue(state, varSpeedCoil.PLFFPLR, 1.0);
                     if (CurveVal > 1.10 || CurveVal < 0.90) {
-                        ShowWarningError(state, EnergyPlus::format("{}{}=\"{}\", curve values", RoutineName, CurrentModuleObject, varSpeedCoil.Name));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("...{} output is not equal to 1.0 (+ or - 10%) at rated conditions.", cFieldName));
-                        ShowContinueError(state, EnergyPlus::format("...Curve output at rated conditions = {:.3f}", CurveVal));
+                        ShowWarningError(state, std::format("{}{}=\"{}\", curve values", RoutineName, CurrentModuleObject, varSpeedCoil.Name));
+                        ShowContinueError(state, std::format("...{} output is not equal to 1.0 (+ or - 10%) at rated conditions.", cFieldName));
+                        ShowContinueError(state, std::format("...Curve output at rated conditions = {:.3f}", CurveVal));
                     }
                 }
 
                 for (int I = 1; I <= varSpeedCoil.NumOfSpeeds; ++I) {
                     std::string fieldName;
-                    fieldName = EnergyPlus::format("speed_{}{}", std::to_string(I), "_reference_unit_gross_rated_total_cooling_capacity");
+                    fieldName = std::format("speed_{}{}", std::to_string(I), "_reference_unit_gross_rated_total_cooling_capacity");
                     varSpeedCoil.MSRatedTotCap(I) = s_ip->getRealFieldValue(fields, schemaProps, fieldName);
-                    fieldName = EnergyPlus::format("speed_{}{}", std::to_string(I), "_reference_unit_gross_rated_sensible_heat_ratio");
+                    fieldName = std::format("speed_{}{}", std::to_string(I), "_reference_unit_gross_rated_sensible_heat_ratio");
                     varSpeedCoil.MSRatedSHR(I) = s_ip->getRealFieldValue(fields, schemaProps, fieldName);
-                    fieldName = EnergyPlus::format("speed_{}{}", std::to_string(I), "_reference_unit_gross_rated_cooling_cop");
+                    fieldName = std::format("speed_{}{}", std::to_string(I), "_reference_unit_gross_rated_cooling_cop");
                     varSpeedCoil.MSRatedCOP(I) = s_ip->getRealFieldValue(fields, schemaProps, fieldName);
-                    fieldName = EnergyPlus::format("speed_{}{}", std::to_string(I), "_reference_unit_rated_air_flow_rate");
+                    fieldName = std::format("speed_{}{}", std::to_string(I), "_reference_unit_rated_air_flow_rate");
                     varSpeedCoil.MSRatedAirVolFlowRate(I) = s_ip->getRealFieldValue(fields, schemaProps, fieldName);
-                    fieldName = EnergyPlus::format("speed_{}{}", std::to_string(I), "_reference_unit_rated_water_flow_rate");
+                    fieldName = std::format("speed_{}{}", std::to_string(I), "_reference_unit_rated_water_flow_rate");
                     varSpeedCoil.MSRatedWaterVolFlowRate(I) = s_ip->getRealFieldValue(fields, schemaProps, fieldName);
                     fieldName =
-                        EnergyPlus::format("speed_{}{}", std::to_string(I), "_reference_unit_waste_heat_fraction_of_input_power_at_rated_conditions");
+                        std::format("speed_{}{}", std::to_string(I), "_reference_unit_waste_heat_fraction_of_input_power_at_rated_conditions");
                     varSpeedCoil.MSWasteHeatFrac(I) = s_ip->getRealFieldValue(fields, schemaProps, fieldName);
 
                     std::string fieldValue =
-                        EnergyPlus::format("speed_{}{}", std::to_string(I), "_total_cooling_capacity_function_of_temperature_curve_name");
+                        std::format("speed_{}{}", std::to_string(I), "_total_cooling_capacity_function_of_temperature_curve_name");
                     std::string cFieldName_curve =
-                        EnergyPlus::format("Speed_{}{}", std::to_string(I), " Total Cooling Capacity Function of Temperature Curve Name");
+                        std::format("Speed_{}{}", std::to_string(I), " Total Cooling Capacity Function of Temperature Curve Name");
                     std::string const coolCapFTCurveName = s_ip->getAlphaFieldValue(fields, schemaProps, fieldValue);
                     if (coolCapFTCurveName.empty()) {
                         ShowWarningEmptyField(state, eoh, cFieldName_curve, "Required field is blank.");
@@ -1804,7 +1802,7 @@ namespace VariableSpeedCoils {
                     if (varSpeedCoil.MSRatedTotCap(I) < 1.e-10) {
                         cFieldName = std::format("Speed_{}{}", std::to_string(I), " Reference Unit Gross Rated Heating Capacity");
                         ShowSevereError(state, std::format("{}{}=\"{}\", invalid value", RoutineName, CurrentModuleObject, varSpeedCoil.Name));
-                        ShowContinueError(state, EnergyPlus::format("...too small {}=[{:.2R}].", cFieldName, varSpeedCoil.MSRatedTotCap(I)));
+                        ShowContinueError(state, std::format("...too small {}=[{:.2f}].", cFieldName, varSpeedCoil.MSRatedTotCap(I)));
                         ErrorsFound = true;
                     }
                     fieldName = std::format("speed_{}{}", std::to_string(I), "_reference_unit_gross_rated_heating_cop");
@@ -4138,12 +4136,12 @@ namespace VariableSpeedCoils {
                                     "In calculating capacity for coil {} on design day {}, the air state would yield negative coil capacity sizing.",
                                     varSpeedCoil.Name,
                                     state.dataSize->FinalSysSizing(state.dataSize->CurSysNum).CoolDesDay));
-                            ShowContinueError(state, EnergyPlus::format("The air properties are: T_mix = {:.4R}", MixTemp));
-                            ShowContinueError(state, EnergyPlus::format("                        T_supply = {:.4R}", SupTemp));
-                            ShowContinueError(state, EnergyPlus::format("                        H_mix = {:.4R}", MixEnth));
-                            ShowContinueError(state, EnergyPlus::format("                        H_supply = {:.4R}", SupEnth));
-                            ShowContinueError(state, EnergyPlus::format("                        W_mix = {:.4R}", MixHumRat));
-                            ShowContinueError(state, EnergyPlus::format("                        W_supply = {:.4R}", SupHumRat));
+                            ShowContinueError(state, std::format("The air properties are: T_mix = {:.4f}", MixTemp));
+                            ShowContinueError(state, std::format("                        T_supply = {:.4f}", SupTemp));
+                            ShowContinueError(state, std::format("                        H_mix = {:.4f}", MixEnth));
+                            ShowContinueError(state, std::format("                        H_supply = {:.4f}", SupEnth));
+                            ShowContinueError(state, std::format("                        W_mix = {:.4f}", MixHumRat));
+                            ShowContinueError(state, std::format("                        W_supply = {:.4f}", SupHumRat));
                             ShowContinueError(state, "Cooling capacity is set to zero during sizing; simulation continues.");
                         }
                         if (state.dataSize->UnitarySysEqSizing(state.dataSize->CurSysNum).CoolingCapacity &&
@@ -4293,11 +4291,9 @@ namespace VariableSpeedCoils {
                                                     varSpeedCoil.CoolHeatType,
                                                     CurrentObjSubfix));
                             ShowContinueError(state, std::format("Coil Name = {}", varSpeedCoil.Name));
-                            ShowContinueError(state,
-                                              EnergyPlus::format("User-Specified Rated Total Cooling Capacity of {:.2R} [W]", RatedCapCoolTotalUser));
+                            ShowContinueError(state, std::format("User-Specified Rated Total Cooling Capacity of {:.2f} [W]", RatedCapCoolTotalUser));
                             ShowContinueError(
-                                state,
-                                EnergyPlus::format("differs from Design Size Rated Total Cooling Capacity of {:.2R} [W]", RatedCapCoolTotalDes));
+                                state, std::format("differs from Design Size Rated Total Cooling Capacity of {:.2f} [W]", RatedCapCoolTotalDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -4419,9 +4415,8 @@ namespace VariableSpeedCoils {
                                                 varSpeedCoil.CoolHeatType,
                                                 CurrentObjSubfix));
                         ShowContinueError(state, std::format("Coil Name = {}", varSpeedCoil.Name));
-                        ShowContinueError(state, EnergyPlus::format("User-Specified Rated Total Heating Capacity of {:.2R} [W]", RatedCapHeatUser));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("differs from Design Size Rated Total Heating Capacity of {:.2R} [W]", RatedCapHeatDes));
+                        ShowContinueError(state, std::format("User-Specified Rated Total Heating Capacity of {:.2f} [W]", RatedCapHeatUser));
+                        ShowContinueError(state, std::format("differs from Design Size Rated Total Heating Capacity of {:.2f} [W]", RatedCapHeatDes));
                         ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                         ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                     }
@@ -4463,10 +4458,9 @@ namespace VariableSpeedCoils {
                                                     varSpeedCoil.CoolHeatType,
                                                     CurrentObjSubfix));
                             ShowContinueError(state, std::format("Coil Name = {}", varSpeedCoil.Name));
+                            ShowContinueError(state, std::format("User-Specified Rated Air Flow Rate of {:.5f} [m3/s]", RatedAirVolFlowRateUser));
                             ShowContinueError(state,
-                                              EnergyPlus::format("User-Specified Rated Air Flow Rate of {:.5R} [m3/s]", RatedAirVolFlowRateUser));
-                            ShowContinueError(
-                                state, EnergyPlus::format("differs from Design Size Rated Air Flow Rate of {:.5R} [m3/s]", RatedAirVolFlowRateDes));
+                                              std::format("differs from Design Size Rated Air Flow Rate of {:.5f} [m3/s]", RatedAirVolFlowRateDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -4716,9 +4710,9 @@ namespace VariableSpeedCoils {
                                     Mode,
                                     Mode + 1));
                     ShowContinueError(state,
-                                      EnergyPlus::format("Instead, {:.2R} > {:.2R}",
-                                                         varSpeedCoil.MSRatedAirVolFlowRate(Mode),
-                                                         varSpeedCoil.MSRatedAirVolFlowRate(Mode + 1)));
+                                      std::format("Instead, {:.2f} > {:.2f}",
+                                                  varSpeedCoil.MSRatedAirVolFlowRate(Mode),
+                                                  varSpeedCoil.MSRatedAirVolFlowRate(Mode + 1)));
                     ShowFatalError(state, "Preceding conditions cause termination.");
                 }
             }
@@ -4740,10 +4734,9 @@ namespace VariableSpeedCoils {
                                                 varSpeedCoil.CoolHeatType,
                                                 CurrentObjSubfix));
                         ShowContinueError(state, std::format("Coil Name = {}", varSpeedCoil.Name));
+                        ShowContinueError(state, std::format("User-Specified Rated Water Flow Rate of {:.5f} [m3/s]", RatedWaterVolFlowRateUser));
                         ShowContinueError(state,
-                                          EnergyPlus::format("User-Specified Rated Water Flow Rate of {:.5R} [m3/s]", RatedWaterVolFlowRateUser));
-                        ShowContinueError(
-                            state, EnergyPlus::format("differs from Design Size Rated Water Flow Rate of {:.5R} [m3/s]", RatedWaterVolFlowRateDes));
+                                          std::format("differs from Design Size Rated Water Flow Rate of {:.5f} [m3/s]", RatedWaterVolFlowRateDes));
                         ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                         ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                     }
@@ -4796,10 +4789,9 @@ namespace VariableSpeedCoils {
                                 varSpeedCoil.Name,
                                 Mode,
                                 Mode + 1));
-                ShowContinueError(state,
-                                  EnergyPlus::format("Instead, {:.2R} > {:.2R}",
-                                                     varSpeedCoil.MSRatedAirVolFlowRate(Mode),
-                                                     varSpeedCoil.MSRatedAirVolFlowRate(Mode + 1)));
+                ShowContinueError(
+                    state,
+                    std::format("Instead, {:.2f} > {:.2f}", varSpeedCoil.MSRatedAirVolFlowRate(Mode), varSpeedCoil.MSRatedAirVolFlowRate(Mode + 1)));
                 ShowFatalError(state, "Preceding conditions cause termination.");
             }
         }
@@ -4815,8 +4807,8 @@ namespace VariableSpeedCoils {
                                 varSpeedCoil.Name,
                                 Mode,
                                 Mode + 1));
-                ShowContinueError(
-                    state, EnergyPlus::format("Instead, {:.2R} > {:.2R}", varSpeedCoil.MSRatedTotCap(Mode), varSpeedCoil.MSRatedTotCap(Mode + 1)));
+                ShowContinueError(state,
+                                  std::format("Instead, {:.2f} > {:.2f}", varSpeedCoil.MSRatedTotCap(Mode), varSpeedCoil.MSRatedTotCap(Mode + 1)));
                 ShowFatalError(state, "Preceding conditions cause termination.");
             }
         }
@@ -5032,12 +5024,11 @@ namespace VariableSpeedCoils {
                                                     CurrentObjSubfix));
                             ShowContinueError(state, std::format("Coil Name = {}", varSpeedCoil.Name));
                             ShowContinueError(state,
-                                              EnergyPlus::format("User-Specified Evaporative Condenser Pump Rated Power Consumption of {:.2R} [W]",
-                                                                 EvapCondPumpElecNomPowerUser));
-                            ShowContinueError(
-                                state,
-                                EnergyPlus::format("differs from Design Size Evaporative Condenser Pump Rated Power Consumption of {:.2R} [W]",
-                                                   EvapCondPumpElecNomPowerDes));
+                                              std::format("User-Specified Evaporative Condenser Pump Rated Power Consumption of {:.2f} [W]",
+                                                          EvapCondPumpElecNomPowerUser));
+                            ShowContinueError(state,
+                                              std::format("differs from Design Size Evaporative Condenser Pump Rated Power Consumption of {:.2f} [W]",
+                                                          EvapCondPumpElecNomPowerDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -5081,11 +5072,10 @@ namespace VariableSpeedCoils {
                                                     varSpeedCoil.CoolHeatType,
                                                     CurrentObjSubfix));
                             ShowContinueError(state, std::format("Coil Name = {}", varSpeedCoil.Name));
+                            ShowContinueError(state,
+                                              std::format("User-Specified Resistive Defrost Heater Capacity of {:.2f} [W]", DefrostCapacityUser));
                             ShowContinueError(
-                                state, EnergyPlus::format("User-Specified Resistive Defrost Heater Capacity of {:.2R} [W]", DefrostCapacityUser));
-                            ShowContinueError(
-                                state,
-                                EnergyPlus::format("differs from Design Size Resistive Defrost Heater Capacity of {:.2R} [W]", DefrostCapacityDes));
+                                state, std::format("differs from Design Size Resistive Defrost Heater Capacity of {:.2f} [W]", DefrostCapacityDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }

--- a/src/EnergyPlus/VentilatedSlab.cc
+++ b/src/EnergyPlus/VentilatedSlab.cc
@@ -153,26 +153,25 @@ namespace VentilatedSlab {
         if (CompIndex == 0) {
             Item = Util::FindItemInList(CompName, state.dataVentilatedSlab->VentSlab);
             if (Item == 0) {
-                ShowFatalError(state, EnergyPlus::format("SimVentilatedSlab: system not found={}", CompName));
+                ShowFatalError(state, std::format("SimVentilatedSlab: system not found={}", CompName));
             }
             CompIndex = Item;
         } else {
             Item = CompIndex;
             if (Item > state.dataVentilatedSlab->NumOfVentSlabs || Item < 1) {
                 ShowFatalError(state,
-                               EnergyPlus::format("SimVentilatedSlab:  Invalid CompIndex passed={}, Number of Systems={}, Entered System name={}",
-                                                  Item,
-                                                  state.dataVentilatedSlab->NumOfVentSlabs,
-                                                  CompName));
+                               std::format("SimVentilatedSlab:  Invalid CompIndex passed={}, Number of Systems={}, Entered System name={}",
+                                           Item,
+                                           state.dataVentilatedSlab->NumOfVentSlabs,
+                                           CompName));
             }
             if (state.dataVentilatedSlab->CheckEquipName(Item)) {
                 if (CompName != state.dataVentilatedSlab->VentSlab(Item).Name) {
-                    ShowFatalError(
-                        state,
-                        EnergyPlus::format("SimVentilatedSlab: Invalid CompIndex passed={}, System name={}, stored System Name for that index={}",
-                                           Item,
-                                           CompName,
-                                           state.dataVentilatedSlab->VentSlab(Item).Name));
+                    ShowFatalError(state,
+                                   std::format("SimVentilatedSlab: Invalid CompIndex passed={}, System name={}, stored System Name for that index={}",
+                                               Item,
+                                               CompName,
+                                               state.dataVentilatedSlab->VentSlab(Item).Name));
                 }
                 state.dataVentilatedSlab->CheckEquipName(Item) = false;
             }
@@ -379,11 +378,11 @@ namespace VentilatedSlab {
                                                        state.dataIPShortCut->cAlphaArgs(4)));
                     ErrorsFound = true;
                 } else if (state.dataSurface->SurfIsRadSurfOrVentSlabOrPool(ventSlab.SurfacePtr(1))) {
-                    ShowSevereError(state, EnergyPlus::format("{}=\"{}\", invalid Surface", CurrentModuleObject, ventSlab.Name));
+                    ShowSevereError(state, std::format("{}=\"{}\", invalid Surface", CurrentModuleObject, ventSlab.Name));
                     ShowContinueError(state,
-                                      EnergyPlus::format("{}=\"{}\" has been used in another radiant system or ventilated slab.",
-                                                         cAlphaFields(4),
-                                                         state.dataIPShortCut->cAlphaArgs(4)));
+                                      std::format("{}=\"{}\" has been used in another radiant system or ventilated slab.",
+                                                  cAlphaFields(4),
+                                                  state.dataIPShortCut->cAlphaArgs(4)));
                     ErrorsFound = true;
                 }
                 if (ventSlab.SurfacePtr(1) != 0) {
@@ -411,13 +410,12 @@ namespace VentilatedSlab {
                     }
                     if (!thisConstruct.SourceSinkPresent) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}=\"{}\" invalid surface=\"{}\".",
-                                                           CurrentModuleObject,
-                                                           ventSlab.Name,
-                                                           state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Name));
+                                        std::format("{}=\"{}\" invalid surface=\"{}\".",
+                                                    CurrentModuleObject,
+                                                    ventSlab.Name,
+                                                    state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Name));
                         ShowContinueError(
-                            state,
-                            EnergyPlus::format("Surface Construction does not have a source/sink, Construction name= \"{}\".", thisConstruct.Name));
+                            state, std::format("Surface Construction does not have a source/sink, Construction name= \"{}\".", thisConstruct.Name));
                         ErrorsFound = true;
                     }
                 }
@@ -433,16 +431,15 @@ namespace VentilatedSlab {
                     }
                     if (state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Zone != ventSlab.ZonePtr) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}=\"{}\" invalid surface=\"{}\".",
-                                                           CurrentModuleObject,
-                                                           ventSlab.Name,
-                                                           state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Name));
-                        ShowContinueError(
-                            state,
-                            EnergyPlus::format("Surface in Zone={} {} in Zone={}",
-                                               state.dataHeatBal->Zone(state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Zone).Name,
-                                               CurrentModuleObject,
-                                               state.dataIPShortCut->cAlphaArgs(3)));
+                                        std::format("{}=\"{}\" invalid surface=\"{}\".",
+                                                    CurrentModuleObject,
+                                                    ventSlab.Name,
+                                                    state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Name));
+                        ShowContinueError(state,
+                                          std::format("Surface in Zone={} {} in Zone={}",
+                                                      state.dataHeatBal->Zone(state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Zone).Name,
+                                                      CurrentModuleObject,
+                                                      state.dataIPShortCut->cAlphaArgs(3)));
                         ErrorsFound = true;
                     }
                     if (state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Construction == 0) {
@@ -450,13 +447,12 @@ namespace VentilatedSlab {
                     }
                     if (!thisConstruct.SourceSinkPresent) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}=\"{}\" invalid surface=\"{}\".",
-                                                           CurrentModuleObject,
-                                                           ventSlab.Name,
-                                                           state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Name));
+                                        std::format("{}=\"{}\" invalid surface=\"{}\".",
+                                                    CurrentModuleObject,
+                                                    ventSlab.Name,
+                                                    state.dataSurface->Surface(ventSlab.SurfacePtr(SurfNum)).Name));
                         ShowContinueError(
-                            state,
-                            EnergyPlus::format("Surface Construction does not have a source/sink, Construction name= \"{}\".", thisConstruct.Name));
+                            state, std::format("Surface Construction does not have a source/sink, Construction name= \"{}\".", thisConstruct.Name));
                         ErrorsFound = true;
                     }
                 }
@@ -538,9 +534,9 @@ namespace VentilatedSlab {
             if (Util::SameString(state.dataIPShortCut->cAlphaArgs(8), "SurfaceListNames")) {
                 if (!lNumericBlanks(4)) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("{}=\"{}\"  Core Diameter is not needed for the series slabs configuration- ignored.",
-                                                        CurrentModuleObject,
-                                                        ventSlab.Name));
+                                     std::format("{}=\"{}\"  Core Diameter is not needed for the series slabs configuration- ignored.",
+                                                 CurrentModuleObject,
+                                                 ventSlab.Name));
                     ShowContinueError(state, "...It has been assigned on SlabGroup.");
                 }
             }
@@ -548,9 +544,9 @@ namespace VentilatedSlab {
             if (Util::SameString(state.dataIPShortCut->cAlphaArgs(8), "SurfaceListNames")) {
                 if (!lNumericBlanks(5)) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("{}=\"{}\"  Core Length is not needed for the series slabs configuration- ignored.",
-                                                        CurrentModuleObject,
-                                                        ventSlab.Name));
+                                     std::format("{}=\"{}\"  Core Length is not needed for the series slabs configuration- ignored.",
+                                                 CurrentModuleObject,
+                                                 ventSlab.Name));
                     ShowContinueError(state, "...It has been assigned on SlabGroup.");
                 }
             }
@@ -558,9 +554,9 @@ namespace VentilatedSlab {
             if (Util::SameString(state.dataIPShortCut->cAlphaArgs(8), "SurfaceListNames")) {
                 if (!lNumericBlanks(6)) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("{}=\"{}\"  Core Numbers is not needed for the series slabs configuration- ignored.",
-                                                        CurrentModuleObject,
-                                                        ventSlab.Name));
+                                     std::format("{}=\"{}\"  Core Numbers is not needed for the series slabs configuration- ignored.",
+                                                 CurrentModuleObject,
+                                                 ventSlab.Name));
                     ShowContinueError(state, "...It has been assigned on SlabGroup.");
                 }
             }
@@ -1901,11 +1897,10 @@ namespace VentilatedSlab {
                                     state,
                                     std::format("SizeVentilatedSlab: Potential issue with equipment sizing for ZoneHVAC:VentilatedSlab = \"{}\".",
                                                 ventSlab.Name));
+                                ShowContinueError(state,
+                                                  std::format("User-Specified Maximum Outdoor Air Flow Rate of {:.5f} [m3/s]", OutAirVolFlowUser));
                                 ShowContinueError(
-                                    state, EnergyPlus::format("User-Specified Maximum Outdoor Air Flow Rate of {:.5R} [m3/s]", OutAirVolFlowUser));
-                                ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("differs from Design Size Maximum Outdoor Air Flow Rate of {:.5R} [m3/s]", OutAirVolFlowDes));
+                                    state, std::format("differs from Design Size Maximum Outdoor Air Flow Rate of {:.5f} [m3/s]", OutAirVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -1952,11 +1947,11 @@ namespace VentilatedSlab {
                                     state,
                                     std::format("SizeVentilatedSlab: Potential issue with equipment sizing for ZoneHVAC:VentilatedSlab = \"{}\".",
                                                 ventSlab.Name));
-                                ShowContinueError(
-                                    state, EnergyPlus::format("User-Specified Minimum Outdoor Air Flow Rate of {:.5R} [m3/s]", MinOutAirVolFlowUser));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("differs from Design Size Minimum Outdoor Air Flow Rate of {:.5R} [m3/s]",
-                                                                     MinOutAirVolFlowDes));
+                                                  std::format("User-Specified Minimum Outdoor Air Flow Rate of {:.5f} [m3/s]", MinOutAirVolFlowUser));
+                                ShowContinueError(
+                                    state,
+                                    std::format("differs from Design Size Minimum Outdoor Air Flow Rate of {:.5f} [m3/s]", MinOutAirVolFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -2076,11 +2071,11 @@ namespace VentilatedSlab {
                                         state,
                                         std::format("SizeVentilatedSlab: Potential issue with equipment sizing for ZoneHVAC:VentilatedSlab = \"{}\".",
                                                     ventSlab.Name));
-                                    ShowContinueError(
-                                        state, EnergyPlus::format("User-Specified Maximum Hot Water Flow of {:.5R} [m3/s]", MaxVolHotWaterFlowUser));
                                     ShowContinueError(state,
-                                                      EnergyPlus::format("differs from Design Size Maximum Hot Water Flow of {:.5R} [m3/s]",
-                                                                         MaxVolHotWaterFlowDes));
+                                                      std::format("User-Specified Maximum Hot Water Flow of {:.5f} [m3/s]", MaxVolHotWaterFlowUser));
+                                    ShowContinueError(
+                                        state,
+                                        std::format("differs from Design Size Maximum Hot Water Flow of {:.5f} [m3/s]", MaxVolHotWaterFlowDes));
                                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                                 }
@@ -2200,11 +2195,10 @@ namespace VentilatedSlab {
                                         state,
                                         std::format("SizeVentilatedSlab: Potential issue with equipment sizing for ZoneHVAC:VentilatedSlab = \"{}\".",
                                                     ventSlab.Name));
+                                    ShowContinueError(state,
+                                                      std::format("User-Specified Maximum Steam Flow of {:.5f} [m3/s]", MaxVolHotSteamFlowUser));
                                     ShowContinueError(
-                                        state, EnergyPlus::format("User-Specified Maximum Steam Flow of {:.5R} [m3/s]", MaxVolHotSteamFlowUser));
-                                    ShowContinueError(
-                                        state,
-                                        EnergyPlus::format("differs from Design Size Maximum Steam Flow of {:.5R} [m3/s]", MaxVolHotSteamFlowDes));
+                                        state, std::format("differs from Design Size Maximum Steam Flow of {:.5f} [m3/s]", MaxVolHotSteamFlowDes));
                                     ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                     ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                                 }
@@ -2334,11 +2328,10 @@ namespace VentilatedSlab {
                                     state,
                                     std::format("SizeVentilatedSlab: Potential issue with equipment sizing for ZoneHVAC:VentilatedSlab = \"{}\".",
                                                 ventSlab.Name));
+                                ShowContinueError(state,
+                                                  std::format("User-Specified Maximum Cold Water Flow of {:.5f} [m3/s]", MaxVolColdWaterFlowUser));
                                 ShowContinueError(
-                                    state, EnergyPlus::format("User-Specified Maximum Cold Water Flow of {:.5R} [m3/s]", MaxVolColdWaterFlowUser));
-                                ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("differs from Design Size Maximum Cold Water Flow of {:.5R} [m3/s]", MaxVolColdWaterFlowDes));
+                                    state, std::format("differs from Design Size Maximum Cold Water Flow of {:.5f} [m3/s]", MaxVolColdWaterFlowDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -3683,17 +3676,17 @@ namespace VentilatedSlab {
                                         ShowContinueError(state, "Flow to the ventilated slab system will be shut-off to avoid condensation");
                                         ShowContinueError(
                                             state,
-                                            EnergyPlus::format("Predicted radiant system surface temperature = {:.2R}",
-                                                               state.dataHeatBalSurf->SurfInsideTempHist(1)(ventSlab.SurfacePtr(RadSurfNum2))));
-                                        ShowContinueError(state,
-                                                          EnergyPlus::format("Zone dew-point temperature + safety factor delta= {:.2R}",
-                                                                             DewPointTemp + CondDeltaTemp));
+                                            std::format("Predicted radiant system surface temperature = {:.2f}",
+                                                        state.dataHeatBalSurf->SurfInsideTempHist(1)(ventSlab.SurfacePtr(RadSurfNum2))));
+                                        ShowContinueError(
+                                            state,
+                                            std::format("Zone dew-point temperature + safety factor delta= {:.2f}", DewPointTemp + CondDeltaTemp));
                                         ShowContinueErrorTimeStamp(state, "");
                                     }
                                     if (state.dataVentilatedSlab->CondensationErrorCount == 1) {
-                                        ShowContinueError(state,
-                                                          EnergyPlus::format("Note that there is a {:.4R} C safety built-in to the shut-off criteria",
-                                                                             CondDeltaTemp));
+                                        ShowContinueError(
+                                            state,
+                                            std::format("Note that there is a {:.4f} C safety built-in to the shut-off criteria", CondDeltaTemp));
                                         ShowContinueError(state, "Note also that this affects all surfaces that are part of this system");
                                     }
                                     ShowRecurringWarningErrorAtEnd(state,
@@ -3741,16 +3734,15 @@ namespace VentilatedSlab {
                                     ShowContinueError(state, "However, it could also result from improper input for the ventilated slab or");
                                     ShowContinueError(state, "illogical control temperatures.  Check your input for this ventilated slab and");
                                     ShowContinueError(state, "also look at the internal data shown below.");
+                                    ShowContinueError(state,
+                                                      std::format("Predicted return air temperature [C] from the overall energy balance = {:.4f}",
+                                                                  state.dataLoopNodes->Node(ReturnAirNode).Temp));
                                     ShowContinueError(
                                         state,
-                                        EnergyPlus::format("Predicted return air temperature [C] from the overall energy balance = {:.4R}",
-                                                           state.dataLoopNodes->Node(ReturnAirNode).Temp));
-                                    ShowContinueError(
-                                        state,
-                                        EnergyPlus::format("Predicted return air temperature [C] from the slab section energy balances = {:.4R}",
-                                                           AirOutletTempCheck));
-                                    ShowContinueError(
-                                        state, EnergyPlus::format("Total energy rate (power) [W] added to the slab = {:.4R}", TotalVentSlabRadPower));
+                                        std::format("Predicted return air temperature [C] from the slab section energy balances = {:.4f}",
+                                                    AirOutletTempCheck));
+                                    ShowContinueError(state,
+                                                      std::format("Total energy rate (power) [W] added to the slab = {:.4f}", TotalVentSlabRadPower));
                                     ShowContinueErrorTimeStamp(state, "");
                                 }
                                 ShowRecurringWarningErrorAtEnd(state,
@@ -3781,16 +3773,15 @@ namespace VentilatedSlab {
                                     ShowContinueError(state, "However, it could also result from improper input for the ventilated slab or");
                                     ShowContinueError(state, "illogical control temperatures.  Check your input for this ventilated slab and");
                                     ShowContinueError(state, "also look at the internal data shown below.");
+                                    ShowContinueError(state,
+                                                      std::format("Predicted return air temperature [C] from the overall energy balance = {:.4f}",
+                                                                  state.dataLoopNodes->Node(ReturnAirNode).Temp));
                                     ShowContinueError(
                                         state,
-                                        EnergyPlus::format("Predicted return air temperature [C] from the overall energy balance = {:.4R}",
-                                                           state.dataLoopNodes->Node(ReturnAirNode).Temp));
-                                    ShowContinueError(
-                                        state,
-                                        EnergyPlus::format("Predicted return air temperature [C] from the slab section energy balances = {:.4R}",
-                                                           AirOutletTempCheck));
-                                    ShowContinueError(
-                                        state, EnergyPlus::format("Total energy rate (power) [W] added to the slab = {:.4R}", TotalVentSlabRadPower));
+                                        std::format("Predicted return air temperature [C] from the slab section energy balances = {:.4f}",
+                                                    AirOutletTempCheck));
+                                    ShowContinueError(state,
+                                                      std::format("Total energy rate (power) [W] added to the slab = {:.4f}", TotalVentSlabRadPower));
                                     ShowContinueErrorTimeStamp(state, "");
                                 }
                                 ShowRecurringWarningErrorAtEnd(state,
@@ -3947,17 +3938,17 @@ namespace VentilatedSlab {
                                         ShowContinueError(state, "Flow to the ventilated slab system will be shut-off to avoid condensation");
                                         ShowContinueError(
                                             state,
-                                            EnergyPlus::format("Predicted radiant system surface temperature = {:.2R}",
-                                                               state.dataHeatBalSurf->SurfInsideTempHist(1)(ventSlab.SurfacePtr(RadSurfNum2))));
-                                        ShowContinueError(state,
-                                                          EnergyPlus::format("Zone dew-point temperature + safety factor delta= {:.2R}",
-                                                                             DewPointTemp + CondDeltaTemp));
+                                            std::format("Predicted radiant system surface temperature = {:.2f}",
+                                                        state.dataHeatBalSurf->SurfInsideTempHist(1)(ventSlab.SurfacePtr(RadSurfNum2))));
+                                        ShowContinueError(
+                                            state,
+                                            std::format("Zone dew-point temperature + safety factor delta= {:.2f}", DewPointTemp + CondDeltaTemp));
                                         ShowContinueErrorTimeStamp(state, "");
                                     }
                                     if (state.dataVentilatedSlab->CondensationErrorCount == 1) {
-                                        ShowContinueError(state,
-                                                          EnergyPlus::format("Note that there is a {:.4R} C safety built-in to the shut-off criteria",
-                                                                             CondDeltaTemp));
+                                        ShowContinueError(
+                                            state,
+                                            std::format("Note that there is a {:.4f} C safety built-in to the shut-off criteria", CondDeltaTemp));
                                         ShowContinueError(state, "Note also that this affects all surfaces that are part of this system");
                                     }
                                     ShowRecurringWarningErrorAtEnd(state,
@@ -4051,14 +4042,13 @@ namespace VentilatedSlab {
                                 ShowContinueError(state, "illogical control temperatures.  Check your input for this ventilated slab and");
                                 ShowContinueError(state, "also look at the internal data shown below.");
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("Predicted return air temperature [C] from the overall energy balance = {:.4R}",
-                                                                     state.dataLoopNodes->Node(ReturnAirNode).Temp));
-                                ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("Predicted return air temperature [C] from the slab section energy balances = {:.4R}",
-                                                       AirOutletTempCheck));
-                                ShowContinueError(
-                                    state, EnergyPlus::format("Total energy rate (power) [W] added to the slab = {:.4R}", TotalVentSlabRadPower));
+                                                  std::format("Predicted return air temperature [C] from the overall energy balance = {:.4f}",
+                                                              state.dataLoopNodes->Node(ReturnAirNode).Temp));
+                                ShowContinueError(state,
+                                                  std::format("Predicted return air temperature [C] from the slab section energy balances = {:.4f}",
+                                                              AirOutletTempCheck));
+                                ShowContinueError(state,
+                                                  std::format("Total energy rate (power) [W] added to the slab = {:.4f}", TotalVentSlabRadPower));
                                 ShowContinueErrorTimeStamp(state, "");
                             }
                             ShowRecurringWarningErrorAtEnd(state,

--- a/src/EnergyPlus/WaterCoils.cc
+++ b/src/EnergyPlus/WaterCoils.cc
@@ -162,27 +162,27 @@ void SimulateWaterCoilComponents(EnergyPlusData &state,
     if (CompIndex == 0) {
         CoilNum = Util::FindItemInList(CompName, state.dataWaterCoils->WaterCoil);
         if (CoilNum == 0) {
-            ShowFatalError(state, EnergyPlus::format("SimulateWaterCoilComponents: Coil not found={}", CompName));
+            ShowFatalError(state, std::format("SimulateWaterCoilComponents: Coil not found={}", CompName));
         }
         CompIndex = CoilNum;
     } else {
         CoilNum = CompIndex;
         if (CoilNum > state.dataWaterCoils->NumWaterCoils || CoilNum < 1) {
             ShowFatalError(state,
-                           EnergyPlus::format("SimulateWaterCoilComponents: Invalid CompIndex passed={}, Number of Water Coils={}, Coil name={}",
-                                              CoilNum,
-                                              state.dataWaterCoils->NumWaterCoils,
-                                              CompName));
+                           std::format("SimulateWaterCoilComponents: Invalid CompIndex passed={}, Number of Water Coils={}, Coil name={}",
+                                       CoilNum,
+                                       state.dataWaterCoils->NumWaterCoils,
+                                       CompName));
         }
         if (state.dataWaterCoils->CheckEquipName(CoilNum)) {
             auto const &waterCoil = state.dataWaterCoils->WaterCoil(CoilNum);
             if (CompName != waterCoil.Name) {
                 ShowFatalError(
                     state,
-                    EnergyPlus::format("SimulateWaterCoilComponents: Invalid CompIndex passed={}, Coil name={}, stored Coil Name for that index={}",
-                                       CoilNum,
-                                       CompName,
-                                       waterCoil.Name));
+                    std::format("SimulateWaterCoilComponents: Invalid CompIndex passed={}, Coil name={}, stored Coil Name for that index={}",
+                                CoilNum,
+                                CompName,
+                                waterCoil.Name));
             }
             state.dataWaterCoils->CheckEquipName(CoilNum) = false;
         }
@@ -422,18 +422,18 @@ void GetWaterCoilInput(EnergyPlusData &state)
             waterCoil.UseDesignWaterDeltaTemp = false;
         }
         if (waterCoil.DesInletWaterTemp <= waterCoil.DesOutletWaterTemp) {
-            ShowSevereError(state, EnergyPlus::format("For {}, {}", CurrentModuleObject, AlphArray(1)));
-            ShowContinueError(state, EnergyPlus::format("  the {} must be greater than the {}.", cNumericFields(4), cNumericFields(6)));
+            ShowSevereError(state, std::format("For {}, {}", CurrentModuleObject, AlphArray(1)));
+            ShowContinueError(state, std::format("  the {} must be greater than the {}.", cNumericFields(4), cNumericFields(6)));
             ErrorsFound = true;
         }
         if (waterCoil.DesInletAirTemp >= waterCoil.DesOutletAirTemp) {
-            ShowSevereError(state, EnergyPlus::format("For {}, {}", CurrentModuleObject, AlphArray(1)));
-            ShowContinueError(state, EnergyPlus::format("  the {} must be less than the {}.", cNumericFields(5), cNumericFields(7)));
+            ShowSevereError(state, std::format("For {}, {}", CurrentModuleObject, AlphArray(1)));
+            ShowContinueError(state, std::format("  the {} must be less than the {}.", cNumericFields(5), cNumericFields(7)));
             ErrorsFound = true;
         }
         if (waterCoil.DesInletAirTemp >= waterCoil.DesInletWaterTemp) {
-            ShowSevereError(state, EnergyPlus::format("For {}, {}", CurrentModuleObject, AlphArray(1)));
-            ShowContinueError(state, EnergyPlus::format("  the {} must be less than the {}.", cNumericFields(5), cNumericFields(4)));
+            ShowSevereError(state, std::format("For {}, {}", CurrentModuleObject, AlphArray(1)));
+            ShowContinueError(state, std::format("  the {} must be less than the {}.", cNumericFields(5), cNumericFields(4)));
             ErrorsFound = true;
         }
 
@@ -553,8 +553,7 @@ void GetWaterCoilInput(EnergyPlusData &state)
         waterCoil.FinThickness = NumArray(8);
         if (waterCoil.FinThickness <= 0.0) {
             ShowSevereError(
-                state,
-                EnergyPlus::format("{}: {} must be > 0.0, for {} = {}", CurrentModuleObject, cNumericFields(8), cAlphaFields(1), waterCoil.Name));
+                state, std::format("{}: {} must be > 0.0, for {} = {}", CurrentModuleObject, cNumericFields(8), cAlphaFields(1), waterCoil.Name));
             ErrorsFound = true;
         }
         waterCoil.TubeInsideDiam = NumArray(9);
@@ -562,15 +561,13 @@ void GetWaterCoilInput(EnergyPlusData &state)
         waterCoil.TubeThermConductivity = NumArray(11);
         if (waterCoil.TubeThermConductivity <= 0.0) {
             ShowSevereError(
-                state,
-                EnergyPlus::format("{}: {} must be > 0.0, for {} = {}", CurrentModuleObject, cNumericFields(11), cAlphaFields(1), waterCoil.Name));
+                state, std::format("{}: {} must be > 0.0, for {} = {}", CurrentModuleObject, cNumericFields(11), cAlphaFields(1), waterCoil.Name));
             ErrorsFound = true;
         }
         waterCoil.FinThermConductivity = NumArray(12);
         if (waterCoil.FinThermConductivity <= 0.0) {
             ShowSevereError(
-                state,
-                EnergyPlus::format("{}: {} must be > 0.0, for {} = {}", CurrentModuleObject, cNumericFields(12), cAlphaFields(1), waterCoil.Name));
+                state, std::format("{}: {} must be > 0.0, for {} = {}", CurrentModuleObject, cNumericFields(12), cAlphaFields(1), waterCoil.Name));
             ErrorsFound = true;
         }
         waterCoil.FinSpacing = NumArray(13);
@@ -930,7 +927,7 @@ void GetWaterCoilInput(EnergyPlusData &state)
     }
 
     if (ErrorsFound) {
-        ShowFatalError(state, EnergyPlus::format("{}Errors found in getting input.", RoutineName));
+        ShowFatalError(state, std::format("{}Errors found in getting input.", RoutineName));
     }
 
     AlphArray.deallocate();
@@ -1060,8 +1057,8 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                 SimAirServingZones::CheckWaterCoilIsOnAirLoop(state, CoilTypeNum, CompType, CompName, WaterCoilOnAirLoop);
                 if (!WaterCoilOnAirLoop) {
                     ShowContinueError(state,
-                                      EnergyPlus::format("Controller:WaterCoil = {}. Invalid water controller entry.",
-                                                         state.dataWaterCoils->WaterCoil(tempCoilNum).ControllerName));
+                                      std::format("Controller:WaterCoil = {}. Invalid water controller entry.",
+                                                  state.dataWaterCoils->WaterCoil(tempCoilNum).ControllerName));
                     ErrorsFound = true;
                 }
             }
@@ -1160,8 +1157,7 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
             //   be less than 1
             TubeToFinDiamRatio = waterCoil.TubeOutsideDiam / waterCoil.EffectiveFinDiam;
             if (TubeToFinDiamRatio > 1.0) {
-                ShowWarningError(state,
-                                 EnergyPlus::format("InitWaterCoil: Detailed Flat Fin Coil, TubetoFinDiamRatio > 1.0, [{:.4R}]", TubeToFinDiamRatio));
+                ShowWarningError(state, std::format("InitWaterCoil: Detailed Flat Fin Coil, TubetoFinDiamRatio > 1.0, [{:.4f}]", TubeToFinDiamRatio));
                 // reset tube depth spacing and recalc dependent parameters
                 waterCoil.TubeDepthSpacing *= (pow_2(TubeToFinDiamRatio) + 0.1);
                 waterCoil.CoilDepth = waterCoil.TubeDepthSpacing * waterCoil.NumOfTubeRows;
@@ -1169,8 +1165,8 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                     std::sqrt(4.0 * waterCoil.FinDiam * waterCoil.CoilDepth / (Constant::Pi * waterCoil.NumOfTubeRows * waterCoil.NumOfTubesPerRow));
                 waterCoil.CoilEffectiveInsideDiam = 4.0 * waterCoil.MinAirFlowArea * waterCoil.CoilDepth / waterCoil.TotCoilOutsideSurfArea;
                 TubeToFinDiamRatio = waterCoil.TubeOutsideDiam / waterCoil.EffectiveFinDiam;
-                ShowContinueError(state, EnergyPlus::format("  Resetting tube depth spacing to {:.4R} meters", waterCoil.TubeDepthSpacing));
-                ShowContinueError(state, EnergyPlus::format("  Resetting coil depth to {:.4R} meters", waterCoil.CoilDepth));
+                ShowContinueError(state, std::format("  Resetting tube depth spacing to {:.4f} meters", waterCoil.TubeDepthSpacing));
+                ShowContinueError(state, std::format("  Resetting coil depth to {:.4f} meters", waterCoil.CoilDepth));
             }
 
             CalcDryFinEffCoef(state, TubeToFinDiamRatio, state.dataWaterCoils->CoefSeries);
@@ -1225,22 +1221,18 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                 DesSatEnthAtWaterInTemp = PsyHFnTdbW(waterCoil.DesInletWaterTemp, waterCoil.DesOutletAirHumRat) - 0.0001;
             }
             if (DesOutletAirEnth >= DesInletAirEnth || waterCoil.DesInletWaterTemp >= waterCoil.DesInletAirTemp) {
-                ShowWarningError(state, EnergyPlus::format("The design cooling capacity is zero for Coil:Cooling:Water {}", waterCoil.Name));
+                ShowWarningError(state, std::format("The design cooling capacity is zero for Coil:Cooling:Water {}", waterCoil.Name));
                 ShowContinueError(state, "  The maximum water flow rate for this coil will be set to zero and the coil will do no cooling.");
+                ShowContinueError(state,
+                                  std::format("  Check the following coil design inputs for problems: Tair,in = {:.4f}", waterCoil.DesInletAirTemp));
                 ShowContinueError(
-                    state, EnergyPlus::format("  Check the following coil design inputs for problems: Tair,in = {:.4R}", waterCoil.DesInletAirTemp));
+                    state, std::format("                                                       Wair,in = {:.6f}", waterCoil.DesInletAirHumRat));
                 ShowContinueError(
-                    state,
-                    EnergyPlus::format("                                                       Wair,in = {:.6R}", waterCoil.DesInletAirHumRat));
+                    state, std::format("                                                       Twater,in = {:.4f}", waterCoil.DesInletWaterTemp));
                 ShowContinueError(
-                    state,
-                    EnergyPlus::format("                                                       Twater,in = {:.4R}", waterCoil.DesInletWaterTemp));
+                    state, std::format("                                                       Tair,out = {:.4f}", waterCoil.DesOutletAirTemp));
                 ShowContinueError(
-                    state,
-                    EnergyPlus::format("                                                       Tair,out = {:.4R}", waterCoil.DesOutletAirTemp));
-                ShowContinueError(
-                    state,
-                    EnergyPlus::format("                                                       Wair,out = {:.6R}", waterCoil.DesOutletAirHumRat));
+                    state, std::format("                                                       Wair,out = {:.6f}", waterCoil.DesOutletAirHumRat));
                 waterCoil.MaxWaterVolFlowRate = 0.0;
                 waterCoil.MaxWaterMassFlowRate = 0.0;
             }
@@ -1260,7 +1252,7 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                         !state.dataWaterCoils->CBFTooLarge) {
                         goto Inlet_Conditions_Loop_exit; // coil UA calcs OK
                     } else {
-                        ShowWarningError(state, EnergyPlus::format("In calculating the design coil UA for Coil:Cooling:Water {}", waterCoil.Name));
+                        ShowWarningError(state, std::format("In calculating the design coil UA for Coil:Cooling:Water {}", waterCoil.Name));
                         if (state.dataWaterCoils->NoSatCurveIntersect) {
                             ShowContinueError(state, "no apparatus dew-point can be found for the initial entering and leaving conditions;");
                         }
@@ -1273,21 +1265,16 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                         if (!state.dataWaterCoils->NoExitCondReset) {
                             ShowContinueError(state, "the coil outlet design conditions will be changed to correct the problem.");
                         }
-                        ShowContinueError(state,
-                                          EnergyPlus::format("The initial design conditions are: Tair,in = {:.4R}", waterCoil.DesInletAirTemp));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("                                   Wair,in = {:.6R}", waterCoil.DesInletAirHumRat));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("                                   Twater,in = {:.4R}", waterCoil.DesInletWaterTemp));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("                                   Tair,out = {:.4R}", waterCoil.DesOutletAirTemp));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("                                   Wair,out = {:.6R}", waterCoil.DesOutletAirHumRat));
+                        ShowContinueError(state, std::format("The initial design conditions are: Tair,in = {:.4f}", waterCoil.DesInletAirTemp));
+                        ShowContinueError(state, std::format("                                   Wair,in = {:.6f}", waterCoil.DesInletAirHumRat));
+                        ShowContinueError(state, std::format("                                   Twater,in = {:.4f}", waterCoil.DesInletWaterTemp));
+                        ShowContinueError(state, std::format("                                   Tair,out = {:.4f}", waterCoil.DesOutletAirTemp));
+                        ShowContinueError(state, std::format("                                   Wair,out = {:.6f}", waterCoil.DesOutletAirHumRat));
                         if (!state.dataWaterCoils->NoExitCondReset) {
-                            ShowContinueError(
-                                state, EnergyPlus::format("The revised design conditions are: Tair,out = {:.4R}", state.dataWaterCoils->TOutNew));
-                            ShowContinueError(
-                                state, EnergyPlus::format("                                   Wair,out = {:.6R}", state.dataWaterCoils->WOutNew));
+                            ShowContinueError(state,
+                                              std::format("The revised design conditions are: Tair,out = {:.4f}", state.dataWaterCoils->TOutNew));
+                            ShowContinueError(state,
+                                              std::format("                                   Wair,out = {:.6f}", state.dataWaterCoils->WOutNew));
                             waterCoil.DesOutletAirHumRat = state.dataWaterCoils->WOutNew;
                             waterCoil.DesOutletAirTemp = state.dataWaterCoils->TOutNew;
                             // update outlet air conditions used for sizing
@@ -1387,15 +1374,14 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                     }
 
                     if (DesEnthWaterOut > DesInletAirEnth) {
-                        ShowWarningError(state, EnergyPlus::format("In calculating the design coil UA for Coil:Cooling:Water {}", waterCoil.Name));
+                        ShowWarningError(state, std::format("In calculating the design coil UA for Coil:Cooling:Water {}", waterCoil.Name));
                         ShowContinueError(state, "the outlet chilled water design enthalpy is greater than the inlet air design enthalpy.");
-                        ShowContinueError(
-                            state,
-                            EnergyPlus::format("To correct this condition the design chilled water flow rate will be increased from {:.5R}",
-                                               waterCoil.MaxWaterVolFlowRate));
+                        ShowContinueError(state,
+                                          std::format("To correct this condition the design chilled water flow rate will be increased from {:.5f}",
+                                                      waterCoil.MaxWaterVolFlowRate));
                         EnthCorrFrac = (DesEnthWaterOut - DesInletAirEnth) / (DesEnthWaterOut - DesSatEnthAtWaterInTemp);
                         waterCoil.MaxWaterVolFlowRate *= (1.0 + 2.0 * EnthCorrFrac);
-                        ShowContinueError(state, EnergyPlus::format("to {:.5R} m3/s", waterCoil.MaxWaterVolFlowRate));
+                        ShowContinueError(state, std::format("to {:.5f} m3/s", waterCoil.MaxWaterVolFlowRate));
                         waterCoil.MaxWaterMassFlowRate = rho * waterCoil.MaxWaterVolFlowRate;
                         DesOutletWaterTemp = waterCoil.DesInletWaterTemp + waterCoil.DesTotWaterCoilLoad / (waterCoil.MaxWaterMassFlowRate * Cp);
                         DesSatEnthAtWaterOutTemp =
@@ -1437,15 +1423,14 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                 } else { // dry coil
 
                     if (DesOutletWaterTemp > waterCoil.DesInletAirTemp) {
-                        ShowWarningError(state, EnergyPlus::format("In calculating the design coil UA for Coil:Cooling:Water {}", waterCoil.Name));
+                        ShowWarningError(state, std::format("In calculating the design coil UA for Coil:Cooling:Water {}", waterCoil.Name));
                         ShowContinueError(state, "the outlet chilled water design temperature is greater than the inlet air design temperature.");
-                        ShowContinueError(
-                            state,
-                            EnergyPlus::format("To correct this condition the design chilled water flow rate will be increased from {:.5R}",
-                                               waterCoil.MaxWaterVolFlowRate));
+                        ShowContinueError(state,
+                                          std::format("To correct this condition the design chilled water flow rate will be increased from {:.5f}",
+                                                      waterCoil.MaxWaterVolFlowRate));
                         TempCorrFrac = (DesOutletWaterTemp - waterCoil.DesInletAirTemp) / (DesOutletWaterTemp - waterCoil.DesInletWaterTemp);
                         waterCoil.MaxWaterVolFlowRate *= (1.0 + 2.0 * TempCorrFrac);
-                        ShowContinueError(state, EnergyPlus::format("to {:.5R} m3/s", waterCoil.MaxWaterVolFlowRate));
+                        ShowContinueError(state, std::format("to {:.5f} m3/s", waterCoil.MaxWaterVolFlowRate));
                         waterCoil.MaxWaterMassFlowRate = rho * waterCoil.MaxWaterVolFlowRate;
                         DesOutletWaterTemp = waterCoil.DesInletWaterTemp + waterCoil.DesTotWaterCoilLoad / (waterCoil.MaxWaterMassFlowRate * Cp);
                     }
@@ -1522,7 +1507,7 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                 waterCoil.UACoilInternalPerUnitArea = waterCoil.UACoilInternal / waterCoil.TotCoilOutsideSurfArea;
                 waterCoil.UAWetExtPerUnitArea = waterCoil.UACoilExternal / waterCoil.TotCoilOutsideSurfArea;
                 waterCoil.UADryExtPerUnitArea = waterCoil.UAWetExtPerUnitArea;
-                ShowContinueError(state, EnergyPlus::format(" Coil design UA set to {:.6R} [W/C]", waterCoil.UACoilTotal));
+                ShowContinueError(state, std::format(" Coil design UA set to {:.6f} [W/C]", waterCoil.UACoilTotal));
             } else if (SolFlag == General::SOLVEROOT_ERROR_INIT) {
                 ShowSevereError(state, std::format("Calculation of cooling coil design UA failed for coil {}", waterCoil.Name));
                 ShowContinueError(state, "  Bad starting values for UA");
@@ -1533,7 +1518,7 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                 waterCoil.UACoilInternalPerUnitArea = waterCoil.UACoilInternal / waterCoil.TotCoilOutsideSurfArea;
                 waterCoil.UAWetExtPerUnitArea = waterCoil.UACoilExternal / waterCoil.TotCoilOutsideSurfArea;
                 waterCoil.UADryExtPerUnitArea = waterCoil.UAWetExtPerUnitArea;
-                ShowContinueError(state, EnergyPlus::format(" Coil design UA set to {:.6R} [W/C]", waterCoil.UACoilTotal));
+                ShowContinueError(state, std::format(" Coil design UA set to {:.6f} [W/C]", waterCoil.UACoilTotal));
             }
 
             // cooling coil surface area
@@ -1626,7 +1611,7 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                     state.dataOutRptPredefined->pdstHeatCoil,
                     "Nominal values are gross at rated conditions, i.e., the supply air fan heat and electric power NOT accounted for.");
                 print(state.files.eio,
-                      "{},{},{:.2R}\n",
+                      "{},{},{:.2f}\n",
                       "Water Heating Coil Capacity Information,Coil:Heating:Water",
                       waterCoil.Name,
                       waterCoil.TotWaterHeatingCoilRate);
@@ -1669,7 +1654,7 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                     state.dataOutRptPredefined->pdstCoolCoil,
                     "Nominal values are gross at rated conditions, i.e., the supply air fan heat and electric power NOT accounted for.");
                 print(state.files.eio,
-                      "{},{},{:.2R},{:.2R},{:.2R},{:.2R}\n",
+                      "{},{},{:.2f},{:.2f},{:.2f},{:.2f}\n",
                       "Water Cooling Coil Capacity Information,Coil:Cooling:Water:DetailedGeometry",
                       waterCoil.Name,
                       waterCoil.TotWaterCoolingCoilRate,
@@ -1721,7 +1706,7 @@ void InitWaterCoil(EnergyPlusData &state, int const CoilNum, bool const FirstHVA
                     state.dataOutRptPredefined->pdstCoolCoil,
                     "Nominal values are gross at rated conditions, i.e., the supply air fan heat and electric power NOT accounted for.");
                 print(state.files.eio,
-                      "{},{},{:.2R},{:.2R},{:.2R},{:.2R},{:.2R},{:.2R}\n",
+                      "{},{},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f}\n",
                       "Water Cooling Coil Capacity Information,Coil:Cooling:Water",
                       waterCoil.Name,
                       waterCoil.TotWaterCoolingCoilRate,
@@ -2204,8 +2189,8 @@ void SizeWaterCoil(EnergyPlusData &state, int const CoilNum)
 
             if ((waterCoil.DesInletWaterTemp > state.dataSize->DataDesOutletAirTemp) && state.dataSize->DataDesOutletAirTemp > 0.0) {
                 ShowWarningError(state, std::format("Invalid design inlet water temperature for {} = {}", CompType, CompName));
-                ShowContinueError(state, EnergyPlus::format("...design inlet water temperature = {:.3R} C", waterCoil.DesInletWaterTemp));
-                ShowContinueError(state, EnergyPlus::format("...design outlet air temperature = {:.3R} C", state.dataSize->DataDesOutletAirTemp));
+                ShowContinueError(state, std::format("...design inlet water temperature = {:.3f} C", waterCoil.DesInletWaterTemp));
+                ShowContinueError(state, std::format("...design outlet air temperature = {:.3f} C", state.dataSize->DataDesOutletAirTemp));
                 ShowContinueError(state, "...design inlet water temperature should be less than the design outlet air temperature");
                 ShowContinueError(state, "...design inlet water temperature is set to the design outlet air temperature minus 5.0C");
                 waterCoil.DesInletWaterTemp = state.dataSize->DataDesOutletAirTemp - 5.0;
@@ -5860,12 +5845,12 @@ Real64 TdbFnHRhPb(EnergyPlusData &state,
     if (SolFla == General::SOLVEROOT_ERROR_ITER) {
         ShowSevereError(state, "Calculation of drybulb temperature failed in TdbFnHRhPb(H,RH,PB)");
         ShowContinueError(state, "   Iteration limit exceeded");
-        ShowContinueError(state, EnergyPlus::format("   H=[{:.6R}], RH=[{:.4R}], PB=[{:.5R}].", H, RH, PB));
+        ShowContinueError(state, std::format("   H=[{:.6f}], RH=[{:.4f}], PB=[{:.5f}].", H, RH, PB));
         return 0.0;
     } else if (SolFla == General::SOLVEROOT_ERROR_INIT) {
         ShowSevereError(state, "Calculation of drybulb temperature failed in TdbFnHRhPb(H,RH,PB)");
         ShowContinueError(state, "  Bad starting values for Tdb");
-        ShowContinueError(state, EnergyPlus::format("   H=[{:.6R}], RH=[{:.4R}], PB=[{:.5R}].", H, RH, PB));
+        ShowContinueError(state, std::format("   H=[{:.6f}], RH=[{:.4f}], PB=[{:.5f}].", H, RH, PB));
         return 0.0;
     } else {
         return Tprov;

--- a/src/EnergyPlus/WaterManager.cc
+++ b/src/EnergyPlus/WaterManager.cc
@@ -304,17 +304,17 @@ namespace WaterManager {
                     state.dataWaterData->WaterStorage(Item).ValveOffCapacity = rNumericArgs(6);
                     if (state.dataWaterData->WaterStorage(Item).ControlSupply != ControlSupplyType::NoControlLevel) {
                         if (state.dataWaterData->WaterStorage(Item).ValveOffCapacity < state.dataWaterData->WaterStorage(Item).ValveOnCapacity) {
-                            ShowSevereError(state, EnergyPlus::format("Invalid {} and/or {}", cNumericFieldNames(5), cNumericFieldNames(6)));
-                            ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
-                            ShowContinueError(state, EnergyPlus::format("{} must be greater than {}", cNumericFieldNames(6), cNumericFieldNames(5)));
+                            ShowSevereError(state, std::format("Invalid {} and/or {}", cNumericFieldNames(5), cNumericFieldNames(6)));
+                            ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
+                            ShowContinueError(state, std::format("{} must be greater than {}", cNumericFieldNames(6), cNumericFieldNames(5)));
                             ShowContinueError(state,
-                                              EnergyPlus::format("Check value for {} = {:.5R}",
-                                                                 cNumericFieldNames(5),
-                                                                 state.dataWaterData->WaterStorage(Item).ValveOnCapacity));
+                                              std::format("Check value for {} = {:.5f}",
+                                                          cNumericFieldNames(5),
+                                                          state.dataWaterData->WaterStorage(Item).ValveOnCapacity));
                             ShowContinueError(state,
-                                              EnergyPlus::format("which must be lower than {} = {:.5R}",
-                                                                 cNumericFieldNames(6),
-                                                                 state.dataWaterData->WaterStorage(Item).ValveOffCapacity));
+                                              std::format("which must be lower than {} = {:.5f}",
+                                                          cNumericFieldNames(6),
+                                                          state.dataWaterData->WaterStorage(Item).ValveOffCapacity));
                             ErrorsFound = true;
                         }
                     }
@@ -377,8 +377,8 @@ namespace WaterManager {
                         state.dataWaterData->WaterStorage(Item).ZoneID = Util::FindItemInList(cAlphaArgs(10), state.dataHeatBal->Zone);
                         if ((state.dataWaterData->WaterStorage(Item).ZoneID == 0) &&
                             (state.dataWaterData->WaterStorage(Item).AmbientTempIndicator == AmbientTempType::Zone)) {
-                            ShowSevereError(state, EnergyPlus::format("Invalid {}={}", cAlphaFieldNames(10), cAlphaArgs(10)));
-                            ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
+                            ShowSevereError(state, std::format("Invalid {}={}", cAlphaFieldNames(10), cAlphaArgs(10)));
+                            ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
                             ErrorsFound = true;
                         }
                         state.dataWaterData->WaterStorage(Item).SurfArea = rNumericArgs(8);
@@ -423,8 +423,8 @@ namespace WaterManager {
                     state.dataWaterData->RainCollector(Item).StorageTankName = cAlphaArgs(2);
                     state.dataWaterData->RainCollector(Item).StorageTankID = Util::FindItemInList(cAlphaArgs(2), state.dataWaterData->WaterStorage);
                     if (state.dataWaterData->RainCollector(Item).StorageTankID == 0) {
-                        ShowSevereError(state, EnergyPlus::format("Invalid {}={}", cAlphaFieldNames(2), cAlphaArgs(2)));
-                        ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
+                        ShowSevereError(state, std::format("Invalid {}={}", cAlphaFieldNames(2), cAlphaArgs(2)));
+                        ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
                         ErrorsFound = true;
                     }
 
@@ -438,13 +438,13 @@ namespace WaterManager {
                     }
                     state.dataWaterData->RainCollector(Item).LossFactor = rNumericArgs(1);
                     if (state.dataWaterData->RainCollector(Item).LossFactor > 1.0) {
-                        ShowWarningError(state, EnergyPlus::format("Invalid {}={:.2R}", cNumericFieldNames(1), rNumericArgs(1)));
-                        ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
+                        ShowWarningError(state, std::format("Invalid {}={:.2f}", cNumericFieldNames(1), rNumericArgs(1)));
+                        ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
                         ShowContinueError(state, "found rain water collection loss factor greater than 1.0, simulation continues");
                     }
                     if (state.dataWaterData->RainCollector(Item).LossFactor < 0.0) {
-                        ShowSevereError(state, EnergyPlus::format("Invalid {}={:.2R}", cNumericFieldNames(1), rNumericArgs(1)));
-                        ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
+                        ShowSevereError(state, std::format("Invalid {}={:.2f}", cNumericFieldNames(1), rNumericArgs(1)));
+                        ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
                         ShowContinueError(state, "found rain water collection loss factor less than 0.0");
                         ErrorsFound = true;
                     }
@@ -478,10 +478,9 @@ namespace WaterManager {
                         state.dataWaterData->RainCollector(Item).SurfID(SurfNum) =
                             Util::FindItemInList(cAlphaArgs(SurfNum + alphaOffset), state.dataSurface->Surface);
                         if (state.dataWaterData->RainCollector(Item).SurfID(SurfNum) == 0) {
-                            ShowSevereError(
-                                state,
-                                EnergyPlus::format("Invalid {}={}", cAlphaFieldNames(SurfNum + alphaOffset), cAlphaArgs(SurfNum + alphaOffset)));
-                            ShowContinueError(state, EnergyPlus::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
+                            ShowSevereError(state,
+                                            std::format("Invalid {}={}", cAlphaFieldNames(SurfNum + alphaOffset), cAlphaArgs(SurfNum + alphaOffset)));
+                            ShowContinueError(state, std::format("Entered in {}={}", cCurrentModuleObject, cAlphaArgs(1)));
                             ErrorsFound = true;
                         }
                     }
@@ -589,9 +588,9 @@ namespace WaterManager {
                         (state.dataWaterData->WaterStorage(Item).ControlSupply == ControlSupplyType::WellFloatMainsBackup)) {
                         if (state.dataWaterData->WaterStorage(Item).GroundWellID == 0) {
                             ShowSevereError(state,
-                                            EnergyPlus::format("{}= \"{}\" does not have a WaterUse:Well (groundwater well) that names it.",
-                                                               cCurrentModuleObject,
-                                                               state.dataWaterData->WaterStorage(Item).Name));
+                                            std::format("{}= \"{}\" does not have a WaterUse:Well (groundwater well) that names it.",
+                                                        cCurrentModuleObject,
+                                                        state.dataWaterData->WaterStorage(Item).Name));
                             ErrorsFound = true;
                         }
                     }
@@ -604,10 +603,10 @@ namespace WaterManager {
                             Util::FindItemInList(state.dataWaterData->WaterStorage(Item).SupplyTankName, state.dataWaterData->WaterStorage);
                         if (state.dataWaterData->WaterStorage(Item).SupplyTankID == 0) {
                             ShowSevereError(state,
-                                            EnergyPlus::format("Other tank called {} not found for {} Named {}",
-                                                               state.dataWaterData->WaterStorage(Item).SupplyTankName,
-                                                               cCurrentModuleObject,
-                                                               state.dataWaterData->WaterStorage(Item).Name)); // TODO rename point
+                                            std::format("Other tank called {} not found for {} Named {}",
+                                                        state.dataWaterData->WaterStorage(Item).SupplyTankName,
+                                                        cCurrentModuleObject,
+                                                        state.dataWaterData->WaterStorage(Item).Name)); // TODO rename point
                             ErrorsFound = true;
                         }
                         InternalSetupTankDemandComponent(state,
@@ -635,10 +634,10 @@ namespace WaterManager {
                             state.dataWaterData->WaterStorage(Item).OverflowMode = Overflow::Discarded;
                         } else {
                             ShowSevereError(state,
-                                            EnergyPlus::format("Overflow tank name of {} not found for {} Named {}",
-                                                               state.dataWaterData->WaterStorage(Item).OverflowTankName,
-                                                               cCurrentModuleObject,
-                                                               state.dataWaterData->WaterStorage(Item).Name));
+                                            std::format("Overflow tank name of {} not found for {} Named {}",
+                                                        state.dataWaterData->WaterStorage(Item).OverflowTankName,
+                                                        cCurrentModuleObject,
+                                                        state.dataWaterData->WaterStorage(Item).Name));
                             ErrorsFound = true;
                         }
                     } else {
@@ -659,7 +658,7 @@ namespace WaterManager {
             cCurrentModuleObject = "Site:Precipitation";
             state.dataWaterData->NumSiteRainFall = state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, cCurrentModuleObject);
             if (state.dataWaterData->NumSiteRainFall > 1) { // throw error
-                ShowSevereError(state, EnergyPlus::format("Only one {} object is allowed", cCurrentModuleObject));
+                ShowSevereError(state, std::format("Only one {} object is allowed", cCurrentModuleObject));
                 ErrorsFound = true;
             }
 
@@ -673,7 +672,7 @@ namespace WaterManager {
                 if (Util::SameString(cAlphaArgs(1), "ScheduleAndDesignLevel")) {
                     state.dataWaterData->RainFall.ModeID = RainfallMode::RainSchedDesign;
                 } else {
-                    ShowSevereError(state, EnergyPlus::format("Precipitation Model Type of {} is incorrect.", cCurrentModuleObject));
+                    ShowSevereError(state, std::format("Precipitation Model Type of {} is incorrect.", cCurrentModuleObject));
                     ShowContinueError(state, "Only available option is ScheduleAndDesignLevel.");
                     ErrorsFound = true;
                 }
@@ -698,7 +697,7 @@ namespace WaterManager {
             cCurrentModuleObject = "RoofIrrigation";
             NumIrrigation = state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, cCurrentModuleObject);
             if (NumIrrigation > 1) {
-                ShowSevereError(state, EnergyPlus::format("Only one {} object is allowed", cCurrentModuleObject));
+                ShowSevereError(state, std::format("Only one {} object is allowed", cCurrentModuleObject));
                 ErrorsFound = true;
             }
 
@@ -741,8 +740,7 @@ namespace WaterManager {
                 state.dataWaterData->Irrigation.IrrigationThreshold = 0.4;
                 if (state.dataWaterData->Irrigation.ModeID == IrrigationMode::SmartSched && NumNumbers > 0) {
                     if (rNumericArgs(1) > 100.0 || rNumericArgs(1) < 0.0) {
-                        ShowSevereError(state,
-                                        EnergyPlus::format("Irrigation threshold for {} object has values > 100 or < 0.", cCurrentModuleObject));
+                        ShowSevereError(state, std::format("Irrigation threshold for {} object has values > 100 or < 0.", cCurrentModuleObject));
                         ErrorsFound = true;
                     } else {
                         state.dataWaterData->Irrigation.IrrigationThreshold = rNumericArgs(1) / 100.0;

--- a/src/EnergyPlus/WaterThermalTanks.cc
+++ b/src/EnergyPlus/WaterThermalTanks.cc
@@ -149,7 +149,7 @@ PlantComponent *WaterThermalTankData::factory(EnergyPlusData &state, std::string
         }
     }
     // If we didn't find it, fatal
-    ShowFatalError(state, EnergyPlus::format("LocalWaterTankFactory: Error getting inputs for tank named: {}", objectName)); // LCOV_EXCL_LINE
+    ShowFatalError(state, std::format("LocalWaterTankFactory: Error getting inputs for tank named: {}", objectName)); // LCOV_EXCL_LINE
     // Shut up the compiler
     return nullptr; // LCOV_EXCL_LINE
 }
@@ -206,26 +206,26 @@ int getTankIDX(EnergyPlusData &state, std::string_view CompName, int &CompIndex)
     if (CompIndex == 0) {
         CompNum = Util::FindItem(CompName, state.dataWaterThermalTanks->WaterThermalTank);
         if (CompNum == 0) {
-            ShowFatalError(state, EnergyPlus::format("SimWaterThermalTank_WaterTank:  Unit not found={}", CompName));
+            ShowFatalError(state, std::format("SimWaterThermalTank_WaterTank:  Unit not found={}", CompName));
         }
         CompIndex = CompNum;
     } else {
         CompNum = CompIndex;
         if (CompNum > state.dataWaterThermalTanks->numWaterThermalTank || CompNum < 1) {
             ShowFatalError(state,
-                           EnergyPlus::format("SimWaterThermalTank_WaterTank:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
-                                              CompNum,
-                                              state.dataWaterThermalTanks->numWaterThermalTank,
-                                              CompName));
+                           std::format("SimWaterThermalTank_WaterTank:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
+                                       CompNum,
+                                       state.dataWaterThermalTanks->numWaterThermalTank,
+                                       CompName));
         }
         if (state.dataWaterThermalTanks->WaterThermalTank(CompNum).CheckWTTEquipName) {
             if (CompName != state.dataWaterThermalTanks->WaterThermalTank(CompNum).Name) {
                 ShowFatalError(
                     state,
-                    EnergyPlus::format("SimWaterThermalTank_WaterTank: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
-                                       CompNum,
-                                       CompName,
-                                       state.dataWaterThermalTanks->WaterThermalTank(CompNum).Name));
+                    std::format("SimWaterThermalTank_WaterTank: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
+                                CompNum,
+                                CompName,
+                                state.dataWaterThermalTanks->WaterThermalTank(CompNum).Name));
             }
             state.dataWaterThermalTanks->WaterThermalTank(CompNum).CheckWTTEquipName = false;
         }
@@ -246,26 +246,26 @@ int getHPTankIDX(EnergyPlusData &state, std::string_view CompName, int &CompInde
     if (CompIndex == 0) {
         CompNum = Util::FindItem(CompName, state.dataWaterThermalTanks->HPWaterHeater);
         if (CompNum == 0) {
-            ShowFatalError(state, EnergyPlus::format("SimWaterThermalTank_HeatPump:  Unit not found={}", CompName));
+            ShowFatalError(state, std::format("SimWaterThermalTank_HeatPump:  Unit not found={}", CompName));
         }
         CompIndex = CompNum;
     } else {
         CompNum = CompIndex;
         if (CompNum > state.dataWaterThermalTanks->numWaterThermalTank || CompNum < 1) {
             ShowFatalError(state,
-                           EnergyPlus::format("SimWaterThermalTank_HeatPump:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
-                                              CompNum,
-                                              state.dataWaterThermalTanks->numHeatPumpWaterHeater,
-                                              CompName));
+                           std::format("SimWaterThermalTank_HeatPump:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
+                                       CompNum,
+                                       state.dataWaterThermalTanks->numHeatPumpWaterHeater,
+                                       CompName));
         }
         if (state.dataWaterThermalTanks->HPWaterHeater(CompNum).CheckHPWHEquipName) {
             if (CompName != state.dataWaterThermalTanks->HPWaterHeater(CompNum).Name) {
                 ShowFatalError(
                     state,
-                    EnergyPlus::format("SimWaterThermalTank_HeatPump: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
-                                       CompNum,
-                                       CompName,
-                                       state.dataWaterThermalTanks->HPWaterHeater(CompNum).Name));
+                    std::format("SimWaterThermalTank_HeatPump: Invalid CompIndex passed={}, Unit name={}, stored Unit Name for that index={}",
+                                CompNum,
+                                CompName,
+                                state.dataWaterThermalTanks->HPWaterHeater(CompNum).Name));
             }
             state.dataWaterThermalTanks->HPWaterHeater(CompNum).CheckHPWHEquipName = false;
         }
@@ -338,8 +338,7 @@ PlantComponent *HeatPumpWaterHeaterData::factory(EnergyPlusData &state, std::str
         }
     }
     // If we didn't find it, fatal
-    ShowFatalError(state,
-                   EnergyPlus::format("LocalHeatPumpWaterHeaterFactory: Error getting inputs for object named: {}", objectName)); // LCOV_EXCL_LINE
+    ShowFatalError(state, std::format("LocalHeatPumpWaterHeaterFactory: Error getting inputs for object named: {}", objectName)); // LCOV_EXCL_LINE
     // Shut up the compiler
     return nullptr; // LCOV_EXCL_LINE
 }
@@ -546,17 +545,17 @@ void SimHeatPumpWaterHeater(EnergyPlusData &state,
     if (CompIndex == 0) {
         HeatPumpNum = Util::FindItemInList(CompName, state.dataWaterThermalTanks->HPWaterHeater);
         if (HeatPumpNum == 0) {
-            ShowFatalError(state, EnergyPlus::format("SimHeatPumpWaterHeater: Unit not found={}", CompName));
+            ShowFatalError(state, std::format("SimHeatPumpWaterHeater: Unit not found={}", CompName));
         }
         CompIndex = HeatPumpNum;
     } else {
         HeatPumpNum = CompIndex;
         if (HeatPumpNum > state.dataWaterThermalTanks->numHeatPumpWaterHeater || HeatPumpNum < 1) {
             ShowFatalError(state,
-                           EnergyPlus::format("SimHeatPumpWaterHeater:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
-                                              HeatPumpNum,
-                                              state.dataWaterThermalTanks->numHeatPumpWaterHeater,
-                                              CompName));
+                           std::format("SimHeatPumpWaterHeater:  Invalid CompIndex passed={}, Number of Units={}, Entered Unit name={}",
+                                       HeatPumpNum,
+                                       state.dataWaterThermalTanks->numHeatPumpWaterHeater,
+                                       CompName));
         }
     }
 
@@ -737,12 +736,12 @@ bool getDesuperHtrInput(EnergyPlusData &state)
         DesupHtr.DeadBandTempDiff = rNumericArgs(1);
         if (DesupHtr.DeadBandTempDiff <= 0.0 || DesupHtr.DeadBandTempDiff > 20.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{} = {}: {} must be > 0 and <= 20. {} = {:.1f}",
-                                               cCurrentModuleObject,
-                                               DesupHtr.Name,
-                                               cNumericFieldNames(1),
-                                               cNumericFieldNames(1),
-                                               rNumericArgs(1)));
+                            std::format("{} = {}: {} must be > 0 and <= 20. {} = {:.1f}",
+                                        cCurrentModuleObject,
+                                        DesupHtr.Name,
+                                        cNumericFieldNames(1),
+                                        cNumericFieldNames(1),
+                                        rNumericArgs(1)));
             ErrorsFound = true;
         }
 
@@ -755,9 +754,8 @@ bool getDesuperHtrInput(EnergyPlusData &state)
         if (!lAlphaFieldBlanks(4)) {
             DesupHtr.HEffFTemp = Curve::GetCurveIndex(state, cAlphaArgs(4));
             if (DesupHtr.HEffFTemp == 0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("{} = {}:  {} not found = {}", cCurrentModuleObject, DesupHtr.Name, cAlphaFieldNames(4), cAlphaArgs(4)));
+                ShowSevereError(state,
+                                std::format("{} = {}:  {} not found = {}", cCurrentModuleObject, DesupHtr.Name, cAlphaFieldNames(4), cAlphaArgs(4)));
                 ErrorsFound = true;
             } else {
                 ErrorsFound |= Curve::CheckCurveDims(state,
@@ -772,10 +770,10 @@ bool getDesuperHtrInput(EnergyPlusData &state)
                         Real64 HEffFTemp = min(
                             1.0, max(0.0, Curve::CurveValue(state, DesupHtr.HEffFTemp, DesupHtr.RatedInletWaterTemp, DesupHtr.RatedOutdoorAirTemp)));
                         if (std::abs(HEffFTemp - 1.0) > 0.05) {
-                            ShowWarningError(state, EnergyPlus::format("{}, \"{}\":", cCurrentModuleObject, DesupHtr.Name));
-                            ShowContinueError(state, EnergyPlus::format("The {} should be normalized ", cAlphaFieldNames(4)));
-                            ShowContinueError(
-                                state, EnergyPlus::format(" to 1.0 at the rating point. Curve output at the rating point = {:.3f}", HEffFTemp));
+                            ShowWarningError(state, std::format("{}, \"{}\":", cCurrentModuleObject, DesupHtr.Name));
+                            ShowContinueError(state, std::format("The {} should be normalized ", cAlphaFieldNames(4)));
+                            ShowContinueError(state,
+                                              std::format(" to 1.0 at the rating point. Curve output at the rating point = {:.3f}", HEffFTemp));
                             ShowContinueError(state, " The simulation continues using the user-specified curve.");
                         }
                     }
@@ -810,9 +808,8 @@ bool getDesuperHtrInput(EnergyPlusData &state)
 
         if (!Util::SameString(DesupHtr.TankType, cMixedWHModuleObj) && !Util::SameString(DesupHtr.TankType, cStratifiedWHModuleObj)) {
 
-            ShowSevereError(state,
-                            EnergyPlus::format("{} = {}:", cCurrentModuleObject, state.dataWaterThermalTanks->HPWaterHeater(DesuperheaterNum).Name));
-            ShowContinueError(state, EnergyPlus::format("Desuperheater can only be used with {} or {}.", cMixedWHModuleObj, cStratifiedWHModuleObj));
+            ShowSevereError(state, std::format("{} = {}:", cCurrentModuleObject, state.dataWaterThermalTanks->HPWaterHeater(DesuperheaterNum).Name));
+            ShowContinueError(state, std::format("Desuperheater can only be used with {} or {}.", cMixedWHModuleObj, cStratifiedWHModuleObj));
             ErrorsFound = true;
         }
 
@@ -832,11 +829,11 @@ bool getDesuperHtrInput(EnergyPlusData &state)
                 DesupHtr.HeatReclaimRecoveryEff = rNumericArgs(2);
                 if (DesupHtr.HeatReclaimRecoveryEff <= 0.0 || DesupHtr.HeatReclaimRecoveryEff > 0.9) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{} = {}: {} must be > 0.0 and <= 0.9, Efficiency = {:.3f}",
-                                                       cCurrentModuleObject,
-                                                       DesupHtr.Name,
-                                                       cNumericFieldNames(2),
-                                                       DesupHtr.HeatReclaimRecoveryEff));
+                                    std::format("{} = {}: {} must be > 0.0 and <= 0.9, Efficiency = {:.3f}",
+                                                cCurrentModuleObject,
+                                                DesupHtr.Name,
+                                                cNumericFieldNames(2),
+                                                DesupHtr.HeatReclaimRecoveryEff));
                     ErrorsFound = true;
                 }
             } // Blank Num(2)
@@ -2905,10 +2902,8 @@ bool getWaterHeaterStratifiedInput(EnergyPlusData &state)
                             std::format("{} = {}: Heater 1 is located higher than overall tank height.",
                                         state.dataIPShortCut->cCurrentModuleObject,
                                         state.dataIPShortCut->cAlphaArgs(1)));
-            ShowContinueError(state,
-                              EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
-            ShowContinueError(state,
-                              EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(7), state.dataIPShortCut->rNumericArgs(7)));
+            ShowContinueError(state, std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
+            ShowContinueError(state, std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(7), state.dataIPShortCut->rNumericArgs(7)));
             ErrorsFound = true;
         }
 
@@ -2936,10 +2931,9 @@ bool getWaterHeaterStratifiedInput(EnergyPlusData &state)
                             std::format("{} = {}: Heater 2 is located higher than overall tank height.",
                                         state.dataIPShortCut->cCurrentModuleObject,
                                         state.dataIPShortCut->cAlphaArgs(1)));
+            ShowContinueError(state, std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
             ShowContinueError(state,
-                              EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
-            ShowContinueError(
-                state, EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(10), state.dataIPShortCut->rNumericArgs(10)));
+                              std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(10), state.dataIPShortCut->rNumericArgs(10)));
             ErrorsFound = true;
         }
 
@@ -3134,10 +3128,9 @@ bool getWaterHeaterStratifiedInput(EnergyPlusData &state)
                             std::format("{} = {}: Use inlet is located higher than overall tank height.",
                                         state.dataIPShortCut->cCurrentModuleObject,
                                         state.dataIPShortCut->cAlphaArgs(1)));
+            ShowContinueError(state, std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
             ShowContinueError(state,
-                              EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
-            ShowContinueError(
-                state, EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(24), state.dataIPShortCut->rNumericArgs(24)));
+                              std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(24), state.dataIPShortCut->rNumericArgs(24)));
             ErrorsFound = true;
         }
 
@@ -3155,10 +3148,9 @@ bool getWaterHeaterStratifiedInput(EnergyPlusData &state)
                             std::format("{} = {}: Use outlet is located higher than overall tank height.",
                                         state.dataIPShortCut->cCurrentModuleObject,
                                         state.dataIPShortCut->cAlphaArgs(1)));
+            ShowContinueError(state, std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
             ShowContinueError(state,
-                              EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
-            ShowContinueError(
-                state, EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(25), state.dataIPShortCut->rNumericArgs(25)));
+                              std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(25), state.dataIPShortCut->rNumericArgs(25)));
             ErrorsFound = true;
         }
 
@@ -3189,10 +3181,9 @@ bool getWaterHeaterStratifiedInput(EnergyPlusData &state)
                             std::format("{} = {}: Source inlet is located higher than overall tank height.",
                                         state.dataIPShortCut->cCurrentModuleObject,
                                         state.dataIPShortCut->cAlphaArgs(1)));
+            ShowContinueError(state, std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
             ShowContinueError(state,
-                              EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
-            ShowContinueError(
-                state, EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(27), state.dataIPShortCut->rNumericArgs(27)));
+                              std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(27), state.dataIPShortCut->rNumericArgs(27)));
             ErrorsFound = true;
         }
 
@@ -3207,10 +3198,9 @@ bool getWaterHeaterStratifiedInput(EnergyPlusData &state)
                             std::format("{} = {}: Source outlet is located higher than overall tank height.",
                                         state.dataIPShortCut->cCurrentModuleObject,
                                         state.dataIPShortCut->cAlphaArgs(1)));
+            ShowContinueError(state, std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
             ShowContinueError(state,
-                              EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(2), state.dataIPShortCut->rNumericArgs(2)));
-            ShowContinueError(
-                state, EnergyPlus::format("{} = {:.4R}", state.dataIPShortCut->cNumericFieldNames(28), state.dataIPShortCut->rNumericArgs(28)));
+                              std::format("{} = {:.4f}", state.dataIPShortCut->cNumericFieldNames(28), state.dataIPShortCut->rNumericArgs(28)));
             ErrorsFound = true;
         }
 
@@ -3973,8 +3963,8 @@ bool getWaterTankStratifiedInput(EnergyPlusData &state, std::string objectType)
             } else if (Tank.UseInletHeight > Tank.Height) {
                 ShowSevereError(state,
                                 std::format("{} = {}: Use inlet is located higher than overall tank height.", cCurrentModuleObject, thisObjectName));
-                ShowContinueError(state, EnergyPlus::format("{} = {:.4R}", "tank_height", Tank.Height));
-                ShowContinueError(state, EnergyPlus::format("{} = {:.4R}", "use_side_inlet_height", Tank.UseInletHeight));
+                ShowContinueError(state, std::format("{} = {:.4f}", "tank_height", Tank.Height));
+                ShowContinueError(state, std::format("{} = {:.4f}", "use_side_inlet_height", Tank.UseInletHeight));
                 ErrorsFound = true;
             }
 
@@ -3983,8 +3973,8 @@ bool getWaterTankStratifiedInput(EnergyPlusData &state, std::string objectType)
             if (Tank.UseOutletHeight > Tank.Height) {
                 ShowSevereError(state,
                                 std::format("{} = {}: Use outlet is located higher than overall tank height.", cCurrentModuleObject, thisObjectName));
-                ShowContinueError(state, EnergyPlus::format("{} = {:.4R}", "tank_height", Tank.Height));
-                ShowContinueError(state, EnergyPlus::format("{} = {:.4R}", "use_side_outlet_height", Tank.UseOutletHeight));
+                ShowContinueError(state, std::format("{} = {:.4f}", "tank_height", Tank.Height));
+                ShowContinueError(state, std::format("{} = {:.4f}", "use_side_outlet_height", Tank.UseOutletHeight));
                 ErrorsFound = true;
             }
 
@@ -3993,8 +3983,8 @@ bool getWaterTankStratifiedInput(EnergyPlusData &state, std::string objectType)
             if (Tank.SourceInletHeight > Tank.Height) {
                 ShowSevereError(
                     state, std::format("{} = {}: Source inlet is located higher than overall tank height.", cCurrentModuleObject, thisObjectName));
-                ShowContinueError(state, EnergyPlus::format("{} = {:.4R}", "tank_height", Tank.Height));
-                ShowContinueError(state, EnergyPlus::format("{} = {:.4R}", "source_side_inlet_height", Tank.SourceInletHeight));
+                ShowContinueError(state, std::format("{} = {:.4f}", "tank_height", Tank.Height));
+                ShowContinueError(state, std::format("{} = {:.4f}", "source_side_inlet_height", Tank.SourceInletHeight));
                 ErrorsFound = true;
             }
 
@@ -4005,8 +3995,8 @@ bool getWaterTankStratifiedInput(EnergyPlusData &state, std::string objectType)
             } else if (Tank.SourceOutletHeight > Tank.Height) {
                 ShowSevereError(
                     state, std::format("{} = {}: Source outlet is located higher than overall tank height.", cCurrentModuleObject, thisObjectName));
-                ShowContinueError(state, EnergyPlus::format("{} = {:.4R}", "tank_height", Tank.Height));
-                ShowContinueError(state, EnergyPlus::format("{} = {:.4R}", "source_side_outlet_height", Tank.SourceOutletHeight));
+                ShowContinueError(state, std::format("{} = {:.4f}", "tank_height", Tank.Height));
+                ShowContinueError(state, std::format("{} = {:.4f}", "source_side_outlet_height", Tank.SourceOutletHeight));
                 ErrorsFound = true;
             }
         }
@@ -4112,7 +4102,7 @@ bool getWaterTankStratifiedInput(EnergyPlusData &state, std::string objectType)
         Tank.AdditionalLossCoeff.allocate(Tank.Nodes);
         Tank.AdditionalLossCoeff = 0.0;
         for (int NodeNum = 1; NodeNum <= Tank.Nodes; ++NodeNum) {
-            auto const &AdditionalLossCoeffNode = fields.find(EnergyPlus::format("node_{}_additional_loss_coefficient", NodeNum));
+            auto const &AdditionalLossCoeffNode = fields.find(std::format("node_{}_additional_loss_coefficient", NodeNum));
             if (AdditionalLossCoeffNode != fields.end()) {
                 Tank.AdditionalLossCoeff(NodeNum) = AdditionalLossCoeffNode.value();
             } else {
@@ -4120,7 +4110,7 @@ bool getWaterTankStratifiedInput(EnergyPlusData &state, std::string objectType)
             }
         }
 
-        if (fields.find(EnergyPlus::format("node_{}_additional_loss_coefficient", Tank.Nodes + 1)) != fields.end()) {
+        if (fields.find(std::format("node_{}_additional_loss_coefficient", Tank.Nodes + 1)) != fields.end()) {
             ShowWarningError(
                 state,
                 std::format("{} = {}:  More Additional Loss Coefficients were entered than the number of nodes; extra coefficients will not be used",
@@ -6386,11 +6376,10 @@ void WaterThermalTankData::initialize(EnergyPlusData &state, bool const FirstHVA
                     if (TankChangeRateScale < 60.0) { // nominal change over in less than one minute
                         ShowSevereError(state, "InitWaterThermalTank: Detected problem for stratified tank model.  Model cannot be applied.");
                         ShowContinueError(state, std::format("Occurs for stratified tank name = {}", this->Name));
-                        ShowContinueError(state, EnergyPlus::format("Tank volume = {:.4R} [m3]", this->Volume));
-                        ShowContinueError(state, EnergyPlus::format("Tank use side volume flow rate = {:.4R} [m3/s]", this->UseDesignVolFlowRate));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Tank source side volume flow rate = {:.4R} [m3/s]", this->SourceDesignVolFlowRate));
-                        ShowContinueError(state, EnergyPlus::format("Nominal tank change over rate = {:.2R} [s]", TankChangeRateScale));
+                        ShowContinueError(state, std::format("Tank volume = {:.4f} [m3]", this->Volume));
+                        ShowContinueError(state, std::format("Tank use side volume flow rate = {:.4f} [m3/s]", this->UseDesignVolFlowRate));
+                        ShowContinueError(state, std::format("Tank source side volume flow rate = {:.4f} [m3/s]", this->SourceDesignVolFlowRate));
+                        ShowContinueError(state, std::format("Nominal tank change over rate = {:.2f} [s]", TankChangeRateScale));
                         ShowContinueError(
                             state, "Change over rate is too fast, increase tank volume, decrease connection flow rates or use mixed tank model");
 
@@ -7615,11 +7604,11 @@ void WaterThermalTankData::CalcWaterThermalTankMixed(EnergyPlusData &state) // W
             if (this->FreezingErrorIndex == 0) {
                 ShowWarningError(
                     state,
-                    EnergyPlus::format("{}: {} = '{}':  Temperature of tank < 2C indicates of possibility of freeze. Tank Temperature = {:.2R} C.",
-                                       RoutineName,
-                                       this->Type,
-                                       this->Name,
-                                       this->TankTemp));
+                    std::format("{}: {} = '{}':  Temperature of tank < 2C indicates of possibility of freeze. Tank Temperature = {:.2f} C.",
+                                RoutineName,
+                                this->Type,
+                                this->Name,
+                                this->TankTemp));
                 ShowContinueErrorTimeStamp(state, "");
             }
             ShowRecurringWarningErrorAtEnd(state,
@@ -8561,11 +8550,11 @@ void WaterThermalTankData::CalcWaterThermalTankStratified(EnergyPlusData &state)
             if (this->FreezingErrorIndex == 0) {
                 ShowWarningError(
                     state,
-                    EnergyPlus::format("{}: {} = '{}':  Temperature of tank < 2C indicates of possibility of freeze. Tank Temperature = {:.2R} C.",
-                                       RoutineName,
-                                       this->Type,
-                                       this->Name,
-                                       this->TankTemp));
+                    std::format("{}: {} = '{}':  Temperature of tank < 2C indicates of possibility of freeze. Tank Temperature = {:.2f} C.",
+                                RoutineName,
+                                this->Type,
+                                this->Name,
+                                this->TankTemp));
                 ShowContinueErrorTimeStamp(state, "");
             }
             ShowRecurringWarningErrorAtEnd(state,
@@ -9035,7 +9024,7 @@ void WaterThermalTankData::CalcDesuperheaterWaterHeater(EnergyPlusData &state, b
                                 "the desuperheater. Desuperheater will be disabled.",
                                 DesupHtr.Type,
                                 DesupHtr.Name));
-                ShowContinueErrorTimeStamp(state, EnergyPlus::format(" ...Desuperheater cut-in temperature = {:.2R}", MinTemp));
+                ShowContinueErrorTimeStamp(state, std::format(" ...Desuperheater cut-in temperature = {:.2f}", MinTemp));
             } else {
                 ShowRecurringWarningErrorAtEnd(state,
                                                DesupHtr.Type + " \"" + DesupHtr.Name +
@@ -9207,10 +9196,10 @@ void WaterThermalTankData::CalcDesuperheaterWaterHeater(EnergyPlusData &state, b
                                 if (DesupHtr.IterLimitExceededNum1 == 1) {
                                     ShowWarningError(state, std::format("{} \"{}\"", DesupHtr.Type, DesupHtr.Name));
                                     ShowContinueError(state,
-                                                      EnergyPlus::format("Iteration limit exceeded calculating desuperheater unit part-load ratio, "
-                                                                         "maximum iterations = {}. Part-load ratio returned = {:.3R}",
-                                                                         MaxIte,
-                                                                         partLoadRatio));
+                                                      std::format("Iteration limit exceeded calculating desuperheater unit part-load ratio, "
+                                                                  "maximum iterations = {}. Part-load ratio returned = {:.3f}",
+                                                                  MaxIte,
+                                                                  partLoadRatio));
                                     ShowContinueErrorTimeStamp(state, "This error occurred in heating mode.");
                                 } else {
                                     ShowRecurringWarningErrorAtEnd(state,
@@ -9231,11 +9220,10 @@ void WaterThermalTankData::CalcDesuperheaterWaterHeater(EnergyPlusData &state, b
                                 ++DesupHtr.RegulaFalsiFailedNum1;
                                 if (DesupHtr.RegulaFalsiFailedNum1 == 1) {
                                     ShowWarningError(state, std::format("{} \"{}\"", DesupHtr.Type, DesupHtr.Name));
-                                    ShowContinueError(
-                                        state,
-                                        EnergyPlus::format("Desuperheater unit part-load ratio calculation failed: PLR limits of 0 to 1 "
-                                                           "exceeded. Part-load ratio used = {:.3R}",
-                                                           partLoadRatio));
+                                    ShowContinueError(state,
+                                                      std::format("Desuperheater unit part-load ratio calculation failed: PLR limits of 0 to 1 "
+                                                                  "exceeded. Part-load ratio used = {:.3f}",
+                                                                  partLoadRatio));
                                     ShowContinueError(state, "Please send this information to the EnergyPlus support group.");
                                     ShowContinueErrorTimeStamp(state, "This error occurred in heating mode.");
                                 } else {
@@ -9339,12 +9327,11 @@ void WaterThermalTankData::CalcDesuperheaterWaterHeater(EnergyPlusData &state, b
                                     ++DesupHtr.IterLimitExceededNum2;
                                     if (DesupHtr.IterLimitExceededNum2 == 1) {
                                         ShowWarningError(state, std::format("{} \"{}\"", DesupHtr.Type, DesupHtr.Name));
-                                        ShowContinueError(
-                                            state,
-                                            EnergyPlus::format("Iteration limit exceeded calculating desuperheater unit part-load ratio, "
-                                                               "maximum iterations = {}. Part-load ratio returned = {:.3R}",
-                                                               MaxIte,
-                                                               partLoadRatio));
+                                        ShowContinueError(state,
+                                                          std::format("Iteration limit exceeded calculating desuperheater unit part-load ratio, "
+                                                                      "maximum iterations = {}. Part-load ratio returned = {:.3f}",
+                                                                      MaxIte,
+                                                                      partLoadRatio));
                                         ShowContinueErrorTimeStamp(state, "This error occurred in float mode.");
                                     } else {
                                         ShowRecurringWarningErrorAtEnd(state,
@@ -9363,11 +9350,10 @@ void WaterThermalTankData::CalcDesuperheaterWaterHeater(EnergyPlusData &state, b
                                     ++DesupHtr.RegulaFalsiFailedNum2;
                                     if (DesupHtr.RegulaFalsiFailedNum2 == 1) {
                                         ShowWarningError(state, std::format("{} \"{}\"", DesupHtr.Type, DesupHtr.Name));
-                                        ShowContinueError(
-                                            state,
-                                            EnergyPlus::format("Desuperheater unit part-load ratio calculation failed: PLR limits of 0 to "
-                                                               "1 exceeded. Part-load ratio used = {:.3R}",
-                                                               partLoadRatio));
+                                        ShowContinueError(state,
+                                                          std::format("Desuperheater unit part-load ratio calculation failed: PLR limits of 0 to "
+                                                                      "1 exceeded. Part-load ratio used = {:.3f}",
+                                                                      partLoadRatio));
                                         ShowContinueError(state, "Please send this information to the EnergyPlus support group.");
                                         ShowContinueErrorTimeStamp(state, "This error occurred in float mode.");
                                     } else {
@@ -10033,12 +10019,11 @@ void WaterThermalTankData::CalcHeatPumpWaterHeater(EnergyPlusData &state, bool c
                         ++HeatPump.IterLimitExceededNum2;
                         if (HeatPump.IterLimitExceededNum2 == 1) {
                             ShowWarningError(state, std::format("{} \"{}\"", HeatPump.Type, HeatPump.Name));
-                            ShowContinueError(
-                                state,
-                                EnergyPlus::format("Iteration limit exceeded calculating heat pump water heater compressor part-load ratio, "
-                                                   "maximum iterations = {}. Part-load ratio returned = {:.3R}",
-                                                   MaxIte,
-                                                   state.dataWaterThermalTanks->hpPartLoadRatio));
+                            ShowContinueError(state,
+                                              std::format("Iteration limit exceeded calculating heat pump water heater compressor part-load ratio, "
+                                                          "maximum iterations = {}. Part-load ratio returned = {:.3f}",
+                                                          MaxIte,
+                                                          state.dataWaterThermalTanks->hpPartLoadRatio));
                             ShowContinueErrorTimeStamp(state, "This error occurred in float mode.");
                         } else {
                             ShowRecurringWarningErrorAtEnd(
@@ -10059,9 +10044,9 @@ void WaterThermalTankData::CalcHeatPumpWaterHeater(EnergyPlusData &state, bool c
                             ShowWarningError(state, std::format("{} \"{}\"", HeatPump.Type, HeatPump.Name));
                             ShowContinueError(
                                 state,
-                                EnergyPlus::format("Heat pump water heater compressor part-load ratio calculation failed: PLR limits of 0 to 1 "
-                                                   "exceeded. Part-load ratio used = {:.3R}",
-                                                   state.dataWaterThermalTanks->hpPartLoadRatio));
+                                std::format("Heat pump water heater compressor part-load ratio calculation failed: PLR limits of 0 to 1 "
+                                            "exceeded. Part-load ratio used = {:.3f}",
+                                            state.dataWaterThermalTanks->hpPartLoadRatio));
                             ShowContinueError(state, "Please send this information to the EnergyPlus support group.");
                             ShowContinueErrorTimeStamp(state, "This error occurred in float mode.");
                         } else {
@@ -10210,12 +10195,11 @@ void WaterThermalTankData::CalcHeatPumpWaterHeater(EnergyPlusData &state, bool c
                             ++HeatPump.IterLimitExceededNum1;
                             if (HeatPump.IterLimitExceededNum1 == 1) {
                                 ShowWarningError(state, std::format("{} \"{}\"", HeatPump.Type, HeatPump.Name));
-                                ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("Iteration limit exceeded calculating heat pump water heater speed speed ratio ratio, "
-                                                       "maximum iterations = {}. speed ratio returned = {:.3R}",
-                                                       MaxIte,
-                                                       SpeedRatio));
+                                ShowContinueError(state,
+                                                  std::format("Iteration limit exceeded calculating heat pump water heater speed speed ratio ratio, "
+                                                              "maximum iterations = {}. speed ratio returned = {:.3f}",
+                                                              MaxIte,
+                                                              SpeedRatio));
                                 ShowContinueErrorTimeStamp(state, "This error occurred in heating mode.");
                             } else {
                                 ShowRecurringWarningErrorAtEnd(
@@ -10233,11 +10217,10 @@ void WaterThermalTankData::CalcHeatPumpWaterHeater(EnergyPlusData &state, bool c
                             ++HeatPump.RegulaFalsiFailedNum1;
                             if (HeatPump.RegulaFalsiFailedNum1 == 1) {
                                 ShowWarningError(state, std::format("{} \"{}\"", HeatPump.Type, HeatPump.Name));
-                                ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("Heat pump water heater speed ratio calculation failed: speed ratio limits of 0 to 1 "
-                                                       "exceeded. speed ratio used = {:.3R}",
-                                                       SpeedRatio));
+                                ShowContinueError(state,
+                                                  std::format("Heat pump water heater speed ratio calculation failed: speed ratio limits of 0 to 1 "
+                                                              "exceeded. speed ratio used = {:.3f}",
+                                                              SpeedRatio));
                                 ShowContinueError(state, "Please send this information to the EnergyPlus support group.");
                                 ShowContinueErrorTimeStamp(state, "This error occurred in heating mode.");
                             } else {

--- a/src/EnergyPlus/WaterToAirHeatPump.cc
+++ b/src/EnergyPlus/WaterToAirHeatPump.cc
@@ -47,6 +47,7 @@
 
 // C++ Headers
 #include <cmath>
+#include <format>
 
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array.functions.hh>
@@ -128,24 +129,23 @@ namespace WaterToAirHeatPump {
         if (CompIndex == 0) {
             HPNum = Util::FindItemInList(CompName, state.dataWaterToAirHeatPump->WatertoAirHP);
             if (HPNum == 0) {
-                ShowFatalError(state, EnergyPlus::format("WaterToAir HP not found={}", CompName));
+                ShowFatalError(state, std::format("WaterToAir HP not found={}", CompName));
             }
             CompIndex = HPNum;
         } else {
             HPNum = CompIndex;
             if (HPNum > state.dataWaterToAirHeatPump->NumWatertoAirHPs || HPNum < 1) {
-                ShowFatalError(
-                    state,
-                    EnergyPlus::format("SimWatertoAirHP: Invalid CompIndex passed={}, Number of Water to Air HPs={}, WaterToAir HP name={}",
-                                       HPNum,
-                                       state.dataWaterToAirHeatPump->NumWatertoAirHPs,
-                                       CompName));
+                ShowFatalError(state,
+                               std::format("SimWatertoAirHP: Invalid CompIndex passed={}, Number of Water to Air HPs={}, WaterToAir HP name={}",
+                                           HPNum,
+                                           state.dataWaterToAirHeatPump->NumWatertoAirHPs,
+                                           CompName));
             }
             if (state.dataWaterToAirHeatPump->CheckEquipName(HPNum)) {
                 if (!CompName.empty() && CompName != state.dataWaterToAirHeatPump->WatertoAirHP(HPNum).Name) {
                     ShowFatalError(
                         state,
-                        EnergyPlus::format(
+                        std::format(
                             "SimWatertoAirHP: Invalid CompIndex passed={}, WaterToAir HP name={}, stored WaterToAir HP Name for that index={}",
                             HPNum,
                             CompName,
@@ -242,7 +242,7 @@ namespace WaterToAirHeatPump {
                 heatPump.WAHPType = DataPlant::PlantEquipmentType::CoilWAHPCoolingParamEst;
                 ErrorObjectHeader eoh{routineName, CurrentModuleObject, heatPump.Name};
                 GlobalNames::VerifyUniqueCoilName(
-                    state, CurrentModuleObject, heatPump.Name, ErrorsFound, EnergyPlus::format("{} Name", CurrentModuleObject));
+                    state, CurrentModuleObject, heatPump.Name, ErrorsFound, std::format("{} Name", CurrentModuleObject));
                 std::string const availSchedName = s_ip->getAlphaFieldValue(fields, schemaProps, "availability_schedule_name");
                 if (availSchedName.empty()) {
                     heatPump.availSched = Sched::GetScheduleAlwaysOn(state);
@@ -312,7 +312,7 @@ namespace WaterToAirHeatPump {
                 heatPump.LoadSideTotalUACoeff = s_ip->getRealFieldValue(fields, schemaProps, "load_side_total_heat_transfer_coefficient");
                 heatPump.LoadSideOutsideUACoeff = s_ip->getRealFieldValue(fields, schemaProps, "load_side_outside_surface_heat_transfer_coefficient");
                 if ((heatPump.LoadSideOutsideUACoeff < Constant::rTinyValue) || (heatPump.LoadSideTotalUACoeff < Constant::rTinyValue)) {
-                    ShowSevereError(state, EnergyPlus::format("Input problem for {}={}", CurrentModuleObject, heatPump.Name));
+                    ShowSevereError(state, std::format("Input problem for {}={}", CurrentModuleObject, heatPump.Name));
                     ShowContinueError(state, " One or both load side UA values entered are below tolerance, likely zero or blank.");
                     ShowContinueError(state, " Verify inputs, as the parameter syntax for this object went through a change with");
                     ShowContinueError(state, "  the release of EnergyPlus version 5.");
@@ -483,7 +483,7 @@ namespace WaterToAirHeatPump {
                 heatPump.WAHPType = DataPlant::PlantEquipmentType::CoilWAHPHeatingParamEst;
                 ErrorObjectHeader eoh{routineName, CurrentModuleObject, heatPump.Name};
                 GlobalNames::VerifyUniqueCoilName(
-                    state, CurrentModuleObject, heatPump.Name, ErrorsFound, EnergyPlus::format("{} Name", CurrentModuleObject));
+                    state, CurrentModuleObject, heatPump.Name, ErrorsFound, std::format("{} Name", CurrentModuleObject));
                 std::string const availSchedName = s_ip->getAlphaFieldValue(fields, schemaProps, "availability_schedule_name");
                 if (availSchedName.empty()) {
                     heatPump.availSched = Sched::GetScheduleAlwaysOn(state);
@@ -550,7 +550,7 @@ namespace WaterToAirHeatPump {
 
                 heatPump.LoadSideTotalUACoeff = s_ip->getRealFieldValue(fields, schemaProps, "load_side_total_heat_transfer_coefficient");
                 if (heatPump.LoadSideTotalUACoeff < Constant::rTinyValue) {
-                    ShowSevereError(state, EnergyPlus::format("Input problem for {}={}", CurrentModuleObject, heatPump.Name));
+                    ShowSevereError(state, std::format("Input problem for {}={}", CurrentModuleObject, heatPump.Name));
                     ShowContinueError(state, " Load side UA value is less than tolerance, likely zero or blank.");
                     ShowContinueError(state, " Verify inputs, as the parameter syntax for this object went through a change with");
                     ShowContinueError(state, "  the release of EnergyPlus version 5.");
@@ -681,7 +681,7 @@ namespace WaterToAirHeatPump {
         }
 
         if (ErrorsFound) {
-            ShowFatalError(state, EnergyPlus::format("{}Errors found getting input. Program terminates.", RoutineName));
+            ShowFatalError(state, std::format("{}Errors found getting input. Program terminates.", RoutineName));
         }
 
         for (HPNum = 1; HPNum <= state.dataWaterToAirHeatPump->NumWatertoAirHPs; ++HPNum) {
@@ -952,7 +952,7 @@ namespace WaterToAirHeatPump {
 
             if (heatPump.plantLoc.loop->FluidName == "WATER") {
                 if (heatPump.SourceSideUACoeff < Constant::rTinyValue) {
-                    ShowSevereError(state, EnergyPlus::format("Input problem for water to air heat pump, \"{}\".", heatPump.Name));
+                    ShowSevereError(state, std::format("Input problem for water to air heat pump, \"{}\".", heatPump.Name));
                     ShowContinueError(state, " Source side UA value is less than tolerance, likely zero or blank.");
                     ShowContinueError(state, " Verify inputs, as the parameter syntax for this object went through a change with");
                     ShowContinueError(state, "  the release of EnergyPlus version 5.");
@@ -960,7 +960,7 @@ namespace WaterToAirHeatPump {
                 }
             } else {
                 if ((heatPump.SourceSideHTR1 < Constant::rTinyValue) || (heatPump.SourceSideHTR2 < Constant::rTinyValue)) {
-                    ShowSevereError(state, EnergyPlus::format("Input problem for water to air heat pump, \"{}\".", heatPump.Name));
+                    ShowSevereError(state, std::format("Input problem for water to air heat pump, \"{}\".", heatPump.Name));
                     ShowContinueError(state, " A source side heat transfer resistance value is less than tolerance, likely zero or blank.");
                     ShowContinueError(state, " Verify inputs, as the parameter syntax for this object went through a change with");
                     ShowContinueError(state, "  the release of EnergyPlus version 5.");
@@ -1347,9 +1347,9 @@ namespace WaterToAirHeatPump {
                     if (LoadSidePressure < heatPump.LowPressCutoff && !FirstHVACIteration) {
                         if (!state.dataGlobal->WarmupFlag) {
                             ShowRecurringWarningErrorAtEnd(state,
-                                                           EnergyPlus::format("WaterToAir Heat pump:cooling [{}] shut off on low pressure < {:.0R}",
-                                                                              heatPump.Name,
-                                                                              heatPump.LowPressCutoff),
+                                                           std::format("WaterToAir Heat pump:cooling [{}] shut off on low pressure < {:.0f}",
+                                                                       heatPump.Name,
+                                                                       heatPump.LowPressCutoff),
                                                            heatPump.LowPressClgError,
                                                            LoadSidePressure,
                                                            LoadSidePressure,
@@ -1364,9 +1364,9 @@ namespace WaterToAirHeatPump {
                     if (SourceSidePressure > heatPump.HighPressCutoff && !FirstHVACIteration) {
                         if (!state.dataGlobal->WarmupFlag) {
                             ShowRecurringWarningErrorAtEnd(state,
-                                                           EnergyPlus::format("WaterToAir Heat pump:cooling [{}] shut off on high pressure > {:.0R}",
-                                                                              heatPump.Name,
-                                                                              heatPump.HighPressCutoff),
+                                                           std::format("WaterToAir Heat pump:cooling [{}] shut off on high pressure > {:.0f}",
+                                                                       heatPump.Name,
+                                                                       heatPump.HighPressCutoff),
                                                            heatPump.HighPressClgError,
                                                            heatPump.InletWaterTemp,
                                                            heatPump.InletWaterTemp,
@@ -1745,9 +1745,9 @@ namespace WaterToAirHeatPump {
                 if (SourceSidePressure < heatPump.LowPressCutoff && !FirstHVACIteration) {
                     if (!state.dataGlobal->WarmupFlag) {
                         ShowRecurringWarningErrorAtEnd(state,
-                                                       EnergyPlus::format("WaterToAir Heat pump:heating [{}] shut off on low pressure < {:.0R}",
-                                                                          heatPump.Name,
-                                                                          heatPump.LowPressCutoff),
+                                                       std::format("WaterToAir Heat pump:heating [{}] shut off on low pressure < {:.0f}",
+                                                                   heatPump.Name,
+                                                                   heatPump.LowPressCutoff),
                                                        heatPump.LowPressHtgError,
                                                        SourceSidePressure,
                                                        SourceSidePressure,
@@ -1762,9 +1762,9 @@ namespace WaterToAirHeatPump {
                 if (LoadSidePressure > heatPump.HighPressCutoff && !FirstHVACIteration) {
                     if (!state.dataGlobal->WarmupFlag) {
                         ShowRecurringWarningErrorAtEnd(state,
-                                                       EnergyPlus::format("WaterToAir Heat pump:heating [{}] shut off on high pressure > {:.0R}",
-                                                                          heatPump.Name,
-                                                                          heatPump.HighPressCutoff),
+                                                       std::format("WaterToAir Heat pump:heating [{}] shut off on high pressure > {:.0f}",
+                                                                   heatPump.Name,
+                                                                   heatPump.HighPressCutoff),
                                                        heatPump.HighPressHtgError,
                                                        heatPump.InletWaterTemp,
                                                        heatPump.InletWaterTemp,
@@ -2246,7 +2246,7 @@ namespace WaterToAirHeatPump {
         int IndexNum = Util::FindItemInList(CoilName, state.dataWaterToAirHeatPump->WatertoAirHP);
 
         if (IndexNum == 0) {
-            ShowSevereError(state, EnergyPlus::format("Could not find CoilType=\"{}\" with Name=\"{}\"", CoilType, CoilName));
+            ShowSevereError(state, std::format("Could not find CoilType=\"{}\" with Name=\"{}\"", CoilType, CoilName));
             ErrorsFound = true;
         }
 
@@ -2296,7 +2296,7 @@ namespace WaterToAirHeatPump {
         }
 
         if (WhichCoil == 0) {
-            ShowSevereError(state, EnergyPlus::format("Could not find CoilType=\"{}\" with Name=\"{}\"", CoilType, CoilName));
+            ShowSevereError(state, std::format("Could not find CoilType=\"{}\" with Name=\"{}\"", CoilType, CoilName));
             ErrorsFound = true;
             CoilCapacity = -1000.0;
         }
@@ -2335,7 +2335,7 @@ namespace WaterToAirHeatPump {
         }
 
         if (WhichCoil == 0) {
-            ShowSevereError(state, EnergyPlus::format("Could not find CoilType=\"{}\" with Name=\"{}\"", CoilType, CoilName));
+            ShowSevereError(state, std::format("Could not find CoilType=\"{}\" with Name=\"{}\"", CoilType, CoilName));
             ErrorsFound = true;
             NodeNumber = 0;
         }
@@ -2374,7 +2374,7 @@ namespace WaterToAirHeatPump {
         }
 
         if (WhichCoil == 0) {
-            ShowSevereError(state, EnergyPlus::format("Could not find CoilType=\"{}\" with Name=\"{}\"", CoilType, CoilName));
+            ShowSevereError(state, std::format("Could not find CoilType=\"{}\" with Name=\"{}\"", CoilType, CoilName));
             ErrorsFound = true;
             NodeNumber = 0;
         }

--- a/src/EnergyPlus/WaterToAirHeatPumpSimple.cc
+++ b/src/EnergyPlus/WaterToAirHeatPumpSimple.cc
@@ -154,23 +154,22 @@ namespace WaterToAirHeatPumpSimple {
         if (CompIndex == 0) {
             HPNum = Util::FindItemInList(CompName, state.dataWaterToAirHeatPumpSimple->SimpleWatertoAirHP);
             if (HPNum == 0) {
-                ShowFatalError(state, EnergyPlus::format("WaterToAirHPSimple not found= {}", CompName));
+                ShowFatalError(state, std::format("WaterToAirHPSimple not found= {}", CompName));
             }
             CompIndex = HPNum;
         } else {
             HPNum = CompIndex;
             if (HPNum > state.dataWaterToAirHeatPumpSimple->NumWatertoAirHPs || HPNum < 1) {
-                ShowFatalError(
-                    state,
-                    EnergyPlus::format("SimWatertoAirHPSimple: Invalid CompIndex passed={}, Number of Water to Air HPs={}, WaterToAir HP name={}",
-                                       HPNum,
-                                       state.dataWaterToAirHeatPumpSimple->NumWatertoAirHPs,
-                                       CompName));
+                ShowFatalError(state,
+                               std::format("SimWatertoAirHPSimple: Invalid CompIndex passed={}, Number of Water to Air HPs={}, WaterToAir HP name={}",
+                                           HPNum,
+                                           state.dataWaterToAirHeatPumpSimple->NumWatertoAirHPs,
+                                           CompName));
             }
             if (!CompName.empty() && CompName != state.dataWaterToAirHeatPumpSimple->SimpleWatertoAirHP(HPNum).Name) {
                 ShowFatalError(
                     state,
-                    EnergyPlus::format(
+                    std::format(
                         "SimWatertoAirHPSimple: Invalid CompIndex passed={}, WaterToAir HP name={}, stored WaterToAir HP Name for that index={}",
                         HPNum,
                         CompName,
@@ -267,7 +266,7 @@ namespace WaterToAirHeatPumpSimple {
 
                 // ErrorsFound will be set to True if problem was found, left untouched otherwise
                 GlobalNames::VerifyUniqueCoilName(
-                    state, CurrentModuleObject, simpleWAHP.Name, ErrorsFound, EnergyPlus::format("{} Name", CurrentModuleObject));
+                    state, CurrentModuleObject, simpleWAHP.Name, ErrorsFound, std::format("{} Name", CurrentModuleObject));
                 simpleWAHP.WAHPType = WatertoAirHP::Cooling;
                 simpleWAHP.WAHPPlantType = DataPlant::PlantEquipmentType::CoilWAHPCoolingEquationFit;
 
@@ -509,7 +508,7 @@ namespace WaterToAirHeatPumpSimple {
                 ErrorObjectHeader eoh{RoutineName, CurrentModuleObject, simpleWAHP.Name};
                 // ErrorsFound will be set to True if problem was found, left untouched otherwise
                 GlobalNames::VerifyUniqueCoilName(
-                    state, CurrentModuleObject, simpleWAHP.Name, ErrorsFound, EnergyPlus::format("{} Name", CurrentModuleObject));
+                    state, CurrentModuleObject, simpleWAHP.Name, ErrorsFound, std::format("{} Name", CurrentModuleObject));
                 simpleWAHP.WAHPType = WatertoAirHP::Heating;
                 simpleWAHP.WAHPPlantType = DataPlant::PlantEquipmentType::CoilWAHPHeatingEquationFit;
 
@@ -696,7 +695,7 @@ namespace WaterToAirHeatPumpSimple {
         }
 
         if (ErrorsFound) {
-            ShowFatalError(state, EnergyPlus::format("{} Errors found getting input. Program terminates.", RoutineName));
+            ShowFatalError(state, std::format("{} Errors found getting input. Program terminates.", RoutineName));
         }
 
         for (int HPNumIdx = 1; HPNumIdx <= state.dataWaterToAirHeatPumpSimple->NumWatertoAirHPs; ++HPNumIdx) {
@@ -1127,10 +1126,9 @@ namespace WaterToAirHeatPumpSimple {
                     if (simpleWAHP.LowFlowFlag) {
                         ShowWarningError(
                             state,
-                            EnergyPlus::format(
-                                "{}: Actual air mass flow rate is smaller than 25% of water-to-air heat pump coil ({}) rated air flow rate.",
-                                RoutineName,
-                                simpleWAHP.Name));
+                            std::format("{}: Actual air mass flow rate is smaller than 25% of water-to-air heat pump coil ({}) rated air flow rate.",
+                                        RoutineName,
+                                        simpleWAHP.Name));
                         simpleWAHP.LowFlowFlag = false;
                     }
                 }
@@ -1335,8 +1333,7 @@ namespace WaterToAirHeatPumpSimple {
         RatedCapHeatUser = 0.0;
         RatedWaterVolFlowRateDes = 0.0;
         RatedWaterVolFlowRateUser = 0.0;
-        std::string CompType =
-            EnergyPlus::format("COIL:{}:WATERTOAIRHEATPUMP:EQUATIONFIT", WatertoAirHPNamesUC[static_cast<int>(simpleWAHP.WAHPType)]);
+        std::string CompType = std::format("COIL:{}:WATERTOAIRHEATPUMP:EQUATIONFIT", WatertoAirHPNamesUC[static_cast<int>(simpleWAHP.WAHPType)]);
 
         if (simpleWAHP.RatedAirVolFlowRate == DataSizing::AutoSize) {
             IsAutoSize = true;
@@ -1405,11 +1402,10 @@ namespace WaterToAirHeatPumpSimple {
                                     "SizeHVACWaterToAir: Potential issue with equipment sizing for coil {}:WATERTOAIRHEATPUMP:EQUATIONFIT \"{}\"",
                                     WatertoAirHPNamesUC[static_cast<int>(simpleWAHP.WAHPType)],
                                     simpleWAHP.Name));
+                            ShowContinueError(state,
+                                              std::format("User-Specified Rated Air Volume Flow Rate of {:.5f} [m3/s]", RatedAirVolFlowRateUser));
                             ShowContinueError(
-                                state, EnergyPlus::format("User-Specified Rated Air Volume Flow Rate of {:.5R} [m3/s]", RatedAirVolFlowRateUser));
-                            ShowContinueError(
-                                state,
-                                EnergyPlus::format("differs from Design Size Rated Air Volume Flow Rate of {:.5R} [m3/s]", RatedAirVolFlowRateDes));
+                                state, std::format("differs from Design Size Rated Air Volume Flow Rate of {:.5f} [m3/s]", RatedAirVolFlowRateDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -1984,15 +1980,14 @@ namespace WaterToAirHeatPumpSimple {
                                 state.dataSize->AutoVsHardSizingThreshold) {
                                 ShowMessage(
                                     state,
-                                    std::format(
+                                    EnergyPlus::format(
                                         "SizeHVACWaterToAir: Potential issue with equipment sizing for coil {}:WATERTOAIRHEATPUMP:EQUATIONFIT {}",
                                         WatertoAirHPNamesUC[static_cast<int>(simpleWAHP.WAHPType)],
                                         simpleWAHP.Name));
+                                ShowContinueError(state,
+                                                  std::format("User-Specified Rated Total Cooling Capacity of {:.2f} [W]", RatedCapCoolTotalUser));
                                 ShowContinueError(
-                                    state, EnergyPlus::format("User-Specified Rated Total Cooling Capacity of {:.2R} [W]", RatedCapCoolTotalUser));
-                                ShowContinueError(
-                                    state,
-                                    EnergyPlus::format("differs from Design Size Rated Total Cooling Capacity of {:.2R} [W]", RatedCapCoolTotalDes));
+                                    state, std::format("differs from Design Size Rated Total Cooling Capacity of {:.2f} [W]", RatedCapCoolTotalDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -2084,15 +2079,15 @@ namespace WaterToAirHeatPumpSimple {
                                 state.dataSize->AutoVsHardSizingThreshold) {
                                 ShowMessage(
                                     state,
-                                    std::format(
+                                    EnergyPlus::format(
                                         "SizeHVACWaterToAir: Potential issue with equipment sizing for coil {}:WATERTOAIRHEATPUMP:EQUATIONFIT {}",
                                         WatertoAirHPNamesUC[static_cast<int>(simpleWAHP.WAHPType)],
                                         simpleWAHP.Name));
-                                ShowContinueError(
-                                    state, EnergyPlus::format("User-Specified Rated Sensible Cooling Capacity of {:.2R} [W]", RatedCapCoolSensUser));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("differs from Design Size Rated Sensible Cooling Capacity of {:.2R} [W]",
-                                                                     RatedCapCoolSensDes));
+                                                  std::format("User-Specified Rated Sensible Cooling Capacity of {:.2f} [W]", RatedCapCoolSensUser));
+                                ShowContinueError(
+                                    state,
+                                    std::format("differs from Design Size Rated Sensible Cooling Capacity of {:.2f} [W]", RatedCapCoolSensDes));
                                 ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                                 ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                             }
@@ -2557,14 +2552,13 @@ namespace WaterToAirHeatPumpSimple {
                     }
                     if (state.dataGlobal->DisplayExtraWarnings) {
                         if ((std::abs(RatedCapHeatDes - RatedCapHeatUser) / RatedCapHeatUser) > state.dataSize->AutoVsHardSizingThreshold) {
-                            ShowMessage(
-                                state,
-                                std::format("SizeHVACWaterToAir: Potential issue with equipment sizing for coil {}:WATERTOAIRHEATPUMP:EQUATIONFIT {}",
+                            ShowMessage(state,
+                                        EnergyPlus::format(
+                                            "SizeHVACWaterToAir: Potential issue with equipment sizing for coil {}:WATERTOAIRHEATPUMP:EQUATIONFIT {}",
                                             WatertoAirHPNamesUC[static_cast<int>(simpleWAHP.WAHPType)],
                                             simpleWAHP.Name));
-                            ShowContinueError(state, EnergyPlus::format("User-Specified Rated Heating Capacity of {:.2R} [W]", RatedCapHeatUser));
-                            ShowContinueError(state,
-                                              EnergyPlus::format("differs from Design Size Rated Heating Capacity of {:.2R} [W]", RatedCapHeatDes));
+                            ShowContinueError(state, std::format("User-Specified Rated Heating Capacity of {:.2f} [W]", RatedCapHeatUser));
+                            ShowContinueError(state, std::format("differs from Design Size Rated Heating Capacity of {:.2f} [W]", RatedCapHeatDes));
                             ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                             ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                         }
@@ -2790,10 +2784,9 @@ namespace WaterToAirHeatPumpSimple {
                                         "SizeHVACWaterToAir: Potential issue with equipment sizing for coil {}:WATERTOAIRHEATPUMP:EQUATIONFIT {}",
                                         simpleWAHP.WAHPType,
                                         simpleWAHP.Name));
+                        ShowContinueError(state, std::format("User-Specified Rated Water Flow Rate of {:.5f} [m3/s]", RatedWaterVolFlowRateUser));
                         ShowContinueError(state,
-                                          EnergyPlus::format("User-Specified Rated Water Flow Rate of {:.5R} [m3/s]", RatedWaterVolFlowRateUser));
-                        ShowContinueError(
-                            state, EnergyPlus::format("differs from Design Size Rated Water Flow Rate of {:.5R} [m3/s]", RatedWaterVolFlowRateDes));
+                                          std::format("differs from Design Size Rated Water Flow Rate of {:.5f} [m3/s]", RatedWaterVolFlowRateDes));
                         ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
                         ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
                     }

--- a/src/EnergyPlus/WaterUse.cc
+++ b/src/EnergyPlus/WaterUse.cc
@@ -47,6 +47,7 @@
 
 // C++ Headers
 #include <cmath>
+#include <format>
 
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array.functions.hh>
@@ -165,8 +166,7 @@ namespace WaterUse {
                     if (!state.dataGlobal->WarmupFlag) {
                         if (waterConnection.MaxIterationsErrorIndex == 0) {
                             ShowWarningError(
-                                state,
-                                EnergyPlus::format("WaterUse:Connections = {}:  Heat recovery temperature did not converge", waterConnection.Name));
+                                state, std::format("WaterUse:Connections = {}:  Heat recovery temperature did not converge", waterConnection.Name));
                             ShowContinueErrorTimeStamp(state, "");
                         }
                         ShowRecurringWarningErrorAtEnd(state,
@@ -200,8 +200,7 @@ namespace WaterUse {
             }
         }
         // If we didn't find it, fatal
-        ShowFatalError(state,
-                       EnergyPlus::format("LocalWaterUseConnectionFactory: Error getting inputs for object named: {}", objectName)); // LCOV_EXCL_LINE
+        ShowFatalError(state, std::format("LocalWaterUseConnectionFactory: Error getting inputs for object named: {}", objectName)); // LCOV_EXCL_LINE
         // Shut up the compiler
         return nullptr; // LCOV_EXCL_LINE
     }
@@ -264,8 +263,7 @@ namespace WaterUse {
             if (NumIteration > MaxIterations) {
                 if (!state.dataGlobal->WarmupFlag) {
                     if (this->MaxIterationsErrorIndex == 0) {
-                        ShowWarningError(state,
-                                         EnergyPlus::format("WaterUse:Connections = {}:  Heat recovery temperature did not converge", this->Name));
+                        ShowWarningError(state, std::format("WaterUse:Connections = {}:  Heat recovery temperature did not converge", this->Name));
                         ShowContinueErrorTimeStamp(state, "");
                     }
                     ShowRecurringWarningErrorAtEnd(state,
@@ -374,7 +372,7 @@ namespace WaterUse {
             } // WaterEquipNum
 
             if (ErrorsFound) {
-                ShowFatalError(state, EnergyPlus::format("Errors found in processing input for {}", state.dataIPShortCut->cCurrentModuleObject));
+                ShowFatalError(state, std::format("Errors found in processing input for {}", state.dataIPShortCut->cCurrentModuleObject));
             }
         }
 
@@ -474,10 +472,8 @@ namespace WaterUse {
                         static_cast<HeatRecovHX>(getEnumValue(HeatRecoverHXNamesUC, Util::makeUPPER(state.dataIPShortCut->cAlphaArgs(8))));
                     if (waterConnection.HeatRecoveryHX == HeatRecovHX::Invalid) {
                         ShowSevereError(
-                            state,
-                            EnergyPlus::format("Invalid {} = {}", state.dataIPShortCut->cAlphaFieldNames(8), state.dataIPShortCut->cAlphaArgs(8)));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, waterConnection.Name));
+                            state, std::format("Invalid {} = {}", state.dataIPShortCut->cAlphaFieldNames(8), state.dataIPShortCut->cAlphaArgs(8)));
+                        ShowContinueError(state, std::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, waterConnection.Name));
                         ErrorsFound = true;
                     }
 
@@ -485,10 +481,8 @@ namespace WaterUse {
                         static_cast<HeatRecovConfig>(getEnumValue(HeatRecoveryConfigNamesUC, Util::makeUPPER(state.dataIPShortCut->cAlphaArgs(9))));
                     if (waterConnection.HeatRecoveryConfig == HeatRecovConfig::Invalid) {
                         ShowSevereError(
-                            state,
-                            EnergyPlus::format("Invalid {} = {}", state.dataIPShortCut->cAlphaFieldNames(9), state.dataIPShortCut->cAlphaArgs(9)));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, waterConnection.Name));
+                            state, std::format("Invalid {} = {}", state.dataIPShortCut->cAlphaFieldNames(9), state.dataIPShortCut->cAlphaArgs(9)));
+                        ShowContinueError(state, std::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, waterConnection.Name));
                         ErrorsFound = true;
                     }
                 }
@@ -502,19 +496,18 @@ namespace WaterUse {
 
                     if (WaterEquipNum == 0) {
                         ShowSevereError(state,
-                                        EnergyPlus::format("Invalid {} = {}",
-                                                           state.dataIPShortCut->cAlphaFieldNames(AlphaNum),
-                                                           state.dataIPShortCut->cAlphaArgs(AlphaNum)));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, waterConnection.Name));
+                                        std::format("Invalid {} = {}",
+                                                    state.dataIPShortCut->cAlphaFieldNames(AlphaNum),
+                                                    state.dataIPShortCut->cAlphaArgs(AlphaNum)));
+                        ShowContinueError(state, std::format("Entered in {} = {}", state.dataIPShortCut->cCurrentModuleObject, waterConnection.Name));
                         ErrorsFound = true;
                     } else {
                         if (state.dataWaterUse->WaterEquipment(WaterEquipNum).Connections > 0) {
                             ShowSevereError(state,
-                                            EnergyPlus::format("{} = {}:  WaterUse:Equipment = {} is already referenced by another object.",
-                                                               state.dataIPShortCut->cCurrentModuleObject,
-                                                               waterConnection.Name,
-                                                               state.dataIPShortCut->cAlphaArgs(AlphaNum)));
+                                            std::format("{} = {}:  WaterUse:Equipment = {} is already referenced by another object.",
+                                                        state.dataIPShortCut->cCurrentModuleObject,
+                                                        waterConnection.Name,
+                                                        state.dataIPShortCut->cAlphaArgs(AlphaNum)));
                             ErrorsFound = true;
                         } else {
                             state.dataWaterUse->WaterEquipment(WaterEquipNum).Connections = WaterConnNum;
@@ -531,7 +524,7 @@ namespace WaterUse {
             } // WaterConnNum
 
             if (ErrorsFound) {
-                ShowFatalError(state, EnergyPlus::format("Errors found in processing input for {}", state.dataIPShortCut->cCurrentModuleObject));
+                ShowFatalError(state, std::format("Errors found in processing input for {}", state.dataIPShortCut->cCurrentModuleObject));
             }
 
             if (state.dataWaterUse->numWaterConnections > 0) {
@@ -1044,20 +1037,20 @@ namespace WaterUse {
                     if (this->TargetCWTempErrorCount < 2) {
                         ShowWarningError(
                             state,
-                            EnergyPlus::format(
-                                "CalcEquipmentFlowRates: \"{}\" - Target water temperature is less than the cold water temperature by ({:.2R} C)",
+                            std::format(
+                                "CalcEquipmentFlowRates: \"{}\" - Target water temperature is less than the cold water temperature by ({:.2f} C)",
                                 this->Name,
                                 TempDiff));
                         ShowContinueErrorTimeStamp(state, "");
-                        ShowContinueError(state, EnergyPlus::format("...target water temperature     = {:.2R} C", this->TargetTemp));
-                        ShowContinueError(state, EnergyPlus::format("...cold water temperature       = {:.2R} C", this->ColdTemp));
+                        ShowContinueError(state, std::format("...target water temperature     = {:.2f} C", this->TargetTemp));
+                        ShowContinueError(state, std::format("...cold water temperature       = {:.2f} C", this->ColdTemp));
                         ShowContinueError(state,
                                           "...Target water temperature should be greater than or equal to the cold water temperature. "
                                           "Verify temperature setpoints and schedules.");
                     } else {
                         ShowRecurringWarningErrorAtEnd(
                             state,
-                            EnergyPlus::format(
+                            std::format(
                                 "\"{}\" - Target water temperature should be greater than or equal to the cold water temperature error continues...",
                                 this->Name),
                             this->TargetCWTempErrIndex,
@@ -1077,22 +1070,21 @@ namespace WaterUse {
                         if (this->CWHWTempErrorCount < 2) {
                             ShowWarningError(
                                 state,
-                                EnergyPlus::format(
-                                    "CalcEquipmentFlowRates: \"{}\" - Hot water temperature is less than the cold water temperature by ({:.2R} C)",
+                                std::format(
+                                    "CalcEquipmentFlowRates: \"{}\" - Hot water temperature is less than the cold water temperature by ({:.2f} C)",
                                     this->Name,
                                     TempDiff));
                             ShowContinueErrorTimeStamp(state, "");
-                            ShowContinueError(state, EnergyPlus::format("...hot water temperature        = {:.2R} C", this->HotTemp));
-                            ShowContinueError(state, EnergyPlus::format("...cold water temperature       = {:.2R} C", this->ColdTemp));
+                            ShowContinueError(state, std::format("...hot water temperature        = {:.2f} C", this->HotTemp));
+                            ShowContinueError(state, std::format("...cold water temperature       = {:.2f} C", this->ColdTemp));
                             ShowContinueError(state,
                                               "...Hot water temperature should be greater than or equal to the cold water temperature. "
                                               "Verify temperature setpoints and schedules.");
                         } else {
                             ShowRecurringWarningErrorAtEnd(
                                 state,
-                                EnergyPlus::format(
-                                    "\"{}\" - Hot water temperature should be greater than the cold water temperature error continues... ",
-                                    this->Name),
+                                std::format("\"{}\" - Hot water temperature should be greater than the cold water temperature error continues... ",
+                                            this->Name),
                                 this->CWHWTempErrIndex,
                                 TempDiff,
                                 TempDiff);
@@ -1101,27 +1093,25 @@ namespace WaterUse {
                         TempDiff = this->TargetTemp - this->HotTemp;
                         ++this->TargetHWTempErrorCount;
                         if (this->TargetHWTempErrorCount < 2) {
-                            ShowWarningError(
-                                state,
-                                EnergyPlus::format("CalcEquipmentFlowRates: \"{}\" - Target water temperature is greater than the hot water "
-                                                   "temperature by ({:.2R} C)",
-                                                   this->Name,
-                                                   TempDiff));
+                            ShowWarningError(state,
+                                             std::format("CalcEquipmentFlowRates: \"{}\" - Target water temperature is greater than the hot water "
+                                                         "temperature by ({:.2f} C)",
+                                                         this->Name,
+                                                         TempDiff));
                             ShowContinueErrorTimeStamp(state, "");
-                            ShowContinueError(state, EnergyPlus::format("...target water temperature     = {:.2R} C", this->TargetTemp));
-                            ShowContinueError(state, EnergyPlus::format("...hot water temperature        = {:.2R} C", this->HotTemp));
+                            ShowContinueError(state, std::format("...target water temperature     = {:.2f} C", this->TargetTemp));
+                            ShowContinueError(state, std::format("...hot water temperature        = {:.2f} C", this->HotTemp));
                             ShowContinueError(state,
                                               "...Target water temperature should be less than or equal to the hot water temperature. "
                                               "Verify temperature setpoints and schedules.");
                         } else {
-                            ShowRecurringWarningErrorAtEnd(
-                                state,
-                                EnergyPlus::format("\"{}\" - Target water temperature should be less than or equal to the hot "
-                                                   "water temperature error continues...",
-                                                   this->Name),
-                                this->TargetHWTempErrIndex,
-                                TempDiff,
-                                TempDiff);
+                            ShowRecurringWarningErrorAtEnd(state,
+                                                           std::format("\"{}\" - Target water temperature should be less than or equal to the hot "
+                                                                       "water temperature error continues...",
+                                                                       this->Name),
+                                                           this->TargetHWTempErrIndex,
+                                                           TempDiff,
+                                                           TempDiff);
                         }
                     }
                 }
@@ -1137,22 +1127,21 @@ namespace WaterUse {
                         TempDiff = this->ColdTemp - this->HotTemp;
                         if (this->CWHWTempErrorCount < 2) {
                             ShowWarningError(state,
-                                             EnergyPlus::format("CalcEquipmentFlowRates: \"{}\" - Hot water temperature is less than the cold water "
-                                                                "temperature by ({:.2R} C)",
-                                                                this->Name,
-                                                                TempDiff));
+                                             std::format("CalcEquipmentFlowRates: \"{}\" - Hot water temperature is less than the cold water "
+                                                         "temperature by ({:.2f} C)",
+                                                         this->Name,
+                                                         TempDiff));
                             ShowContinueErrorTimeStamp(state, "");
-                            ShowContinueError(state, EnergyPlus::format("...hot water temperature        = {:.2R} C", this->HotTemp));
-                            ShowContinueError(state, EnergyPlus::format("...cold water temperature       = {:.2R} C", this->ColdTemp));
+                            ShowContinueError(state, std::format("...hot water temperature        = {:.2f} C", this->HotTemp));
+                            ShowContinueError(state, std::format("...cold water temperature       = {:.2f} C", this->ColdTemp));
                             ShowContinueError(state,
                                               "...Hot water temperature should be greater than or equal to the cold water temperature. "
                                               "Verify temperature setpoints and schedules.");
                         } else {
                             ShowRecurringWarningErrorAtEnd(
                                 state,
-                                EnergyPlus::format(
-                                    "\"{}\" - Hot water temperature should be greater than the cold water temperature error continues... ",
-                                    this->Name),
+                                std::format("\"{}\" - Hot water temperature should be greater than the cold water temperature error continues... ",
+                                            this->Name),
                                 this->CWHWTempErrIndex,
                                 TempDiff,
                                 TempDiff);

--- a/src/EnergyPlus/WeatherManager.cc
+++ b/src/EnergyPlus/WeatherManager.cc
@@ -2476,49 +2476,49 @@ namespace Weather {
                     bool ErrorsFound = false;
                     if (DryBulb < 99.9 && (DryBulb < -90.0 || DryBulb > 70.0)) {
                         ShowSevereError(state, std::format("{}: {}", routineName, state.dataEnvrn->WeatherFileLocationTitle));
-                        ShowContinueError(state, EnergyPlus::format("DryBulb Temperature ({:.2R}) is out of range [-90.0, 70.0]", DryBulb));
+                        ShowContinueError(state, std::format("DryBulb Temperature ({:.2f}) is out of range [-90.0, 70.0]", DryBulb));
                         ErrorsFound = true;
                     }
 
                     if (DewPoint < 99.9 && (DewPoint < -90.0 || DewPoint > 70.0)) {
                         ShowSevereError(state, std::format("{}: {}", routineName, state.dataEnvrn->WeatherFileLocationTitle));
-                        ShowContinueError(state, EnergyPlus::format("DewPoint Temperature ({:.2R}) is out of range [-90.0, 70.0]", DewPoint));
+                        ShowContinueError(state, std::format("DewPoint Temperature ({:.2f}) is out of range [-90.0, 70.0]", DewPoint));
                         ErrorsFound = true;
                     }
 
                     if (RelHum < 999.0 && (RelHum < 0.0 || RelHum > 110.0)) {
                         ShowSevereError(state, std::format("{}: {}", routineName, state.dataEnvrn->WeatherFileLocationTitle));
-                        ShowContinueError(state, EnergyPlus::format("Relative Humidity ({:.2R}) is out of range [0.0, 100.0]", RelHum));
+                        ShowContinueError(state, std::format("Relative Humidity ({:.2f}) is out of range [0.0, 100.0]", RelHum));
                         ErrorsFound = true;
                     }
 
                     if (AtmPress < 999999.0 && (AtmPress <= 31000.0 || AtmPress > 120000.0)) {
                         ShowSevereError(state, std::format("{}: {}", routineName, state.dataEnvrn->WeatherFileLocationTitle));
-                        ShowContinueError(state, EnergyPlus::format("Atmospheric Pressure ({:.0R}) is out of range [31000, 120000]", AtmPress));
+                        ShowContinueError(state, std::format("Atmospheric Pressure ({:.0f}) is out of range [31000, 120000]", AtmPress));
                         ErrorsFound = true;
                     }
 
                     if (DirectRad < 0.0) {
                         ShowSevereError(state, std::format("{}: {}", routineName, state.dataEnvrn->WeatherFileLocationTitle));
-                        ShowContinueError(state, EnergyPlus::format("Direct Radiation ({:.2R}) is out of range [0.0, -]", DirectRad));
+                        ShowContinueError(state, std::format("Direct Radiation ({:.2f}) is out of range [0.0, -]", DirectRad));
                         ErrorsFound = true;
                     }
 
                     if (DiffuseRad < 0.0) {
                         ShowSevereError(state, std::format("{}: {}", routineName, state.dataEnvrn->WeatherFileLocationTitle));
-                        ShowContinueError(state, EnergyPlus::format("Diffuse Radiation ({:.2R}) is out of range [0.0, -]", DiffuseRad));
+                        ShowContinueError(state, std::format("Diffuse Radiation ({:.2f}) is out of range [0.0, -]", DiffuseRad));
                         ErrorsFound = true;
                     }
 
                     if (WindDir < 999.0 && (WindDir < 0.0 || WindDir > 360.0)) {
                         ShowSevereError(state, std::format("{}: {}", routineName, state.dataEnvrn->WeatherFileLocationTitle));
-                        ShowContinueError(state, EnergyPlus::format("Wind Direction ({:.2R}) is out of range [0.0, 360.0]", WindDir));
+                        ShowContinueError(state, std::format("Wind Direction ({:.2f}) is out of range [0.0, 360.0]", WindDir));
                         ErrorsFound = true;
                     }
 
                     if (WindSpeed < 999.0 && (WindSpeed < 0.0 || WindSpeed > 40.0)) {
                         ShowSevereError(state, std::format("{}: {}", routineName, state.dataEnvrn->WeatherFileLocationTitle));
-                        ShowContinueError(state, EnergyPlus::format("Wind Speed ({:.2R}) is out of range [0.0, 40.0]", WindSpeed));
+                        ShowContinueError(state, std::format("Wind Speed ({:.2f}) is out of range [0.0, 40.0]", WindSpeed));
                         ErrorsFound = true;
                     }
 
@@ -3554,12 +3554,11 @@ namespace Weather {
         // Check that barometric pressure is within range
         if (desDayInput.PressureEntered) {
             if (std::abs((desDayInput.PressBarom - state.dataEnvrn->StdBaroPress) / state.dataEnvrn->StdBaroPress) > 0.1) { // 10% off
-                ShowWarningError(
-                    state,
-                    EnergyPlus::format("SetUpDesignDay: Entered DesignDay Barometric Pressure={:.0R} differs by more than 10% from Standard "
-                                       "Barometric Pressure={:.0R}.",
-                                       desDayInput.PressBarom,
-                                       state.dataEnvrn->StdBaroPress));
+                ShowWarningError(state,
+                                 std::format("SetUpDesignDay: Entered DesignDay Barometric Pressure={:.0f} differs by more than 10% from Standard "
+                                             "Barometric Pressure={:.0f}.",
+                                             desDayInput.PressBarom,
+                                             state.dataEnvrn->StdBaroPress));
                 ShowContinueError(
                     state,
                     std::format("...occurs in DesignDay={}, Standard Pressure (based on elevation) will be used.", state.dataEnvrn->EnvironmentName));
@@ -3614,8 +3613,8 @@ namespace Weather {
             std::string_view const AlpUseRain = (desDayInput.RainInd == 1) ? "Yes" : "No";
             std::string_view const AlpUseSnow = (desDayInput.SnowInd == 1) ? "Yes" : "No";
             print(state.files.eio, "Environment:Design Day Data,");
-            print(state.files.eio, "{:.2R},", desDayInput.MaxDryBulb);
-            print(state.files.eio, "{:.2R},", desDayInput.DailyDBRange);
+            print(state.files.eio, "{:.2f},", desDayInput.MaxDryBulb);
+            print(state.files.eio, "{:.2f},", desDayInput.DailyDBRange);
 
             static constexpr std::array<std::string_view, (int)DesDayDryBulbRangeType::Num> DesDayDryBulbRangeTypeStrings = {
                 "DefaultMultipliers,", "MultiplierSchedule,", "DifferenceSchedule,", "TemperatureProfile,"};
@@ -3623,14 +3622,14 @@ namespace Weather {
             print(state.files.eio, "{}", DesDayDryBulbRangeTypeStrings[(int)desDayInput.dryBulbRangeType]);
 
             static constexpr std::array<std::string_view, (int)DesDayHumIndType::Num> DesDayHumIndTypeStrings = {
-                "Wetbulb,{:.2R},{{C}},",
-                "Dewpoint,{:.2R},{{C}},",
-                "Enthalpy,{:.2R},{{J/kgDryAir}},",
-                "HumidityRatio,{:.4R},{{kgWater/kgDryAir}},",
+                "Wetbulb,{:.2f},{{C}},",
+                "Dewpoint,{:.2f},{{C}},",
+                "Enthalpy,{:.2f},{{J/kgDryAir}},",
+                "HumidityRatio,{:.4f},{{kgWater/kgDryAir}},",
                 "Schedule,<schedule values from 0.0 to 100.0>,{{percent}},",
-                "WetBulbProfileDefaultMultipliers,{:.2R},{{C}},",
-                "WetBulbProfileDifferenceSchedule,{:.2R},{{C}},",
-                "WetBulbProfileMultiplierSchedule,{:.2R},{{C}},"};
+                "WetBulbProfileDefaultMultipliers,{:.2f},{{C}},",
+                "WetBulbProfileDifferenceSchedule,{:.2f},{{C}},",
+                "WetBulbProfileMultiplierSchedule,{:.2f},{{C}},"};
 
             // Hum Ind Type, Hum Ind Value at Max Temp, Hum Ind Units
             if (desDayInput.HumIndType == DesDayHumIndType::RelHumSch) {
@@ -3643,21 +3642,21 @@ namespace Weather {
                 print(state.files.eio, DesDayHumIndTypeStrings[(int)desDayInput.HumIndType], desDayInput.HumIndValue);
             }
 
-            print(state.files.eio, "{:.0R},", desDayInput.PressBarom);
-            print(state.files.eio, "{:.0R},", desDayInput.WindDir);
-            print(state.files.eio, "{:.1R},", desDayInput.WindSpeed);
-            print(state.files.eio, "{:.2R},", desDayInput.SkyClear);
+            print(state.files.eio, "{:.0f},", desDayInput.PressBarom);
+            print(state.files.eio, "{:.0f},", desDayInput.WindDir);
+            print(state.files.eio, "{:.1f},", desDayInput.WindSpeed);
+            print(state.files.eio, "{:.2f},", desDayInput.SkyClear);
 
             print(state.files.eio, "{},{}\n", AlpUseRain, AlpUseSnow);
 
             static constexpr std::string_view DDayMiscFormat("Environment:Design Day Misc,{:3},");
             print(state.files.eio, DDayMiscFormat, designDay.DayOfYear);
-            print(state.files.eio, "{:.1R},", A);
-            print(state.files.eio, "{:.4R},", B);
-            print(state.files.eio, "{:.4R},", C);
-            print(state.files.eio, "{:.1R},", AVSC);
-            print(state.files.eio, "{:.2R},", designDay.EquationOfTime * 60.0);
-            print(state.files.eio, "{:.1R},", std::asin(designDay.SinSolarDeclinAngle) / Constant::DegToRad);
+            print(state.files.eio, "{:.1f},", A);
+            print(state.files.eio, "{:.4f},", B);
+            print(state.files.eio, "{:.4f},", C);
+            print(state.files.eio, "{:.1f},", AVSC);
+            print(state.files.eio, "{:.2f},", designDay.EquationOfTime * 60.0);
+            print(state.files.eio, "{:.1f},", std::asin(designDay.SinSolarDeclinAngle) / Constant::DegToRad);
 
             // Why have a different string for "Schedule" here than the one used for input? Really, why?
             static constexpr std::array<std::string_view, (int)DesDaySolarModel::Num> DesDaySolarModelStrings = {
@@ -4436,17 +4435,16 @@ namespace Weather {
                         ShowContinueError(state, std::format("..Weather File Location={}", state.dataEnvrn->WeatherFileLocationTitle));
                         ShowContinueError(
                             state,
-                            EnergyPlus::format(
-                                "..due to location differences, Latitude difference=[{:.2R}] degrees, Longitude difference=[{:.2R}] degrees.",
-                                std::abs(state.dataEnvrn->Latitude - state.dataWeather->WeatherFileLatitude),
-                                std::abs(state.dataEnvrn->Longitude - state.dataWeather->WeatherFileLongitude)));
+                            std::format("..due to location differences, Latitude difference=[{:.2f}] degrees, Longitude difference=[{:.2f}] degrees.",
+                                        std::abs(state.dataEnvrn->Latitude - state.dataWeather->WeatherFileLatitude),
+                                        std::abs(state.dataEnvrn->Longitude - state.dataWeather->WeatherFileLongitude)));
                         ShowContinueError(
                             state,
-                            EnergyPlus::format("..Time Zone difference=[{:.1R}] hour(s), Elevation difference=[{:.2R}] percent, [{:.2R}] meters.",
-                                               std::abs(state.dataEnvrn->TimeZoneNumber - state.dataWeather->WeatherFileTimeZone),
-                                               std::abs((state.dataEnvrn->Elevation - state.dataWeather->WeatherFileElevation) /
-                                                        max(state.dataEnvrn->Elevation, 1.0) * 100.0),
-                                               std::abs(state.dataEnvrn->Elevation - state.dataWeather->WeatherFileElevation)));
+                            std::format("..Time Zone difference=[{:.1f}] hour(s), Elevation difference=[{:.2f}] percent, [{:.2f}] meters.",
+                                        std::abs(state.dataEnvrn->TimeZoneNumber - state.dataWeather->WeatherFileTimeZone),
+                                        std::abs((state.dataEnvrn->Elevation - state.dataWeather->WeatherFileElevation) /
+                                                 max(state.dataEnvrn->Elevation, 1.0) * 100.0),
+                                        std::abs(state.dataEnvrn->Elevation - state.dataWeather->WeatherFileElevation)));
                     }
                 }
             }
@@ -4473,7 +4471,7 @@ namespace Weather {
                 "{GMT+/-}, Elevation {m},  Standard Pressure at Elevation {Pa}, Standard RhoAir at Elevation\n");
             print(state.files.eio, "{}", LocHdFormat);
 
-            static constexpr std::string_view LocFormat("Site:Location,{},{:.2R},{:.2R},{:.2R},{:.2R},{:.0R},{:.4R}\n");
+            static constexpr std::string_view LocFormat("Site:Location,{},{:.2f},{:.2f},{:.2f},{:.2f},{:.0f},{:.4f}\n");
             print(state.files.eio,
                   LocFormat,
                   state.dataWeather->LocationTitle,
@@ -4507,17 +4505,17 @@ namespace Weather {
         }
 
         if ((state.dataEnvrn->Latitude < -90.0) || (state.dataEnvrn->Latitude > 90.0)) {
-            ShowSevereError(state, EnergyPlus::format("Latitude must be between -90 and 90; Entered={:.2R}", state.dataEnvrn->Latitude));
+            ShowSevereError(state, std::format("Latitude must be between -90 and 90; Entered={:.2f}", state.dataEnvrn->Latitude));
             LocationError = true;
         }
 
         if ((state.dataEnvrn->Longitude < -180.0) || (state.dataEnvrn->Longitude > 180.0)) {
-            ShowSevereError(state, EnergyPlus::format("Longitude must be between -180 and 180; Entered={:.2R}", state.dataEnvrn->Longitude));
+            ShowSevereError(state, std::format("Longitude must be between -180 and 180; Entered={:.2f}", state.dataEnvrn->Longitude));
             LocationError = true;
         }
 
         if ((state.dataEnvrn->TimeZoneNumber < -12.00) || (state.dataEnvrn->TimeZoneNumber > 14.00)) {
-            ShowSevereError(state, EnergyPlus::format("Time Zone must be between -12 and +14; Entered={:.2R}", state.dataEnvrn->TimeZoneNumber));
+            ShowSevereError(state, std::format("Time Zone must be between -12 and +14; Entered={:.2f}", state.dataEnvrn->TimeZoneNumber));
             LocationError = true;
         }
 
@@ -4535,12 +4533,12 @@ namespace Weather {
                 Real64 const DiffCalc = std::abs(state.dataEnvrn->TimeZoneNumber - StdTimeMerid);
                 if (DiffCalc > 1.0 && DiffCalc < 24.0) {
                     if (DiffCalc < 3.0) {
-                        ShowWarningError(
-                            state, EnergyPlus::format("Standard Time Meridian and Time Zone differ by more than 1, Difference=\"{:.1R}\"", DiffCalc));
+                        ShowWarningError(state,
+                                         std::format("Standard Time Meridian and Time Zone differ by more than 1, Difference=\"{:.1f}\"", DiffCalc));
                         ShowContinueError(state, "Solar Positions may be incorrect");
                     } else {
-                        ShowSevereError(
-                            state, EnergyPlus::format("Standard Time Meridian and Time Zone differ by more than 2, Difference=\"{:.1R}\"", DiffCalc));
+                        ShowSevereError(state,
+                                        std::format("Standard Time Meridian and Time Zone differ by more than 2, Difference=\"{:.1f}\"", DiffCalc));
                         ShowContinueError(state, "Solar Positions will be incorrect");
                         //          LocationError=.TRUE.
                     }
@@ -6139,7 +6137,7 @@ namespace Weather {
                 Real64 testval = desDayInput.MaxDryBulb - desDayInput.DailyDBRange;
                 if (testval < -90.0 || testval > 70.0) {
                     ShowSevereError(state, std::format("{}: {} = {}", routineName, ipsc->cCurrentModuleObject, desDayInput.Title));
-                    ShowContinueError(state, EnergyPlus::format("{} ({:.2R}) is out of range [-90.0, 70.0]", ipsc->cAlphaFieldNames(3), testval));
+                    ShowContinueError(state, std::format("{} ({:.2f}) is out of range [-90.0, 70.0]", ipsc->cAlphaFieldNames(3), testval));
                     ErrorsFound = true;
                 }
             }
@@ -6212,10 +6210,10 @@ namespace Weather {
                 if (desDayInput.dryBulbRangeType == DesDayDryBulbRangeType::Profile) {
                     if (MaxDryBulbEntered) {
                         ShowWarningError(state, std::format("{}=\"{}\", data override.", ipsc->cCurrentModuleObject, desDayInput.Title));
-                        ShowContinueError(
-                            state, EnergyPlus::format("..{}=[{:.2R}] will be overwritten.", ipsc->cNumericFieldNames(3), desDayInput.MaxDryBulb));
+                        ShowContinueError(state,
+                                          std::format("..{}=[{:.2f}] will be overwritten.", ipsc->cNumericFieldNames(3), desDayInput.MaxDryBulb));
                         ShowContinueError(state, std::format("..{}=\"{}\".", ipsc->cAlphaFieldNames(3), ipsc->cAlphaArgs(3)));
-                        ShowContinueError(state, EnergyPlus::format("..with max value=[{:.2R}].", testval));
+                        ShowContinueError(state, std::format("..with max value=[{:.2f}].", testval));
                     }
                     desDayInput.MaxDryBulb = testval;
                 }
@@ -6224,7 +6222,7 @@ namespace Weather {
                 if (testval < -90.0 || testval > 70.0) {
                     ShowSevereError(state, std::format("{}: {} = {}", routineName, ipsc->cCurrentModuleObject, desDayInput.Title));
                     // should this be cNumericFieldNames?
-                    ShowContinueError(state, EnergyPlus::format("{} = ({:.2R}) is out of range [-90.0, 70.0]", ipsc->cAlphaFieldNames(4), testval));
+                    ShowContinueError(state, std::format("{} = ({:.2f}) is out of range [-90.0, 70.0]", ipsc->cAlphaFieldNames(4), testval));
                     ErrorsFound = true;
                 }
             }
@@ -6244,10 +6242,9 @@ namespace Weather {
 
                 if (desDayInput.HumIndValue < -90.0 || desDayInput.HumIndValue > 70.0) {
                     ShowSevereError(state, std::format("{}: {} = {}", routineName, ipsc->cCurrentModuleObject, desDayInput.Title));
-                    ShowContinueError(state,
-                                      EnergyPlus::format("{} = {:.2R} is out of range [-90.0, 70.0]",
-                                                         ipsc->cAlphaFieldNames(5) + " - WetBulb",
-                                                         desDayInput.HumIndValue));
+                    ShowContinueError(
+                        state,
+                        std::format("{} = {:.2f} is out of range [-90.0, 70.0]", ipsc->cAlphaFieldNames(5) + " - WetBulb", desDayInput.HumIndValue));
                     ErrorsFound = true;
                 }
             } break;
@@ -6262,10 +6259,9 @@ namespace Weather {
 
                 if (desDayInput.HumIndValue < -90.0 || desDayInput.HumIndValue > 70.0) {
                     ShowSevereError(state, std::format("{}: {} = {}", routineName, ipsc->cCurrentModuleObject, desDayInput.Title));
-                    ShowContinueError(state,
-                                      EnergyPlus::format("{} = {:.2R} is out of range [-90.0, 70.0]",
-                                                         ipsc->cAlphaFieldNames(5) + " - DewPoint",
-                                                         desDayInput.HumIndValue));
+                    ShowContinueError(
+                        state,
+                        std::format("{} = {:.2f} is out of range [-90.0, 70.0]", ipsc->cAlphaFieldNames(5) + " - DewPoint", desDayInput.HumIndValue));
                     ErrorsFound = true;
                 }
             } break;
@@ -6282,9 +6278,9 @@ namespace Weather {
                 if (desDayInput.HumIndValue < 0.0 || desDayInput.HumIndValue > 0.03) {
                     ShowSevereError(state, std::format("{}: {} = {}", routineName, ipsc->cCurrentModuleObject, desDayInput.Title));
                     ShowContinueError(state,
-                                      EnergyPlus::format("{} = {:.2R} is out of range [0.0, 0.03]",
-                                                         ipsc->cAlphaFieldNames(5) + " - Humidity-Ratio",
-                                                         desDayInput.HumIndValue));
+                                      std::format("{} = {:.2f} is out of range [0.0, 0.03]",
+                                                  ipsc->cAlphaFieldNames(5) + " - Humidity-Ratio",
+                                                  desDayInput.HumIndValue));
                     ErrorsFound = true;
                 }
             } break;
@@ -6302,9 +6298,9 @@ namespace Weather {
                 if (desDayInput.HumIndValue < 0.0 || desDayInput.HumIndValue > 130000.0) {
                     ShowSevereError(state, std::format("{}: {} = {}", routineName, ipsc->cCurrentModuleObject, desDayInput.Title));
                     ShowContinueError(state,
-                                      EnergyPlus::format("{} = {.0R} is out of range [0.0, 130000.0]",
-                                                         ipsc->cAlphaFieldNames(5) + " - Enthalpy",
-                                                         desDayInput.HumIndValue));
+                                      std::format("{} = {:.0f} is out of range [0.0, 130000.0]",
+                                                  ipsc->cAlphaFieldNames(5) + " - Enthalpy",
+                                                  desDayInput.HumIndValue));
                     ErrorsFound = true;
                 }
             } break;
@@ -6437,9 +6433,9 @@ namespace Weather {
                 if (desDayInput.HumIndValue > desDayInput.MaxDryBulb) {
                     ShowWarningError(state, std::format("{}=\"{}\", range check data.", ipsc->cCurrentModuleObject, desDayInput.Title));
                     ShowContinueError(state,
-                                      EnergyPlus::format("..Humidity Indicator Temperature at Max Temperature={:.1R} > Max DryBulb={:.1R}",
-                                                         desDayInput.HumIndValue,
-                                                         desDayInput.MaxDryBulb));
+                                      std::format("..Humidity Indicator Temperature at Max Temperature={:.1f} > Max DryBulb={:.1f}",
+                                                  desDayInput.HumIndValue,
+                                                  desDayInput.MaxDryBulb));
                     ShowContinueError(state, std::format("..{}=\"{}\".", ipsc->cAlphaFieldNames(5), ipsc->cAlphaArgs(5)));
                     ShowContinueError(state, "..Conditions for day will be set to Relative Humidity = 100%");
                     if (desDayInput.HumIndType == DesDayHumIndType::DewPoint) {
@@ -7274,7 +7270,7 @@ namespace Weather {
               "Speed Modifier Coefficient-Internal,Temperature Modifier Coefficient-Internal");
 
         // Formats
-        static constexpr std::string_view Format_720("Environment:Weather Station,{:.3R},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R}\n");
+        static constexpr std::string_view Format_720("Environment:Weather Station,{:.3f},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f}\n");
         print(state.files.eio,
               Format_720,
               WeatherFileWindSensorHeight,
@@ -8821,31 +8817,31 @@ namespace Weather {
             *eiostream << "Site Water Mains Temperature Information,";
             *eiostream << waterMainsCalcMethodNames[static_cast<int>(state.dataWeather->WaterMainsTempsMethod)] << ","
                        << state.dataWeather->waterMainsTempSched->Name << ",";
-            *eiostream << EnergyPlus::format("{:.2R}", state.dataWeather->WaterMainsTempsAnnualAvgAirTemp) << ","
-                       << EnergyPlus::format("{:.2R}", state.dataWeather->WaterMainsTempsMaxDiffAirTemp) << ",";
+            *eiostream << std::format("{:.2f}", state.dataWeather->WaterMainsTempsAnnualAvgAirTemp) << ","
+                       << std::format("{:.2f}", state.dataWeather->WaterMainsTempsMaxDiffAirTemp) << ",";
             *eiostream << "NA\n";
             break;
         case WaterMainsTempCalcMethod::Correlation:
             *eiostream << "Site Water Mains Temperature Information,";
             *eiostream << waterMainsCalcMethodNames[static_cast<int>(state.dataWeather->WaterMainsTempsMethod)] << "," << "NA" << ",";
-            *eiostream << EnergyPlus::format("{:.2R}", state.dataWeather->WaterMainsTempsAnnualAvgAirTemp) << ","
-                       << EnergyPlus::format("{:.2R}", state.dataWeather->WaterMainsTempsMaxDiffAirTemp) << ",";
+            *eiostream << std::format("{:.2f}", state.dataWeather->WaterMainsTempsAnnualAvgAirTemp) << ","
+                       << std::format("{:.2f}", state.dataWeather->WaterMainsTempsMaxDiffAirTemp) << ",";
             *eiostream << "NA\n";
             break;
         case WaterMainsTempCalcMethod::CorrelationFromWeatherFile:
             if (state.dataWeather->OADryBulbAverage.OADryBulbWeatherDataProcessed) {
                 *eiostream << "Site Water Mains Temperature Information,";
                 *eiostream << waterMainsCalcMethodNames[static_cast<int>(state.dataWeather->WaterMainsTempsMethod)] << "," << "NA" << ",";
-                *eiostream << EnergyPlus::format("{:.2R}", state.dataWeather->OADryBulbAverage.AnnualAvgOADryBulbTemp) << ","
-                           << EnergyPlus::format("{:.2R}", state.dataWeather->OADryBulbAverage.MonthlyAvgOADryBulbTempMaxDiff) << "," << "NA\n";
+                *eiostream << std::format("{:.2f}", state.dataWeather->OADryBulbAverage.AnnualAvgOADryBulbTemp) << ","
+                           << std::format("{:.2f}", state.dataWeather->OADryBulbAverage.MonthlyAvgOADryBulbTempMaxDiff) << "," << "NA\n";
             } else {
                 *eiostream << "Site Water Mains Temperature Information,";
-                *eiostream << "FixedDefault" << "," << "NA" << "," << "NA" << "," << "NA" << "," << EnergyPlus::format("{:.1R}", 10.0) << '\n';
+                *eiostream << "FixedDefault" << "," << "NA" << "," << "NA" << "," << "NA" << "," << std::format("{:.1f}", 10.0) << '\n';
             }
             break;
         default:
             *eiostream << "Site Water Mains Temperature Information,";
-            *eiostream << "FixedDefault" << "," << "NA" << "," << "NA" << "," << "NA" << "," << EnergyPlus::format("{:.1R}", 10.0) << '\n';
+            *eiostream << "FixedDefault" << "," << "NA" << "," << "NA" << "," << "NA" << "," << std::format("{:.1f}", 10.0) << '\n';
             break;
         }
 

--- a/src/EnergyPlus/WindTurbine.cc
+++ b/src/EnergyPlus/WindTurbine.cc
@@ -134,8 +134,7 @@ namespace WindTurbine {
         if (GeneratorIndex == 0) {
             WindTurbineNum = Util::FindItemInList(GeneratorName, state.dataWindTurbine->WindTurbineSys);
             if (WindTurbineNum == 0) {
-                ShowFatalError(state,
-                               EnergyPlus::format("SimWindTurbine: Specified Generator not one of Valid Wind Turbine Generators {}", GeneratorName));
+                ShowFatalError(state, std::format("SimWindTurbine: Specified Generator not one of Valid Wind Turbine Generators {}", GeneratorName));
             }
             GeneratorIndex = WindTurbineNum;
         } else {
@@ -144,18 +143,18 @@ namespace WindTurbine {
             if (WindTurbineNum > NumWindTurbines || WindTurbineNum < 1) {
                 ShowFatalError(
                     state,
-                    EnergyPlus::format("SimWindTurbine: Invalid GeneratorIndex passed={}, Number of Wind Turbine Generators={}, Generator name={}",
-                                       WindTurbineNum,
-                                       NumWindTurbines,
-                                       GeneratorName));
+                    std::format("SimWindTurbine: Invalid GeneratorIndex passed={}, Number of Wind Turbine Generators={}, Generator name={}",
+                                WindTurbineNum,
+                                NumWindTurbines,
+                                GeneratorName));
             }
             if (GeneratorName != state.dataWindTurbine->WindTurbineSys(WindTurbineNum).Name) {
-                ShowFatalError(state,
-                               EnergyPlus::format(
-                                   "SimMWindTurbine: Invalid GeneratorIndex passed={}, Generator name={}, stored Generator Name for that index={}",
-                                   WindTurbineNum,
-                                   GeneratorName,
-                                   state.dataWindTurbine->WindTurbineSys(WindTurbineNum).Name));
+                ShowFatalError(
+                    state,
+                    std::format("SimMWindTurbine: Invalid GeneratorIndex passed={}, Generator name={}, stored Generator Name for that index={}",
+                                WindTurbineNum,
+                                GeneratorName,
+                                state.dataWindTurbine->WindTurbineSys(WindTurbineNum).Name));
             }
         }
 
@@ -274,11 +273,11 @@ namespace WindTurbine {
                     windTurbine.rotorType = RotorType::HorizontalAxis;
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=\"{}\".",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cAlphaFields(3),
-                                                       state.dataIPShortCut->cAlphaArgs(3)));
+                                    std::format("{}=\"{}\" invalid {}=\"{}\".",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cAlphaFields(3),
+                                                state.dataIPShortCut->cAlphaArgs(3)));
                     ErrorsFound = true;
                 }
             }
@@ -291,11 +290,11 @@ namespace WindTurbine {
                     windTurbine.controlType = ControlType::VariableSpeedVariablePitch;
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=\"{}\".",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cAlphaFields(4),
-                                                       state.dataIPShortCut->cAlphaArgs(4)));
+                                    std::format("{}=\"{}\" invalid {}=\"{}\".",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cAlphaFields(4),
+                                                state.dataIPShortCut->cAlphaArgs(4)));
                     ErrorsFound = true;
                 }
             }
@@ -304,17 +303,17 @@ namespace WindTurbine {
             if (windTurbine.RatedRotorSpeed <= 0.0) {
                 if (lNumericBlanks(1)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(1)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(1)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(1),
-                                                       rNumericArgs(1)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(1),
+                                                rNumericArgs(1)));
                 }
                 ErrorsFound = true;
             }
@@ -323,17 +322,17 @@ namespace WindTurbine {
             if (windTurbine.RotorDiameter <= 0.0) {
                 if (lNumericBlanks(2)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(2)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(2)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.1R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(2),
-                                                       rNumericArgs(2)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.1f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(2),
+                                                rNumericArgs(2)));
                 }
                 ErrorsFound = true;
             }
@@ -342,17 +341,17 @@ namespace WindTurbine {
             if (windTurbine.RotorHeight <= 0.0) {
                 if (lNumericBlanks(3)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(3)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(3)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.1R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(3),
-                                                       rNumericArgs(3)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.1f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(3),
+                                                rNumericArgs(3)));
                 }
                 ErrorsFound = true;
             }
@@ -360,11 +359,11 @@ namespace WindTurbine {
             windTurbine.NumOfBlade = state.dataIPShortCut->rNumericArgs(4); // Total number of blade
             if (windTurbine.NumOfBlade == 0) {
                 ShowSevereError(state,
-                                EnergyPlus::format("{}=\"{}\" invalid {}=[{:.0R}] must be greater than zero.",
-                                                   CurrentModuleObject,
-                                                   state.dataIPShortCut->cAlphaArgs(1),
-                                                   cNumericFields(4),
-                                                   rNumericArgs(4)));
+                                std::format("{}=\"{}\" invalid {}=[{:.0f}] must be greater than zero.",
+                                            CurrentModuleObject,
+                                            state.dataIPShortCut->cAlphaArgs(1),
+                                            cNumericFields(4),
+                                            rNumericArgs(4)));
                 ErrorsFound = true;
             }
 
@@ -372,17 +371,17 @@ namespace WindTurbine {
             if (windTurbine.RatedPower == 0.0) {
                 if (lNumericBlanks(5)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(5)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(5)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(5),
-                                                       rNumericArgs(5)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(5),
+                                                rNumericArgs(5)));
                 }
                 ErrorsFound = true;
             }
@@ -391,17 +390,17 @@ namespace WindTurbine {
             if (windTurbine.RatedWindSpeed == 0.0) {
                 if (lNumericBlanks(6)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(6)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(6)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(6),
-                                                       rNumericArgs(6)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(6),
+                                                rNumericArgs(6)));
                 }
                 ErrorsFound = true;
             }
@@ -410,17 +409,17 @@ namespace WindTurbine {
             if (windTurbine.CutInSpeed == 0.0) {
                 if (lNumericBlanks(7)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(7)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(7)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(7),
-                                                       rNumericArgs(7)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(7),
+                                                rNumericArgs(7)));
                 }
                 ErrorsFound = true;
             }
@@ -429,26 +428,26 @@ namespace WindTurbine {
             if (windTurbine.CutOutSpeed == 0.0) {
                 if (lNumericBlanks(8)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(8)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(8)));
                 } else if (windTurbine.CutOutSpeed <= windTurbine.RatedWindSpeed) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than {}=[{:.2R}].",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(8),
-                                                       rNumericArgs(8),
-                                                       cNumericFields(6),
-                                                       rNumericArgs(6)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than {}=[{:.2f}].",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(8),
+                                                rNumericArgs(8),
+                                                cNumericFields(6),
+                                                rNumericArgs(6)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(8),
-                                                       rNumericArgs(8)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(8),
+                                                rNumericArgs(8)));
                 }
                 ErrorsFound = true;
             }
@@ -457,87 +456,87 @@ namespace WindTurbine {
             if (lNumericBlanks(9) || windTurbine.SysEfficiency == 0.0 || windTurbine.SysEfficiency > 1.0) {
                 windTurbine.SysEfficiency = SysEffDefault;
                 ShowWarningError(state,
-                                 EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}].",
-                                                    CurrentModuleObject,
-                                                    state.dataIPShortCut->cAlphaArgs(1),
-                                                    cNumericFields(9),
-                                                    state.dataIPShortCut->rNumericArgs(9)));
-                ShowContinueError(state, EnergyPlus::format("...The default value of {:.3R} was assumed. for {}", SysEffDefault, cNumericFields(9)));
+                                 std::format("{}=\"{}\" invalid {}=[{:.2f}].",
+                                             CurrentModuleObject,
+                                             state.dataIPShortCut->cAlphaArgs(1),
+                                             cNumericFields(9),
+                                             state.dataIPShortCut->rNumericArgs(9)));
+                ShowContinueError(state, std::format("...The default value of {:.3f} was assumed. for {}", SysEffDefault, cNumericFields(9)));
             }
 
             windTurbine.MaxTipSpeedRatio = state.dataIPShortCut->rNumericArgs(10); // Maximum tip speed ratio
             if (windTurbine.MaxTipSpeedRatio == 0.0) {
                 if (lNumericBlanks(10)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(10)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(10)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(10),
-                                                       rNumericArgs(10)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(10),
+                                                rNumericArgs(10)));
                 }
                 ErrorsFound = true;
             }
             if (windTurbine.SysEfficiency > MaxTSR) {
                 windTurbine.SysEfficiency = MaxTSR;
                 ShowWarningError(state,
-                                 EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}].",
-                                                    CurrentModuleObject,
-                                                    state.dataIPShortCut->cAlphaArgs(1),
-                                                    cNumericFields(10),
-                                                    state.dataIPShortCut->rNumericArgs(10)));
-                ShowContinueError(state, EnergyPlus::format("...The default value of {:.1R} was assumed. for {}", MaxTSR, cNumericFields(10)));
+                                 std::format("{}=\"{}\" invalid {}=[{:.2f}].",
+                                             CurrentModuleObject,
+                                             state.dataIPShortCut->cAlphaArgs(1),
+                                             cNumericFields(10),
+                                             state.dataIPShortCut->rNumericArgs(10)));
+                ShowContinueError(state, std::format("...The default value of {:.1f} was assumed. for {}", MaxTSR, cNumericFields(10)));
             }
 
             windTurbine.MaxPowerCoeff = state.dataIPShortCut->rNumericArgs(11); // Maximum power coefficient
             if (windTurbine.rotorType == RotorType::HorizontalAxis && windTurbine.MaxPowerCoeff == 0.0) {
                 if (lNumericBlanks(11)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(11)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(11)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(11),
-                                                       rNumericArgs(11)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(11),
+                                                rNumericArgs(11)));
                 }
                 ErrorsFound = true;
             }
             if (windTurbine.MaxPowerCoeff > MaxPowerCoeff) {
                 windTurbine.MaxPowerCoeff = DefaultPC;
                 ShowWarningError(state,
-                                 EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}].",
-                                                    CurrentModuleObject,
-                                                    state.dataIPShortCut->cAlphaArgs(1),
-                                                    cNumericFields(11),
-                                                    state.dataIPShortCut->rNumericArgs(11)));
-                ShowContinueError(state, EnergyPlus::format("...The default value of {:.2R} will be used. for {}", DefaultPC, cNumericFields(11)));
+                                 std::format("{}=\"{}\" invalid {}=[{:.2f}].",
+                                             CurrentModuleObject,
+                                             state.dataIPShortCut->cAlphaArgs(1),
+                                             cNumericFields(11),
+                                             state.dataIPShortCut->rNumericArgs(11)));
+                ShowContinueError(state, std::format("...The default value of {:.2f} will be used. for {}", DefaultPC, cNumericFields(11)));
             }
 
             windTurbine.LocalAnnualAvgWS = state.dataIPShortCut->rNumericArgs(12); // Local wind speed annually averaged
             if (windTurbine.LocalAnnualAvgWS == 0.0) {
                 if (lNumericBlanks(12)) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("{}=\"{}\" invalid {} is necessary for accurate prediction but input is blank.",
-                                                        CurrentModuleObject,
-                                                        state.dataIPShortCut->cAlphaArgs(1),
-                                                        cNumericFields(12)));
+                                     std::format("{}=\"{}\" invalid {} is necessary for accurate prediction but input is blank.",
+                                                 CurrentModuleObject,
+                                                 state.dataIPShortCut->cAlphaArgs(1),
+                                                 cNumericFields(12)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(12),
-                                                       rNumericArgs(12)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(12),
+                                                rNumericArgs(12)));
                     ErrorsFound = true;
                 }
             }
@@ -550,19 +549,18 @@ namespace WindTurbine {
                     windTurbine.HeightForLocalWS = DefaultH;
                     if (lNumericBlanks(13)) {
                         ShowWarningError(state,
-                                         EnergyPlus::format("{}=\"{}\" invalid {} is necessary for accurate prediction but input is blank.",
-                                                            CurrentModuleObject,
-                                                            state.dataIPShortCut->cAlphaArgs(1),
-                                                            cNumericFields(13)));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("...The default value of {:.2R} will be used. for {}", DefaultH, cNumericFields(13)));
+                                         std::format("{}=\"{}\" invalid {} is necessary for accurate prediction but input is blank.",
+                                                     CurrentModuleObject,
+                                                     state.dataIPShortCut->cAlphaArgs(1),
+                                                     cNumericFields(13)));
+                        ShowContinueError(state, std::format("...The default value of {:.2f} will be used. for {}", DefaultH, cNumericFields(13)));
                     } else {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                           CurrentModuleObject,
-                                                           state.dataIPShortCut->cAlphaArgs(1),
-                                                           cNumericFields(13),
-                                                           rNumericArgs(13)));
+                                        std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                    CurrentModuleObject,
+                                                    state.dataIPShortCut->cAlphaArgs(1),
+                                                    cNumericFields(13),
+                                                    rNumericArgs(13)));
                         ErrorsFound = true;
                     }
                 }
@@ -572,17 +570,17 @@ namespace WindTurbine {
             if (windTurbine.rotorType == RotorType::VerticalAxis && windTurbine.ChordArea == 0.0) {
                 if (lNumericBlanks(14)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(14)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(14)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(14),
-                                                       rNumericArgs(14)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(14),
+                                                rNumericArgs(14)));
                 }
                 ErrorsFound = true;
             }
@@ -591,17 +589,17 @@ namespace WindTurbine {
             if (windTurbine.rotorType == RotorType::VerticalAxis && windTurbine.DragCoeff == 0.0) {
                 if (lNumericBlanks(15)) {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {} is required but input is blank.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(15)));
+                                    std::format("{}=\"{}\" invalid {} is required but input is blank.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(15)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(15),
-                                                       rNumericArgs(15)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(15),
+                                                rNumericArgs(15)));
                 }
                 ErrorsFound = true;
             }
@@ -616,11 +614,11 @@ namespace WindTurbine {
                                                 cNumericFields(16)));
                 } else {
                     ShowSevereError(state,
-                                    EnergyPlus::format("{}=\"{}\" invalid {}=[{:.2R}] must be greater than zero.",
-                                                       CurrentModuleObject,
-                                                       state.dataIPShortCut->cAlphaArgs(1),
-                                                       cNumericFields(16),
-                                                       rNumericArgs(16)));
+                                    std::format("{}=\"{}\" invalid {}=[{:.2f}] must be greater than zero.",
+                                                CurrentModuleObject,
+                                                state.dataIPShortCut->cAlphaArgs(1),
+                                                cNumericFields(16),
+                                                rNumericArgs(16)));
                 }
                 ErrorsFound = true;
             }

--- a/src/EnergyPlus/WindowManager.cc
+++ b/src/EnergyPlus/WindowManager.cc
@@ -565,12 +565,12 @@ namespace Window {
                         // Add warning message for the glazing defined with full spectral data.
                         ShowWarningError(
                             state,
-                            EnergyPlus::format(
+                            std::format(
                                 "Window glazing material \"{}\" was defined with full spectral data and has been converted to average spectral data",
                                 matGlass->Name));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("due to its use with between-glass shades or blinds of the window construction \"{}\".",
-                                                             thisConstruct.Name));
+                        ShowContinueError(
+                            state,
+                            std::format("due to its use with between-glass shades or blinds of the window construction \"{}\".", thisConstruct.Name));
                         ShowContinueError(state, "All occurrences of this glazing material will be modeled as SpectralAverage.");
                         ShowContinueError(state,
                                           "If this material is also used in other window constructions  without between-glass shades or blinds,");
@@ -616,14 +616,13 @@ namespace Window {
                     numpt[iGlass] = numptDAT;
                     if (wm->BGFlag) {
                         // 5/16/2012 CR 8793. Add warning message for the glazing defined with full spectral data.
-                        ShowWarningError(
+                        ShowWarningError(state,
+                                         std::format("Window glazing material \"{}\" was defined with full spectral and angular data and has been "
+                                                     "converted to average spectral data",
+                                                     matGlass->Name));
+                        ShowContinueError(
                             state,
-                            EnergyPlus::format("Window glazing material \"{}\" was defined with full spectral and angular data and has been "
-                                               "converted to average spectral data",
-                                               matGlass->Name));
-                        ShowContinueError(state,
-                                          EnergyPlus::format("due to its use with between-glass shades or blinds of the window construction \"{}\".",
-                                                             thisConstruct.Name));
+                            std::format("due to its use with between-glass shades or blinds of the window construction \"{}\".", thisConstruct.Name));
                         ShowContinueError(state, "All occurrences of this glazing material will be modeled as SpectralAverage.");
                         ShowContinueError(state,
                                           "If this material is also used in other window constructions  without between-glass shades or blinds,");
@@ -1766,9 +1765,9 @@ namespace Window {
                 ++DifOverrideCount;
                 if (state.dataGlobal->DisplayExtraWarnings) {
                     ShowWarningError(state,
-                                     EnergyPlus::format("W5InitGlassParameters: Window=\"{}\" has interior material with Solar Diffusing=Yes, but "
-                                                        "existing Window Shading Device sets Diffusing=No.",
-                                                        surf.Name));
+                                     std::format("W5InitGlassParameters: Window=\"{}\" has interior material with Solar Diffusing=Yes, but "
+                                                 "existing Window Shading Device sets Diffusing=No.",
+                                                 surf.Name));
                 }
             }
         } // for (SurfNum)
@@ -1777,13 +1776,12 @@ namespace Window {
             if (!state.dataGlobal->DisplayExtraWarnings) {
                 ShowWarningError(
                     state,
-                    EnergyPlus::format("W5InitGlassParameters: {} Windows had Solar Diffusing=Yes overridden by presence of Window Shading Device.",
-                                       DifOverrideCount));
+                    std::format("W5InitGlassParameters: {} Windows had Solar Diffusing=Yes overridden by presence of Window Shading Device.",
+                                DifOverrideCount));
             } else {
-                ShowMessage(
-                    state,
-                    EnergyPlus::format("W5InitGlassParameters: {} Windows had Solar Diffusing=Yes overridden by presence of Window Shading Device.",
-                                       DifOverrideCount));
+                ShowMessage(state,
+                            std::format("W5InitGlassParameters: {} Windows had Solar Diffusing=Yes overridden by presence of Window Shading Device.",
+                                        DifOverrideCount));
             }
         }
     } // W5InitGlassParameters()
@@ -2369,9 +2367,9 @@ namespace Window {
                         if (state.dataGlobal->AnyEnergyManagementSystemInModel) {
                             // check to make sure the user hasn't messed up the shade control values
                             if (matShade->group == Material::Group::Blind) {
-                                ShowSevereError(state,
-                                                EnergyPlus::format("CalcWindowHeatBalance: ShadeFlag indicates Shade but Blind=\"{}\" is being used.",
-                                                                   matShade->Name));
+                                ShowSevereError(
+                                    state,
+                                    std::format("CalcWindowHeatBalance: ShadeFlag indicates Shade but Blind=\"{}\" is being used.", matShade->Name));
                                 ShowContinueError(state, "This is most likely a fault of the EMS values for shading control.");
                                 ShowFatalError(state, "Preceding condition terminates program.");
                             }
@@ -2396,10 +2394,9 @@ namespace Window {
                         if (state.dataGlobal->AnyEnergyManagementSystemInModel) {
                             // check to make sure the user hasn't messed up the shade control values
                             if (matShade->group == Material::Group::Shade || matShade->group == Material::Group::Screen) {
-                                ShowSevereError(
-                                    state,
-                                    EnergyPlus::format("CalcWindowHeatBalance: ShadeFlag indicates Blind but Shade/Screen=\"{}\" is being used.",
-                                                       matShade->Name));
+                                ShowSevereError(state,
+                                                std::format("CalcWindowHeatBalance: ShadeFlag indicates Blind but Shade/Screen=\"{}\" is being used.",
+                                                            matShade->Name));
                                 ShowContinueError(state, "This is most likely a fault of the EMS values for shading control.");
                                 ShowFatalError(state, "Preceding condition terminates program.");
                             }
@@ -3187,8 +3184,7 @@ namespace Window {
             }
 
         } else {
-            ShowFatalError(state,
-                           EnergyPlus::format("SolveForWindowTemperatures: Invalid number of Glass Layers={}, up to 4 allowed.", wm->ngllayer));
+            ShowFatalError(state, std::format("SolveForWindowTemperatures: Invalid number of Glass Layers={}, up to 4 allowed.", wm->ngllayer));
         }
     } // GetHeatBalanceEqCoefMatrix()
 
@@ -3604,24 +3600,23 @@ namespace Window {
             }
         } else {
             // No convergence after MaxIterations even with relaxed error tolerance
-            ShowSevereError(state,
-                            EnergyPlus::format("Convergence error in SolveForWindowTemperatures for window {}", s_surf->Surface(SurfNum).Name));
+            ShowSevereError(state, std::format("Convergence error in SolveForWindowTemperatures for window {}", s_surf->Surface(SurfNum).Name));
             ShowContinueErrorTimeStamp(state, "");
 
             if (state.dataGlobal->DisplayExtraWarnings) {
                 // report out temperatures
                 for (int i = 1; i <= wm->nglfacep; ++i) {
                     ShowContinueError(state,
-                                      EnergyPlus::format("Glazing face index = {} ; new temperature ={:.4R}C  ; previous temperature = {:.4R}C",
-                                                         i,
-                                                         wm->thetas[i - 1] - Constant::Kelvin,
-                                                         wm->thetasPrev[i - 1] - Constant::Kelvin));
+                                      std::format("Glazing face index = {} ; new temperature ={:.4f}C  ; previous temperature = {:.4f}C",
+                                                  i,
+                                                  wm->thetas[i - 1] - Constant::Kelvin,
+                                                  wm->thetasPrev[i - 1] - Constant::Kelvin));
                 }
             }
 
             ShowFatalError(state,
-                           EnergyPlus::format("Program halted because of convergence error in SolveForWindowTemperatures for window {}",
-                                              s_surf->Surface(SurfNum).Name));
+                           std::format("Program halted because of convergence error in SolveForWindowTemperatures for window {}",
+                                       s_surf->Surface(SurfNum).Name));
         }
     } // SolveForWindowTemperatures()
 
@@ -6524,9 +6519,9 @@ namespace Window {
         // No convergence after MaxIterations; and/or error tolerance
         if (errtemp >= 10 * errtemptol) {
             // Fatal error: didn't converge
-            ShowFatalError(state,
-                           EnergyPlus::format("Convergence error in WindowTempsForNominalCond for construction {}",
-                                              state.dataConstruction->Construct(ConstrNum).Name));
+            ShowFatalError(
+                state,
+                std::format("Convergence error in WindowTempsForNominalCond for construction {}", state.dataConstruction->Construct(ConstrNum).Name));
         }
     } // WindowTempsForNominalCond()
 
@@ -6761,7 +6756,7 @@ namespace Window {
                     WindowComplexManager::CalcComplexWindowThermal(
                         state, 0, i, TempVar, TempVar, TempVar, TempVar, DataBSDFWindow::Condition::Summer);
 
-                    static constexpr std::string_view Format_800(" WindowConstruction:Complex,{},{},{},{:.3R},{:.3R}\n");
+                    static constexpr std::string_view Format_800(" WindowConstruction:Complex,{},{},{},{:.3f},{:.3f}\n");
                     print(state.files.eio,
                           Format_800,
                           construct.Name,
@@ -6783,7 +6778,7 @@ namespace Window {
                         // Construct(ThisNum)%SummerSHGC = SHGCSummer
                         construct.VisTransNorm = 0.0; // TODO list
 
-                        static constexpr std::string_view Format_799(" Construction:WindowEquivalentLayer,{},{},{},{:.3R},{:.3R},{:.3R}\n");
+                        static constexpr std::string_view Format_799(" Construction:WindowEquivalentLayer,{},{},{},{:.3f},{:.3f},{:.3f}\n");
                         print(state.files.eio,
                               Format_799,
                               construct.Name,
@@ -6798,7 +6793,7 @@ namespace Window {
                         CalcNominalWindowCond(state, ThisNum, 1, NominalConductanceWinter, SHGCWinter, TransSolNorm, TransVisNorm, errFlag);
 
                         if (errFlag == 1) {
-                            ShowWarningError(state, EnergyPlus::format("Window construction {} has an interior or exterior blind", construct.Name));
+                            ShowWarningError(state, std::format("Window construction {} has an interior or exterior blind", construct.Name));
                             ShowContinueError(state, "but the corresponding construction without the blind cannot be found.");
                             ShowContinueError(state, "The ReportGlass entry for this construction will not be printed in eplusout.eio.");
                             continue;
@@ -6808,7 +6803,7 @@ namespace Window {
                         // nominal conductance and SHGC.
 
                         if (errFlag == 2) {
-                            ShowWarningError(state, EnergyPlus::format("Window construction {} has a between-glass shade or blind", construct.Name));
+                            ShowWarningError(state, std::format("Window construction {} has a between-glass shade or blind", construct.Name));
                             ShowContinueError(state, "The ReportGlass entry for this construction will not be printed in eplusout.eio.");
                             continue;
                         }
@@ -6822,7 +6817,7 @@ namespace Window {
                         construct.VisTransNorm = TransVisNorm;
                         construct.SolTransNorm = TransSolNorm;
 
-                        static constexpr std::string_view Format_700(" WindowConstruction,{},{},{},{},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R}\n");
+                        static constexpr std::string_view Format_700(" WindowConstruction,{},{},{},{},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f}\n");
                         print(state.files.eio,
                               Format_700,
                               construct.Name,
@@ -6848,7 +6843,7 @@ namespace Window {
                         case Material::Group::Gas: {
                             auto const *matGas = dynamic_cast<Material::MaterialGasMix const *>(mat);
                             assert(matGas != nullptr);
-                            static constexpr std::string_view Format_702(" WindowMaterial:Gas,{},{},{:.3R}\n");
+                            static constexpr std::string_view Format_702(" WindowMaterial:Gas,{},{},{:.3f}\n");
                             print(state.files.eio, Format_702, matGas->Name, Material::gasTypeNames[(int)matGas->gases[0].type], matGas->Thickness);
                             //! fw CASE(WindowGasMixture)
                         } break;
@@ -6857,7 +6852,7 @@ namespace Window {
                             auto const *matShade = dynamic_cast<Material::MaterialShade const *>(mat);
                             assert(matShade != nullptr);
 
-                            static constexpr std::string_view Format_703(" WindowMaterial:Shade,{},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R}\n");
+                            static constexpr std::string_view Format_703(" WindowMaterial:Shade,{},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f}\n");
                             print(state.files.eio,
                                   Format_703,
                                   matShade->Name,
@@ -6873,7 +6868,7 @@ namespace Window {
                             auto const *matBlind = dynamic_cast<Material::MaterialBlind const *>(mat);
 
                             static constexpr std::string_view Format_704(
-                                " WindowMaterial:Blind,{},{:.4R},{:.4R},{:.4R},{:.3R},{:.3R},{:.3R},{:.3R}\n");
+                                " WindowMaterial:Blind,{},{:.4f},{:.4f},{:.4f},{:.3f},{:.3f},{:.3f},{:.3f}\n");
                             print(state.files.eio,
                                   Format_704,
                                   matBlind->Name,
@@ -6892,7 +6887,7 @@ namespace Window {
                             auto const &btar = matScreen->btars[0][0]; // AR: Going with normal incidence here
 
                             static constexpr std::string_view Format_706 =
-                                " WindowMaterial:Screen,{},{:.5R},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R},{:.3R}\n";
+                                " WindowMaterial:Screen,{},{:.5f},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f},{:.3f}\n";
 
                             // AR: assuming normal incidence
                             print(state.files.eio,
@@ -6922,17 +6917,17 @@ namespace Window {
                             if (matGlass->windowOpticalData == Window::OpticalDataModel::Spectral) {
                                 SpectralDataName = s_mat->SpectralData(matGlass->GlassSpectralDataPtr).Name;
                             } else if (matGlass->windowOpticalData == Window::OpticalDataModel::SpectralAndAngle) {
-                                SpectralDataName = EnergyPlus::format("{}, {}, {}",
-                                                                      matGlass->GlassSpecAngTransCurve->Name,
-                                                                      matGlass->GlassSpecAngFReflCurve->Name,
-                                                                      matGlass->GlassSpecAngBReflCurve->Name);
+                                SpectralDataName = std::format("{}, {}, {}",
+                                                               matGlass->GlassSpecAngTransCurve->Name,
+                                                               matGlass->GlassSpecAngFReflCurve->Name,
+                                                               matGlass->GlassSpecAngBReflCurve->Name);
                             } else {
                                 SpectralDataName = "";
                             }
 
                             static constexpr std::string_view Format_707(
-                                " WindowMaterial:Glazing,{},{},{},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{"
-                                ":.5R},{:.5R},{:.5R},{:.5R},{:.5R},{}\n");
+                                " WindowMaterial:Glazing,{},{},{},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{"
+                                ":.5R},{:.5f},{:.5f},{:.5f},{:.5f},{}\n");
                             print(state.files.eio,
                                   Format_707,
                                   matGlass->Name,
@@ -6959,8 +6954,8 @@ namespace Window {
                             std::string OpticalDataType = "SpectralAverage";
                             SpectralDataName = "";
                             static constexpr std::string_view Format_708(
-                                " WindowMaterial:Glazing:EquivalentLayer,{},{},{},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R}"
-                                ",{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R}\n");
+                                " WindowMaterial:Glazing:EquivalentLayer,{},{},{},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f}"
+                                ",{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f}\n");
                             print(state.files.eio,
                                   Format_708,
                                   matEQL->Name,
@@ -6986,7 +6981,7 @@ namespace Window {
                             auto const *matEQL = dynamic_cast<Material::MaterialShadeEQL const *>(mat);
                             assert(matEQL != nullptr);
                             static constexpr std::string_view Format_709(
-                                " WindowMaterial:Shade:EquivalentLayer,{},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R}\n");
+                                " WindowMaterial:Shade:EquivalentLayer,{},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f}\n");
                             print(state.files.eio,
                                   Format_709,
                                   matEQL->Name,
@@ -7005,8 +7000,8 @@ namespace Window {
                             auto const *matEQL = dynamic_cast<Material::MaterialDrapeEQL const *>(mat);
                             assert(matEQL != nullptr);
                             static constexpr std::string_view Format_710(
-                                " WindowMaterial:Drape:EquivalentLayer,{},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R},"
-                                "{:.4R},{:.4R},{:.5R},{:.5R}\n");
+                                " WindowMaterial:Drape:EquivalentLayer,{},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f},"
+                                "{:.4f},{:.4f},{:.5f},{:.5f}\n");
                             print(state.files.eio,
                                   Format_710,
                                   matEQL->Name,
@@ -7026,8 +7021,8 @@ namespace Window {
                             auto const *matEQL = dynamic_cast<Material::MaterialScreenEQL const *>(mat);
                             assert(matEQL != nullptr);
                             static constexpr std::string_view Format_711(
-                                " WindowMaterial:Screen:EquivalentLayer,{},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R},{:.4R}"
-                                ",{:.4R},{:.4R},{:.5R},{:.5R}\n");
+                                " WindowMaterial:Screen:EquivalentLayer,{},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f},{:.4f}"
+                                ",{:.4f},{:.4f},{:.5f},{:.5f}\n");
                             print(state.files.eio,
                                   Format_711,
                                   matEQL->Name,
@@ -7049,8 +7044,8 @@ namespace Window {
 
                             // Formats
                             static constexpr std::string_view Format_712(
-                                " WindowMaterial:Blind:EquivalentLayer,{},{},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:."
-                                "5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R},{:.5R}");
+                                " WindowMaterial:Blind:EquivalentLayer,{},{},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:."
+                                "5R},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f}");
                             print(state.files.eio,
                                   Format_712,
                                   matEQL->Name,
@@ -7074,7 +7069,7 @@ namespace Window {
                         case Material::Group::WindowGapEQL: {
                             auto const *matGas = dynamic_cast<Material::MaterialGasMix const *>(mat);
                             assert(matGas != nullptr);
-                            static constexpr std::string_view Format_713(" WindowMaterial:Gap:EquivalentLayer,{},{},{:.3R},{}\n");
+                            static constexpr std::string_view Format_713(" WindowMaterial:Gap:EquivalentLayer,{},{},{:.3f},{}\n");
                             print(state.files.eio,
                                   Format_713,
                                   matGas->Name,
@@ -7530,7 +7525,7 @@ namespace Window {
                                                         screen->btars[ip2][it2].BmTrans,
                                                         coeffs);
                         // bmTrans = screen->btars[ip][it].BmTrans;
-                        print(screenCsvFile, ",{:.6R}", bmTrans);
+                        print(screenCsvFile, ",{:.6f}", bmTrans);
                     }
                     print(screenCsvFile, "\n");
                 }
@@ -7563,7 +7558,7 @@ namespace Window {
                                                         coeffs);
 
                         // dfTrans = screen->btars[ip][it].DfTrans;
-                        print(screenCsvFile, ",{:.6R}", dfTrans);
+                        print(screenCsvFile, ",{:.6f}", dfTrans);
                     }
                     print(screenCsvFile, "\n");
                 }
@@ -8294,7 +8289,7 @@ namespace Window {
 
         // read custom spectrum data from Site:SolarAndVisibleSpectrum
         if (NumSiteSpectrum > 1) { // throw error
-            ShowSevereError(state, EnergyPlus::format("Only one {} object is allowed", cCurrentModuleObject));
+            ShowSevereError(state, std::format("Only one {} object is allowed", cCurrentModuleObject));
             ErrorsFound = true;
         }
 
@@ -8326,7 +8321,7 @@ namespace Window {
             cCurrentModuleObject = "Site:SpectrumData";
             NumSiteSpectrum = state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, cCurrentModuleObject);
             if (NumSiteSpectrum == 0) { // throw error
-                ShowSevereError(state, EnergyPlus::format("No {} object is found", cCurrentModuleObject));
+                ShowSevereError(state, std::format("No {} object is found", cCurrentModuleObject));
                 ErrorsFound = true;
             }
 

--- a/src/EnergyPlus/WindowManager.cc
+++ b/src/EnergyPlus/WindowManager.cc
@@ -6926,8 +6926,8 @@ namespace Window {
                             }
 
                             static constexpr std::string_view Format_707(
-                                " WindowMaterial:Glazing,{},{},{},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{"
-                                ":.5R},{:.5f},{:.5f},{:.5f},{:.5f},{}\n");
+                                " WindowMaterial:Glazing,{},{},{},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},"
+                                "{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{}\n");
                             print(state.files.eio,
                                   Format_707,
                                   matGlass->Name,
@@ -7044,8 +7044,8 @@ namespace Window {
 
                             // Formats
                             static constexpr std::string_view Format_712(
-                                " WindowMaterial:Blind:EquivalentLayer,{},{},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:."
-                                "5R},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f}");
+                                " WindowMaterial:Blind:EquivalentLayer,{},{},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},"
+                                "{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f},{:.5f}");
                             print(state.files.eio,
                                   Format_712,
                                   matEQL->Name,

--- a/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneContaminantPredictorCorrector.cc
@@ -249,12 +249,12 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.ActualZoneNum = Util::FindItemInList(AlphaName(2), state.dataHeatBal->Zone);
         if (contam.ActualZoneNum == 0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}{}=\"{}\", invalid {} entered={}",
-                                               RoutineName,
-                                               CurrentModuleObject,
-                                               AlphaName(1),
-                                               state.dataIPShortCut->cAlphaFieldNames(2),
-                                               AlphaName(2)));
+                            std::format("{}{}=\"{}\", invalid {} entered={}",
+                                        RoutineName,
+                                        CurrentModuleObject,
+                                        AlphaName(1),
+                                        state.dataIPShortCut->cAlphaFieldNames(2),
+                                        AlphaName(2)));
             ErrorsFound = true;
         }
 
@@ -350,12 +350,12 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.SurfNum = Util::FindItemInList(AlphaName(2), state.afn->MultizoneSurfaceData, &AirflowNetwork::MultizoneSurfaceProp::SurfName);
         if (contam.SurfNum == 0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}{}=\"{}\", invalid {} entered={}",
-                                               RoutineName,
-                                               CurrentModuleObject,
-                                               AlphaName(1),
-                                               state.dataIPShortCut->cAlphaFieldNames(2),
-                                               AlphaName(2)));
+                            std::format("{}{}=\"{}\", invalid {} entered={}",
+                                        RoutineName,
+                                        CurrentModuleObject,
+                                        AlphaName(1),
+                                        state.dataIPShortCut->cAlphaFieldNames(2),
+                                        AlphaName(2)));
             ShowContinueError(state, "which is not listed in AirflowNetwork:MultiZone:Surface.");
             ErrorsFound = true;
         }
@@ -364,7 +364,7 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
             state.dataSurface->Surface(state.afn->MultizoneSurfaceData(contam.SurfNum).SurfNum).ExtBoundCond != DataSurfaces::ExternalEnvironment) {
             ShowSevereError(
                 state,
-                EnergyPlus::format(
+                std::format(
                     "{}{}=\"{}. The entered surface ({}) is not an exterior surface", RoutineName, CurrentModuleObject, AlphaName(1), AlphaName(2)));
             ErrorsFound = true;
         }
@@ -383,34 +383,34 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.GenRateCoef = IHGNumbers(1);
         if (IHGNumbers(1) < 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative values are not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(1),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(1)));
+                            std::format("{}Negative values are not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(1),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(1)));
             ErrorsFound = true;
         }
 
         contam.Expo = IHGNumbers(2);
         if (IHGNumbers(2) <= 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative or zero value is not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(2),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(2)));
+                            std::format("{}Negative or zero value is not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(2),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(2)));
             ErrorsFound = true;
         }
         if (IHGNumbers(2) > 1.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}The value greater than 1.0 is not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(2),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(2)));
+                            std::format("{}The value greater than 1.0 is not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(2),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(2)));
             ErrorsFound = true;
         }
 
@@ -483,12 +483,12 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.ActualZoneNum = Util::FindItemInList(AlphaName(2), state.dataHeatBal->Zone);
         if (contam.ActualZoneNum == 0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}{}=\"{}\", invalid {} entered={}",
-                                               RoutineName,
-                                               CurrentModuleObject,
-                                               AlphaName(1),
-                                               state.dataIPShortCut->cAlphaFieldNames(2),
-                                               AlphaName(2)));
+                            std::format("{}{}=\"{}\", invalid {} entered={}",
+                                        RoutineName,
+                                        CurrentModuleObject,
+                                        AlphaName(1),
+                                        state.dataIPShortCut->cAlphaFieldNames(2),
+                                        AlphaName(2)));
             ErrorsFound = true;
         }
 
@@ -508,22 +508,22 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
 
         if (IHGNumbers(1) < 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative values are not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(1),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(1)));
+                            std::format("{}Negative values are not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(1),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(1)));
             ErrorsFound = true;
         }
         if (IHGNumbers(2) <= 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative values or zero are not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(2),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(2)));
+                            std::format("{}Negative values or zero are not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(2),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(2)));
             ErrorsFound = true;
         }
 
@@ -591,12 +591,12 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.ActualZoneNum = Util::FindItemInList(AlphaName(2), state.dataHeatBal->Zone);
         if (contam.ActualZoneNum == 0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}{}=\"{}\", invalid {} entered={}",
-                                               RoutineName,
-                                               CurrentModuleObject,
-                                               AlphaName(1),
-                                               state.dataIPShortCut->cAlphaFieldNames(2),
-                                               AlphaName(2)));
+                            std::format("{}{}=\"{}\", invalid {} entered={}",
+                                        RoutineName,
+                                        CurrentModuleObject,
+                                        AlphaName(1),
+                                        state.dataIPShortCut->cAlphaFieldNames(2),
+                                        AlphaName(2)));
             ErrorsFound = true;
         }
 
@@ -616,22 +616,22 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
 
         if (IHGNumbers(1) < 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative values are not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(1),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(1)));
+                            std::format("{}Negative values are not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(1),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(1)));
             ErrorsFound = true;
         }
         if (IHGNumbers(2) <= 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative values or zero are not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(2),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(2)));
+                            std::format("{}Negative values or zero are not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(2),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(2)));
             ErrorsFound = true;
         }
 
@@ -704,12 +704,12 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.SurfNum = Util::FindItemInList(AlphaName(2), state.dataSurface->Surface);
         if (contam.SurfNum == 0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}{}=\"{}\", invalid {} entered={}",
-                                               RoutineName,
-                                               CurrentModuleObject,
-                                               AlphaName(1),
-                                               state.dataIPShortCut->cAlphaFieldNames(2),
-                                               AlphaName(2)));
+                            std::format("{}{}=\"{}\", invalid {} entered={}",
+                                        RoutineName,
+                                        CurrentModuleObject,
+                                        AlphaName(1),
+                                        state.dataIPShortCut->cAlphaFieldNames(2),
+                                        AlphaName(2)));
             ErrorsFound = true;
         }
 
@@ -728,22 +728,22 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.HenryCoef = IHGNumbers(2);
         if (IHGNumbers(1) < 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative values are not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(1),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(1)));
+                            std::format("{}Negative values are not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(1),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(1)));
             ErrorsFound = true;
         }
         if (IHGNumbers(2) <= 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative values or zero are not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(2),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(2)));
+                            std::format("{}Negative values or zero are not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(2),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(2)));
             ErrorsFound = true;
         }
 
@@ -819,12 +819,12 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.SurfNum = Util::FindItemInList(AlphaName(2), state.dataSurface->Surface);
         if (contam.SurfNum == 0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}{}=\"{}\", invalid {} entered={}",
-                                               RoutineName,
-                                               CurrentModuleObject,
-                                               AlphaName(1),
-                                               state.dataIPShortCut->cAlphaFieldNames(2),
-                                               AlphaName(2)));
+                            std::format("{}{}=\"{}\", invalid {} entered={}",
+                                        RoutineName,
+                                        CurrentModuleObject,
+                                        AlphaName(1),
+                                        state.dataIPShortCut->cAlphaFieldNames(2),
+                                        AlphaName(2)));
             ErrorsFound = true;
         }
 
@@ -842,12 +842,12 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.DepoVelo = IHGNumbers(1);
         if (IHGNumbers(1) < 0.0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}Negative values are not allowed for {} in {} = {}",
-                                               RoutineName,
-                                               state.dataIPShortCut->cNumericFieldNames(1),
-                                               CurrentModuleObject,
-                                               AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(1)));
+                            std::format("{}Negative values are not allowed for {} in {} = {}",
+                                        RoutineName,
+                                        state.dataIPShortCut->cNumericFieldNames(1),
+                                        CurrentModuleObject,
+                                        AlphaName(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(1)));
             ErrorsFound = true;
         }
 
@@ -914,12 +914,12 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
         contam.ActualZoneNum = Util::FindItemInList(AlphaName(2), state.dataHeatBal->Zone);
         if (contam.ActualZoneNum == 0) {
             ShowSevereError(state,
-                            EnergyPlus::format("{}{}=\"{}\", invalid {} entered={}",
-                                               RoutineName,
-                                               CurrentModuleObject,
-                                               AlphaName(1),
-                                               state.dataIPShortCut->cAlphaFieldNames(2),
-                                               AlphaName(2)));
+                            std::format("{}{}=\"{}\", invalid {} entered={}",
+                                        RoutineName,
+                                        CurrentModuleObject,
+                                        AlphaName(1),
+                                        state.dataIPShortCut->cAlphaFieldNames(2),
+                                        AlphaName(2)));
             ErrorsFound = true;
         }
 
@@ -943,7 +943,7 @@ void GetZoneContaminanInputs(EnergyPlusData &state)
                                         state.dataIPShortCut->cNumericFieldNames(1),
                                         CurrentModuleObject,
                                         AlphaName(1)));
-            ShowContinueError(state, EnergyPlus::format("The input value is {:.2R}", IHGNumbers(1)));
+            ShowContinueError(state, std::format("The input value is {:.2f}", IHGNumbers(1)));
             ErrorsFound = true;
         }
 

--- a/src/EnergyPlus/ZoneEquipmentManager.cc
+++ b/src/EnergyPlus/ZoneEquipmentManager.cc
@@ -378,8 +378,7 @@ void sizeZoneSpaceEquipmentPart1(EnergyPlusData &state,
             supplyAirNodeNum1 = zoneEquipConfig.InletNode(1);
             supplyAirNodeNum2 = 0;
         } else {
-            ShowSevereError(state,
-                            EnergyPlus::format("{}: to account for the effect a Dedicated Outside Air System on zone equipment sizing", RoutineName));
+            ShowSevereError(state, std::format("{}: to account for the effect a Dedicated Outside Air System on zone equipment sizing", RoutineName));
             ShowContinueError(state, "there must be at least one zone air inlet node");
             ShowFatalError(state, "Previous severe error causes abort ");
         }
@@ -765,7 +764,7 @@ void CalcDOASSupCondsForSizing(EnergyPlusData &state,
             DOASSupHR = min(OutHR, W90L);
         }
     } else {
-        ShowFatalError(state, EnergyPlus::format("{}:illegal DOAS design control strategy", RoutineName));
+        ShowFatalError(state, std::format("{}:illegal DOAS design control strategy", RoutineName));
     }
 }
 
@@ -793,8 +792,8 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
         int ZoneIndex = Util::FindItemInList(state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName, state.dataHeatBal->Zone);
         if (ZoneIndex == 0) {
             ShowSevereError(state,
-                            EnergyPlus::format("SetUpZoneSizingArrays: Sizing:Zone=\"{}\" references unknown zone",
-                                               state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName));
+                            std::format("SetUpZoneSizingArrays: Sizing:Zone=\"{}\" references unknown zone",
+                                        state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName));
             ErrorsFound = true;
         }
         if (std::any_of(state.dataZoneEquip->ZoneEquipConfig.begin(), state.dataZoneEquip->ZoneEquipConfig.end(), [](EquipConfiguration const &e) {
@@ -806,8 +805,8 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
                 if (!state.dataGlobal->isPulseZoneSizing) {
                     ShowWarningError(
                         state,
-                        EnergyPlus::format("SetUpZoneSizingArrays: Requested Sizing for Zone=\"{}\", Zone is not found in the Controlled Zones List",
-                                           state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName));
+                        std::format("SetUpZoneSizingArrays: Requested Sizing for Zone=\"{}\", Zone is not found in the Controlled Zones List",
+                                    state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName));
                 }
             } else {
                 state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneNum = ZoneIndex;
@@ -817,9 +816,9 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
                 if (!ZoneTempPredictorCorrector::VerifyThermostatInZone(state, state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName)) {
                     if (!state.dataGlobal->isPulseZoneSizing) {
                         ShowWarningError(state,
-                                         EnergyPlus::format("SetUpZoneSizingArrays: Requested Sizing for Zone=\"{}\", Zone has no thermostat (ref: "
-                                                            "ZoneControl:Thermostat, et al)",
-                                                            state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName));
+                                         std::format("SetUpZoneSizingArrays: Requested Sizing for Zone=\"{}\", Zone has no thermostat (ref: "
+                                                     "ZoneControl:Thermostat, et al)",
+                                                     state.dataSize->ZoneSizingInput(ZoneSizIndex).ZoneName));
                     }
                 }
             }
@@ -872,9 +871,9 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
             if (!state.dataGlobal->isPulseZoneSizing) {
                 ShowWarningError(
                     state,
-                    EnergyPlus::format("SetUpZoneSizingArrays: Sizing for Zone=\"{}\" will use Sizing:Zone specifications listed for Zone=\"{}\".",
-                                       state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneName,
-                                       zoneSizingInput.ZoneName));
+                    std::format("SetUpZoneSizingArrays: Sizing for Zone=\"{}\" will use Sizing:Zone specifications listed for Zone=\"{}\".",
+                                state.dataZoneEquip->ZoneEquipConfig(CtrlZoneNum).ZoneName,
+                                zoneSizingInput.ZoneName));
             }
         }
 
@@ -1006,17 +1005,16 @@ void SetUpZoneSizingArrays(EnergyPlusData &state)
                 if (thisSpaceNum > 0) {
                     thisOAReq.dsoaSpaceIndexes.emplace_back(thisSpaceNum);
                 } else {
-                    ShowSevereError(state, EnergyPlus::format("SetUpZoneSizingArrays: DesignSpecification:OutdoorAir:SpaceList={}", thisOAReq.Name));
-                    ShowContinueError(state, EnergyPlus::format("Space Name={} not found.", thisSpaceName));
+                    ShowSevereError(state, std::format("SetUpZoneSizingArrays: DesignSpecification:OutdoorAir:SpaceList={}", thisOAReq.Name));
+                    ShowContinueError(state, std::format("Space Name={} not found.", thisSpaceName));
                     dsoaError = true;
                     ErrorsFound = true;
                 }
                 // Check for duplicate spaces
                 for (int loop = 1; loop <= int(thisOAReq.dsoaSpaceIndexes.size()) - 1; ++loop) {
                     if (thisSpaceNum == thisOAReq.dsoaSpaceIndexes(loop)) {
-                        ShowSevereError(state,
-                                        EnergyPlus::format("SetUpZoneSizingArrays: DesignSpecification:OutdoorAir:SpaceList={}", thisOAReq.Name));
-                        ShowContinueError(state, EnergyPlus::format("Space Name={} appears more than once in the list.", thisSpaceName));
+                        ShowSevereError(state, std::format("SetUpZoneSizingArrays: DesignSpecification:OutdoorAir:SpaceList={}", thisOAReq.Name));
+                        ShowContinueError(state, std::format("Space Name={} appears more than once in the list.", thisSpaceName));
                         dsoaError = true;
                         ErrorsFound = true;
                     }
@@ -1109,9 +1107,8 @@ void calcSizingOA(EnergyPlusData &state,
                 int thisSpaceNum = thisOAReq.dsoaSpaceIndexes(spaceCounter);
                 if (thisSpaceNum > 0) {
                     if (state.dataHeatBal->space(thisSpaceNum).zoneNum != zoneNum) {
-                        ShowSevereError(state,
-                                        EnergyPlus::format("SetUpZoneSizingArrays: DesignSpecification:OutdoorAir:SpaceList={}", thisOAReq.Name));
-                        ShowContinueError(state, EnergyPlus::format("is invalid for Sizing:Zone={}", zsFinalSizing.ZoneName));
+                        ShowSevereError(state, std::format("SetUpZoneSizingArrays: DesignSpecification:OutdoorAir:SpaceList={}", thisOAReq.Name));
+                        ShowContinueError(state, std::format("is invalid for Sizing:Zone={}", zsFinalSizing.ZoneName));
                         ShowContinueError(state, "All spaces in the list must be part of this zone.");
                         ErrorsFound = true;
                     }
@@ -2303,11 +2300,11 @@ void updateZoneSizingEndZoneSizingCalc1(EnergyPlusData &state, int const zoneNum
 void updateZoneSizingEndZoneSizingCalc2(EnergyPlusData &state, DataSizing::ZoneSizingData &zsCalcSizing)
 {
     if (std::abs(zsCalcSizing.DesCoolLoad) <= 1.e-8) {
-        ShowWarningError(state, EnergyPlus::format("Calculated design cooling load for zone={} is zero.", zsCalcSizing.ZoneName));
+        ShowWarningError(state, std::format("Calculated design cooling load for zone={} is zero.", zsCalcSizing.ZoneName));
         ShowContinueError(state, "Check Sizing:Zone and ZoneControl:Thermostat inputs.");
     }
     if (std::abs(zsCalcSizing.DesHeatLoad) <= 1.e-8) {
-        ShowWarningError(state, EnergyPlus::format("Calculated design heating load for zone={} is zero.", zsCalcSizing.ZoneName));
+        ShowWarningError(state, std::format("Calculated design heating load for zone={} is zero.", zsCalcSizing.ZoneName));
         ShowContinueError(state, "Check Sizing:Zone and ZoneControl:Thermostat inputs.");
     }
 
@@ -2332,25 +2329,25 @@ void updateZoneSizingEndZoneSizingCalc2(EnergyPlusData &state, DataSizing::ZoneS
                 ShowSevereError(state, "UpdateZoneSizing: Cooling supply air temperature (calculated) within 2C of zone temperature");
             }
             ShowContinueError(state, "...check zone thermostat set point and design supply air temperatures");
-            ShowContinueError(state, EnergyPlus::format("...zone name = {}", zsCalcSizing.ZoneName));
-            ShowContinueError(state, EnergyPlus::format("...design sensible cooling load = {:.2R} W", zsCalcSizing.DesCoolLoad));
-            ShowContinueError(state, EnergyPlus::format("...thermostat set point temp    = {:.3R} C", zsCalcSizing.CoolTstatTemp));
-            ShowContinueError(state, EnergyPlus::format("...zone temperature             = {:.3R} C", zsCalcSizing.ZoneTempAtCoolPeak));
-            ShowContinueError(state, EnergyPlus::format("...supply air temperature       = {:.3R} C", SupplyTemp));
-            ShowContinueError(state, EnergyPlus::format("...temperature difference       = {:.5R} C", DeltaTemp));
-            ShowContinueError(state, EnergyPlus::format("...calculated volume flow rate  = {:.5R} m3/s", (zsCalcSizing.DesCoolVolFlow)));
-            ShowContinueError(state, EnergyPlus::format("...calculated mass flow rate    = {:.5R} kg/s", (zsCalcSizing.DesCoolMassFlow)));
+            ShowContinueError(state, std::format("...zone name = {}", zsCalcSizing.ZoneName));
+            ShowContinueError(state, std::format("...design sensible cooling load = {:.2f} W", zsCalcSizing.DesCoolLoad));
+            ShowContinueError(state, std::format("...thermostat set point temp    = {:.3f} C", zsCalcSizing.CoolTstatTemp));
+            ShowContinueError(state, std::format("...zone temperature             = {:.3f} C", zsCalcSizing.ZoneTempAtCoolPeak));
+            ShowContinueError(state, std::format("...supply air temperature       = {:.3f} C", SupplyTemp));
+            ShowContinueError(state, std::format("...temperature difference       = {:.5f} C", DeltaTemp));
+            ShowContinueError(state, std::format("...calculated volume flow rate  = {:.5f} m3/s", (zsCalcSizing.DesCoolVolFlow)));
+            ShowContinueError(state, std::format("...calculated mass flow rate    = {:.5f} kg/s", (zsCalcSizing.DesCoolMassFlow)));
             if (SupplyTemp > zsCalcSizing.ZoneTempAtCoolPeak) {
                 ShowContinueError(state, "...Note: supply air temperature should be less than zone temperature during cooling air flow calculations");
             }
         } else if (std::abs(DeltaTemp) > HVAC::SmallTempDiff && SupplyTemp > zsCalcSizing.ZoneTempAtCoolPeak) {
             ShowSevereError(state, "UpdateZoneSizing: Supply air temperature is greater than zone temperature during cooling air flow calculations");
-            ShowContinueError(state, EnergyPlus::format("...calculated volume flow rate  = {:.5R} m3/s", (zsCalcSizing.DesCoolVolFlow)));
-            ShowContinueError(state, EnergyPlus::format("...calculated mass flow rate    = {:.5R} kg/s", (zsCalcSizing.DesCoolMassFlow)));
-            ShowContinueError(state, EnergyPlus::format("...thermostat set point temp    = {:.3R} C", zsCalcSizing.CoolTstatTemp));
-            ShowContinueError(state, EnergyPlus::format("...zone temperature            = {:.3R} C", zsCalcSizing.ZoneTempAtCoolPeak));
-            ShowContinueError(state, EnergyPlus::format("...supply air temperature      = {:.3R} C", SupplyTemp));
-            ShowContinueError(state, EnergyPlus::format("...occurs in zone              = {}", zsCalcSizing.ZoneName));
+            ShowContinueError(state, std::format("...calculated volume flow rate  = {:.5f} m3/s", (zsCalcSizing.DesCoolVolFlow)));
+            ShowContinueError(state, std::format("...calculated mass flow rate    = {:.5f} kg/s", (zsCalcSizing.DesCoolMassFlow)));
+            ShowContinueError(state, std::format("...thermostat set point temp    = {:.3f} C", zsCalcSizing.CoolTstatTemp));
+            ShowContinueError(state, std::format("...zone temperature            = {:.3f} C", zsCalcSizing.ZoneTempAtCoolPeak));
+            ShowContinueError(state, std::format("...supply air temperature      = {:.3f} C", SupplyTemp));
+            ShowContinueError(state, std::format("...occurs in zone              = {}", zsCalcSizing.ZoneName));
             ShowContinueError(state, "...Note: supply air temperature should be less than zone temperature during cooling air flow calculations");
         }
     }
@@ -2372,14 +2369,14 @@ void updateZoneSizingEndZoneSizingCalc2(EnergyPlusData &state, DataSizing::ZoneS
                 ShowSevereError(state, "UpdateZoneSizing: Heating supply air temperature (calculated) within 2C of zone temperature");
             }
             ShowContinueError(state, "...check zone thermostat set point and design supply air temperatures");
-            ShowContinueError(state, EnergyPlus::format("...zone name = {}", zsCalcSizing.ZoneName));
-            ShowContinueError(state, EnergyPlus::format("...design heating load         = {:.2R} W", zsCalcSizing.DesHeatLoad));
-            ShowContinueError(state, EnergyPlus::format("...thermostat set point temp   = {:.3R} C", zsCalcSizing.HeatTstatTemp));
-            ShowContinueError(state, EnergyPlus::format("...zone temperature            = {:.3R} C", zsCalcSizing.ZoneTempAtHeatPeak));
-            ShowContinueError(state, EnergyPlus::format("...supply air temperature      = {:.3R} C", SupplyTemp));
-            ShowContinueError(state, EnergyPlus::format("...temperature difference      = {:.5R} C", DeltaTemp));
-            ShowContinueError(state, EnergyPlus::format("...calculated volume flow rate = {:.5R} m3/s", (zsCalcSizing.DesHeatVolFlow)));
-            ShowContinueError(state, EnergyPlus::format("...calculated mass flow rate   = {:.5R} kg/s", (zsCalcSizing.DesHeatMassFlow)));
+            ShowContinueError(state, std::format("...zone name = {}", zsCalcSizing.ZoneName));
+            ShowContinueError(state, std::format("...design heating load         = {:.2f} W", zsCalcSizing.DesHeatLoad));
+            ShowContinueError(state, std::format("...thermostat set point temp   = {:.3f} C", zsCalcSizing.HeatTstatTemp));
+            ShowContinueError(state, std::format("...zone temperature            = {:.3f} C", zsCalcSizing.ZoneTempAtHeatPeak));
+            ShowContinueError(state, std::format("...supply air temperature      = {:.3f} C", SupplyTemp));
+            ShowContinueError(state, std::format("...temperature difference      = {:.5f} C", DeltaTemp));
+            ShowContinueError(state, std::format("...calculated volume flow rate = {:.5f} m3/s", (zsCalcSizing.DesHeatVolFlow)));
+            ShowContinueError(state, std::format("...calculated mass flow rate   = {:.5f} kg/s", (zsCalcSizing.DesHeatMassFlow)));
             if (SupplyTemp < zsCalcSizing.ZoneTempAtHeatPeak) {
                 ShowContinueError(state,
                                   "...Note: supply air temperature should be greater than zone temperature during heating air "
@@ -2387,14 +2384,12 @@ void updateZoneSizingEndZoneSizingCalc2(EnergyPlusData &state, DataSizing::ZoneS
             }
         } else if (std::abs(DeltaTemp) > HVAC::SmallTempDiff && SupplyTemp < zsCalcSizing.ZoneTempAtHeatPeak) {
             ShowSevereError(state, "UpdateZoneSizing: Supply air temperature is less than zone temperature during heating air flow calculations");
-            ShowContinueError(state,
-                              EnergyPlus::format("...calculated design heating volume flow rate = {:.5R} m3/s", (zsCalcSizing.DesHeatVolFlow)));
-            ShowContinueError(state,
-                              EnergyPlus::format("...calculated design heating mass flow rate   = {:.5R} kg/s", (zsCalcSizing.DesHeatMassFlow)));
-            ShowContinueError(state, EnergyPlus::format("...thermostat set point temp   = {:.3R} C", zsCalcSizing.HeatTstatTemp));
-            ShowContinueError(state, EnergyPlus::format("...zone temperature            = {:.3R} C", zsCalcSizing.ZoneTempAtHeatPeak));
-            ShowContinueError(state, EnergyPlus::format("...supply air temperature      = {:.3R} C", SupplyTemp));
-            ShowContinueError(state, EnergyPlus::format("...occurs in zone              = {}", zsCalcSizing.ZoneName));
+            ShowContinueError(state, std::format("...calculated design heating volume flow rate = {:.5f} m3/s", (zsCalcSizing.DesHeatVolFlow)));
+            ShowContinueError(state, std::format("...calculated design heating mass flow rate   = {:.5f} kg/s", (zsCalcSizing.DesHeatMassFlow)));
+            ShowContinueError(state, std::format("...thermostat set point temp   = {:.3f} C", zsCalcSizing.HeatTstatTemp));
+            ShowContinueError(state, std::format("...zone temperature            = {:.3f} C", zsCalcSizing.ZoneTempAtHeatPeak));
+            ShowContinueError(state, std::format("...supply air temperature      = {:.3f} C", SupplyTemp));
+            ShowContinueError(state, std::format("...occurs in zone              = {}", zsCalcSizing.ZoneName));
             ShowContinueError(state,
                               "...Note: supply air temperature should be greater than zone temperature during heating air "
                               "flow calculations");
@@ -5257,19 +5252,19 @@ void CalcZoneMassBalance(EnergyPlusData &state, bool const FirstHVACIteration)
                                                              thisZoneEquip.ZoneName));
                                 ShowContinueErrorTimeStamp(state, "");
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("  Flows [m3/s]: Inlets: {:.6R}  Unbalanced exhausts: {:.6R}  Returns: {:.6R}",
-                                                                     thisZoneEquip.TotInletAirMassFlowRate / state.dataEnvrn->StdRhoAir,
-                                                                     sysUnbalExhaust / state.dataEnvrn->StdRhoAir,
-                                                                     totalZoneReturnMassFlow / state.dataEnvrn->StdRhoAir));
+                                                  std::format("  Flows [m3/s]: Inlets: {:.6f}  Unbalanced exhausts: {:.6f}  Returns: {:.6f}",
+                                                              thisZoneEquip.TotInletAirMassFlowRate / state.dataEnvrn->StdRhoAir,
+                                                              sysUnbalExhaust / state.dataEnvrn->StdRhoAir,
+                                                              totalZoneReturnMassFlow / state.dataEnvrn->StdRhoAir));
                                 ShowContinueError(state,
-                                                  EnergyPlus::format("  Infiltration: {:.6R}  Zone Ventilation: {:.6R}  Mixing (incoming): {:.6R}",
-                                                                     thisZoneHB.OAMFL / rhoZone,
-                                                                     thisZoneHB.VAMFL / rhoZone,
-                                                                     thisZoneHB.MixingMassFlowZone / rhoZone));
+                                                  std::format("  Infiltration: {:.6f}  Zone Ventilation: {:.6f}  Mixing (incoming): {:.6f}",
+                                                              thisZoneHB.OAMFL / rhoZone,
+                                                              thisZoneHB.VAMFL / rhoZone,
+                                                              thisZoneHB.MixingMassFlowZone / rhoZone));
                                 ShowContinueError(
                                     state,
-                                    EnergyPlus::format(
-                                        "  Imbalance (excess outflow): {:.6R}  Total system OA flow (for all airloops serving this zone): {:.6R}",
+                                    std::format(
+                                        "  Imbalance (excess outflow): {:.6f}  Total system OA flow (for all airloops serving this zone): {:.6f}",
                                         unbalancedVolFlow,
                                         thisZoneEquip.TotAvailAirLoopOA / state.dataEnvrn->StdRhoAir));
                                 ShowContinueError(state, "  This error will only be reported once per zone.");
@@ -7121,7 +7116,7 @@ void ReportZoneSizingDOASInputs(EnergyPlusData &state,
         headerAlreadyPrinted = true;
     }
 
-    static constexpr std::string_view Format_991(" Zone Sizing DOAS Inputs, {}, {}, {:.3R}, {:.3R}\n");
+    static constexpr std::string_view Format_991(" Zone Sizing DOAS Inputs, {}, {}, {:.3f}, {:.3f}\n");
     print(state.files.eio, Format_991, ZoneName, DOASCtrlStrategy, DOASLowTemp, DOASHighTemp);
 
     // BSLLC Start

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -374,7 +374,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
     }
 
     if (ErrorsFound) {
-        ShowSevereError(state, EnergyPlus::format("GetZoneAirSetpoints: Errors with invalid names in {} objects.", s_ipsc->cCurrentModuleObject));
+        ShowSevereError(state, std::format("GetZoneAirSetpoints: Errors with invalid names in {} objects.", s_ipsc->cCurrentModuleObject));
         ShowContinueError(state, "...These will not be read in.  Other errors may occur.");
         state.dataZoneCtrls->NumTempControlledZones = 0;
     }
@@ -500,23 +500,22 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
                         }
                     } else {
                         ShowSevereError(state,
-                                        EnergyPlus::format("{}=\"{} invalid {}=[{:.0f}].",
-                                                           s_ipsc->cCurrentModuleObject,
-                                                           s_ipsc->cAlphaArgs(1),
-                                                           s_ipsc->cNumericFieldNames(1),
-                                                           s_ipsc->rNumericArgs(1)));
+                                        std::format("{}=\"{} invalid {}=[{:.0f}].",
+                                                    s_ipsc->cCurrentModuleObject,
+                                                    s_ipsc->cAlphaArgs(1),
+                                                    s_ipsc->cNumericFieldNames(1),
+                                                    s_ipsc->rNumericArgs(1)));
                         ShowContinueError(state, "..Allowable values must be greater or equal to 0");
                         ErrorsFound = true;
                     }
                 }
 
                 if (tempZone.DeltaTCutSet > 0.0 && !tempZone.setpts[(int)HVAC::SetptType::SingleHeatCool].Name.empty()) {
-                    ShowWarningError(
-                        state,
-                        EnergyPlus::format("{}=\"{}: The choice of Temperature Difference Between Cutout And Setpoint will not be applied "
-                                           "to ThermostatSetpoint:SingleHeatingOrCooling.",
-                                           s_ipsc->cCurrentModuleObject,
-                                           s_ipsc->cAlphaArgs(1)));
+                    ShowWarningError(state,
+                                     std::format("{}=\"{}: The choice of Temperature Difference Between Cutout And Setpoint will not be applied "
+                                                 "to ThermostatSetpoint:SingleHeatingOrCooling.",
+                                                 s_ipsc->cCurrentModuleObject,
+                                                 s_ipsc->cAlphaArgs(1)));
                 }
             }
         } // NumTStatStatements
@@ -686,12 +685,11 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
 
             int setptIdx = Util::FindItem(setpt.Name, s_ztpc->tempSetptScheds[(int)setptType]);
             if (setptIdx <= 0) {
-                ShowSevereError(
-                    state,
-                    EnergyPlus::format("ZoneControl:Thermostat = {}, control name = {} was not found in ThermostatSetpoint object type = {}.",
-                                       tempZone.Name,
-                                       setpt.Name,
-                                       setptTypeNames[(int)setptType]));
+                ShowSevereError(state,
+                                std::format("ZoneControl:Thermostat = {}, control name = {} was not found in ThermostatSetpoint object type = {}.",
+                                            tempZone.Name,
+                                            setpt.Name,
+                                            setptTypeNames[(int)setptType]));
                 ShowContinueError(state, "  In the input syntax for the ZoneControl:Thermostat, the user must enter valid pairs of control");
                 ShowContinueError(state, "  type and control name.  The ZoneControl:Thermostat control name shown above was either blank or");
                 ShowContinueError(state, "  was not found among the valid ThermostatSetpoint objects.  Either add a ThermostatSetpoint object");
@@ -727,7 +725,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
 
         if (SchedMin == (int)HVAC::SetptType::Uncontrolled && SchedMax == (int)HVAC::SetptType::Uncontrolled) {
             if (FindNumberInList(tempZone.setptTypeSched->Num, CTSchedMapToControlledZone, state.dataZoneCtrls->NumTempControlledZones) == 0) {
-                ShowSevereError(state, EnergyPlus::format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
+                ShowSevereError(state, std::format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
                 ShowContinueError(state, "..specifies control type 0 for all entries.");
                 ShowContinueError(state, "All zones using this Control Type Schedule have no heating or cooling available.");
             }
@@ -740,13 +738,13 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
             if (!setpt.isUsed) {
                 // Catch early issues
                 if (tempZone.setptTypeSched->hasVal(state, (int)setptType)) {
-                    ShowSevereError(state, EnergyPlus::format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
+                    ShowSevereError(state, std::format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
                     ShowContinueError(state,
-                                      EnergyPlus::format("..specifies {} ({}) as the control type. Not valid for this zone.",
-                                                         (int)setptType,
-                                                         setptTypeNames[(int)setptType]));
-                    ShowContinueError(state, EnergyPlus::format("..reference {}={}", cZControlTypes((int)ZoneControlTypes::TStat), tempZone.Name));
-                    ShowContinueError(state, EnergyPlus::format("..reference ZONE={}", tempZone.ZoneName));
+                                      std::format("..specifies {} ({}) as the control type. Not valid for this zone.",
+                                                  (int)setptType,
+                                                  setptTypeNames[(int)setptType]));
+                    ShowContinueError(state, std::format("..reference {}={}", cZControlTypes((int)ZoneControlTypes::TStat), tempZone.Name));
+                    ShowContinueError(state, std::format("..reference ZONE={}", tempZone.ZoneName));
                     ErrorsFound = true;
                 }
                 continue;
@@ -756,13 +754,12 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
                 (setptType == HVAC::SetptType::SingleHeat || setptType == HVAC::SetptType::SingleHeatCool ||
                  setptType == HVAC::SetptType::DualHeatCool) &&
                 tempZone.setptTypeSched->hasVal(state, (int)setptType)) {
-                ShowSevereError(state, EnergyPlus::format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
-                ShowContinueError(state,
-                                  EnergyPlus::format("..specifies {} ({}) as the control type. Not valid for this zone.",
-                                                     (int)setptType,
-                                                     setptTypeNames[(int)setptType]));
-                ShowContinueError(state, EnergyPlus::format("..reference {}={}", cZControlTypes((int)ZoneControlTypes::TStat), tempZone.Name));
-                ShowContinueError(state, EnergyPlus::format("..reference ZONE={}", tempZone.ZoneName));
+                ShowSevereError(state, std::format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
+                ShowContinueError(
+                    state,
+                    std::format("..specifies {} ({}) as the control type. Not valid for this zone.", (int)setptType, setptTypeNames[(int)setptType]));
+                ShowContinueError(state, std::format("..reference {}={}", cZControlTypes((int)ZoneControlTypes::TStat), tempZone.Name));
+                ShowContinueError(state, std::format("..reference ZONE={}", tempZone.ZoneName));
                 ErrorsFound = true;
             }
 
@@ -770,13 +767,12 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
                 (setptType == HVAC::SetptType::SingleCool || setptType == HVAC::SetptType::SingleHeatCool ||
                  setptType == HVAC::SetptType::DualHeatCool) &&
                 tempZone.setptTypeSched->hasVal(state, (int)setptType)) {
-                ShowSevereError(state, EnergyPlus::format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
-                ShowContinueError(state,
-                                  EnergyPlus::format("..specifies {} ({}) as the control type. Not valid for this zone.",
-                                                     (int)setptType,
-                                                     setptTypeNames[(int)setptType]));
-                ShowContinueError(state, EnergyPlus::format("..reference {}={}", cZControlTypes((int)ZoneControlTypes::TStat), tempZone.Name));
-                ShowContinueError(state, EnergyPlus::format("..reference ZONE={}", tempZone.ZoneName));
+                ShowSevereError(state, std::format("Control Type Schedule={}", tempZone.setptTypeSched->Name));
+                ShowContinueError(
+                    state,
+                    std::format("..specifies {} ({}) as the control type. Not valid for this zone.", (int)setptType, setptTypeNames[(int)setptType]));
+                ShowContinueError(state, std::format("..reference {}={}", cZControlTypes((int)ZoneControlTypes::TStat), tempZone.Name));
+                ShowContinueError(state, std::format("..reference ZONE={}", tempZone.ZoneName));
                 ErrorsFound = true;
             }
         } // for (setptType)
@@ -799,7 +795,7 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
             if (!TStatControlTypes(TempControlledZoneNum).MustHave[(int)setptType]) {
                 continue;
             }
-            ShowWarningError(state, EnergyPlus::format("Schedule={}", tempZone.setptTypeSched->Name));
+            ShowWarningError(state, std::format("Schedule={}", tempZone.setptTypeSched->Name));
             ShowContinueError(state,
                               std::format("...should include control type {} ({}) but does not.", (int)setptType, setptTypeNames[(int)setptType]));
             ShowContinueError(state, std::format("..reference {}={}", cZControlTypes((int)ZoneControlTypes::TStat), tempZone.Name));
@@ -2096,11 +2092,11 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
                             if (s_ipsc->rNumericArgs(2 + i) >= s_ipsc->rNumericArgs(1 + i)) {
                                 ShowSevereCustom(state,
                                                  eoh,
-                                                 EnergyPlus::format("{} = {:.1R} must be less than than  {}={:.1R}",
-                                                                    s_ipsc->cNumericFieldNames(2 + i),
-                                                                    s_ipsc->rNumericArgs(2 + i),
-                                                                    s_ipsc->cNumericFieldNames(1 + i),
-                                                                    s_ipsc->rNumericArgs(1 + i)));
+                                                 std::format("{} = {:.1f} must be less than than  {}={:.1f}",
+                                                             s_ipsc->cNumericFieldNames(2 + i),
+                                                             s_ipsc->rNumericArgs(2 + i),
+                                                             s_ipsc->cNumericFieldNames(1 + i),
+                                                             s_ipsc->rNumericArgs(1 + i)));
                                 ErrorsFound = true;
                             }
                         }
@@ -2146,11 +2142,11 @@ void GetZoneAirSetPoints(EnergyPlusData &state)
                         if (i > 1 && s_ipsc->rNumericArgs(8 + i) <= s_ipsc->rNumericArgs(7 + i)) {
                             ShowSevereCustom(state,
                                              eoh,
-                                             EnergyPlus::format("{} = {:.1R} must be greater than {} = {:.1R}",
-                                                                s_ipsc->cNumericFieldNames(8 + i),
-                                                                s_ipsc->rNumericArgs(8 + i),
-                                                                s_ipsc->cNumericFieldNames(7 + i),
-                                                                s_ipsc->rNumericArgs(7 + i)));
+                                             std::format("{} = {:.1f} must be greater than {} = {:.1f}",
+                                                         s_ipsc->cNumericFieldNames(8 + i),
+                                                         s_ipsc->rNumericArgs(8 + i),
+                                                         s_ipsc->cNumericFieldNames(7 + i),
+                                                         s_ipsc->rNumericArgs(7 + i)));
                             ErrorsFound = true;
                         }
                     }
@@ -3098,8 +3094,8 @@ void PredictSystemLoads(EnergyPlusData &state,
                                         "setpoint is greater than the cooling setpoint. ");
                         ShowContinueErrorTimeStamp(
                             state, std::format("occurs in Zone={}", state.dataHeatBal->Zone(thisTempControlledZone.ActualZoneNum).Name));
-                        ShowContinueError(state, EnergyPlus::format("Zone Heating ThermostatSetPoint={:.2R}", zoneTstatSetpt.setptLo));
-                        ShowContinueError(state, EnergyPlus::format("Zone Cooling ThermostatSetPoint={:.2R}", zoneTstatSetpt.setptHi));
+                        ShowContinueError(state, std::format("Zone Heating ThermostatSetPoint={:.2f}", zoneTstatSetpt.setptLo));
+                        ShowContinueError(state, std::format("Zone Cooling ThermostatSetPoint={:.2f}", zoneTstatSetpt.setptHi));
                         ShowFatalError(state, "Program terminates due to above conditions.");
                     }
                 } break;
@@ -3795,12 +3791,11 @@ void ZoneSpaceHeatBalanceData::calcPredictedHumidityRatio(EnergyPlusData &state,
                 ShowSevereError(
                     state, "Humidistat: Unanticipated combination of humidifying and dehumidifying loads - report to EnergyPlus Development Team");
                 ShowContinueErrorTimeStamp(state, std::format("occurs in Zone = {}", thisZone.Name));
-                ShowContinueError(state,
-                                  EnergyPlus::format("LoadToHumidifySetPoint={:.5R}, LoadToDehumidifySetPoint={:.5R}",
-                                                     LoadToHumidifySetPoint,
-                                                     LoadToDehumidifySetPoint));
-                ShowContinueError(state, EnergyPlus::format("Zone RH Humidifying Set-point={:.1R}", ZoneRHHumidifyingSetPoint));
-                ShowContinueError(state, EnergyPlus::format("Zone RH Dehumidifying Set-point={:.2R}", ZoneRHDehumidifyingSetPoint));
+                ShowContinueError(
+                    state,
+                    std::format("LoadToHumidifySetPoint={:.5f}, LoadToDehumidifySetPoint={:.5f}", LoadToHumidifySetPoint, LoadToDehumidifySetPoint));
+                ShowContinueError(state, std::format("Zone RH Humidifying Set-point={:.1f}", ZoneRHHumidifyingSetPoint));
+                ShowContinueError(state, std::format("Zone RH Dehumidifying Set-point={:.2f}", ZoneRHDehumidifyingSetPoint));
                 ShowFatalError(state, "Program terminates due to above conditions.");
             }
         }
@@ -4988,7 +4983,7 @@ void processInverseModelMultpHM(EnergyPlusData &state,
         if (thisZoneHB.hmThermalMassMultErrIndex == 0) {
             ShowWarningMessage(state, std::format("Hybrid model thermal mass multiplier higher than the limit for {}", zone.Name));
             ShowContinueError(state, "This means that the ratio of the zone air heat capacity for the current time step to the");
-            ShowContinueError(state, EnergyPlus::format("zone air heat storage is higher than the maximum limit of {:.1R}.", maxHMMultValue));
+            ShowContinueError(state, std::format("zone air heat storage is higher than the maximum limit of {:.1f}.", maxHMMultValue));
         }
         ShowRecurringWarningErrorAtEnd(
             state, "Hybrid model thermal mass multiplier limit exceeded in zone " + zone.Name, thisZoneHB.hmThermalMassMultErrIndex);
@@ -5672,7 +5667,7 @@ void CalcZoneComponentLoadSums(EnergyPlusData &state,
             (!state.dataGlobal->DoingSizing)) { // air balance is out by more than threshold
             if (thisZone.AirHBimBalanceErrIndex == 0) {
                 ShowWarningMessage(state, std::format("Zone Air Heat Balance is out of balance for zone named {}", thisZone.Name));
-                ShowContinueError(state, EnergyPlus::format("Zone Air Heat Balance Deviation Rate is more than {:.1R} {{W}}", Threshold));
+                ShowContinueError(state, std::format("Zone Air Heat Balance Deviation Rate is more than {:.1f} {{W}}", Threshold));
                 if (state.dataHVACGlobal->TurnFansOn) {
                     ShowContinueError(state, "Night cycle fan operation may be causing above error");
                 }
@@ -7003,11 +6998,10 @@ void ZoneSpaceHeatBalanceData::calcPredictedSystemLoad(EnergyPlusData &state, Re
                             "DualSetPointWithDeadBand if using unmixed air model");
             ShowContinueErrorTimeStamp(state, std::format("occurs in Zone={}", thisZone.Name));
             ShowContinueError(
-                state,
-                EnergyPlus::format("LoadToHeatingSetPoint={:.3R}, LoadToCoolingSetPoint={:.3R}", LoadToHeatingSetPoint, LoadToCoolingSetPoint));
-            ShowContinueError(state, EnergyPlus::format("Zone TempDepZnLd={:.2R}", this->tempDepLoad));
-            ShowContinueError(state, EnergyPlus::format("Zone TempIndZnLd={:.2R}", this->tempIndLoad));
-            ShowContinueError(state, EnergyPlus::format("Zone ThermostatSetPoint={:.2R}", zoneTstatSetpt.setpt));
+                state, std::format("LoadToHeatingSetPoint={:.3f}, LoadToCoolingSetPoint={:.3f}", LoadToHeatingSetPoint, LoadToCoolingSetPoint));
+            ShowContinueError(state, std::format("Zone TempDepZnLd={:.2f}", this->tempDepLoad));
+            ShowContinueError(state, std::format("Zone TempIndZnLd={:.2f}", this->tempIndLoad));
+            ShowContinueError(state, std::format("Zone ThermostatSetPoint={:.2f}", zoneTstatSetpt.setpt));
             ShowFatalError(state, "Program terminates due to above conditions.");
         }
 
@@ -7028,11 +7022,10 @@ void ZoneSpaceHeatBalanceData::calcPredictedSystemLoad(EnergyPlusData &state, Re
                             "SingleHeatCoolSetPoint: Unanticipated combination of heating and cooling loads - report to EnergyPlus Development Team");
             ShowContinueErrorTimeStamp(state, std::format("occurs in Zone={}", thisZone.Name));
             ShowContinueError(
-                state,
-                EnergyPlus::format("LoadToHeatingSetPoint={:.3R}, LoadToCoolingSetPoint={:.3R}", LoadToHeatingSetPoint, LoadToCoolingSetPoint));
-            ShowContinueError(state, EnergyPlus::format("Zone TempDepZnLd={:.2R}", this->tempDepLoad));
-            ShowContinueError(state, EnergyPlus::format("Zone TempIndZnLd={:.2R}", this->tempIndLoad));
-            ShowContinueError(state, EnergyPlus::format("Zone ThermostatSetPoint={:.2R}", zoneTstatSetpt.setpt));
+                state, std::format("LoadToHeatingSetPoint={:.3f}, LoadToCoolingSetPoint={:.3f}", LoadToHeatingSetPoint, LoadToCoolingSetPoint));
+            ShowContinueError(state, std::format("Zone TempDepZnLd={:.2f}", this->tempDepLoad));
+            ShowContinueError(state, std::format("Zone TempIndZnLd={:.2f}", this->tempIndLoad));
+            ShowContinueError(state, std::format("Zone ThermostatSetPoint={:.2f}", zoneTstatSetpt.setpt));
             ShowFatalError(state, "Program terminates due to above conditions.");
         }
     } break;
@@ -7089,12 +7082,11 @@ void ZoneSpaceHeatBalanceData::calcPredictedSystemLoad(EnergyPlusData &state, Re
                             "deadband if using unmixed air model");
             ShowContinueErrorTimeStamp(state, std::format("occurs in Zone={}", thisZone.Name));
             ShowContinueError(
-                state,
-                EnergyPlus::format("LoadToHeatingSetPoint={:.3R}, LoadToCoolingSetPoint={:.3R}", LoadToHeatingSetPoint, LoadToCoolingSetPoint));
-            ShowContinueError(state, EnergyPlus::format("Zone TempDepZnLd={:.2R}", this->tempDepLoad));
-            ShowContinueError(state, EnergyPlus::format("Zone TempIndZnLd={:.2R}", this->tempIndLoad));
-            ShowContinueError(state, EnergyPlus::format("Zone Heating ThermostatSetPoint={:.2R}", zoneTstatSetpt.setptLo));
-            ShowContinueError(state, EnergyPlus::format("Zone Cooling ThermostatSetPoint={:.2R}", zoneTstatSetpt.setptHi));
+                state, std::format("LoadToHeatingSetPoint={:.3f}, LoadToCoolingSetPoint={:.3f}", LoadToHeatingSetPoint, LoadToCoolingSetPoint));
+            ShowContinueError(state, std::format("Zone TempDepZnLd={:.2f}", this->tempDepLoad));
+            ShowContinueError(state, std::format("Zone TempIndZnLd={:.2f}", this->tempIndLoad));
+            ShowContinueError(state, std::format("Zone Heating ThermostatSetPoint={:.2f}", zoneTstatSetpt.setptLo));
+            ShowContinueError(state, std::format("Zone Cooling ThermostatSetPoint={:.2f}", zoneTstatSetpt.setptHi));
             ShowFatalError(state, "Program terminates due to above conditions.");
         }
 
@@ -7118,13 +7110,12 @@ void ZoneSpaceHeatBalanceData::calcPredictedSystemLoad(EnergyPlusData &state, Re
                 state, "DualSetPointWithDeadBand: Unanticipated combination of heating and cooling loads - report to EnergyPlus Development Team");
             ShowContinueErrorTimeStamp(state, std::format("occurs in Zone={}", thisZone.Name));
             ShowContinueError(
-                state,
-                EnergyPlus::format("LoadToHeatingSetPoint={:.3R}, LoadToCoolingSetPoint={:.3R}", LoadToHeatingSetPoint, LoadToCoolingSetPoint));
-            ShowContinueError(state, EnergyPlus::format("Zone Heating Set-point={:.2R}", zoneTstatSetpt.setptLo));
-            ShowContinueError(state, EnergyPlus::format("Zone Cooling Set-point={:.2R}", zoneTstatSetpt.setptHi));
-            ShowContinueError(state, EnergyPlus::format("Zone TempDepZnLd={:.2R}", this->tempDepLoad));
-            ShowContinueError(state, EnergyPlus::format("Zone TempIndZnLd={:.2R}", this->tempIndLoad));
-            ShowContinueError(state, EnergyPlus::format("Zone ThermostatSetPoint={:.2R}", zoneTstatSetpt.setpt));
+                state, std::format("LoadToHeatingSetPoint={:.3f}, LoadToCoolingSetPoint={:.3f}", LoadToHeatingSetPoint, LoadToCoolingSetPoint));
+            ShowContinueError(state, std::format("Zone Heating Set-point={:.2f}", zoneTstatSetpt.setptLo));
+            ShowContinueError(state, std::format("Zone Cooling Set-point={:.2f}", zoneTstatSetpt.setptHi));
+            ShowContinueError(state, std::format("Zone TempDepZnLd={:.2f}", this->tempDepLoad));
+            ShowContinueError(state, std::format("Zone TempIndZnLd={:.2f}", this->tempIndLoad));
+            ShowContinueError(state, std::format("Zone ThermostatSetPoint={:.2f}", zoneTstatSetpt.setpt));
 
             ShowFatalError(state, "Program terminates due to above conditions.");
         }

--- a/tst/EnergyPlus/unit/Coils/CoilCoolingDX.unit.cc
+++ b/tst/EnergyPlus/unit/Coils/CoilCoolingDX.unit.cc
@@ -637,7 +637,7 @@ TEST_F(CoilCoolingDXTest, CoilCoolingDXAlternateModePerformanceHitsSaturation)
 //     Real64 MultiSpeedElecPower6 = Coil.ElecCoolingPower;
 //
 //     Real64 ratedVolFlowRate = state->dataHVACGlobal->MSHPMassFlowRateHigh / ratedRhoAir;
-//     std::string volFlowRateStr = format("{:.4R}", ratedVolFlowRate);
+//     std::string volFlowRateStr = format("{:.4f}", ratedVolFlowRate);
 //
 //     std::string idf_objects = delimited_string({
 //         "  Coil:Cooling:DX,",
@@ -1055,7 +1055,7 @@ TEST_F(CoilCoolingDXTest, CoilCoolingDXAlternateModePerformanceHitsSaturation)
 //     Real64 MultiSpeedElecPower6 = Coil.ElecCoolingPower;
 //
 //     Real64 ratedVolFlowRate = state->dataHVACGlobal->MSHPMassFlowRateHigh / ratedRhoAir;
-//     std::string volFlowRateStr = format("{:.4R}", ratedVolFlowRate);
+//     std::string volFlowRateStr = format("{:.4f}", ratedVolFlowRate);
 //
 //     std::string idf_objects = delimited_string({
 //         "  Coil:Cooling:DX,",

--- a/tst/EnergyPlus/unit/InternalHeatGains.unit.cc
+++ b/tst/EnergyPlus/unit/InternalHeatGains.unit.cc
@@ -1635,14 +1635,14 @@ TEST_F(EnergyPlusFixture, InternalHeatGains_ZoneBaseboardOutdoorTemperatureContr
                           "   **   ~~~   ** ...Capacity passed by parent object to size child component = 0.00 [W]",
                           "   ************* SizeOaControlledBaseboard: Potential issue with equipment sizing for "
                           "ZoneBaseboard:OutdoorTemperatureControlled SECOND ZONE BBHEAT",
-                          "   **   ~~~   ** User-Specified Low Temperature [C] = -5.0",
-                          "   **   ~~~   ** differs from Design Size Low Temperature [C] = -17.3",
+                          "   **   ~~~   ** User-Specified Low Temperature [C] = -5.00",
+                          "   **   ~~~   ** differs from Design Size Low Temperature [C] = -17.30",
                           "   **   ~~~   ** This may, or may not, indicate mismatched component sizes.",
                           "   **   ~~~   ** Verify that the value entered is intended and is consistent with other components.",
                           "   ************* SizeOaControlledBaseboard: Potential issue with equipment sizing for "
                           "ZoneBaseboard:OutdoorTemperatureControlled SECOND ZONE BBHEAT",
-                          "   **   ~~~   ** User-Specified High Temperature [C] = 5.0",
-                          "   **   ~~~   ** differs from Design Size High Temperature [C] = 20.0",
+                          "   **   ~~~   ** User-Specified High Temperature [C] = 5.00",
+                          "   **   ~~~   ** differs from Design Size High Temperature [C] = 20.00",
                           "   **   ~~~   ** This may, or may not, indicate mismatched component sizes.",
                           "   **   ~~~   ** Verify that the value entered is intended and is consistent with other components.",
                           "   ************* SizeOaControlledBaseboard: Potential issue with equipment sizing for "

--- a/tst/EnergyPlus/unit/LowTempRadiantSystem.unit.cc
+++ b/tst/EnergyPlus/unit/LowTempRadiantSystem.unit.cc
@@ -2160,7 +2160,7 @@ TEST_F(LowTempRadiantSystemTest, InitLowTempRadiantSystemCFloPump)
     InitLowTempRadiantSystem(*state, false, RadSysNum, systemType, InitErrorFound);
     actualEfficiencyPercentage = state->dataLowTempRadSys->CFloRadSys(RadSysNum).PumpEffic * 100.0;
     std::string const error_string02 = delimited_string(
-        {EnergyPlus::format("   ** Warning ** Check input.  Calc Pump Efficiency={:.5R}% which is less than 50%, for pump in radiant system {}",
+        {EnergyPlus::format("   ** Warning ** Check input.  Calc Pump Efficiency={:.5f}% which is less than 50%, for pump in radiant system {}",
                             actualEfficiencyPercentage,
                             state->dataLowTempRadSys->CFloRadSys(RadSysNum).Name)});
     EXPECT_EQ(state->dataLowTempRadSys->CFloRadSys(RadSysNum).WaterVolFlowMax, state->dataLowTempRadSys->CFloRadSys(RadSysNum).PumpEffic);
@@ -2205,7 +2205,7 @@ TEST_F(LowTempRadiantSystemTest, InitLowTempRadiantSystemCFloPump)
     InitLowTempRadiantSystem(*state, false, RadSysNum, systemType, InitErrorFound);
     actualEfficiencyPercentage = state->dataLowTempRadSys->CFloRadSys(RadSysNum).PumpEffic * 100.0;
     std::string const error_string03 = delimited_string(
-        {EnergyPlus::format("   ** Warning ** Check input.  Calc Pump Efficiency={:.5R}% is approaching 100%, for pump in radiant system {}",
+        {EnergyPlus::format("   ** Warning ** Check input.  Calc Pump Efficiency={:.5f}% is approaching 100%, for pump in radiant system {}",
                             actualEfficiencyPercentage,
                             state->dataLowTempRadSys->CFloRadSys(RadSysNum).Name)});
     EXPECT_EQ(state->dataLowTempRadSys->CFloRadSys(RadSysNum).WaterVolFlowMax, state->dataLowTempRadSys->CFloRadSys(RadSysNum).PumpEffic);
@@ -2250,7 +2250,7 @@ TEST_F(LowTempRadiantSystemTest, InitLowTempRadiantSystemCFloPump)
     InitLowTempRadiantSystem(*state, false, RadSysNum, systemType, InitErrorFound);
     actualEfficiencyPercentage = state->dataLowTempRadSys->CFloRadSys(RadSysNum).PumpEffic * 100.0;
     std::string const error_string04 = delimited_string(
-        {EnergyPlus::format("   ** Severe  ** Check input.  Calc Pump Efficiency={:.5R}% which is bigger than 100%, for pump in radiant system {}",
+        {EnergyPlus::format("   ** Severe  ** Check input.  Calc Pump Efficiency={:.5f}% which is bigger than 100%, for pump in radiant system {}",
                             actualEfficiencyPercentage,
                             state->dataLowTempRadSys->CFloRadSys(RadSysNum).Name)});
     EXPECT_EQ(state->dataLowTempRadSys->CFloRadSys(RadSysNum).WaterVolFlowMax, state->dataLowTempRadSys->CFloRadSys(RadSysNum).PumpEffic);

--- a/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
+++ b/tst/EnergyPlus/unit/OutputReportTabular.unit.cc
@@ -7612,7 +7612,7 @@ TEST_F(EnergyPlusFixture, AzimuthToCardinal)
         std::string cardinalDir = expectedAzimuthToCard.second;
 
         // Internal: Just to ensure that we gets the same one with round
-        EXPECT_EQ(format("{:.2R}", round(oriAzimuth * 100.0) / 100.0), format("{:.2R}", oriAzimuth));
+        EXPECT_EQ(std::format("{:.2f}", round(oriAzimuth * 100.0) / 100.0), std::format("{:.2f}", oriAzimuth));
 
         // Wall (odd entries)
 
@@ -7622,7 +7622,7 @@ TEST_F(EnergyPlusFixture, AzimuthToCardinal)
         // Check that the azimuth entry is the rounded version indeed
         EXPECT_EQ(
             OutputReportPredefined::RetrievePreDefTableEntry(*state, state->dataOutRptPredefined->pdchOpAzimuth, state->dataSurface->Surface(i).Name),
-            format("{:.2R}", expectedAzimuthToCard.first))
+            std::format("{:.2f}", expectedAzimuthToCard.first))
             << "Surface Name = " << state->dataSurface->Surface(i).Name;
         // Check that we do get the expected cardinal direction
         EXPECT_EQ(
@@ -7637,7 +7637,7 @@ TEST_F(EnergyPlusFixture, AzimuthToCardinal)
         // Check that the azimuth entry is the rounded version indeed
         EXPECT_EQ(OutputReportPredefined::RetrievePreDefTableEntry(
                       *state, state->dataOutRptPredefined->pdchFenAzimuth, state->dataSurface->Surface(i + 1).Name),
-                  format("{:.2R}", expectedAzimuthToCard.first))
+                  std::format("{:.2f}", expectedAzimuthToCard.first))
             << "Surface Name = " << state->dataSurface->Surface(i + 1).Name;
         // Check that we do get the expected cardinal direction
         EXPECT_EQ(OutputReportPredefined::RetrievePreDefTableEntry(

--- a/tst/EnergyPlus/unit/SimAirServingZones.unit.cc
+++ b/tst/EnergyPlus/unit/SimAirServingZones.unit.cc
@@ -1168,7 +1168,7 @@ TEST_F(EnergyPlusFixture, SizeAirLoopBranches_0Airflow)
     SimAirServingZones::InitAirLoops(*state, true);
     // Expect warnings about 0 airflow
     std::string error_msg = delimited_string({
-        "   ** Severe  ** SizeAirLoopBranches: AirLoopHVAC VAV SYS 1 has air flow less than 1.0000E-003 m3/s.",
+        "   ** Severe  ** SizeAirLoopBranches: AirLoopHVAC VAV SYS 1 has air flow less than 0.0010 m3/s.",
         "   **   ~~~   ** Primary air system volumetric flow rate = 0.0000 m3/s.",
         "   **   ~~~   ** Check flow rate inputs for components in this air loop and,",
         "   **   ~~~   ** if autosized, check Sizing:Zone and Sizing:System objects and related inputs.",

--- a/tst/EnergyPlus/unit/SimulationManager.unit.cc
+++ b/tst/EnergyPlus/unit/SimulationManager.unit.cc
@@ -156,7 +156,7 @@ TEST_F(EnergyPlusFixture, Simulationmanager_writeInitialPerfLogValues)
     std::string expectedContents = "Program, Version, TimeStamp,Use Coil Direct Solution,Zone Radiant Exchange Algorithm,"
                                    "Override Mode,Number of Timesteps per Hour,Minimum Number of Warmup "
                                    "Days,SuppressAllBeginEnvironmentResets,Minimum System Timestep,MaxZoneTempDiff,MaxAllowedDelTemp,lastHeader,\n" +
-                                   state->dataStrGlobals->VerStringVar + ",False,ScriptF,MODE193,0,1,False,1.0,0.30,2.0000E-003,lastValue,\n";
+                                   state->dataStrGlobals->VerStringVar + ",False,ScriptF,MODE193,0,1,False,1.0,0.30,0.0020,lastValue,\n";
 
     EXPECT_EQ(perfLogContents, expectedContents);
 

--- a/tst/EnergyPlus/unit/WaterToAirHeatPumpSimple.unit.cc
+++ b/tst/EnergyPlus/unit/WaterToAirHeatPumpSimple.unit.cc
@@ -216,7 +216,7 @@ TEST_F(EnergyPlusFixture, WaterToAirHeatPumpSimpleTest_SizeHVACWaterToAir)
 
     if (wahpSimple1.RatedCapCoolTotal != 0.0) {
         ShowMessage(*state,
-                    EnergyPlus::format("SizeHVACWaterToAir: Rated Sensible Heat Ratio = {:.2R} [-]",
+                    EnergyPlus::format("SizeHVACWaterToAir: Rated Sensible Heat Ratio = {:.2f} [-]",
                                        wahpSimple1.RatedCapCoolSens / wahpSimple1.RatedCapCoolTotal));
     }
     EXPECT_TRUE(compare_eio_stream_substring("Design Size Rated Air Flow Rate", false));


### PR DESCRIPTION
﻿Part 6 of the Remove-fmt campaign (drop vendored `third_party/fmt` for C++20 `std::format`). Converts the **S-Z** source files; sibling to part 4 (#11619, I*, merged) and part 5 (#11630, J-R, open). No file overlap with part 5.

## Scope
36 files (S-Z basenames): **855 `{:.NR}` -> `{:.Nf}`**, ~1040 `EnergyPlus::format`/`fmt::format` -> `std::format`. 0 residual `{R}` in these files.

## Kept on original entry point (std::format cannot express)
- **11 raw-enum args** (no `std::formatter`) -> kept `EnergyPlus::format`: SurfaceGeometry x6 (`CalculationMethod`), WaterToAirHeatPumpSimple x2 (`WAHPType`), SteamBaseboardRadiator (`EquipType`), UnitarySystem (`.type`), ZoneTempPredictorCorrector (`TempControlType`).
- **1 runtime/string-spec call** (`{:2.2F}` on `std::string`, pre-existing) -> kept `EnergyPlus::format` (ScheduleManager).
- **1 `fmt::join`** -> kept `fmt::format` (ZoneTempPredictorCorrector).

## Notable
- Fixed one malformed spec `{.0R}` (missing colon) -> `{:.0f}` (WeatherManager) as part of the `{R}` removal.
- Updated 2 unit-test expected strings where sub-0.1 values switch from `{R}` scientific to `{:.Nf}` fixed (SimAirServingZones, SimulationManager).
- **No `{:#G}`** introduced (it is non-portable: `0.500000` MSVC/libstdc++ vs `0.50000` macOS libc++). All conversions are portable `{:.Nf}`/`{:.NE}`.

Label: Refactoring (matches parts 1-5).
