### PR TITLE
Remove or replace `compare_err_stream_substring` when an empty string is being compared

### DIFF
--- a/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
+++ b/src/EnergyPlus/AirflowNetwork/src/Solver.cpp
@@ -13310,7 +13310,7 @@ namespace AirflowNetwork {
         if (Toperative > (Tcomfort + ComfortBand)) {
             if (opening_probability(state, ZoneNum, TimeCloseDuration)) {
                 OpeningProbStatus = ProbabilityCheck::ForceChange;
-                ; // forced to open
+                // forced to open
             } else {
                 OpeningProbStatus = ProbabilityCheck::KeepStatus; // Keep previous status
             }

--- a/src/EnergyPlus/DaylightingManager.cc
+++ b/src/EnergyPlus/DaylightingManager.cc
@@ -56,7 +56,6 @@
 #include <ObjexxFCL/Array.functions.hh>
 #include <ObjexxFCL/Fmath.hh>
 #include <ObjexxFCL/Vector3.hh>
-// #include <ObjexxFCL/Vector4.hh>
 #include <ObjexxFCL/member.functions.hh>
 #include <ObjexxFCL/random.hh>
 #include <ObjexxFCL/string.functions.hh>
@@ -9245,7 +9244,7 @@ void ReportIllumMap(EnergyPlusData &state, int const MapNum)
                 for (int R = RefPt; R <= RefPt + illumMap.Xnum - 1; ++R) {
                     int IllumOut = nint(illumMap.refPts(R).lumsHr[iLum_Illum]);
                     std::string String = std::to_string(IllumOut);
-                    ;
+
                     if (!illumMap.refPts(R).inBounds) {
                         String = "*" + String;
                     }

--- a/src/EnergyPlus/OutputReportTabular.cc
+++ b/src/EnergyPlus/OutputReportTabular.cc
@@ -18675,7 +18675,7 @@ bool isNumber(std::string const &s)
     char *p;
     strtod(s.c_str(), &p);
     for (; isspace(*p) != 0; ++p) {
-        ; // handle trailing whitespace
+        // handle trailing whitespace
     }
     return *p == 0;
 }

--- a/src/EnergyPlus/SimulationManager.cc
+++ b/src/EnergyPlus/SimulationManager.cc
@@ -53,7 +53,6 @@
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array.functions.hh>
 #include <ObjexxFCL/Array1D.hh>
-#include <ObjexxFCL/environment.hh>
 #include <ObjexxFCL/string.functions.hh>
 
 // Third Party Headers
@@ -67,7 +66,6 @@ extern "C" {
 #include <EnergyPlus/CostEstimateManager.hh>
 #include <EnergyPlus/CurveManager.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
-#include <EnergyPlus/DataAirLoop.hh>
 #include <EnergyPlus/DataBranchNodeConnections.hh>
 #include <EnergyPlus/DataConvergParams.hh>
 #include <EnergyPlus/DataErrorTracking.hh>
@@ -95,7 +93,6 @@ extern "C" {
 #include <EnergyPlus/ExternalInterface.hh>
 #include <EnergyPlus/FaultsManager.hh>
 #include <EnergyPlus/FileSystem.hh>
-#include <EnergyPlus/FluidProperties.hh>
 #include <EnergyPlus/GeneralRoutines.hh>
 #include <EnergyPlus/HVACControllers.hh>
 #include <EnergyPlus/HVACManager.hh>
@@ -109,7 +106,6 @@ extern "C" {
 #include <EnergyPlus/NodeInputManager.hh>
 #include <EnergyPlus/OutAirNodeManager.hh>
 #include <EnergyPlus/OutputProcessor.hh>
-#include <EnergyPlus/OutputReportPredefined.hh>
 #include <EnergyPlus/OutputReportTabular.hh>
 #include <EnergyPlus/OutputReports.hh>
 #include <EnergyPlus/Plant/PlantManager.hh>
@@ -118,7 +114,6 @@ extern "C" {
 #include <EnergyPlus/PollutionModule.hh>
 #include <EnergyPlus/Psychrometrics.hh>
 #include <EnergyPlus/RefrigeratedCase.hh>
-#include <EnergyPlus/ReportCoilSelection.hh>
 #include <EnergyPlus/ResultsFramework.hh>
 #include <EnergyPlus/SetPointManager.hh>
 #include <EnergyPlus/SimulationManager.hh>

--- a/src/EnergyPlus/SolarShading.cc
+++ b/src/EnergyPlus/SolarShading.cc
@@ -7121,7 +7121,7 @@ void CalcInteriorSolarDistribution(EnergyPlusData &state)
                         // Factor for front beam radiation absorbed for equivalent layer window model
                         Real64 AbWinEQL = state.dataSolarShading->SurfWinAbsSolBeamEQL(1, Lay) * CosInc * SunLitFract *
                                           s_surf->SurfaceWindow(SurfNum).InOutProjSLFracMult[state.dataGlobal->HourOfDay];
-                        ;
+
                         if (CFS(EQLNum).L(1).LTYPE != LayerType::GLAZE) {
                             // if the first layer is not glazing (or it is a shade) do not
                             s_surf->SurfWinA(SurfNum, Lay) = AbWinEQL;

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -2303,11 +2303,10 @@ void CalculateAdaptiveComfortSetPointSchl(EnergyPlusData &state, Array1D<Real64>
             if (GrossApproxAvgDryBulbDesignDay > 10 && GrossApproxAvgDryBulbDesignDay < 30) {
                 s_ztpc->AdapComfortSetPointSummerDesDay[3] = 0.33 * GrossApproxAvgDryBulbDesignDay + 18.8;
                 s_ztpc->AdapComfortSetPointSummerDesDay[4] = 0.33 * GrossApproxAvgDryBulbDesignDay + 20.8;
-                ; // What is this?
+                // What is this?
                 s_ztpc->AdapComfortSetPointSummerDesDay[5] = 0.33 * GrossApproxAvgDryBulbDesignDay + 21.8;
-                ;
+
                 s_ztpc->AdapComfortSetPointSummerDesDay[6] = 0.33 * GrossApproxAvgDryBulbDesignDay + 22.8;
-                ;
             }
         }
     }

--- a/tst/EnergyPlus/unit/AirLoopHVACDOAS.unit.cc
+++ b/tst/EnergyPlus/unit/AirLoopHVACDOAS.unit.cc
@@ -10422,7 +10422,7 @@ TEST_F(EnergyPlusFixture, AirLoopHVACDOAS_TestOACompConnectionError)
     });
 
     ASSERT_TRUE(process_idf(idf_objects));
-    compare_err_stream_substring("", true);
+    compare_err_stream("", true);
 
     state->init_state(*state);
 

--- a/tst/EnergyPlus/unit/AirTerminalSingleDuct.unit.cc
+++ b/tst/EnergyPlus/unit/AirTerminalSingleDuct.unit.cc
@@ -1011,7 +1011,7 @@ TEST_F(EnergyPlusFixture, SingleDuctVAVReheatAirTerminal_MinFlowTurnDownTest)
     });
 
     ASSERT_TRUE(process_idf(idf_objects));
-    compare_err_stream_substring("", true); // clear idf errors
+    compare_err_stream("", true); // clear idf errors
     // setup variables for VAV Reheat
     int SysNum = 1;
     int ZoneNum = 1;
@@ -1221,7 +1221,7 @@ TEST_F(EnergyPlusFixture, SingleDuctVAVReheatVSFanAirTerminal_MinFlowTurnDownTes
     });
 
     ASSERT_TRUE(process_idf(idf_objects));
-    compare_err_stream_substring("", true); // clear idf errors
+    compare_err_stream("", true); // clear idf errors
     // setup variables for VAV Reheat VS Fan
     int SysNum = 1;
     int ZoneNum = 1;
@@ -1399,7 +1399,7 @@ TEST_F(EnergyPlusFixture, SingleDuctVAVHeatCoolReheatAirTerminal_MinFlowTurnDown
     });
 
     ASSERT_TRUE(process_idf(idf_objects));
