### PR TITLE
Fix #11626 - Support existing ZoneControl:Humidistat in HVACTemplate:Zone:IdealLoadsAirSystem

### DIFF
--- a/doc/input-output-reference/src/hvac-template-objects/group-hvac-templates.tex
+++ b/doc/input-output-reference/src/hvac-template-objects/group-hvac-templates.tex
@@ -393,11 +393,36 @@ The name of a schedule (ref: Schedule) that denotes whether cooling is available
 
 \paragraph{Field: Dehumidification Control Type}\label{field-dehumidification-control-type-000}
 
-Select from \emph{ConstantSensibleHeatRatio}, \emph{Humidistat, None, or ConstantSupplyHumidityRatio}. \emph{ConstantSensibleHeatRatio} (the default) means that the ideal loads system will be controlled to meet the sensible cooling load, and the latent cooling rate will be computed using a constant sensible heat ratio (SHR) (see next field). \emph{Humidistat} means that there is a \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} for this zone and the ideal loads system will attempt to meet the humidistat request (i.e.~will dehumidify according to the Dehumidifying Relative Humidity Schedule in the \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} object). \emph{None} means that there is no dehumidification. \emph{ConstantSupplyHumidityRatio} means that during cooling the supply air will always be at the Minimum Cooling Supply Humidity Ratio. For \emph{ConstantSensibleHeatRatio} and \emph{Humidistat}, if the mixed air humidity ratio is less than the target humidity ratio, then the mixed air humidity ratio will be used. For all options, the supply air humidity ratio will never be allowed to exceed saturation at the supply dry bulb temperature.
+Select from the following:
+
+\begin{itemize}
+\item
+  \emph{ConstantSensibleHeatRatio} (the default): the ideal loads system will be controlled to meet the sensible cooling load, and the latent cooling rate will be computed using a constant sensible heat ratio (SHR) (see the Cooling Sensible Heat Ratio field below).
+\item
+  \emph{Humidistat}: there is a \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} for this zone and the ideal loads system will attempt to meet the humidistat request (i.e.~will dehumidify according to the Dehumidifying Relative Humidity Schedule in the \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} object).
+\item
+  \emph{None}: there is no dehumidification.
+\item
+  \emph{ConstantSupplyHumidityRatio}: during cooling the supply air will always be at the Minimum Cooling Supply Humidity Ratio.
+\end{itemize}
+
+For \emph{ConstantSensibleHeatRatio} and \emph{Humidistat}, if the mixed air humidity ratio is less than the target humidity ratio, then the mixed air humidity ratio will be used. For all options, the supply air humidity ratio will never be allowed to exceed saturation at the supply dry bulb temperature.
 
 The selected dehumidification control type is always applied when the unit is in cooling mode. If the unit is in deadband mode (not actively heating the supply air) control type \emph{Humidistat} will be active. If the unit is in heating mode, control type \emph{Humidistat} will be active if the Humidification Control Type field below is set to \emph{Humidistat} or \emph{None}.
 
 This allows the ideal loads system to heat and dehumidify at the same time.
+
+\begin{center}\rule{0.5\linewidth}{0.4pt}\end{center}
+
+\textbf{Note: About the creation of ZoneControl:Humidistat}
+
+When the \hyperref[field-dehumidification-control-type-000]{Dehumidification Control Type} or the \hyperref[field-humidification-control-type]{Humidification Control Type} (or both) is set to \emph{Humidistat}, ExpandObjects checks whether a \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} object already references this zone.
+
+If none is found, ExpandObjects automatically creates one, with its Dehumidifying and/or Humidifying Relative Humidity Setpoint Schedule Name fields generated from the Dehumidification Setpoint and Humidification Setpoint fields above (using \emph{HVACTemplate-Always} schedules).
+If only one of the two control types is set to \emph{Humidistat}, the other setpoint schedule of the generated object is set so that it never triggers: 1\% for the Humidifying Relative Humidity Setpoint Schedule when only Dehumidification Control Type = \emph{Humidistat}, or 100\% for the Dehumidifying Relative Humidity Setpoint Schedule when only Humidification Control Type = \emph{Humidistat}.
+
+If a \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} object already exists for the zone, ExpandObjects will not create a new one (a warning is issued) and the existing object is used as-is. In that case, if Dehumidification Control Type = \emph{Humidistat}, the existing object's Dehumidifying Relative Humidity Setpoint Schedule Name field must not be blank, and if Humidification Control Type = \emph{Humidistat}, its Humidifying Relative Humidity Setpoint Schedule Name field must not be blank; otherwise ExpandObjects will issue a fatal error.
+
 
 \paragraph{Field: Cooling Sensible Heat Ratio}\label{field-cooling-sensible-heat-ratio}
 
@@ -409,7 +434,18 @@ This field specifies the zone humidistat relative humidity setpoint for dehumidi
 
 \paragraph{Field: Humidification Control Type}\label{field-humidification-control-type}
 
-Select from \emph{None}, \emph{Humidistat, or ConstantSupplyHumidityRatio}. \emph{None} means that there is no humidification. \emph{Humidistat} means that there is a \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} for this zone and the ideal loads system will attempt to meet the humidistat request (i.e., humidify according to the Humidifying Relative Humidity Setpoint Schedule in the \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} object). \emph{ConstantSupplyHumidityRatio} means that during heating the supply air will always be at the Maximum Heating Supply Humidity Ratio. The default is \emph{None}. For \emph{Humidistat}, if the mixed air humidity ratio is greater than the target humidity ratio, then the mixed air humidity ratio will be used. For all options, the supply air humidity ratio will never be allowed to exceed saturation at the supply dry bulb temperature.
+Select from the following:
+
+\begin{itemize}
+\item
+  \emph{None} (the default): there is no humidification.
+\item
+  \emph{Humidistat}: there is a \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} for this zone and the ideal loads system will attempt to meet the humidistat request (i.e.~will humidify according to the Humidifying Relative Humidity Setpoint Schedule in the \hyperref[zonecontrolhumidistat]{ZoneControl:Humidistat} object).
+\item
+  \emph{ConstantSupplyHumidityRatio}: during heating the supply air will always be at the Maximum Heating Supply Humidity Ratio.
+\end{itemize}
+
+For \emph{Humidistat}, if the mixed air humidity ratio is greater than the target humidity ratio, then the mixed air humidity ratio will be used. For all options, the supply air humidity ratio will never be allowed to exceed saturation at the supply dry bulb temperature.
 
 The selected humidification control type is always applied when the unit is in heating mode. If the unit is in deadband mode (not actively heating the supply air) control type \emph{Humidistat} will be active. If the unit is in cooling mode, control type \emph{Humidistat} will be active if the Dehumidification Control Type field above is set to \emph{Humidistat} or \emph{None}.
 

--- a/src/ExpandObjects/CMakeLists.txt
+++ b/src/ExpandObjects/CMakeLists.txt
@@ -37,3 +37,14 @@ if(APPLE AND CPACK_CODESIGNING_DEVELOPPER_ID_APPLICATION)
   include("${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/CodeSigning.cmake")
   register_install_codesign_target(ExpandObjects "." Unspecified)
 endif()
+
+if(BUILD_TESTING)
+  if(Pytest_AVAILABLE)
+    add_test(NAME ExpandObjects.tests
+      COMMAND ${Python_EXECUTABLE} -m pytest --verbose
+              --expandobjects-cli-path $<TARGET_FILE:ExpandObjects>
+              "${CMAKE_CURRENT_SOURCE_DIR}/tests/"
+    )
+    set_tests_properties(ExpandObjects.tests PROPERTIES TIMEOUT 120)
+  endif()
+endif()

--- a/src/ExpandObjects/epfilter.f90
+++ b/src/ExpandObjects/epfilter.f90
@@ -1544,6 +1544,14 @@ INTEGER,PARAMETER :: twrvsInletNodeOff = 2
 INTEGER,PARAMETER :: twrvsOutletNodeOff = 3
 INTEGER,PARAMETER :: twrvsLastFieldOff = 31
 
+  ! ZoneControl:Humidistat (registered as pass-through so existing user-defined
+  ! instances can be scanned for one already controlling a given zone)
+INTEGER,PARAMETER :: zchNameOff = 1
+INTEGER,PARAMETER :: zchZoneNameOff = 2
+INTEGER,PARAMETER :: zchHumidifyingSchedNameOff = 3
+INTEGER,PARAMETER :: zchDehumidifyingSchedNameOff = 4
+INTEGER,PARAMETER :: zchControlVariableOff = 5
+
 !following objects are identified just by the first and last fields
 INTEGER,PARAMETER :: ghtBsSimParamFirstOff = 1
 INTEGER,PARAMETER :: ghtBsSimParamLastOff = 2
