### PR TITLE
Fix cold start deadlock on condenser loops with constant speed branch pumps

### DIFF
--- a/src/EnergyPlus/Plant/LoopSide.cc
+++ b/src/EnergyPlus/Plant/LoopSide.cc
@@ -138,7 +138,7 @@ namespace DataPlant {
         // On constant speed branch pump loop sides we need to re-simulate
         if (this->hasConstSpeedBranchPumps) {
             // turn off any pumps connected to unloaded equipment and re-do the flow/load solution pass
-            this->DisableAnyBranchPumpsConnectedToUnloadedEquipment();
+            this->DisableAnyBranchPumpsConnectedToUnloadedEquipment(state);
             this->DoFlowAndLoadSolutionPass(state, OtherLoopSide, ThisSideInletNode, FirstHVACIteration);
         }
 
@@ -662,8 +662,19 @@ namespace DataPlant {
         }
     }
 
-    void HalfLoopData::DisableAnyBranchPumpsConnectedToUnloadedEquipment()
+    void HalfLoopData::DisableAnyBranchPumpsConnectedToUnloadedEquipment(EnergyPlusData &state)
     {
+        // A tower branch can read zero dispatched load just because the loop has not started circulating yet;
+        // disabling its pump while the other side is turning the loop on deadlocks the cold start.
+        bool demandIsTurningLoopOn = false;
+        // plantLoc on a half loop side carries only loopNum/loopSideNum; its .loop pointer is never set
+        if (this->plantLoc.loopNum > 0 && this->plantLoc.loopNum <= state.dataPlnt->TotNumLoops) {
+            auto &thisLoop = state.dataPlnt->PlantLoop(this->plantLoc.loopNum);
+            auto const otherSide = LoopSideOther[static_cast<int>(this->plantLoc.loopSideNum)];
+            demandIsTurningLoopOn = (thisLoop.TypeOfLoop == DataPlant::LoopType::Condenser) &&
+                                    (thisLoop.LoopSide(otherSide).flowRequestNeedAndTurnOn > DataBranchAirLoopPlant::MassFlowTolerance);
+        }
+
         for (int branchNum = 2; branchNum <= this->TotalBranches - 1; ++branchNum) {
             auto &branch = this->Branch(branchNum);
             Real64 totalDispatchedLoadOnBranch = 0.0;
@@ -677,7 +688,7 @@ namespace DataPlant {
                     totalDispatchedLoadOnBranch += component.MyLoad;
                 }
             }
-            if (std::abs(totalDispatchedLoadOnBranch) < 0.001) {
+            if (std::abs(totalDispatchedLoadOnBranch) < 0.001 && !demandIsTurningLoopOn) {
                 branch.disableOverrideForCSBranchPumping = true;
             }
         }

--- a/src/EnergyPlus/Plant/LoopSide.hh
+++ b/src/EnergyPlus/Plant/LoopSide.hh
@@ -173,7 +173,7 @@ namespace DataPlant {
 
         void TurnOnAllLoopSideBranches();
 
-        void DisableAnyBranchPumpsConnectedToUnloadedEquipment();
+        void DisableAnyBranchPumpsConnectedToUnloadedEquipment(EnergyPlusData &state);
 
         void DoFlowAndLoadSolutionPass(EnergyPlusData &state, LoopSideLocation OtherSide, int ThisSideInletNode, bool FirstHVACIteration);
 

--- a/tst/EnergyPlus/unit/DataPlant.unit.cc
+++ b/tst/EnergyPlus/unit/DataPlant.unit.cc
@@ -127,3 +127,98 @@ TEST_F(EnergyPlusFixture, DataPlant_verifyTwoNodeNumsOnSamePlantLoop)
     state->dataPlnt->PlantLoop(2).LoopSide(DataPlant::LoopSideLocation::Supply).Branch.deallocate();
     state->dataPlnt->PlantLoop.deallocate();
 }
+
+// Three unit tests for the condenser loop constant speed branch pump cold start deadlock
+// (chiller runs and rejects heat, but the cooling tower/condenser pump stay off).
+// See HalfLoopData::DisableAnyBranchPumpsConnectedToUnloadedEquipment in Plant/LoopSide.cc
+TEST_F(EnergyPlusFixture, PlantLoopSide_CondenserTowerBranchPumpNotDisabledWhenDemandCallsForFlow)
+{
+    state->dataPlnt->TotNumLoops = 1;
+    state->dataPlnt->PlantLoop.allocate(1);
+    auto &loop = state->dataPlnt->PlantLoop(1);
+    loop.TypeOfLoop = DataPlant::LoopType::Condenser;
+
+    auto &supply = loop.LoopSide(DataPlant::LoopSideLocation::Supply);
+    supply.TotalBranches = 3; // inlet(1), parallel tower branch(2), outlet(3)
+    supply.Branch.allocate(3);
+    supply.plantLoc.loopNum = 1;
+    supply.plantLoc.loopSideNum = DataPlant::LoopSideLocation::Supply;
+
+    auto &branch = supply.Branch(2);
+    branch.TotalComponents = 2;
+    branch.Comp.allocate(2);
+    branch.Comp(1).Type = DataPlant::PlantEquipmentType::PumpConstantSpeed; // pumps are skipped in the load sum
+    branch.Comp(1).MyLoad = 0.0;
+    branch.Comp(2).Type = DataPlant::PlantEquipmentType::CoolingTower_TwoSpd; // tower, unloaded because no flow yet
+    branch.Comp(2).MyLoad = 0.0;
+    branch.disableOverrideForCSBranchPumping = false;
+
+    // the chiller condenser on the demand side is asking for flow
+    loop.LoopSide(DataPlant::LoopSideLocation::Demand).flowRequestNeedAndTurnOn = 1.0;
+
+    supply.DisableAnyBranchPumpsConnectedToUnloadedEquipment(*state);
+
+    // the branch pump must stay available, otherwise the loop can never start circulating
+    EXPECT_FALSE(supply.Branch(2).disableOverrideForCSBranchPumping);
+}
+
+TEST_F(EnergyPlusFixture, PlantLoopSide_CondenserTowerBranchPumpDisabledWhenNoDemand)
+{
+    state->dataPlnt->TotNumLoops = 1;
+    state->dataPlnt->PlantLoop.allocate(1);
+    auto &loop = state->dataPlnt->PlantLoop(1);
+    loop.TypeOfLoop = DataPlant::LoopType::Condenser;
+
+    auto &supply = loop.LoopSide(DataPlant::LoopSideLocation::Supply);
+    supply.TotalBranches = 3;
+    supply.Branch.allocate(3);
+    supply.plantLoc.loopNum = 1;
+    supply.plantLoc.loopSideNum = DataPlant::LoopSideLocation::Supply;
+
+    auto &branch = supply.Branch(2);
+    branch.TotalComponents = 2;
+    branch.Comp.allocate(2);
+    branch.Comp(1).Type = DataPlant::PlantEquipmentType::PumpConstantSpeed;
+    branch.Comp(1).MyLoad = 0.0;
+    branch.Comp(2).Type = DataPlant::PlantEquipmentType::CoolingTower_TwoSpd;
+    branch.Comp(2).MyLoad = 0.0;
+    branch.disableOverrideForCSBranchPumping = false;
+
+    // nothing on the demand side wants flow
+    loop.LoopSide(DataPlant::LoopSideLocation::Demand).flowRequestNeedAndTurnOn = 0.0;
+
+    supply.DisableAnyBranchPumpsConnectedToUnloadedEquipment(*state);
+
+    // existing behavior is preserved: an unloaded branch pump is still shut off
+    EXPECT_TRUE(supply.Branch(2).disableOverrideForCSBranchPumping);
+}
+
+TEST_F(EnergyPlusFixture, PlantLoopSide_PlantLoopBranchPumpStillDisabledEvenWithDemand)
+{
+    state->dataPlnt->TotNumLoops = 1;
+    state->dataPlnt->PlantLoop.allocate(1);
+    auto &loop = state->dataPlnt->PlantLoop(1);
+    loop.TypeOfLoop = DataPlant::LoopType::Plant; // not a condenser loop
+
+    auto &supply = loop.LoopSide(DataPlant::LoopSideLocation::Supply);
+    supply.TotalBranches = 3;
+    supply.Branch.allocate(3);
+    supply.plantLoc.loopNum = 1;
+    supply.plantLoc.loopSideNum = DataPlant::LoopSideLocation::Supply;
+
+    auto &branch = supply.Branch(2);
+    branch.TotalComponents = 2;
+    branch.Comp.allocate(2);
+    branch.Comp(1).Type = DataPlant::PlantEquipmentType::PumpConstantSpeed;
+    branch.Comp(1).MyLoad = 0.0;
+    branch.Comp(2).Type = DataPlant::PlantEquipmentType::CoolingTower_TwoSpd;
+    branch.Comp(2).MyLoad = 0.0;
+    branch.disableOverrideForCSBranchPumping = false;
+
+    loop.LoopSide(DataPlant::LoopSideLocation::Demand).flowRequestNeedAndTurnOn = 1.0;
+
+    supply.DisableAnyBranchPumpsConnectedToUnloadedEquipment(*state);
+
+    // the new exception is scoped to condenser loops only
+    EXPECT_TRUE(supply.Branch(2).disableOverrideForCSBranchPumping);
+}


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #10265 

<!-- NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE -->

### Description of the purpose of this PR

- Fix cold-start deadlock on condenser loops with constant-speed branch pumps
- A condenser loop whose supply side has only constant-speed tower branch pumps could never start circulating. With no flow the tower reads zero dispatched load, so `DisableAnyBranchPumpsConnectedToUnloadedEquipment` shuts its branch pump off, which keeps the loop from ever starting. The chiller kept reporting condenser heat transfer against a frozen condenser inlet temperature while the pump and tower stayed off.
- Skip disabling those branch pumps when the other loop side is turning a condenser loop on. The half loop side's plantLoc carries only loopNum, so the loop is looked up through state rather than the .loop pointer, which is never populated.
- Adds three unit tests covering the condenser case, the no-demand case, and the plant-loop scope guard.
- Defect file:  
[UnmetHours_ChillerIsOnbutCoolingTowerIsOff_Project_PS_V2610_JuneJulyruntime.idf.txt](https://github.com/user-attachments/files/30314197/UnmetHours_ChillerIsOnbutCoolingTowerIsOff_Project_PS_V2610_JuneJulyruntime.idf.txt)
(The author of the issue provided three defect files. This is one of them, and the runtime has been shortened to June through July)
- Weather: USA_IL_Chicago-OHare.725300_TMY2.epw
- Results (defect file, June 1 to July 31)
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns="http://www.w3.org/TR/REC-html40"
xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=PowerPoint.Slide>
<meta name=Generator content="Microsoft PowerPoint 15">
<!--tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
td
	{padding-top:1.0px;
	padding-right:1.0px;
	padding-left:1.0px;
	mso-ignore:padding;
	color:windowtext;
	font-size:18.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial;
	mso-generic-font-family:auto;
	mso-font-charset:0;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;}
.oa1
	{border:1.0pt solid black;
	vertical-align:middle;
	padding-bottom:3.6pt;
	padding-left:7.2pt;
	padding-top:3.6pt;
	padding-right:7.2pt;}
-->
</head>

<body>
<!--StartFragment-->


  | Before | After
-- | -- | --
Cooling tower fan operating hours | 48 (design days only) | 933
Condenser branch pump flow hours | 48 | 935
Chiller rejecting heat while tower off | 452 hrs | 2 hrs
Chiller condenser inlet temperature | frozen at 11.14 C | 6.0 to 29.3 C



<!--EndFragment-->
</body>

</html>

- Before the fix, the cooling tower fan and the condenser branch pumps only ran during the 48 design day hours, while the chiller reported condenser heat rejection for 452 hours against a condenser inlet temperature frozen at a single value of 11.14 C. 
- After the fix, the tower fan runs 933 hours and the branch pumps 935 hours, and the condenser inlet temperature varies from 6.0 to 29.3 C. 
- The two remaining hours are not a deadlock. Condenser water is circulating in both (5.0 and 60.4 kg/s) with only the tower fan off, which is normal low-load operation.
- The chiller now runs more hours because it sees realistic condenser temperatures instead of an artificially cold frozen value, which lowers its COP as expected.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