-    compare_err_stream_substring("", true); // clear idf errors
+    compare_err_stream("", true); // clear idf errors
     // setup variables for VAV Reheat VS Fan
     int SysNum = 1;
     int ZoneNum = 1;
@@ -1588,7 +1588,7 @@ TEST_F(EnergyPlusFixture, SingleDuctVAVReheatVSFan_DamperPositionTest)
     });
 
     ASSERT_TRUE(process_idf(idf_objects));
-    compare_err_stream_substring("", true); // clear idf errors
+    compare_err_stream("", true); // clear idf errors
     // setup variables for VAV Reheat VS Fan
     int SysNum = 1;
     int ZoneNum = 1;
@@ -1735,7 +1735,7 @@ TEST_F(EnergyPlusFixture, VAVHeatCoolReheatAirTerminal_ZoneOAVolumeFlowRateTest)
     });
 
     ASSERT_TRUE(process_idf(idf_objects));
-    compare_err_stream_substring("", true); // clear idf errors
+    compare_err_stream("", true); // clear idf errors
     // setup variables for VAV HeatCoolReheat
     int SysNum = 1;
     int ZoneNum = 1;

--- a/tst/EnergyPlus/unit/AirTerminalSingleDuctConstantVolumeNoReheat.unit.cc
+++ b/tst/EnergyPlus/unit/AirTerminalSingleDuctConstantVolumeNoReheat.unit.cc
@@ -345,7 +345,6 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_Sim)
     state->dataLoopNodes->Node(InletNode).HumRat = 0.0075;
     state->dataLoopNodes->Node(InletNode).Enthalpy =
         Psychrometrics::PsyHFnTdbW(state->dataLoopNodes->Node(InletNode).Temp, state->dataLoopNodes->Node(InletNode).HumRat);