@@ -1715,6 +1723,10 @@ INTEGER                            :: ptCompactBoilerOR=0
 INTEGER, ALLOCATABLE, DIMENSION(:) :: detBoilerHWBase
 INTEGER                            :: numDetBoilerHW=0
 INTEGER                            :: ptDetBoilerHW=0
+
+INTEGER, ALLOCATABLE, DIMENSION(:) :: detZCHumidistatBase
+INTEGER                            :: numDetZCHumidistat=0
+INTEGER                            :: ptDetZCHumidistat=0
 
 INTEGER                            :: compactHotLoopBase = 0
 INTEGER                            :: ptCompactHotLoop=0
@@ -2522,6 +2534,7 @@ CALL AddObjToProcess('Chiller:Electric:ReformulatedEIR',.FALSE.,    chlreirCondO
 CALL AddObjToProcess('CoolingTower:SingleSpeed',.FALSE.,            twrssOutletNodeOff,          twrssLastFieldOff,         29)
 CALL AddObjToProcess('CoolingTower:TwoSpeed',.FALSE.,               twrtsOutletNodeOff,          twrtsLastFieldOff,         32)
 CALL AddObjToProcess('CoolingTower:VariableSpeed',.FALSE.,          twrvsOutletNodeOff,          twrvsLastFieldOff,         30)
+CALL AddObjToProcess('ZoneControl:Humidistat',.FALSE.,              zchZoneNameOff,              zchControlVariableOff,      5)
 ! Ground Heat Transfer
 CALL AddObjToProcess('GroundHeatTransfer:Control',.TRUE.,           ghtCtrlNameOff,              ghtCtrlSlabOff,             3)
 IF (doGatherSurfaces) THEN !only gather these surfaces if groundheattransfer has been found.
@@ -6828,6 +6841,9 @@ INTEGER    :: actCount
 INTEGER    :: fldValStart
 INTEGER    :: fldValEnd
 INTEGER    :: iObj
+LOGICAL    :: isAnyHumidistatRequested = .FALSE.
+LOGICAL    :: isDehumCtrlTypeHumidistat
+LOGICAL    :: isHumidCtrlTypeHumidistat
 
 CALL CountOldObj('HVACTemplate:Zone:IdealLoadsAirSystem',ptCompactPurchAir,prelimCount)
 
@@ -6861,9 +6877,32 @@ DO iObj= 1, prelimCount
     CALL SetIfBlank(fldValStart + pazHeatRecTypeOff, 'None')
     CALL SetIfBlank(fldValStart + pazHeatRecSenEffOff, '0.7')
     CALL SetIfBlank(fldValStart + pazHeatRecLatEffOff, '0.65')
+
+    isDehumCtrlTypeHumidistat = SameString(FldVal(fldValStart + pazDehumCtrlTypeOff),'Humidistat')
+    isHumidCtrlTypeHumidistat = SameString(FldVal(fldValStart + pazHumidCtrlTypeOff),'Humidistat')
+    IF (isDehumCtrlTypeHumidistat .OR. isHumidCtrlTypeHumidistat) THEN
+      isAnyHumidistatRequested = .TRUE.
+    END IF
   END IF
 END DO
 numCompactPurchAir = actCount
+
+IF (isAnyHumidistatRequested) THEN
+  ! Pre-scan existing ZoneControl:Humidistat objects so each zone can later check
+  ! whether the user already defined one pointing to it
+  CALL CountOldObj('ZoneControl:Humidistat',ptDetZCHumidistat,prelimCount)
+  ALLOCATE(detZCHumidistatBase(prelimCount))
+  actCount = 0
+  DO iObj = 1, prelimCount
+    CALL NextOldObj(ptDetZCHumidistat,fldValStart,fldValEnd)
+    IF (fldValEnd - fldValStart .EQ. zchControlVariableOff) THEN
+      actCount = actCount + 1
+      detZCHumidistatBase(actCount) = fldValStart
+    END IF
+  END DO
+  numDetZCHumidistat = actCount
+END IF
+
 END SUBROUTINE
 
 !----------------------------------------------------------------------------------
@@ -24467,6 +24506,9 @@ LOGICAL :: isAnyZoneAutosized = .FALSE.
 LOGICAL :: isNoEconomizer = .FALSE.
 LOGICAL :: isCoolFlowLimited = .FALSE.
 
+INTEGER :: humidistatIdx = -1
+CHARACTER(len=MaxAlphaLength) :: existingHumidistatName = ''
+
 ! Check if any of the HVACTemplate:Zone:IdealLoadsAirSystem objects have an autosized field
 isAnyZoneAutosized = .FALSE.
 DO iPurchAir = 1, numCompactPurchAir
@@ -24605,45 +24647,80 @@ DO iPurchAir = 1, numCompactPurchAir
   END IF
 
   ! Humdistat(s) if needed
-  !    Single humidistat if humidification and dehumidification are both active
-  IF ((isHumidCtrlTypeHumidistat) .AND. (isDehumCtrlTypeHumidistat)) THEN
-    CALL CreateNewObj('ZoneControl:Humidistat')
-    CALL AddToObjFld('Name', base + pazNameOff,' Humidistat')
-    CALL AddToObjFld('Zone Name', base + pazNameOff,'')
-    CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
-                     'HVACTemplate-Always ' // TRIM(FldVal(base + pazHumidSetPtOff)))
-    CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
-                     'HVACTemplate-Always ' // TRIM(FldVal(base + pazDehumSetPtOff)),.TRUE.)
+  humidistatIdx = -1
+  IF ((isHumidCtrlTypeHumidistat) .OR. (isDehumCtrlTypeHumidistat)) THEN
+    ! Scan existing ZoneControl:Humidistat objects for one already pointing to this zone
+    DO ptDetZCHumidistat = 1, numDetZCHumidistat
+      IF (SameString(FldVal(detZCHumidistatBase(ptDetZCHumidistat) + zchZoneNameOff), FldVal(base + pazNameOff))) THEN
+        humidistatIdx = detZCHumidistatBase(ptDetZCHumidistat)
+        EXIT
+      END IF
+    END DO
+    IF (humidistatIdx .NE. -1) THEN
+      existingHumidistatName = TRIM(FldVal(humidistatIdx + zchNameOff))
 
-    CALL AddAlwaysSchedule(FldVal(base + pazHumidSetPtOff))
-    CALL AddAlwaysSchedule(FldVal(base + pazDehumSetPtOff))
+      CALL WriteError('Warning: In HVACTemplate:Zone:IdealLoadsAirSystem "'//TRIM(FldVal(base + pazNameOff))//'"'// &
+                      ' a ZoneControl:Humidistat named "'//TRIM(existingHumidistatName)//'" was already'// &
+                      ' defined for this zone, so the HVACTemplate-generated humidistat will not be created.',msgWarning)
 
-  ELSE
-    IF (isDehumCtrlTypeHumidistat) THEN
-  !   Dehumidification humidistat
+
+      IF (isHumidCtrlTypeHumidistat .AND. (TRIM(FldVal(humidistatIdx + zchHumidifyingSchedNameOff)) .EQ. '')) THEN
+        CALL WriteError('In HVACTemplate:Zone:IdealLoadsAirSystem "'//TRIM(FldVal(base + pazNameOff))//'"'// &
+                        ' the Humidification Control Type field is Humidistat, but the existing'// &
+                        ' ZoneControl:Humidistat named "'//TRIM(existingHumidistatName)//'" for this zone'// &
+                        ' has a blank Humidifying Relative Humidity Setpoint Schedule Name.')
+      END IF
+      IF (isDehumCtrlTypeHumidistat .AND. (TRIM(FldVal(humidistatIdx + zchDehumidifyingSchedNameOff)) .EQ. '')) THEN
+        CALL WriteError('In HVACTemplate:Zone:IdealLoadsAirSystem "'//TRIM(FldVal(base + pazNameOff))//'"'// &
+                        ' the Dehumidification Control Type field is Humidistat, but the existing'// &
+                        ' ZoneControl:Humidistat named "'//TRIM(existingHumidistatName)//'" for this zone'// &
+                        ' has a blank Dehumidifying Relative Humidity Setpoint Schedule Name.')
+      END IF
+
+    END IF
+  END IF
+
+  IF (humidistatIdx .EQ. -1) THEN ! .NOT. isExistingHumidistatFound
+    !    Single humidistat if humidification and dehumidification are both active
+    IF ((isHumidCtrlTypeHumidistat) .AND. (isDehumCtrlTypeHumidistat)) THEN
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + pazNameOff,' Humidistat')
       CALL AddToObjFld('Zone Name', base + pazNameOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
+      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+                       'HVACTemplate-Always ' // TRIM(FldVal(base + pazHumidSetPtOff)))
       CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
                        'HVACTemplate-Always ' // TRIM(FldVal(base + pazDehumSetPtOff)),.TRUE.)
 
-      CALL AddAlwaysSchedule('1')
-      CALL AddAlwaysSchedule(FldVal(base + pazDehumSetPtOff))
-    ENDIF
-    IF (isHumidCtrlTypeHumidistat) THEN
-  !    Humidification humidistat
-      CALL CreateNewObj('ZoneControl:Humidistat')
-      CALL AddToObjFld('Name', base + pazNameOff,' Humidification Humidistat')
-      CALL AddToObjFld('Zone Name', base + pazNameOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
-                       'HVACTemplate-Always ' // TRIM(FldVal(base + pazHumidSetPtOff)))
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
-
       CALL AddAlwaysSchedule(FldVal(base + pazHumidSetPtOff))
-      CALL AddAlwaysSchedule('100')
+      CALL AddAlwaysSchedule(FldVal(base + pazDehumSetPtOff))
+
+    ELSE
+      IF (isDehumCtrlTypeHumidistat) THEN
+    !   Dehumidification humidistat
+        CALL CreateNewObj('ZoneControl:Humidistat')
+        CALL AddToObjFld('Name', base + pazNameOff,' Humidistat')
+        CALL AddToObjFld('Zone Name', base + pazNameOff,'')
+        CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
+        CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
+                         'HVACTemplate-Always ' // TRIM(FldVal(base + pazDehumSetPtOff)),.TRUE.)
+
+        CALL AddAlwaysSchedule('1')
+        CALL AddAlwaysSchedule(FldVal(base + pazDehumSetPtOff))
+      ENDIF
+      IF (isHumidCtrlTypeHumidistat) THEN
+    !    Humidification humidistat
+        CALL CreateNewObj('ZoneControl:Humidistat')
+        CALL AddToObjFld('Name', base + pazNameOff,' Humidification Humidistat')
+        CALL AddToObjFld('Zone Name', base + pazNameOff,'')
+        CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+                         'HVACTemplate-Always ' // TRIM(FldVal(base + pazHumidSetPtOff)))
+        CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
+
+        CALL AddAlwaysSchedule(FldVal(base + pazHumidSetPtOff))
+        CALL AddAlwaysSchedule('100')
+      ENDIF
     ENDIF
-  ENDIF
+  END IF
 
 
       !ZONE SIZING - If one or more zones need a sizing:zone object, add it for all zones to prevent warnings

--- a/src/ExpandObjects/epfilter.f90
+++ b/src/ExpandObjects/epfilter.f90
@@ -11024,9 +11024,9 @@ DO iSys = 1, numCompactSysVAV
     CALL CreateNewObj('ZoneControl:Humidistat')
     CALL AddToObjFld('Name', base + vsAirHandlerNameOff,' Humidistat')
     CALL AddToObjFld('Zone Name', base + vsDehumCtrlZoneOff,'')
-    CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+    CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                      'HVACTemplate-Always ' // TRIM(FldVal(base + vsHumidSetPtOff)))
-    CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
+    CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', &
                      'HVACTemplate-Always ' // TRIM(FldVal(base + vsDehumSetPtOff)),.TRUE.)
 
     CALL AddAlwaysSchedule(FldVal(base + vsHumidSetPtOff))
@@ -11038,8 +11038,8 @@ DO iSys = 1, numCompactSysVAV
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + vsAirHandlerNameOff,' Dehumidification Humidistat')
       CALL AddToObjFld('Zone Name', base + vsDehumCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name','HVACTemplate-Always 1')
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', &
                        'HVACTemplate-Always ' // TRIM(FldVal(base + vsDehumSetPtOff)),.TRUE.)
 
       CALL AddAlwaysSchedule('1')
@@ -11050,9 +11050,9 @@ DO iSys = 1, numCompactSysVAV
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + vsAirHandlerNameOff,' Humidification Humidistat')
       CALL AddToObjFld('Zone Name', base + vsHumidCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                        'HVACTemplate-Always ' // TRIM(FldVal(base + vsHumidSetPtOff)))
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
 
       CALL AddAlwaysSchedule(FldVal(base + vsHumidSetPtOff))
       CALL AddAlwaysSchedule('100')
@@ -12699,9 +12699,9 @@ DO iSys = 1, numCompactSysPVAV
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + pvavsAirHandlerNameOff,' Humidistat')
       CALL AddToObjFld('Zone Name', base + pvavsDehumCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                        'HVACTemplate-Always ' // TRIM(FldVal(base + pvavsHumidSetPtOff)))
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', &
                        'HVACTemplate-Always ' // TRIM(FldVal(base + pvavsDehumSetPtOff)),.TRUE.)
       CALL AddAlwaysSchedule(FldVal(base + pvavsHumidSetPtOff))
       CALL AddAlwaysSchedule(FldVal(base + pvavsDehumSetPtOff))
@@ -12712,8 +12712,8 @@ DO iSys = 1, numCompactSysPVAV
         CALL CreateNewObj('ZoneControl:Humidistat')
         CALL AddToObjFld('Name', base + pvavsAirHandlerNameOff,' Dehumidification Humidistat')
         CALL AddToObjFld('Zone Name', base + pvavsDehumCtrlZoneOff,'')
-        CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
-        CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
+        CALL AddToObjStr('Humidifying Setpoint Schedule Name','HVACTemplate-Always 1')
+        CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', &
                          'HVACTemplate-Always ' // TRIM(FldVal(base + pvavsDehumSetPtOff)),.TRUE.)
 
         CALL AddAlwaysSchedule('1')
@@ -12725,9 +12725,9 @@ DO iSys = 1, numCompactSysPVAV
         CALL CreateNewObj('ZoneControl:Humidistat')
         CALL AddToObjFld('Name', base + pvavsAirHandlerNameOff,' Humidification Humidistat')
         CALL AddToObjFld('Zone Name', base + pvavsHumidCtrlZoneOff,'')
-        CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+        CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                          'HVACTemplate-Always ' // TRIM(FldVal(base + pvavsHumidSetPtOff)))
-        CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
+        CALL AddToObjStr('Dehumidifying Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
 
         CALL AddAlwaysSchedule(FldVal(base + pvavsHumidSetPtOff))
         CALL AddAlwaysSchedule('100')
@@ -14204,9 +14204,9 @@ DO iSys = 1, numCompactSysUnit
     CALL CreateNewObj('ZoneControl:Humidistat')
     CALL AddToObjFld('Name', base + usAirHandlerNameOff,' Humidistat')
     CALL AddToObjFld('Zone Name', base + usControlZoneOff,'')
-    CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+    CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                      'HVACTemplate-Always ' // TRIM(FldVal(base + usHumidSetPtOff)))
-    CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
+    CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', &
                      'HVACTemplate-Always ' // TRIM(FldVal(base + usDehumSetPtOff)),.TRUE.)
 
     CALL AddAlwaysSchedule(FldVal(base + usHumidSetPtOff))
@@ -14218,8 +14218,8 @@ DO iSys = 1, numCompactSysUnit
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + usAirHandlerNameOff,' Dehumidification Humidistat')
       CALL AddToObjFld('Zone Name', base + usControlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name','HVACTemplate-Always 1')
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', &
                        'HVACTemplate-Always ' // TRIM(FldVal(base + usDehumSetPtOff)),.TRUE.)
 
       CALL AddAlwaysSchedule('1')
@@ -14230,9 +14230,9 @@ DO iSys = 1, numCompactSysUnit
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + usAirHandlerNameOff,' Humidification Humidistat')
       CALL AddToObjFld('Zone Name', base + usHumidCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                        'HVACTemplate-Always ' // TRIM(FldVal(base + usHumidSetPtOff)))
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
 
       CALL AddAlwaysSchedule(FldVal(base + usHumidSetPtOff))
       CALL AddAlwaysSchedule('100')
@@ -15193,9 +15193,9 @@ DO iSys = 1, numCompactSysUnitHP
     CALL CreateNewObj('ZoneControl:Humidistat')
     CALL AddToObjFld('Name', base + uhpsAirHandlerNameOff,' Humidistat')
     CALL AddToObjFld('Zone Name', base + uhpsHumidCtrlZoneOff,'')
-    CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+    CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                      'HVACTemplate-Always ' // TRIM(FldVal(base + uhpsHumidSetPtOff)))
-    CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', ' ',.TRUE.)
+    CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', ' ',.TRUE.)
     CALL AddAlwaysSchedule(FldVal(base + uhpsHumidSetPtOff))
     !Object ==> SetpointManager:SingleZone:Humidity:Minimum
     CALL CreateNewObj('SetpointManager:SingleZone:Humidity:Minimum')
@@ -16289,16 +16289,16 @@ DO iSys = 1, numCompactSysUnitarySystem
     CALL CreateNewObj('ZoneControl:Humidistat')
     CALL AddToObjFld('Name', base + ussAirHandlerNameOff,' Humidistat')
     CALL AddToObjFld('Zone Name', base + ussControlZoneOff,'')
-    CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', TRIM(humscheduleName))
-    CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
+    CALL AddToObjStr('Humidifying Setpoint Schedule Name', TRIM(humscheduleName))
+    CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
   ELSE
     IF (.NOT. isDehumidifyNone) THEN
   !   Dehumidification humidistat
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + ussAirHandlerNameOff,' Dehumidification Humidistat')
       CALL AddToObjFld('Zone Name', base + ussControlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name','HVACTemplate-Always 1')
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
 
       CALL AddAlwaysSchedule('1')
     ENDIF
@@ -16307,8 +16307,8 @@ DO iSys = 1, numCompactSysUnitarySystem
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + ussAirHandlerNameOff,' Humidification Humidistat')
       CALL AddToObjFld('Zone Name', base + ussHumidCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', TRIM(humscheduleName))
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name', TRIM(humscheduleName))
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
 
       CALL AddAlwaysSchedule('100')
     ENDIF
@@ -20229,16 +20229,16 @@ DO iSys = 1, numCompactSysConstVol
     CALL CreateNewObj('ZoneControl:Humidistat')
     CALL AddToObjFld('Name', base + cvsAirHandlerNameOff,' Humidistat')
     CALL AddToObjFld('Zone Name', base + cvsDehumCtrlZoneOff,'')
-    CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', TRIM(humscheduleName))
-    CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
+    CALL AddToObjStr('Humidifying Setpoint Schedule Name', TRIM(humscheduleName))
+    CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
   ELSE
     IF (.NOT. isDehumidifyNone) THEN
   !   Dehumidification humidistat
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + cvsAirHandlerNameOff,' Dehumidification Humidistat')
       CALL AddToObjFld('Zone Name', base + cvsDehumCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name','HVACTemplate-Always 1')
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
 
       CALL AddAlwaysSchedule('1')
     ENDIF
@@ -20247,8 +20247,8 @@ DO iSys = 1, numCompactSysConstVol
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + cvsAirHandlerNameOff,' Humidification Humidistat')
       CALL AddToObjFld('Zone Name', base + cvsHumidCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', TRIM(humscheduleName))
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name', TRIM(humscheduleName))
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
 
       CALL AddAlwaysSchedule('100')
     ENDIF
@@ -22000,16 +22000,16 @@ DO iSys = 1, numCompactSysDualDuct
     CALL CreateNewObj('ZoneControl:Humidistat')
     CALL AddToObjFld('Name', base + ddsAirHandlerNameOff,' Humidistat')
     CALL AddToObjFld('Zone Name', base + ddsDehumCtrlZoneOff,'')
-    CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', TRIM(humscheduleName))
-    CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
+    CALL AddToObjStr('Humidifying Setpoint Schedule Name', TRIM(humscheduleName))
+    CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
   ELSE
     IF (.NOT. isDehumidifyNone) THEN
   !   Dehumidification humidistat
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + ddsAirHandlerNameOff,' Dehumidification Humidistat')
       CALL AddToObjFld('Zone Name', base + ddsDehumCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name','HVACTemplate-Always 1')
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', TRIM(dehumscheduleName),.TRUE.)
 
       CALL AddAlwaysSchedule('1')
     ENDIF
@@ -22018,8 +22018,8 @@ DO iSys = 1, numCompactSysDualDuct
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + ddsAirHandlerNameOff,' Humidification Humidistat')
       CALL AddToObjFld('Zone Name', base + ddsHumidCtrlZoneOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', TRIM(humscheduleName))
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name', TRIM(humscheduleName))
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
 
       CALL AddAlwaysSchedule('100')
     ENDIF
@@ -24668,13 +24668,13 @@ DO iPurchAir = 1, numCompactPurchAir
         CALL WriteError('In HVACTemplate:Zone:IdealLoadsAirSystem "'//TRIM(FldVal(base + pazNameOff))//'"'// &
                         ' the Humidification Control Type field is Humidistat, but the existing'// &
                         ' ZoneControl:Humidistat named "'//TRIM(existingHumidistatName)//'" for this zone'// &
-                        ' has a blank Humidifying Relative Humidity Setpoint Schedule Name.')
+                        ' has a blank Humidifying Setpoint Schedule Name.')
       END IF
       IF (isDehumCtrlTypeHumidistat .AND. (TRIM(FldVal(humidistatIdx + zchDehumidifyingSchedNameOff)) .EQ. '')) THEN
         CALL WriteError('In HVACTemplate:Zone:IdealLoadsAirSystem "'//TRIM(FldVal(base + pazNameOff))//'"'// &
                         ' the Dehumidification Control Type field is Humidistat, but the existing'// &
                         ' ZoneControl:Humidistat named "'//TRIM(existingHumidistatName)//'" for this zone'// &
-                        ' has a blank Dehumidifying Relative Humidity Setpoint Schedule Name.')
+                        ' has a blank Dehumidifying Setpoint Schedule Name.')
       END IF
 
     END IF
@@ -24686,10 +24686,11 @@ DO iPurchAir = 1, numCompactPurchAir
       CALL CreateNewObj('ZoneControl:Humidistat')
       CALL AddToObjFld('Name', base + pazNameOff,' Humidistat')
       CALL AddToObjFld('Zone Name', base + pazNameOff,'')
-      CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+      CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                        'HVACTemplate-Always ' // TRIM(FldVal(base + pazHumidSetPtOff)))
-      CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
-                       'HVACTemplate-Always ' // TRIM(FldVal(base + pazDehumSetPtOff)),.TRUE.)
+      CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', &
+                       'HVACTemplate-Always ' // TRIM(FldVal(base + pazDehumSetPtOff)))
+      CALL AddToObjStr('Control Variable', 'RelativeHumidity',.TRUE.)
 
       CALL AddAlwaysSchedule(FldVal(base + pazHumidSetPtOff))
       CALL AddAlwaysSchedule(FldVal(base + pazDehumSetPtOff))
@@ -24700,9 +24701,10 @@ DO iPurchAir = 1, numCompactPurchAir
         CALL CreateNewObj('ZoneControl:Humidistat')
         CALL AddToObjFld('Name', base + pazNameOff,' Humidistat')
         CALL AddToObjFld('Zone Name', base + pazNameOff,'')
-        CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 1')
-        CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name', &
-                         'HVACTemplate-Always ' // TRIM(FldVal(base + pazDehumSetPtOff)),.TRUE.)
+        CALL AddToObjStr('Humidifying Setpoint Schedule Name','HVACTemplate-Always 1')
+        CALL AddToObjStr('Dehumidifying Setpoint Schedule Name', &
+                         'HVACTemplate-Always ' // TRIM(FldVal(base + pazDehumSetPtOff)))
+        CALL AddToObjStr('Control Variable', 'RelativeHumidity',.TRUE.)
 
         CALL AddAlwaysSchedule('1')
         CALL AddAlwaysSchedule(FldVal(base + pazDehumSetPtOff))
@@ -24712,9 +24714,10 @@ DO iPurchAir = 1, numCompactPurchAir
         CALL CreateNewObj('ZoneControl:Humidistat')
         CALL AddToObjFld('Name', base + pazNameOff,' Humidification Humidistat')
         CALL AddToObjFld('Zone Name', base + pazNameOff,'')
-        CALL AddToObjStr('Humidifying Relative Humidity Setpoint Schedule Name', &
+        CALL AddToObjStr('Humidifying Setpoint Schedule Name', &
                          'HVACTemplate-Always ' // TRIM(FldVal(base + pazHumidSetPtOff)))
-        CALL AddToObjStr('Dehumidifying Relative Humidity Setpoint Schedule Name','HVACTemplate-Always 100',.TRUE.)
+        CALL AddToObjStr('Dehumidifying Setpoint Schedule Name','HVACTemplate-Always 100')
+        CALL AddToObjStr('Control Variable', 'RelativeHumidity',.TRUE.)
 
         CALL AddAlwaysSchedule(FldVal(base + pazHumidSetPtOff))
         CALL AddAlwaysSchedule('100')

--- a/src/ExpandObjects/tests/.gitignore
+++ b/src/ExpandObjects/tests/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/src/ExpandObjects/tests/conftest.py
+++ b/src/ExpandObjects/tests/conftest.py
@@ -1,0 +1,144 @@
+# EnergyPlus, Copyright (c) 1996-present, The Board of Trustees of the
+# University of Illinois, The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory (subject to receipt of any required
+# approvals from the U.S. Dept. of Energy), Oak Ridge National Laboratory,
+# managed by UT-Battelle, Alliance for Energy Innovation, LLC, and other
+# contributors. All rights reserved.
+#
+# NOTICE: This Software was developed under funding from the U.S. Department of
+# Energy and the U.S. Government consequently retains certain rights. As such,
+# the U.S. Government has been granted for itself and others acting on its
+# behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+# Software to reproduce, distribute copies to the public, prepare derivative
+# works, and perform publicly and display publicly, and to permit others to do
+# so.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the University of California, Lawrence Berkeley
+#     National Laboratory, the University of Illinois, U.S. Dept. of Energy nor
+#     the names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# (4) Use of EnergyPlus(TM) Name. If Licensee (i) distributes the software in
+#     stand-alone form without changes from the version obtained under this
+#     License, or (ii) Licensee makes a reference solely to the software
+#     portion of its product, Licensee must refer to the software as
+#     "EnergyPlus version X" software, where "X" is the version number Licensee
+#     obtained under this License and may not use a different name for the
+#     software. Except as specifically required in this Section (4), Licensee
+#     shall not use in a company name, a product name, in advertising,
+#     publicity, or other promotional activities any name, trade name,
+#     trademark, logo, or other designation of "EnergyPlus", "E+", "e+" or
+#     confusingly similar designation, without the U.S. Department of Energy's
+#     prior written consent.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import inspect
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+
+def validate_file(arg):
+    if (filepath := Path(arg).expanduser()).is_file():
+        return filepath
+    else:
+        raise FileNotFoundError(arg)
+
+
+def pytest_addoption(parser):
+    parser.addoption("--expandobjects-cli-path", type=validate_file, help="Path to the ExpandObjects executable")
+
+
+@pytest.fixture(scope="module")
+def expandobjectsclipath(request) -> Path:
+    cli_path = request.config.getoption("--expandobjects-cli-path")
+    if cli_path is None:
+        raise ValueError("You must supply --expandobjects-cli-path [Path]")
+    return cli_path
+
+
+def who_called_me():
+    return inspect.stack()[2].function
+
+
+class ExpandObjectsResult:
+    def __init__(self, run_dir: Path):
+        self.run_dir = run_dir
+
+        self.idf_text: str = (run_dir / "expanded.idf").read_text()
+
+        self.err_text: str | None = None
+        err_path = run_dir / "expandedidf.err"
+        if err_path.is_file():
+            self.err_text = (run_dir / "expandedidf.err").read_text()
+
+        self.addition_index: int = -1
+
+        # Scan for
+        # !
+        # ! -------------------------------------------------------------
+        # ! New objects created from ExpandObjects
+        # ! -------------------------------------------------------------
+        # !
+        idf_lines = self.idf_text.splitlines()
+        for i, line in enumerate(idf_lines):
+            if line.strip() == "! New objects created from ExpandObjects":
+                self.addition_index = i
+                break
+        assert (
+            self.addition_index > 0
+        ), "Could not find the section for new objects created from ExpandObjects in the expanded IDF"
+
+        self.existing_section_lines: list[str] = idf_lines[: (self.addition_index - 2)]
+        self.existing_section_text = "\n".join(self.existing_section_lines)
+        self.new_section_lines: list[str] = idf_lines[(self.addition_index + 3) :]
+        self.new_section_text = "\n".join(self.new_section_lines)
+
+
+@pytest.fixture
+def prepare_and_run_expandobjects(expandobjectsclipath: Path) -> Callable[[str], ExpandObjectsResult]:
+    def _run(
+        ori_idf_text: str,
+    ):
+
+        run_dir = Path(__file__).parent / "outputs" / who_called_me()
+        if run_dir.is_dir():
+            shutil.rmtree(run_dir)
+        run_dir.mkdir(parents=True)
+        idf_file_path = run_dir / "in.idf"
+        idf_file_path.write_text(ori_idf_text)
+
+        ep_idd = expandobjectsclipath.parent / "Energy+.idd"
+        assert ep_idd.is_file(), f"Energy+.idd not found at {ep_idd}"
+        target_ep_idd_path = run_dir / ep_idd.name
+        shutil.copy(ep_idd, run_dir / target_ep_idd_path)
+
+        subprocess.check_call([str(expandobjectsclipath), idf_file_path], cwd=run_dir)
+
+        return ExpandObjectsResult(run_dir=run_dir)
+
+    return _run

--- a/src/ExpandObjects/tests/test_ideal_loads_humidistat.py
+++ b/src/ExpandObjects/tests/test_ideal_loads_humidistat.py
@@ -100,8 +100,9 @@ HVACTemplate:Zone:IdealLoadsAirSystem,
 ZoneControl:Humidistat,
   Zone 1 Humidistat,                                       !- Name
   Zone 1,                                                  !- Zone Name
-  HVACTemplate-Always 30,                                  !- Humidifying Relative Humidity Setpoint Schedule Name
-  HVACTemplate-Always 60;                                  !- Dehumidifying Relative Humidity Setpoint Schedule Name
+  HVACTemplate-Always 30,                                  !- Humidifying Setpoint Schedule Name
+  HVACTemplate-Always 60,                                  !- Dehumidifying Setpoint Schedule Name
+  RelativeHumidity;                                        !- Control Variable
 
 ScheduleTypeLimits,
   HVACTemplate Any Number;                                 !- Name
@@ -210,8 +211,8 @@ HVACTemplate:Zone:IdealLoadsAirSystem,
 ZoneControl:Humidistat,
   Zone Control Humidistat 1,              !- Name
   Zone 1,                                 !- Zone Name
-  Humidifying Setpoint Schedule,          !- Humidifying Relative Humidity Setpoint Schedule Name
-  Dehumidifying Setpoint Schedule;        !- Dehumidifying Relative Humidity Setpoint Schedule Name
+  Humidifying Setpoint Schedule,          !- Humidifying Setpoint Schedule Name
+  Dehumidifying Setpoint Schedule;        !- Dehumidifying Setpoint Schedule Name
 
 ScheduleTypeLimits,
   Any Number;                             !- Name
@@ -343,8 +344,8 @@ HVACTemplate:Zone:IdealLoadsAirSystem,
 ZoneControl:Humidistat,
   Zone Control Humidistat 1,              !- Name
   Zone 1,                                 !- Zone Name
-  Humidifying Setpoint Schedule,          !- Humidifying Relative Humidity Setpoint Schedule Name
-  ;                                       !- Dehumidifying Relative Humidity Setpoint Schedule Name
+  Humidifying Setpoint Schedule,          !- Humidifying Setpoint Schedule Name
+  ;                                       !- Dehumidifying Setpoint Schedule Name
 
 ScheduleTypeLimits,
   Any Number;                             !- Name
@@ -364,7 +365,7 @@ Schedule:Constant,
     assert (
         'ExpandObjects: In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" the Dehumidification Control Type field '
         'is Humidistat, but the existing ZoneControl:Humidistat named "Zone Control Humidistat 1" for this zone '
-        "has a blank Dehumidifying Relative Humidity Setpoint Schedule Name."
+        "has a blank Dehumidifying Setpoint Schedule Name."
     ) in result.err_text
 
     assert "! HVACTemplate:Zone:IdealLoadsAirSystem," in result.existing_section_text
@@ -377,7 +378,7 @@ Output:PreprocessorMessage,
   In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" the Dehumidification,  !- message line
   Control Type field is Humidistat, but the existing ZoneControl:Humidistat,  !- message line
   named "Zone Control Humidistat 1" for this zone has a blank Dehumidifying,  !- message line
-  Relative Humidity Setpoint Schedule Name.;               !- message line"""
+  Setpoint Schedule Name.;                                 !- message line"""
         in result.new_section_text
     )
 
@@ -424,8 +425,9 @@ HVACTemplate:Zone:IdealLoadsAirSystem,
 ZoneControl:Humidistat,
   Zone Control Humidistat 1,              !- Name
   Zone 1,                                 !- Zone Name
-  ,                                       !- Humidifying Relative Humidity Setpoint Schedule Name
-  Dehumidifying Setpoint Schedule;        !- Dehumidifying Relative Humidity Setpoint Schedule Name
+  ,                                       !- Humidifying Setpoint Schedule Name
+  Dehumidifying Setpoint Schedule,        !- Dehumidifying Setpoint Schedule Name
+  RelativeHumidity;                       !- Control Variable
 
 ScheduleTypeLimits,
   Any Number;                             !- Name
@@ -445,7 +447,7 @@ Schedule:Constant,
     assert (
         'ExpandObjects: In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" the Humidification Control Type field '
         'is Humidistat, but the existing ZoneControl:Humidistat named "Zone Control Humidistat 1" for this zone '
-        "has a blank Humidifying Relative Humidity Setpoint Schedule Name."
+        "has a blank Humidifying Setpoint Schedule Name."
     ) in result.err_text
 
     assert "! HVACTemplate:Zone:IdealLoadsAirSystem," in result.existing_section_text
@@ -458,6 +460,6 @@ Output:PreprocessorMessage,
   In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" the Humidification,  !- message line
   Control Type field is Humidistat, but the existing ZoneControl:Humidistat,  !- message line
   named "Zone Control Humidistat 1" for this zone has a blank Humidifying,  !- message line
-  Relative Humidity Setpoint Schedule Name.;               !- message line"""
+  Setpoint Schedule Name.;                                 !- message line"""
         in result.new_section_text
     )

--- a/src/ExpandObjects/tests/test_ideal_loads_humidistat.py
+++ b/src/ExpandObjects/tests/test_ideal_loads_humidistat.py
@@ -171,3 +171,293 @@ ZoneHVAC:IdealLoadsAirSystem,
 """
 
     assert expected_addition_text.strip() in result.new_section_text
+
+
+def test_ideal_loads_with_exising_humidistat(prepare_and_run_expandobjects):
+
+    ori_idf_text = """
+Zone,
+  Zone 1;                                 !- Name
+
+HVACTemplate:Zone:IdealLoadsAirSystem,
+  Zone 1,                                 !- Zone Name
+  ,                                       !- Template Thermostat Name
+  ,                                       !- System Availability Schedule Name
+  ,                                       !- Maximum Heating Supply Air Temperature {C}
+  ,                                       !- Minimum Cooling Supply Air Temperature {C}
+  ,                                       !- Maximum Heating Supply Air Humidity Ratio {kgWater/kgDryAir}
+  ,                                       !- Minimum Cooling Supply Air Humidity Ratio {kgWater/kgDryAir}
+  ,                                       !- Heating Limit
+  ,                                       !- Maximum Heating Air Flow Rate {m3/s}
+  ,                                       !- Maximum Sensible Heating Capacity {W}
+  ,                                       !- Cooling Limit
+  ,                                       !- Maximum Cooling Air Flow Rate {m3/s}
+  ,                                       !- Maximum Total Cooling Capacity {W}
+  ,                                       !- Heating Availability Schedule Name
+  ,                                       !- Cooling Availability Schedule Name
+  Humidistat,                             !- Dehumidification Control Type
+  ,                                       !- Cooling Sensible Heat Ratio {dimensionless}
+  ,                                       !- Dehumidification Setpoint {percent}
+  Humidistat,                             !- Humidification Control Type
+  ,                                       !- Humidification Setpoint {percent}
+  ,                                       !- Outdoor Air Method
+  ,                                       !- Outdoor Air Flow Rate per Person {m3/s}
+  ,                                       !- Outdoor Air Flow Rate per Zone Floor Area {m3/s-m2}
+  ,                                       !- Outdoor Air Flow Rate per Zone {m3/s}
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ;                                       !- Demand Controlled Ventilation Type
+
+ZoneControl:Humidistat,
+  Zone Control Humidistat 1,              !- Name
+  Zone 1,                                 !- Zone Name
+  Humidifying Setpoint Schedule,          !- Humidifying Relative Humidity Setpoint Schedule Name
+  Dehumidifying Setpoint Schedule;        !- Dehumidifying Relative Humidity Setpoint Schedule Name
+
+ScheduleTypeLimits,
+  Any Number;                             !- Name
+
+Schedule:Constant,
+  Humidifying Setpoint Schedule,          !- Name
+  Any Number,                             !- Schedule Type Limits Name
+  30.0;                                   !- Hourly Value
+
+Schedule:Constant,
+  Dehumidifying Setpoint Schedule,        !- Name
+  Any Number,                             !- Schedule Type Limits Name
+  60.0;                                   !- Hourly Value
+"""
+    result: ExpandObjectsResult = prepare_and_run_expandobjects(ori_idf_text=ori_idf_text)
+    assert result.err_text is not None
+    assert (
+        'ExpandObjects: Warning: In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" a ZoneControl:Humidistat named '
+        '"Zone Control Humidistat 1" was already defined for this zone, so the HVACTemplate-generated humidistat '
+        "will not be created."
+    ) in result.err_text
+    assert (
+        "! HVACTemplate:Zone:IdealLoadsAirSystem," in result.idf_text
+    ), "Ideal Loads Air System should be preserved in the expanded IDF"
+
+    assert "ZoneControl:Humidistat," not in result.new_section_text
+    assert "HVACTemplate-Always 30," not in result.new_section_text
+    assert "HVACTemplate-Always 60," not in result.new_section_text
+
+    expected_addition_text = """
+ZoneHVAC:EquipmentConnections,
+  Zone 1,                                                  !- Zone Name
+  Zone 1 Equipment,                                        !- Zone Conditioning Equipment List Name
+  Zone 1 Ideal Loads Supply Inlet,                         !- Zone Air Inlet Node or NodeList Name
+  ,                                                        !- Zone Air Exhaust Node or NodeList Name
+  Zone 1 Zone Air Node,                                    !- Zone Air Node Name
+  Zone 1 Return Outlet;                                    !- Zone Return Air Node Name
+
+ZoneHVAC:EquipmentList,
+  Zone 1 Equipment,                                        !- Name
+  SequentialLoad,                                          !- Load Distribution Scheme
+  ZoneHVAC:IdealLoadsAirSystem,                            !- Zone Equipment Object Type
+  Zone 1 Ideal Loads Air System,                           !- Zone Equipment Name
+  1,                                                       !- Zone Equipment Cooling Sequence
+  1,                                                       !- Zone Equipment Heating or No-Load Sequence
+  ,                                                        !- Zone Equipment Sequential Cooling Fraction Schedule Name
+  ;                                                        !- Zone Equipment Sequential Heating Fraction Schedule Name
+
+ZoneHVAC:IdealLoadsAirSystem,
+  Zone 1 Ideal Loads Air System,                           !- Name
+  ,                                                        !- Availability Schedule Name
+  Zone 1 Ideal Loads Supply Inlet,                         !- Zone Supply Air Node Name
+  ,                                                        !- Zone Exhaust Air Node Name
+  ,                                                        !- System Inlet Air Node Name
+  50,                                                      !- Maximum Heating Supply Air Temperature [C]
+  13,                                                      !- Minimum Cooling Supply Air Temperature [C]
+  0.0156,                                                  !- Maximum Heating Supply Air Humidity Ratio [kg-H20/kg-air]
+  0.0077,                                                  !- Minimum Cooling Supply Air Humidity Ratio [kg-H20/kg-air]
+  NoLimit,                                                 !- Heating Limit
+  ,                                                        !- Maximum Heating Air Flow Rate {m3/s}
+  ,                                                        !- Maximum Sensible Heating Capacity {m3/s}
+  NoLimit,                                                 !- Cooling Limit
+  ,                                                        !- Maximum Cooling Air Flow Rate {m3/s}
+  ,                                                        !- Maximum Total Cooling Capacity {m3/s}
+  ,                                                        !- Heating Availability Schedule Name
+  ,                                                        !- Cooling Availability Schedule Name
+  Humidistat,                                              !- Dehumidification Control Type
+  0.7,                                                     !- Cooling Sensible Heat Ratio
+  Humidistat,                                              !- Humidification Control Type
+  ,                                                        !- Design Specification Outdoor Air Object Name
+  ,                                                        !- Outdoor Air Inlet Node Name
+  None,                                                    !- Demand Controlled Ventilation Type
+  NoEconomizer,                                            !- Outdoor Air Economizer Type
+  None,                                                    !- Heat Recovery Type
+  0.7,                                                     !- Sensible Heat Recovery Effectiveness
+  0.65;                                                    !- Latent Heat Recovery Effectiveness
+
+Output:PreprocessorMessage,
+  ExpandObjects,                                           !- Preprocessor Name
+  Warning,                                                 !- Error Severity
+  Warning: In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" a,  !- message line
+  ZoneControl:Humidistat named "Zone Control Humidistat 1" was already,  !- message line
+  defined for this zone, so the HVACTemplate-generated humidistat will not be,  !- message line
+  created.;                                                !- message line
+"""
+
+    assert expected_addition_text.strip() in result.new_section_text
+
+
+def test_ideal_loads_with_exising_humidistat_but_no_dehum_schedule(prepare_and_run_expandobjects):
+    """Test IdealLoadsAirSystem with Humidistat but existing ZoneControl:Humidistat has no dehum schedule.
+
+    IdealLoadsAirSystem has Humidistat for both dehumidification and humidification control types.
+    The existing ZoneControl:Humidistat is missing the Dehumidifying Schedule => hard error
+    """
+
+    ori_idf_text = """
+Zone,
+  Zone 1;                                 !- Name
+
+HVACTemplate:Zone:IdealLoadsAirSystem,
+  Zone 1,                                 !- Zone Name
+  ,                                       !- Template Thermostat Name
+  ,                                       !- System Availability Schedule Name
+  ,                                       !- Maximum Heating Supply Air Temperature {C}
+  ,                                       !- Minimum Cooling Supply Air Temperature {C}
+  ,                                       !- Maximum Heating Supply Air Humidity Ratio {kgWater/kgDryAir}
+  ,                                       !- Minimum Cooling Supply Air Humidity Ratio {kgWater/kgDryAir}
+  ,                                       !- Heating Limit
+  ,                                       !- Maximum Heating Air Flow Rate {m3/s}
+  ,                                       !- Maximum Sensible Heating Capacity {W}
+  ,                                       !- Cooling Limit
+  ,                                       !- Maximum Cooling Air Flow Rate {m3/s}
+  ,                                       !- Maximum Total Cooling Capacity {W}
+  ,                                       !- Heating Availability Schedule Name
+  ,                                       !- Cooling Availability Schedule Name
+  Humidistat,                             !- Dehumidification Control Type
+  ,                                       !- Cooling Sensible Heat Ratio {dimensionless}
+  ,                                       !- Dehumidification Setpoint {percent}
+  Humidistat,                             !- Humidification Control Type
+  ,                                       !- Humidification Setpoint {percent}
+  ,                                       !- Outdoor Air Method
+  ,                                       !- Outdoor Air Flow Rate per Person {m3/s}
+  ,                                       !- Outdoor Air Flow Rate per Zone Floor Area {m3/s-m2}
+  ,                                       !- Outdoor Air Flow Rate per Zone {m3/s}
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ;                                       !- Demand Controlled Ventilation Type
+
+ZoneControl:Humidistat,
+  Zone Control Humidistat 1,              !- Name
+  Zone 1,                                 !- Zone Name
+  Humidifying Setpoint Schedule,          !- Humidifying Relative Humidity Setpoint Schedule Name
+  ;                                       !- Dehumidifying Relative Humidity Setpoint Schedule Name
+
+ScheduleTypeLimits,
+  Any Number;                             !- Name
+
+Schedule:Constant,
+  Humidifying Setpoint Schedule,          !- Name
+  Any Number,                             !- Schedule Type Limits Name
+  30.0;                                   !- Hourly Value
+"""
+    result: ExpandObjectsResult = prepare_and_run_expandobjects(ori_idf_text=ori_idf_text)
+    assert result.err_text is not None
+    assert (
+        'ExpandObjects: Warning: In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" a ZoneControl:Humidistat named '
+        '"Zone Control Humidistat 1" was already defined for this zone, so the HVACTemplate-generated humidistat '
+        "will not be created."
+    ) in result.err_text
+    assert (
+        'ExpandObjects: In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" the Dehumidification Control Type field '
+        'is Humidistat, but the existing ZoneControl:Humidistat named "Zone Control Humidistat 1" for this zone '
+        "has a blank Dehumidifying Relative Humidity Setpoint Schedule Name."
+    ) in result.err_text
+
+    assert "! HVACTemplate:Zone:IdealLoadsAirSystem," in result.existing_section_text
+
+    assert (
+        """
+Output:PreprocessorMessage,
+  ExpandObjects,                                           !- Preprocessor Name
+  Fatal,                                                   !- Error Severity
+  In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" the Dehumidification,  !- message line
+  Control Type field is Humidistat, but the existing ZoneControl:Humidistat,  !- message line
+  named "Zone Control Humidistat 1" for this zone has a blank Dehumidifying,  !- message line
+  Relative Humidity Setpoint Schedule Name.;               !- message line"""
+        in result.new_section_text
+    )
+
+
+def test_ideal_loads_with_exising_humidistat_but_no_hum_schedule(prepare_and_run_expandobjects):
+    """Test IdealLoadsAirSystem with Humidistat but existing ZoneControl:Humidistat has no hum schedule.
+
+    IdealLoadsAirSystem has Humidistat for both dehumidification and humidification control types.
+    The existing ZoneControl:Humidistat is missing the Humidifying Schedule => hard error
+    """
+
+    ori_idf_text = """
+Zone,
+  Zone 1;                                 !- Name
+
+HVACTemplate:Zone:IdealLoadsAirSystem,
+  Zone 1,                                 !- Zone Name
+  ,                                       !- Template Thermostat Name
+  ,                                       !- System Availability Schedule Name
+  ,                                       !- Maximum Heating Supply Air Temperature {C}
+  ,                                       !- Minimum Cooling Supply Air Temperature {C}
+  ,                                       !- Maximum Heating Supply Air Humidity Ratio {kgWater/kgDryAir}
+  ,                                       !- Minimum Cooling Supply Air Humidity Ratio {kgWater/kgDryAir}
+  ,                                       !- Heating Limit
+  ,                                       !- Maximum Heating Air Flow Rate {m3/s}
+  ,                                       !- Maximum Sensible Heating Capacity {W}
+  ,                                       !- Cooling Limit
+  ,                                       !- Maximum Cooling Air Flow Rate {m3/s}
+  ,                                       !- Maximum Total Cooling Capacity {W}
+  ,                                       !- Heating Availability Schedule Name
+  ,                                       !- Cooling Availability Schedule Name
+  Humidistat,                             !- Dehumidification Control Type
+  ,                                       !- Cooling Sensible Heat Ratio {dimensionless}
+  ,                                       !- Dehumidification Setpoint {percent}
+  Humidistat,                             !- Humidification Control Type
+  ,                                       !- Humidification Setpoint {percent}
+  ,                                       !- Outdoor Air Method
+  ,                                       !- Outdoor Air Flow Rate per Person {m3/s}
+  ,                                       !- Outdoor Air Flow Rate per Zone Floor Area {m3/s-m2}
+  ,                                       !- Outdoor Air Flow Rate per Zone {m3/s}
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ;                                       !- Demand Controlled Ventilation Type
+
+ZoneControl:Humidistat,
+  Zone Control Humidistat 1,              !- Name
+  Zone 1,                                 !- Zone Name
+  ,                                       !- Humidifying Relative Humidity Setpoint Schedule Name
+  Dehumidifying Setpoint Schedule;        !- Dehumidifying Relative Humidity Setpoint Schedule Name
+
+ScheduleTypeLimits,
+  Any Number;                             !- Name
+
+Schedule:Constant,
+  Dehumidifying Setpoint Schedule,        !- Name
+  Any Number,                             !- Schedule Type Limits Name
+  60.0;                                   !- Hourly Value
+"""
+    result: ExpandObjectsResult = prepare_and_run_expandobjects(ori_idf_text=ori_idf_text)
+    assert result.err_text is not None
+    assert (
+        'ExpandObjects: Warning: In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" a ZoneControl:Humidistat named '
+        '"Zone Control Humidistat 1" was already defined for this zone, so the HVACTemplate-generated humidistat '
+        "will not be created."
+    ) in result.err_text
+    assert (
+        'ExpandObjects: In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" the Humidification Control Type field '
+        'is Humidistat, but the existing ZoneControl:Humidistat named "Zone Control Humidistat 1" for this zone '
+        "has a blank Humidifying Relative Humidity Setpoint Schedule Name."
+    ) in result.err_text
+
+    assert "! HVACTemplate:Zone:IdealLoadsAirSystem," in result.existing_section_text
+
+    assert (
+        """
+Output:PreprocessorMessage,
+  ExpandObjects,                                           !- Preprocessor Name
+  Fatal,                                                   !- Error Severity
+  In HVACTemplate:Zone:IdealLoadsAirSystem "Zone 1" the Humidification,  !- message line
+  Control Type field is Humidistat, but the existing ZoneControl:Humidistat,  !- message line
+  named "Zone Control Humidistat 1" for this zone has a blank Humidifying,  !- message line
+  Relative Humidity Setpoint Schedule Name.;               !- message line"""
+        in result.new_section_text
+    )

--- a/src/ExpandObjects/tests/test_ideal_loads_humidistat.py
+++ b/src/ExpandObjects/tests/test_ideal_loads_humidistat.py
@@ -1,0 +1,173 @@
+# EnergyPlus, Copyright (c) 1996-present, The Board of Trustees of the
+# University of Illinois, The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory (subject to receipt of any required
+# approvals from the U.S. Dept. of Energy), Oak Ridge National Laboratory,
+# managed by UT-Battelle, Alliance for Energy Innovation, LLC, and other
+# contributors. All rights reserved.
+#
+# NOTICE: This Software was developed under funding from the U.S. Department of
+# Energy and the U.S. Government consequently retains certain rights. As such,
+# the U.S. Government has been granted for itself and others acting on its
+# behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+# Software to reproduce, distribute copies to the public, prepare derivative
+# works, and perform publicly and display publicly, and to permit others to do
+# so.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the University of California, Lawrence Berkeley
+#     National Laboratory, the University of Illinois, U.S. Dept. of Energy nor
+#     the names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# (4) Use of EnergyPlus(TM) Name. If Licensee (i) distributes the software in
+#     stand-alone form without changes from the version obtained under this
+#     License, or (ii) Licensee makes a reference solely to the software
+#     portion of its product, Licensee must refer to the software as
+#     "EnergyPlus version X" software, where "X" is the version number Licensee
+#     obtained under this License and may not use a different name for the
+#     software. Except as specifically required in this Section (4), Licensee
+#     shall not use in a company name, a product name, in advertising,
+#     publicity, or other promotional activities any name, trade name,
+#     trademark, logo, or other designation of "EnergyPlus", "E+", "e+" or
+#     confusingly similar designation, without the U.S. Department of Energy's
+#     prior written consent.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from conftest import ExpandObjectsResult
+
+
+def test_ideal_loads_without_exising_humidistat(prepare_and_run_expandobjects):
+    """Test that Ideal Loads with a Humidistat are expanded correctly when no Humidistat exists in the original model."""
+    ori_idf_text = """
+Zone,
+  Zone 1;                                 !- Name
+
+HVACTemplate:Zone:IdealLoadsAirSystem,
+  Zone 1,                                 !- Zone Name
+  ,                                       !- Template Thermostat Name
+  ,                                       !- System Availability Schedule Name
+  ,                                       !- Maximum Heating Supply Air Temperature {C}
+  ,                                       !- Minimum Cooling Supply Air Temperature {C}
+  ,                                       !- Maximum Heating Supply Air Humidity Ratio {kgWater/kgDryAir}
+  ,                                       !- Minimum Cooling Supply Air Humidity Ratio {kgWater/kgDryAir}
+  ,                                       !- Heating Limit
+  ,                                       !- Maximum Heating Air Flow Rate {m3/s}
+  ,                                       !- Maximum Sensible Heating Capacity {W}
+  ,                                       !- Cooling Limit
+  ,                                       !- Maximum Cooling Air Flow Rate {m3/s}
+  ,                                       !- Maximum Total Cooling Capacity {W}
+  ,                                       !- Heating Availability Schedule Name
+  ,                                       !- Cooling Availability Schedule Name
+  Humidistat,                             !- Dehumidification Control Type
+  ,                                       !- Cooling Sensible Heat Ratio {dimensionless}
+  ,                                       !- Dehumidification Setpoint {percent}
+  Humidistat,                             !- Humidification Control Type
+  ,                                       !- Humidification Setpoint {percent}
+  ,                                       !- Outdoor Air Method
+  ,                                       !- Outdoor Air Flow Rate per Person {m3/s}
+  ,                                       !- Outdoor Air Flow Rate per Zone Floor Area {m3/s-m2}
+  ,                                       !- Outdoor Air Flow Rate per Zone {m3/s}
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ;                                       !- Demand Controlled Ventilation Type
+    """
+
+    result: ExpandObjectsResult = prepare_and_run_expandobjects(ori_idf_text=ori_idf_text)
+    assert result.err_text is None, f"ExpandObjects failed with error: {result.err_text}"
+    assert (
+        "! HVACTemplate:Zone:IdealLoadsAirSystem," in result.idf_text
+    ), "Ideal Loads Air System should be preserved in the expanded IDF"
+    expected_addition_text = """
+ZoneControl:Humidistat,
+  Zone 1 Humidistat,                                       !- Name
+  Zone 1,                                                  !- Zone Name
+  HVACTemplate-Always 30,                                  !- Humidifying Relative Humidity Setpoint Schedule Name
+  HVACTemplate-Always 60;                                  !- Dehumidifying Relative Humidity Setpoint Schedule Name
+
+ScheduleTypeLimits,
+  HVACTemplate Any Number;                                 !- Name
+
+Schedule:Compact,
+  HVACTemplate-Always 30,                                  !- Name
+  HVACTemplate Any Number,                                 !- Schedule Type Limits Name
+  Through: 12/31,                                          !- Field 1
+  For: AllDays,                                            !- Field 2
+  Until: 24:00,                                            !- Field 3
+  30;                                                      !- Field 4
+
+Schedule:Compact,
+  HVACTemplate-Always 60,                                  !- Name
+  HVACTemplate Any Number,                                 !- Schedule Type Limits Name
+  Through: 12/31,                                          !- Field 1
+  For: AllDays,                                            !- Field 2
+  Until: 24:00,                                            !- Field 3
+  60;                                                      !- Field 4
+
+ZoneHVAC:EquipmentConnections,
+  Zone 1,                                                  !- Zone Name
+  Zone 1 Equipment,                                        !- Zone Conditioning Equipment List Name
+  Zone 1 Ideal Loads Supply Inlet,                         !- Zone Air Inlet Node or NodeList Name
+  ,                                                        !- Zone Air Exhaust Node or NodeList Name
+  Zone 1 Zone Air Node,                                    !- Zone Air Node Name
+  Zone 1 Return Outlet;                                    !- Zone Return Air Node Name
+
+ZoneHVAC:EquipmentList,
+  Zone 1 Equipment,                                        !- Name
+  SequentialLoad,                                          !- Load Distribution Scheme
+  ZoneHVAC:IdealLoadsAirSystem,                            !- Zone Equipment Object Type
+  Zone 1 Ideal Loads Air System,                           !- Zone Equipment Name
+  1,                                                       !- Zone Equipment Cooling Sequence
+  1,                                                       !- Zone Equipment Heating or No-Load Sequence
+  ,                                                        !- Zone Equipment Sequential Cooling Fraction Schedule Name
+  ;                                                        !- Zone Equipment Sequential Heating Fraction Schedule Name
+
+ZoneHVAC:IdealLoadsAirSystem,
+  Zone 1 Ideal Loads Air System,                           !- Name
+  ,                                                        !- Availability Schedule Name
+  Zone 1 Ideal Loads Supply Inlet,                         !- Zone Supply Air Node Name
+  ,                                                        !- Zone Exhaust Air Node Name
+  ,                                                        !- System Inlet Air Node Name
+  50,                                                      !- Maximum Heating Supply Air Temperature [C]
+  13,                                                      !- Minimum Cooling Supply Air Temperature [C]
+  0.0156,                                                  !- Maximum Heating Supply Air Humidity Ratio [kg-H20/kg-air]
+  0.0077,                                                  !- Minimum Cooling Supply Air Humidity Ratio [kg-H20/kg-air]
+  NoLimit,                                                 !- Heating Limit
+  ,                                                        !- Maximum Heating Air Flow Rate {m3/s}
+  ,                                                        !- Maximum Sensible Heating Capacity {m3/s}
+  NoLimit,                                                 !- Cooling Limit
+  ,                                                        !- Maximum Cooling Air Flow Rate {m3/s}
+  ,                                                        !- Maximum Total Cooling Capacity {m3/s}
+  ,                                                        !- Heating Availability Schedule Name
+  ,                                                        !- Cooling Availability Schedule Name
+  Humidistat,                                              !- Dehumidification Control Type
+  0.7,                                                     !- Cooling Sensible Heat Ratio
+  Humidistat,                                              !- Humidification Control Type
+  ,                                                        !- Design Specification Outdoor Air Object Name
+  ,                                                        !- Outdoor Air Inlet Node Name
+  None,                                                    !- Demand Controlled Ventilation Type
+  NoEconomizer,                                            !- Outdoor Air Economizer Type
+  None,                                                    !- Heat Recovery Type
+  0.7,                                                     !- Sensible Heat Recovery Effectiveness
+  0.65;                                                    !- Latent Heat Recovery Effectiveness
+"""
+
+    assert expected_addition_text.strip() in result.new_section_text


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11626

### Description of the purpose of this PR

ExpandObjects now properly handles ZoneControl:Humidistat objects when expanding `HVACTemplate:Zone:IdealLoadsAirSystem.`

It pre-scans for user-defined ZoneControl:Humidistat objects for the zone. If an existing humidistat is found, a warning is issued, and the template will not generate a brand new ZoneControl:Humidistat.

Fatal errors are issued if the existing humidistat lacks required setpoint schedules for the humidification/ dehumidification control specified in the template.

If no user-defined humidistat is present, the template generates one as needed (business as usual)

----

**I've setup pytest tests machinery for ExpandObjects as part of this PR**


---- 

I/O ref is updated to clarify what happens

<img width="777" height="326" alt="Screenshot from 2026-06-11 14-29-46" src="https://github.com/user-attachments/assets/e47d3c8c-c036-4ef4-8f8f-8b90e221151e" />


### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