-    ;
     // set zone air node properties
     state->dataLoopNodes->Node(ZoneAirNodeNum).Temp = 20.0;
     state->dataLoopNodes->Node(ZoneAirNodeNum).HumRat = 0.0075;
@@ -719,13 +718,11 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_EMSOverrideAirFlow)
     state->dataLoopNodes->Node(InletNode).HumRat = 0.0075;
     state->dataLoopNodes->Node(InletNode).Enthalpy =
         Psychrometrics::PsyHFnTdbW(state->dataLoopNodes->Node(InletNode).Temp, state->dataLoopNodes->Node(InletNode).HumRat);
-    ;
     // set zone air node properties
     state->dataLoopNodes->Node(ZoneAirNodeNum).Temp = 20.0;
     state->dataLoopNodes->Node(ZoneAirNodeNum).HumRat = 0.0075;
     state->dataLoopNodes->Node(ZoneAirNodeNum).Enthalpy =
         Psychrometrics::PsyHFnTdbW(state->dataLoopNodes->Node(ZoneAirNodeNum).Temp, state->dataLoopNodes->Node(ZoneAirNodeNum).HumRat);
-    ;
     state->dataSingleDuct->GetInputFlag = false;
     FirstHVACIteration = false;
     state->dataLoopNodes->Node(InletNode).MassFlowRateMaxAvail = MassFlowRateMaxAvail;
@@ -1083,7 +1080,6 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_SimSensibleOutPutTest)
     int const ZoneAirNodeNum = state->dataZoneEquip->ZoneEquipConfig(ZonePtr).ZoneNode;
 
     thisAirTerminal.availSched->currentVal = 1.0; // unit is always available
-    ;
     // design maximum air mass flow rate
     Real64 MassFlowRateMaxAvail = thisAirTerminal.MaxAirVolFlowRate * state->dataEnvrn->StdRhoAir;
     EXPECT_EQ(1.0, thisAirTerminal.MaxAirVolFlowRate);
@@ -1137,7 +1133,6 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_SimSensibleOutPutTest)
     EXPECT_EQ(thisAirTerminal.sd_airterminalOutlet.AirHumRat, thisAirTerminal.sd_airterminalInlet.AirHumRat);
     EXPECT_EQ(thisAirTerminal.sd_airterminalOutlet.AirEnthalpy, thisAirTerminal.sd_airterminalInlet.AirEnthalpy);
     EXPECT_EQ(thisAirTerminal.sd_airterminalOutlet.AirMassFlowRate, thisAirTerminal.sd_airterminalInlet.AirMassFlowRate);
-    ;
     // test 2: cooling mode test
     // set air inlet node properties
     state->dataLoopNodes->Node(InletNode).Temp = 15.0;
@@ -1167,7 +1162,6 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_SimSensibleOutPutTest)
     EXPECT_EQ(0.0, thisAirTerminal.sd_airterminalInlet.AirMassFlowRate);         // inlet mass flow rate is zero
     EXPECT_EQ(0.0, thisAirTerminal.sd_airterminalOutlet.AirMassFlowRate);        // outlet mass flow rate is zero
     EXPECT_EQ(0.0, SysOutputProvided);                                           // delivered sensible cooling is zero
-    ;
     // reset mass flow rate to the maximum available
     state->dataLoopNodes->Node(InletNode).MassFlowRateMaxAvail = MassFlowRateMaxAvail;
     EXPECT_EQ(1.0, MassFlowRateMaxAvail);
@@ -1279,7 +1273,6 @@ TEST_F(EnergyPlusFixture, AirTerminalSingleDuctCVNoReheat_DownstreamLeakTest)
     int const ZoneAirNodeNum = state->dataZoneEquip->ZoneEquipConfig(ZonePtr).ZoneNode;
 
     thisAirTerminal.availSched->currentVal = 1.0; // unit is always available
-    ;
     // design maximum air mass flow rate
     Real64 MassFlowRateMaxAvail = thisAirTerminal.MaxAirVolFlowRate * state->dataEnvrn->StdRhoAir;
     EXPECT_EQ(1.0, thisAirTerminal.MaxAirVolFlowRate);

--- a/tst/EnergyPlus/unit/AirflowNetworkConditions.unit.cc
+++ b/tst/EnergyPlus/unit/AirflowNetworkConditions.unit.cc
@@ -302,9 +302,7 @@ TEST_F(EnergyPlusFixture, AirflowNetworkSimulationControl_SetSolver)
 
     SurfaceGeometry::AllocateSurfaceWindows(*state, 2);
     state->dataSurface->Surface(1).OriginalClass = DataSurfaces::SurfaceClass::Window;
-    ;
     state->dataSurface->Surface(2).OriginalClass = DataSurfaces::SurfaceClass::Window;
-    ;
     state->dataGlobal->NumOfZones = 1;
 
     state->dataHeatBal->TotPeople = 1; // Total number of people statements

--- a/tst/EnergyPlus/unit/DaylightingManager.unit.cc
+++ b/tst/EnergyPlus/unit/DaylightingManager.unit.cc
@@ -421,7 +421,6 @@ TEST_F(EnergyPlusFixture, DaylightingManager_GetInputOutputIlluminanceMap_Test)
     dl->enclDaylight.allocate(state->dataViewFactor->NumOfSolarEnclosures);
 
     GetInputIlluminanceMap(*state, foundErrors);
-    // compare_err_stream(""); // expecting errors because zone is not really defined
 
     EXPECT_EQ(1, (int)dl->illumMaps.size());
 

--- a/tst/EnergyPlus/unit/EconomicTariff.unit.cc
+++ b/tst/EnergyPlus/unit/EconomicTariff.unit.cc
@@ -345,7 +345,6 @@ TEST_F(EnergyPlusFixture, EconomicTariff_Gas_CCF_Test)
     state->dataOutputProcessor->meterMap.insert_or_assign("NATURALGAS:FACILITY", state->dataOutputProcessor->meters.size() - 1);
 
     UpdateUtilityBills(*state);
-    ;
 
     // tariff
     EXPECT_EQ(1, state->dataEconTariff->numTariff);
@@ -386,7 +385,6 @@ TEST_F(EnergyPlusFixture, EconomicTariff_Electric_CCF_Test)
     state->dataOutputProcessor->meterMap.insert_or_assign("ELECTRICITY:FACILITY", state->dataOutputProcessor->meters.size() - 1);
 
     UpdateUtilityBills(*state);
-    ;
 
     // tariff
     EXPECT_EQ(1, state->dataEconTariff->numTariff);
@@ -603,7 +601,6 @@ TEST_F(EnergyPlusFixture, EconomicTariff_GatherForEconomics)
 
     // This will only do the get input routines
     EconomicTariff::UpdateUtilityBills(*state);
-    ;
 
     // tariff
     EXPECT_EQ(1, state->dataEconTariff->numTariff);
@@ -653,7 +650,6 @@ TEST_F(EnergyPlusFixture, EconomicTariff_GatherForEconomics)
     // This Should now call GatherForEconomics
     state->dataGlobal->DoOutputReporting = true;
     EconomicTariff::UpdateUtilityBills(*state);
-    ;
     EXPECT_ENUM_EQ(Season::Winter, state->dataEconTariff->tariff(1).seasonForMonth(5));
     EXPECT_ENUM_EQ(Season::Invalid, state->dataEconTariff->tariff(1).seasonForMonth(6));
 
@@ -679,7 +675,6 @@ TEST_F(EnergyPlusFixture, EconomicTariff_GatherForEconomics)
 
     // This Should now call GatherForEconomics
     EconomicTariff::UpdateUtilityBills(*state);
-    ;
     EXPECT_ENUM_EQ(Season::Winter, state->dataEconTariff->tariff(1).seasonForMonth(5));
     EXPECT_ENUM_EQ(Season::Summer, state->dataEconTariff->tariff(1).seasonForMonth(6));
 }

--- a/tst/EnergyPlus/unit/FiniteDifferenceGroundTemperatureModel.unit.cc
+++ b/tst/EnergyPlus/unit/FiniteDifferenceGroundTemperatureModel.unit.cc
@@ -104,7 +104,6 @@ TEST_F(EnergyPlusFixture, FiniteDiffGroundTempModelTest)
         tdwd.relativeHumidity = relHum_const;
         tdwd.windSpeed = windSpeed_const;
         tdwd.horizontalRadiation = solar_amp * std::sin(theta - omega) + (solar_min + solar_amp);
-        ;
         tdwd.airDensity = 1.2;
     }
 

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc
@@ -192,6 +192,11 @@ bool EnergyPlusFixture::compare_eio_stream(std::string const &expected_string, b
 
 bool EnergyPlusFixture::compare_eio_stream_substring(std::string const &search_string, bool reset_stream)
 {
+    if (search_string.empty()) {
+        ADD_FAILURE() << "compare_eio_stream_substring cannot search for an empty string; use compare_eso_stream or has_eso_output instead.";
+        return false;
+    }
+
     auto const stream_str = state->files.eio.get_output();
     bool const found = stream_str.find(search_string) != std::string::npos;
     EXPECT_TRUE(found);
@@ -225,6 +230,11 @@ bool EnergyPlusFixture::compare_err_stream(std::string const &expected_string, b
 
 bool EnergyPlusFixture::compare_err_stream_substring(std::string const &search_string, bool reset_stream, bool call_expect)
 {
+    if (search_string.empty()) {
+        ADD_FAILURE() << "compare_err_stream_substring cannot search for an empty string; use compare_err_stream or has_err_output instead.";
+        return false;
+    }
+
     auto const stream_str = this->err_stream->str();
     bool const found = stream_str.find(search_string) != std::string::npos;
     if (call_expect) {
@@ -248,6 +258,11 @@ bool EnergyPlusFixture::compare_cout_stream(std::string const &expected_string, 
 }
 bool EnergyPlusFixture::compare_cout_stream_substring(std::string const &search_string, bool reset_stream)
 {
+    if (search_string.empty()) {
+        ADD_FAILURE() << "compare_cout_stream_substring cannot search for an empty string; use compare_cout_stream or has_cout_output instead.";
+        return false;
+    }
+
     auto const stream_str = this->m_cout_buffer->str();
     bool const found = stream_str.find(search_string) != std::string::npos;
     if (reset_stream) {

--- a/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.hh
+++ b/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.hh
@@ -175,7 +175,7 @@ protected:
     // It is easier to test successive functions if the EIO stream is 'empty' before the next call.
     // This calls EXPECT_* within the function as well as returns a boolean so you can call [ASSERT/EXPECT]_[TRUE/FALSE] depending
     // if it makes sense for the unit test to continue after returning from function.
-    // Will return true if string matches the stream and false if it does not
+    // Will return true if a non-empty string is found in the stream and false if it is not
     bool compare_eio_stream_substring(std::string const &expected_string, bool reset_stream = true);
 
     // Compare an expected string against the MTR stream. The default is to reset the MTR stream after every call.
@@ -196,7 +196,7 @@ protected:
     // It is easier to test successive functions if the ERR stream is 'empty' before the next call.
     // This calls EXPECT_* within the function as well as returns a boolean so you can call [ASSERT/EXPECT]_[TRUE/FALSE] depending
     // if it makes sense for the unit test to continue after returning from function.
-    // Will return true if string is found in the stream and false if it is not
+    // Will return true if a non-empty string is found in the stream and false if it is not
     bool compare_err_stream_substring(std::string const &search_string, bool reset_stream = true, bool call_expect = true);
 
     // Compare an expected string against the COUT stream. The default is to reset the COUT stream after every call.
@@ -210,7 +210,7 @@ protected:
     // It is easier to test successive functions if the COUT stream is 'empty' before the next call.
     // This returns a boolean so you can call [ASSERT/EXPECT]_[TRUE/FALSE] depending
     // if it makes sense for the unit test to continue after returning from function.
-    // Will return true if string is found in the stream and false if it is not
+    // Will return true if a non-empty string is found in the stream and false if it is not
     bool compare_cout_stream_substring(std::string const &search_string, bool reset_stream = true);
 
     // Compare an expected string against the CERR stream. The default is to reset the CERR stream after every call.

--- a/tst/EnergyPlus/unit/HVACDXSystem.unit.cc
+++ b/tst/EnergyPlus/unit/HVACDXSystem.unit.cc
@@ -457,9 +457,8 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_DOASDXCoilTest)
     thisSys->CoolCoilOutletNodeNum = 2;
     thisSys->CoolCtrlNode = 2;
     bool errorsFound = thisSys->checkNodeSetPoint(*state, AirLoopNum, thisSys->CoolCtrlNode, CoolingCoil, OAUCoilOutTemp);
-    EXPECT_FALSE(errorsFound); // no errors when TempSetPoint is set on the control node
-    expected_error = "";
-    EXPECT_TRUE(compare_err_stream_substring(expected_error, true)); // no warnings when control node = cooling coil outlet node
+    EXPECT_FALSE(errorsFound);                 // no errors when TempSetPoint is set on the control node
+    EXPECT_TRUE(compare_err_stream("", true)); // no warnings when control node = cooling coil outlet node
 
     state->dataLoopNodes->Node(2).TempSetPoint = -999.0; // reset to invalid setpoint to test error case
     errorsFound = thisSys->checkNodeSetPoint(*state, AirLoopNum, thisSys->CoolCtrlNode, CoolingCoil, OAUCoilOutTemp);

--- a/tst/EnergyPlus/unit/OutdoorAirUnit.unit.cc
+++ b/tst/EnergyPlus/unit/OutdoorAirUnit.unit.cc
@@ -105,7 +105,6 @@ TEST_F(EnergyPlusFixture, OutdoorAirUnit_AutoSize)
     int CurZoneNum(1);             // index to zone
     Real64 SysOutputProvided(0.0); // function returns sensible capacity [W]
     Real64 LatOutputProvided(0.0); // function returns latent capacity [W]
-    int ZoneInletNode(0);
 
     std::string const idf_objects = delimited_string({
         "Output:Diagnostics, DisplayExtraWarnings;",
@@ -328,7 +327,7 @@ TEST_F(EnergyPlusFixture, OutdoorAirUnit_AutoSize)
     state->dataSize->FinalZoneSizing(state->dataSize->CurZoneEqNum).CoolDesTemp = 13.1;                   // 55.58 F
     state->dataSize->FinalZoneSizing(state->dataSize->CurZoneEqNum).CoolDesHumRat = 0.009297628698818194; // humrat at 12.77777 C db / 12.6 C wb
 
-    ZoneInletNode = OutdoorAirUnit::GetOutdoorAirUnitZoneInletNode(*state, OAUnitNum);
+    OutdoorAirUnit::GetOutdoorAirUnitZoneInletNode(*state, OAUnitNum);
 
     // schedule values will get reset to 0 if initialized before GetInput
     Sched::GetSchedule(*state, "AVAILSCHED")->currentVal = 1.0;    // enable the VRF condenser
@@ -361,7 +360,6 @@ TEST_F(EnergyPlusFixture, OutdoorAirUnit_AutoSize)
     EXPECT_DOUBLE_EQ(SAFanPower, 75.0);
     EXPECT_DOUBLE_EQ(EAFanPower, 75.0);
     EXPECT_DOUBLE_EQ(SAFanPower + EAFanPower, state->dataOutdoorAirUnit->OutAirUnit(OAUnitNum).ElecFanRate);
-    compare_err_stream_substring("", true);
     EXPECT_TRUE(compare_err_stream("", true));
 
     // #6173

--- a/tst/EnergyPlus/unit/OutdoorAirUnit.unit.cc
+++ b/tst/EnergyPlus/unit/OutdoorAirUnit.unit.cc
@@ -360,7 +360,19 @@ TEST_F(EnergyPlusFixture, OutdoorAirUnit_AutoSize)
     EXPECT_DOUBLE_EQ(SAFanPower, 75.0);
     EXPECT_DOUBLE_EQ(EAFanPower, 75.0);
     EXPECT_DOUBLE_EQ(SAFanPower + EAFanPower, state->dataOutdoorAirUnit->OutAirUnit(OAUnitNum).ElecFanRate);
-    EXPECT_TRUE(compare_err_stream("", true));
+    std::string const sizing_error_string = delimited_string({
+        "   ** Warning ** SizeDXCoil Coil:Cooling:DX:SingleSpeed ACDXCOIL 1",
+        "   **   ~~~   ** ...Gross Rated Total Cooling Capacity [W] will be limited by the maximum rated volume flow per rated total capacity ratio.",
+        "   **   ~~~   ** ...DX coil volume flow rate [m3/s] = 0.500000",
+        "   **   ~~~   ** ...Requested capacity [W] = 75.000",
+        "   **   ~~~   ** ...Requested flow/capacity ratio [m3/s/W] = 0.00666667",
+        "   **   ~~~   ** ...Maximum flow/capacity ratio [m3/s/W] = 6.04100E-05",
+        "   **   ~~~   ** ...Adjusted capacity [W] = 8276.775",
+        "   ** Warning ** SizeHeatingCoil: : Potential issue with equipment sizing for Coil:Heating:Electric ZONE1OAUHEATINGCOIL",
+        "   **   ~~~   ** ...Rated Total Heating Capacity = 0.00 [W]",
+        "   **   ~~~   ** ...Capacity used to size child component set to 0 [W]",
+    });
+    EXPECT_TRUE(compare_err_stream(sizing_error_string, true));
 
     // #6173
     state->dataOutdoorAirUnit->OutAirUnit(OAUnitNum).ExtAirMassFlow = 0.0;

--- a/tst/EnergyPlus/unit/Psychrometrics.unit.cc
+++ b/tst/EnergyPlus/unit/Psychrometrics.unit.cc
@@ -417,7 +417,6 @@ TEST_F(EnergyPlusFixture, Psychrometrics_CpAirAverageValue_Test)
     Real64 CpAirOut = PsyCpAirFnW(W2);                  // cp of air at state 2
     Real64 CpAir_result = PsyCpAirFnW(0.5 * (W1 + W2)); // cp of air at average humidity ratio
     Real64 CpAir_average = (CpAirIn + CpAirOut) / 2;
-    ;
     // check heating results
     EXPECT_DOUBLE_EQ(CpAirIn, 1.00484e3 + W1 * 1.85895e3);
     EXPECT_DOUBLE_EQ(CpAirOut, 1.00484e3 + W2 * 1.85895e3);
@@ -430,7 +429,6 @@ TEST_F(EnergyPlusFixture, Psychrometrics_CpAirAverageValue_Test)
     CpAirOut = PsyCpAirFnW(W2);                  // cp of air at state 2
     CpAir_result = PsyCpAirFnW(0.5 * (W1 + W2)); // cp of air at average humidity ratio
     CpAir_average = (CpAirIn + CpAirOut) / 2;
-    ;
     // check cooling results
     EXPECT_DOUBLE_EQ(CpAirIn, 1.00484e3 + W1 * 1.85895e3);
     EXPECT_DOUBLE_EQ(CpAirOut, 1.00484e3 + W2 * 1.85895e3);

--- a/tst/EnergyPlus/unit/SimulationManager.unit.cc
+++ b/tst/EnergyPlus/unit/SimulationManager.unit.cc
@@ -230,7 +230,7 @@ TEST_F(EnergyPlusFixture, SimulationManager_OutputDebuggingData)
         });
 
         state->init_state_called = false;
-        compare_err_stream_substring("", true);
+        compare_err_stream("", true);
         // Input processor with throw a severe, so do not use assertions
         EXPECT_FALSE(process_idf(idf_objects, false));
         state->init_state(*state);
@@ -359,7 +359,7 @@ TEST_F(EnergyPlusFixture, SimulationManager_OutputDiagnostics_Unicity)
         "    DisplayAllWarnings;      !- Key 1",
     });
 
-    compare_err_stream_substring("", true);
+    compare_err_stream("", true);
     // Input processor will throw a severe, so do not use assertions
     EXPECT_FALSE(process_idf(idf_objects, false));
     state->init_state(*state);

--- a/tst/EnergyPlus/unit/UnitarySystem.unit.cc
+++ b/tst/EnergyPlus/unit/UnitarySystem.unit.cc
@@ -19865,7 +19865,6 @@ Curve:Biquadratic,
     state->dataZoneEquip->ZoneEquipInputsFilled = true;                                  // indicate zone data is available
     thisSys->getUnitarySystemInputData(*state, compName, zoneEquipment, 0, ErrorsFound); // get UnitarySystem input from object above
     EXPECT_FALSE(ErrorsFound);                                                           // expect no errors
-    ;
     // Verify UnitarySystem air flow rates are read in as AutoSized
     EXPECT_EQ(thisSys->m_MaxCoolAirVolFlow, DataSizing::AutoSize);
     EXPECT_EQ(thisSys->m_MaxHeatAirVolFlow, DataSizing::AutoSize);

--- a/tst/EnergyPlus/unit/VariableSpeedCoils.unit.cc
+++ b/tst/EnergyPlus/unit/VariableSpeedCoils.unit.cc
@@ -3039,12 +3039,10 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_ContFanCycCoil_Test)
     state->dataLoopNodes->Node(vsCoolingCoil.AirInletNodeNum).MassFlowRate = vsCoolingCoil.AirMassFlowRate;
     VariableSpeedCoils::CalcVarSpeedCoilCooling(
         *state, DXCoilNum, fanOp, SensLoad, LatentLoad, compressorOp, PartLoadFrac, OnOffAirFlowRatio, SpeedRatio, SpeedCal);
-    ;
     // check coil outlet and inlet air conditions match
     EXPECT_EQ(vsCoolingCoil.OutletAirDBTemp, vsCoolingCoil.InletAirDBTemp);
     EXPECT_EQ(vsCoolingCoil.OutletAirHumRat, vsCoolingCoil.InletAirHumRat);
     EXPECT_EQ(vsCoolingCoil.OutletAirEnthalpy, vsCoolingCoil.InletAirEnthalpy);
-    ;
     // test 2: compressor is On and PLR > 0
     compressorOp = HVAC::CompressorOp::On;
     PartLoadFrac = 0.1;
@@ -3066,7 +3064,6 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_ContFanCycCoil_Test)
     EXPECT_NEAR(vsCoolingCoil.Power, 785.588, 0.001);
     EXPECT_NEAR(vsCoolingCoil.QSource, 3915.355, 0.001);
     EXPECT_NEAR(vsCoolingCoil.QLoadTotal, 3182.143, 0.001);
-    ;
     // test 3: dx cooling coil unavailable, compressor is On and PLR > 0
     // run init the coil to reset coil air inlet and outlet conditions
     VariableSpeedCoils::InitVarSpeedCoil(*state, DXCoilNum, SensLoad, LatentLoad, fanOp, OnOffAirFlowRatio, SpeedRatio, SpeedCal);
@@ -7082,7 +7079,6 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_Coil_Defrost_Power_Fix_Test)
 
     // Without the current PR (PR 10109), the DefrostPower would remain 908.1 and fail the following test:
     EXPECT_NEAR(state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum).DefrostPower, 0.0, 1e-3);
-    ;
     // new test: dx cooling coil unavailable, compressor is On and PLR > 0
     auto &vsHeatingCoil = state->dataVariableSpeedCoils->VarSpeedCoil(DXCoilNum);
     // Set up some environmental parameters
@@ -7109,7 +7105,6 @@ TEST_F(EnergyPlusFixture, VariableSpeedCoils_Coil_Defrost_Power_Fix_Test)
     EXPECT_NEAR(vsHeatingCoil.Power, 280.91365138509082, 0.0);
     EXPECT_NEAR(vsHeatingCoil.QSource, 1163.0343848520001, 0.0);
     EXPECT_NEAR(vsHeatingCoil.QLoadTotal, 1443.9480362370909, 0.001);
-    ;
     // reset the heating coil availability schedule to AlwaysOff
     vsHeatingCoil.availSched = Sched::GetScheduleAlwaysOff(*state);
     VariableSpeedCoils::SimVariableSpeedCoils(*state,

--- a/tst/EnergyPlus/unit/WeatherManager.unit.cc
+++ b/tst/EnergyPlus/unit/WeatherManager.unit.cc
@@ -615,7 +615,7 @@ TEST_F(EnergyPlusFixture, WaterMainsOutputReports_CorrelationFromWeatherFileTest
     });
 
     ASSERT_TRUE(process_idf(idf_objects));
-    compare_eio_stream_substring("", true);
+    compare_err_stream("", true);
     bool foundErrors(false);
     Weather::GetWaterMainsTemperatures(*state, foundErrors);
     EXPECT_FALSE(foundErrors); // expect no errors


### PR DESCRIPTION
Pull request overview
---------------------

The behavior of [```compare_err_stream_substring```](https://github.com/NatLabRockies/EnergyPlus/blob/ebf7b4f07567e7e47b10db97f829afd6212c51f1/tst/EnergyPlus/unit/Fixtures/EnergyPlusFixture.cc#L229) appears to have been misunderstood, (propagated via copy/paste,) and possibly allowed errors to pass by uncaught. For `std::string::find("")`, C++ considers the empty string found at position 0 for any string, including another empty string. See the MWE, [here](https://godbolt.org/z/Wfh8xoM1G).

This makes usages like `compare_err_stream_substring("", true)` ineffective at doing anything other than clearing the err stream. If the intent is really to expect an empty err stream, we should be using `compare_err_stream` instead.

This PR replaces those usages, and adds guards to protect against further misuse.

<!-- NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE -->

### Description of the purpose of this PR

<!-- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
